### PR TITLE
Setup ctest to run the unit tests when you call 'make test'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ endif()
 
 enable_language(CXX)
 
+ENABLE_TESTING()
+
 if(APPLE)
     if(NOT CMAKE_OSX_ARCHITECTURES)
         set(CMAKE_OSX_ARCHITECTURES x86_64 CACHE STRING
@@ -106,6 +108,13 @@ endif()
 
 add_subdirectory (src/pyglue)
 
+###############################################################################
+### CTEST ###
+
+add_custom_target(test_verbose
+                  COMMAND ctest -VV
+                  DEPENDS ocio_core_tests
+                  COMMENT "Running ctest with verbose output")
 
 # Log CMake first run done
 SET(CMAKE_FIRST_RUN 0 CACHE INTERNAL "")

--- a/src/core_tests/CMakeLists.txt
+++ b/src/core_tests/CMakeLists.txt
@@ -25,4 +25,7 @@ if(Boost_FOUND)
         )
     
     install(TARGETS ocio_core_tests DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+    
+    ADD_TEST(ocio_core_tests COMMAND ${CMAKE_CURRENT_BINARY_DIR}/ocio_core_tests --log_level=test_suite)
+    
 endif()


### PR DESCRIPTION
Notes:
- setup ctest in the CMakeLists.txt so that the 'make test' calls the unit tests
- added test that calls ocio_core_tests with --log_level set to 'test_suite'
- added custom target 'test_verbose' which will only build ocio_core_tests and run ctest in verbose mode

To build and run the tests (with verbose output):
:$ cmake ...
:$ make test_verbose
