### PR TITLE
Replaced BOOST test with OIIO test

### DIFF
--- a/ext/oiio/src/include/unittest.h
+++ b/ext/oiio/src/include/unittest.h
@@ -1,0 +1,151 @@
+ /*
+  Copyright 2010 Larry Gritz and the other authors and contributors.
+  All Rights Reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+  * Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+  * Neither the name of the software's owners nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+  (This is the Modified BSD License)
+*/
+
+#ifndef OPENIMAGEIO_UNITTEST_H
+#define OPENIMAGEIO_UNITTEST_H
+
+#include <iostream>
+#include <cmath>
+#include <vector>
+
+extern int unit_test_failures;
+
+void unittest_fail();
+
+typedef void (*OIIOTestFunc)();
+
+struct OIIOTest
+{
+    OIIOTest(std::string testgroup, std::string testname, OIIOTestFunc test) :
+        group(testgroup), name(testname), function(test) { };
+    std::string group, name;
+    OIIOTestFunc function;
+};
+
+typedef std::vector<OIIOTest*> UnitTests;
+
+UnitTests& GetUnitTests();
+
+struct AddTest { AddTest(OIIOTest* test); };
+
+/// OIIO_CHECK_* macros checks if the conditions is met, and if not,
+/// prints an error message indicating the module and line where the
+/// error occurred, but does NOT abort.  This is helpful for unit tests
+/// where we do not want one failure.
+#define OIIO_CHECK_ASSERT(x)                                            \
+    ((x) ? ((void)0)                                                    \
+         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
+                       << "FAILED: " << #x << "\n"),                    \
+            (void)++unit_test_failures))
+
+#define OIIO_CHECK_EQUAL(x,y)                                           \
+    (((x) == (y)) ? ((void)0)                                           \
+         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
+             << "FAILED: " << #x << " == " << #y << "\n"                \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
+            (void)++unit_test_failures))
+
+#define OIIO_CHECK_NE(x,y)                                              \
+    (((x) != (y)) ? ((void)0)                                           \
+         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
+             << "FAILED: " << #x << " != " << #y << "\n"                \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
+            (void)++unit_test_failures))
+
+#define OIIO_CHECK_LT(x,y)                                              \
+    (((x) < (y)) ? ((void)0)                                            \
+         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
+             << "FAILED: " << #x << " < " << #y << "\n"                 \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
+            (void)++unit_test_failures))
+
+#define OIIO_CHECK_GT(x,y)                                              \
+    (((x) > (y)) ? ((void)0)                                            \
+         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
+             << "FAILED: " << #x << " > " << #y << "\n"                 \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
+            (void)++unit_test_failures))
+
+#define OIIO_CHECK_LE(x,y)                                              \
+    (((x) <= (y)) ? ((void)0)                                           \
+         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
+             << "FAILED: " << #x << " <= " << #y << "\n"                \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
+            (void)++unit_test_failures))
+
+#define OIIO_CHECK_GE(x,y)                                              \
+    (((x) >= (y)) ? ((void)0)                                           \
+         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
+             << "FAILED: " << #x << " >= " << #y << "\n"                \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
+            (void)++unit_test_failures))
+
+#define OIIO_CHECK_CLOSE(x,y,tol)                                       \
+    ((std::abs((x) - (y)) < tol) ? ((void)0)                            \
+         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
+             << "FAILED: abs(" << #x << " - " << #y << ") < " << #tol << "\n" \
+             << "\tvalues were '" << (x) << "', '" << (y) << "' and '" << (tol) << "'\n"), \
+            (void)++unit_test_failures))
+
+#define OIIO_CHECK_THOW(S, E)                                           \
+    try { S; throw "throwanything"; } catch( E const& ex ) { } catch (...) { \
+        std::cout << __FILE__ << ":" << __LINE__ << ":\n"               \
+        << "FAILED: " << #E << " is expected to be thrown\n";           \
+        ++unit_test_failures; }
+
+#define OIIO_CHECK_NO_THOW(S)                                           \
+    try { S; } catch (...) {                                            \
+        std::cout << __FILE__ << ":" << __LINE__ << ":\n"               \
+        << "FAILED: exception thrown from " << #S <<"\n";               \
+        ++unit_test_failures; }
+
+#define OIIO_ADD_TEST(group, name)                                      \
+    static void oiiotest_##group##_##name();                            \
+    AddTest oiioaddtest_##group##_##name(new OIIOTest(#group, #name, oiiotest_##group##_##name)); \
+    static void oiiotest_##group##_##name()
+
+#define OIIO_TEST_SETUP() \
+    int unit_test_failures = 0
+
+#define OIIO_TEST_APP(app)                                              \
+    std::vector<OIIOTest*>& GetUnitTests() {                            \
+        static std::vector<OIIOTest*> oiio_unit_tests;                  \
+        return oiio_unit_tests; }                                       \
+    AddTest::AddTest(OIIOTest* test){GetUnitTests().push_back(test);};  \
+    OIIO_TEST_SETUP(); \
+    int main(int, char) { std::cerr << "\n" << #app <<"\n\n";           \
+        for(size_t i = 0; i < GetUnitTests().size(); ++i) {             \
+            int _tmp = unit_test_failures; GetUnitTests()[i]->function(); \
+            std::cerr << "Test [" << GetUnitTests()[i]->group << "] [" << GetUnitTests()[i]->name << "] - "; \
+            std::cerr << (_tmp == unit_test_failures ? "PASSED" : "FAILED") << "\n"; } \
+        std::cerr << "\n" << unit_test_failures << " tests failed\n\n";   \
+        return unit_test_failures; }
+
+#endif /* OPENIMAGEIO_UNITTEST_H */

--- a/src/core/Baker.cpp
+++ b/src/core/Baker.cpp
@@ -353,9 +353,7 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 #include "UnitTest.h"
 
-BOOST_AUTO_TEST_SUITE( Baker_Unit_Tests )
-
-BOOST_AUTO_TEST_CASE ( test_listlutwriters )
+OIIO_ADD_TEST(Baker_Unit_Tests, test_listlutwriters)
 {
     
     std::vector<std::string> current_writers;
@@ -364,18 +362,16 @@ BOOST_AUTO_TEST_CASE ( test_listlutwriters )
     
     OCIO::BakerRcPtr baker = OCIO::Baker::Create();
     
-    BOOST_CHECK_EQUAL(baker->getNumFormats(), (int)current_writers.size());
+    OIIO_CHECK_EQUAL(baker->getNumFormats(), (int)current_writers.size());
     
     std::vector<std::string> test;
     for(int i = 0; i < baker->getNumFormats(); ++i)
         test.push_back(baker->getFormatNameByIndex(i));
     
     for(unsigned int i = 0; i < current_writers.size(); ++i)
-        BOOST_CHECK_EQUAL(current_writers[i], test[i]);
+        OIIO_CHECK_EQUAL(current_writers[i], test[i]);
     
 }
-
-BOOST_AUTO_TEST_SUITE_END()
 
 #endif // OCIO_BUILD_TESTS
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -6,12 +6,13 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/export/
     ${CMAKE_BINARY_DIR}/export/
     ${YAML_CPP_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/ext/oiio/src/include
 )
 
 set(EXTERNAL_INCLUDE_DIRS)
-set(EXTERNAL_COMPILE_FLAGS "")
+set(EXTERNAL_COMPILE_FLAGS "-fPIC -fvisibility-inlines-hidden -fvisibility=hidden")
 set(EXTERNAL_LINK_FLAGS "")
-set(EXTERNAL_LIBRARIES)
+set(EXTERNAL_LIBRARIES ${YAML_CPP_STATIC_LIBRARIES})
 
 if(Boost_FOUND)
     set(EXTERNAL_INCLUDE_DIRS ${EXTERNAL_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
@@ -34,38 +35,43 @@ configure_file(${CMAKE_SOURCE_DIR}/export/OpenColorIO/OpenColorVersion.h.in
     ${CMAKE_BINARY_DIR}/export/OpenColorVersion.h @ONLY)
 list(APPEND core_export_headers ${CMAKE_BINARY_DIR}/export/OpenColorVersion.h)
 
-add_library(OpenColorIO SHARED
-    ${core_src_files})
+# SHARED
 
-add_dependencies(OpenColorIO
-    YAML_CPP_LOCAL)
-
-target_link_libraries(OpenColorIO
-    ${YAML_CPP_STATIC_LIBRARIES})
-
-target_link_libraries(OpenColorIO
-    ${EXTERNAL_LIBRARIES})
-
+add_library(OpenColorIO SHARED ${core_src_files})
+add_dependencies(OpenColorIO YAML_CPP_LOCAL)
+target_link_libraries(OpenColorIO ${EXTERNAL_LIBRARIES})
 set_target_properties(OpenColorIO PROPERTIES
-    COMPILE_FLAGS "-fPIC -fvisibility-inlines-hidden -fvisibility=hidden ${EXTERNAL_COMPILE_FLAGS}"
+    OUTPUT_NAME OpenColorIO
+    COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS}"
     LINK_FLAGS "${EXTERNAL_LINK_FLAGS}")
+install(TARGETS OpenColorIO DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 
+# STATIC
+
+list(REMOVE_ITEM core_src_files ${CMAKE_SOURCE_DIR}/src/core/UnitTest.cpp)
+add_library(OpenColorIO_STATIC STATIC ${core_src_files})
+add_dependencies(OpenColorIO_STATIC YAML_CPP_LOCAL)
+target_link_libraries(OpenColorIO_STATIC ${EXTERNAL_LIBRARIES})
+set_target_properties(OpenColorIO_STATIC PROPERTIES
+    OUTPUT_NAME OpenColorIO
+    COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS}"
+    LINK_FLAGS "${EXTERNAL_LINK_FLAGS}")
+install(TARGETS OpenColorIO_STATIC DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+
+#
 if (SOVERSION)
 message(STATUS "Setting OCIO SOVERSION to: ${SOVERSION}")
 set_target_properties(OpenColorIO PROPERTIES
     VERSION ${OCIO_VERSION}
     SOVERSION ${SOVERSION}
 )
+set_target_properties(OpenColorIO_STATIC PROPERTIES
+    VERSION ${OCIO_VERSION}
+    SOVERSION ${SOVERSION}
+)
 endif ()
 
-install(TARGETS OpenColorIO DESTINATION
-    ${CMAKE_INSTALL_PREFIX}/lib)
-
-# TODO: RegisterFileFormat() mechanism doesn't seem to work when static linked?
-#add_library(OpenColorIOStatic STATIC ${core_src_files})
-#set_target_properties(OpenColorIOStatic PROPERTIES OUTPUT_NAME OpenColorIO)
-#install(TARGETS OpenColorIOStatic DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-
+# public interface
 install(FILES ${core_export_headers}
     DESTINATION ${CMAKE_INSTALL_PREFIX}/include/OpenColorIO/)
 

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -1460,10 +1460,8 @@ namespace OCIO = OCIO_NAMESPACE;
 #include <sys/stat.h>
 #include "pystring/pystring.h"
 
-BOOST_AUTO_TEST_SUITE( Config_Unit_Tests )
-
 #if 0
-BOOST_AUTO_TEST_CASE ( test_searchpath_filesystem )
+OIIO_ADD_TEST(Config_Unit_Tests, test_searchpath_filesystem)
 {
     
     OCIO::EnvMap env = OCIO::GetEnvMap();
@@ -1526,15 +1524,14 @@ BOOST_AUTO_TEST_CASE ( test_searchpath_filesystem )
 }
 #endif
 
-BOOST_AUTO_TEST_CASE ( test_INTERNAL_RAW_PROFILE )
+OIIO_ADD_TEST(Config_Unit_Tests, test_INTERNAL_RAW_PROFILE)
 {
     std::istringstream is;
     is.str(OCIO::INTERNAL_RAW_PROFILE);
-    
-    BOOST_CHECK_NO_THROW(OCIO::ConstConfigRcPtr config = OCIO::Config::CreateFromStream(is));
+    OIIO_CHECK_NO_THOW(OCIO::ConstConfigRcPtr config = OCIO::Config::CreateFromStream(is));
 }
 
-BOOST_AUTO_TEST_CASE ( test_simpleConfig )
+OIIO_ADD_TEST(Config_Unit_Tests, test_simpleConfig)
 {
     
     std::string SIMPLE_PROFILE =
@@ -1602,10 +1599,10 @@ BOOST_AUTO_TEST_CASE ( test_simpleConfig )
     std::istringstream is;
     is.str(SIMPLE_PROFILE);
     OCIO::ConstConfigRcPtr config;
-    BOOST_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OIIO_CHECK_NO_THOW(config = OCIO::Config::CreateFromStream(is));
 }
 
-BOOST_AUTO_TEST_CASE ( test_roleAccess )
+OIIO_ADD_TEST(Config_Unit_Tests, test_roleAccess)
 {
     
     std::string SIMPLE_PROFILE =
@@ -1627,23 +1624,23 @@ BOOST_AUTO_TEST_CASE ( test_roleAccess )
     std::istringstream is;
     is.str(SIMPLE_PROFILE);
     OCIO::ConstConfigRcPtr config;
-    BOOST_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OIIO_CHECK_NO_THOW(config = OCIO::Config::CreateFromStream(is));
     
-    BOOST_CHECK_EQUAL(config->getNumRoles(), 3);
+    OIIO_CHECK_EQUAL(config->getNumRoles(), 3);
     
-    BOOST_CHECK(config->hasRole("compositing_log") == true);
-    BOOST_CHECK(config->hasRole("cheese") == false);
-    BOOST_CHECK(config->hasRole("") == false);
+    OIIO_CHECK_ASSERT(config->hasRole("compositing_log") == true);
+    OIIO_CHECK_ASSERT(config->hasRole("cheese") == false);
+    OIIO_CHECK_ASSERT(config->hasRole("") == false);
     
-    BOOST_CHECK_EQUAL(config->getRoleName(2), "scene_linear");
-    BOOST_CHECK_EQUAL(config->getRoleName(0), "compositing_log");
-    BOOST_CHECK_EQUAL(config->getRoleName(1), "default");
-    BOOST_CHECK_EQUAL(config->getRoleName(10), "");
-    BOOST_CHECK_EQUAL(config->getRoleName(-4), "");
+    OIIO_CHECK_ASSERT(strcmp(config->getRoleName(2), "scene_linear") == 0);
+    OIIO_CHECK_ASSERT(strcmp(config->getRoleName(0), "compositing_log") == 0);
+    OIIO_CHECK_ASSERT(strcmp(config->getRoleName(1), "default") == 0);
+    OIIO_CHECK_ASSERT(strcmp(config->getRoleName(10), "") == 0);
+    OIIO_CHECK_ASSERT(strcmp(config->getRoleName(-4), "") == 0);
     
 }
 
-BOOST_AUTO_TEST_CASE ( test_ser )
+OIIO_ADD_TEST(Config_Unit_Tests, test_ser)
 {
     
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
@@ -1722,11 +1719,9 @@ BOOST_AUTO_TEST_CASE ( test_ser )
     std::vector<std::string> PROFILE_OUTvec;
     OCIO::pystring::splitlines(PROFILE_OUT, PROFILE_OUTvec);
     
-    BOOST_CHECK_EQUAL(osvec.size(), PROFILE_OUTvec.size());
+    OIIO_CHECK_EQUAL(osvec.size(), PROFILE_OUTvec.size());
     for(unsigned int i = 0; i < PROFILE_OUTvec.size(); ++i)
-        BOOST_CHECK_EQUAL(osvec[i], PROFILE_OUTvec[i]);
+        OIIO_CHECK_EQUAL(osvec[i], PROFILE_OUTvec[i]);
 }
-
-BOOST_AUTO_TEST_SUITE_END()
 
 #endif // OCIO_UNIT_TEST

--- a/src/core/FileFormat3DL.cpp
+++ b/src/core/FileFormat3DL.cpp
@@ -495,8 +495,6 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 #include "UnitTest.h"
 
-BOOST_AUTO_TEST_SUITE( FileFormat3DL_Unit_Tests )
-
 // FILE      EXPECTED MAX    CORRECTLY DECODED IF MAX IN THIS RANGE 
 // 8-bit     255             [0, 511]      
 // 10-bit    1023            [512, 2047]
@@ -504,35 +502,33 @@ BOOST_AUTO_TEST_SUITE( FileFormat3DL_Unit_Tests )
 // 14-bit    16383           [8192, 32767]
 // 16-bit    65535           [32768, 131071]
 
-BOOST_AUTO_TEST_CASE ( test_GetLikelyLutBitDepth )
+OIIO_ADD_TEST(FileFormat3DL, GetLikelyLutBitDepth)
 {
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(-1), -1);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(-1), -1);
     
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(0), 8);
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(1), 8);
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(255), 8);
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(256), 8);
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(511), 8);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(0), 8);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(1), 8);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(255), 8);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(256), 8);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(511), 8);
     
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(512), 10);
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(1023), 10);
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(1024), 10);
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(2047), 10);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(512), 10);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(1023), 10);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(1024), 10);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(2047), 10);
     
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(2048), 12);
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(4095), 12);
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(4096), 12);
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(8191), 12);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(2048), 12);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(4095), 12);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(4096), 12);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(8191), 12);
     
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(16383), 14);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(16383), 14);
     
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(65535), 16);
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(65536), 16);
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(131071), 16);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(65535), 16);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(65536), 16);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(131071), 16);
     
-    BOOST_CHECK_EQUAL (OCIO::GetLikelyLutBitDepth(131072), 16);
+    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(131072), 16);
 }
-
-BOOST_AUTO_TEST_SUITE_END()
 
 #endif // OCIO_UNIT_TEST

--- a/src/core/FileFormatCSP.cpp
+++ b/src/core/FileFormatCSP.cpp
@@ -798,9 +798,7 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 #include "UnitTest.h"
 
-BOOST_AUTO_TEST_SUITE( FileFormatCSP_Unit_Tests )
-
-BOOST_AUTO_TEST_CASE ( test_simple1D )
+OIIO_ADD_TEST(FileFormatCSP, simple1D)
 {
     std::ostringstream strebuf;
     strebuf << "CSPLUTV100"              << "\n";
@@ -847,25 +845,24 @@ BOOST_AUTO_TEST_CASE ( test_simple1D )
         {
             float input = float(i) / float(csplut->prelut->luts[c].size()-1);
             float output = csplut->prelut->luts[c][i];
-            BOOST_CHECK_CLOSE (input*2.0f, output, 1e-4);
+            OIIO_CHECK_CLOSE(input*2.0f, output, 1e-4);
         }
     }
     // check 1D data
     // red
     unsigned int i;
     for(i = 0; i < csplut->lut1D->luts[0].size(); ++i)
-        BOOST_CHECK_EQUAL (red[i], csplut->lut1D->luts[0][i]);
+        OIIO_CHECK_EQUAL(red[i], csplut->lut1D->luts[0][i]);
     // green
     for(i = 0; i < csplut->lut1D->luts[1].size(); ++i)
-        BOOST_CHECK_EQUAL (green[i], csplut->lut1D->luts[1][i]);
+        OIIO_CHECK_EQUAL(green[i], csplut->lut1D->luts[1][i]);
     // blue
     for(i = 0; i < csplut->lut1D->luts[2].size(); ++i)
-        BOOST_CHECK_EQUAL (blue[i], csplut->lut1D->luts[2][i]);
+        OIIO_CHECK_EQUAL(blue[i], csplut->lut1D->luts[2][i]);
     
 }
 
-
-BOOST_AUTO_TEST_CASE ( test_simple3D )
+OIIO_ADD_TEST(FileFormatCSP, simple3D)
 {
     std::ostringstream strebuf;
     strebuf << "CSPLUTV100"                                  << "\n";
@@ -909,11 +906,11 @@ BOOST_AUTO_TEST_CASE ( test_simple3D )
     OCIO::CachedFileCSPRcPtr csplut = OCIO::DynamicPtrCast<OCIO::CachedFileCSP>(cachedFile);
     
     // check prelut data
-    BOOST_CHECK(csplut->hasprelut == false);
+    OIIO_CHECK_ASSERT(csplut->hasprelut == false);
     
     // check cube data
     for(unsigned int i = 0; i < csplut->lut3D->lut.size(); ++i) {
-        BOOST_CHECK_EQUAL (cube[i], csplut->lut3D->lut[i]);
+        OIIO_CHECK_EQUAL(cube[i], csplut->lut3D->lut[i]);
     }
     
     // check baker output
@@ -992,17 +989,15 @@ BOOST_AUTO_TEST_CASE ( test_simple3D )
     OCIO::pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
     OCIO::pystring::splitlines(bout, resvec);
-    BOOST_CHECK_EQUAL(osvec.size(), resvec.size());
+    OIIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
     {
         // skip timestamp line
-        if(i != 4) BOOST_CHECK_EQUAL(osvec[i], resvec[i]);
+        if(i != 4) OIIO_CHECK_EQUAL(osvec[i], resvec[i]);
     }
     
 }
 
 // TODO: More strenuous tests of prelut resampling (non-noop preluts)
-
-BOOST_AUTO_TEST_SUITE_END()
 
 #endif // OCIO_UNIT_TEST

--- a/src/core/FileFormatHDL.cpp
+++ b/src/core/FileFormatHDL.cpp
@@ -548,9 +548,7 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 #include "UnitTest.h"
 
-BOOST_AUTO_TEST_SUITE( FileFormatHDL_Unit_Tests )
-
-BOOST_AUTO_TEST_CASE ( test_simple1D )
+OIIO_ADD_TEST(FileFormatHDL, simple1D)
 {
     
     std::ostringstream strebuf;
@@ -593,23 +591,23 @@ BOOST_AUTO_TEST_CASE ( test_simple1D )
     OCIO::CachedFileHDLRcPtr lut = OCIO::DynamicPtrCast<OCIO::CachedFileHDL>(cachedFile);
     
     //
-    BOOST_CHECK_EQUAL (to_min, lut->to_min);
-    BOOST_CHECK_EQUAL (to_max, lut->to_max);
-    BOOST_CHECK_EQUAL (black, lut->hdlblack);
-    BOOST_CHECK_EQUAL (white, lut->hdlwhite);
+    OIIO_CHECK_EQUAL(to_min, lut->to_min);
+    OIIO_CHECK_EQUAL(to_max, lut->to_max);
+    OIIO_CHECK_EQUAL(black, lut->hdlblack);
+    OIIO_CHECK_EQUAL(white, lut->hdlwhite);
     
     // check 1D data (each channel has the same data)
     for(int c = 0; c < 3; ++c) {
-        BOOST_CHECK_EQUAL (from_min, lut->lut1D->from_min[c]);
-        BOOST_CHECK_EQUAL (from_max, lut->lut1D->from_max[c]);
+        OIIO_CHECK_EQUAL(from_min, lut->lut1D->from_min[c]);
+        OIIO_CHECK_EQUAL(from_max, lut->lut1D->from_max[c]);
         for(unsigned int i = 0; i < lut->lut1D->luts[c].size(); ++i) {
-            BOOST_CHECK_EQUAL (lut1d[i], lut->lut1D->luts[c][i]);
+            OIIO_CHECK_EQUAL(lut1d[i], lut->lut1D->luts[c][i]);
         }
     }
     
 }
 
-BOOST_AUTO_TEST_CASE ( test_simple3D )
+OIIO_ADD_TEST(FileFormatHDL, simple3D)
 {
     
     std::ostringstream strebuf;
@@ -659,14 +657,14 @@ BOOST_AUTO_TEST_CASE ( test_simple3D )
         0.f, 0.601016f, 0.917034f };
     
     //
-    BOOST_CHECK_EQUAL (to_min, lut->to_min);
-    BOOST_CHECK_EQUAL (to_max, lut->to_max);
-    BOOST_CHECK_EQUAL (black, lut->hdlblack);
-    BOOST_CHECK_EQUAL (white, lut->hdlwhite);
+    OIIO_CHECK_EQUAL(to_min, lut->to_min);
+    OIIO_CHECK_EQUAL(to_max, lut->to_max);
+    OIIO_CHECK_EQUAL(black, lut->hdlblack);
+    OIIO_CHECK_EQUAL(white, lut->hdlwhite);
     
     // check cube data
     for(unsigned int i = 0; i < lut->lut3D->lut.size(); ++i) {
-        BOOST_CHECK_EQUAL (cube[i], lut->lut3D->lut[i]);
+        OIIO_CHECK_EQUAL(cube[i], lut->lut3D->lut[i]);
     }
     
     // check baker output
@@ -725,13 +723,13 @@ BOOST_AUTO_TEST_CASE ( test_simple3D )
     OCIO::pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
     OCIO::pystring::splitlines(bout, resvec);
-    BOOST_CHECK_EQUAL(osvec.size(), resvec.size());
+    OIIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
-        BOOST_CHECK_EQUAL(osvec[i], resvec[i]);
+        OIIO_CHECK_EQUAL(osvec[i], resvec[i]);
     
 }
 
-BOOST_AUTO_TEST_CASE ( test_simple3D1D )
+OIIO_ADD_TEST(FileFormatHDL, simple3D1D)
 {
     std::ostringstream strebuf;
     strebuf << "Version		3" << "\n";
@@ -794,23 +792,23 @@ BOOST_AUTO_TEST_CASE ( test_simple3D1D )
     OCIO::CachedFileHDLRcPtr lut = OCIO::DynamicPtrCast<OCIO::CachedFileHDL>(cachedFile);
     
     //
-    BOOST_CHECK_EQUAL (to_min, lut->to_min);
-    BOOST_CHECK_EQUAL (to_max, lut->to_max);
-    BOOST_CHECK_EQUAL (black, lut->hdlblack);
-    BOOST_CHECK_EQUAL (white, lut->hdlwhite);
+    OIIO_CHECK_EQUAL(to_min, lut->to_min);
+    OIIO_CHECK_EQUAL(to_max, lut->to_max);
+    OIIO_CHECK_EQUAL(black, lut->hdlblack);
+    OIIO_CHECK_EQUAL(white, lut->hdlwhite);
     
     // check prelut data (each channel has the same data)
     for(int c = 0; c < 3; ++c) {
-        BOOST_CHECK_EQUAL (from_min, lut->lut1D->from_min[c]);
-        BOOST_CHECK_EQUAL (from_max, lut->lut1D->from_max[c]);
+        OIIO_CHECK_EQUAL(from_min, lut->lut1D->from_min[c]);
+        OIIO_CHECK_EQUAL(from_max, lut->lut1D->from_max[c]);
         for(unsigned int i = 0; i < lut->lut1D->luts[c].size(); ++i) {
-            BOOST_CHECK_EQUAL (prelut[i], lut->lut1D->luts[c][i]);
+            OIIO_CHECK_EQUAL(prelut[i], lut->lut1D->luts[c][i]);
         }
     }
     
     // check cube data
     for(unsigned int i = 0; i < lut->lut3D->lut.size(); ++i) {
-        BOOST_CHECK_EQUAL (cube[i], lut->lut3D->lut[i]);
+        OIIO_CHECK_EQUAL(cube[i], lut->lut3D->lut[i]);
     }
     
     // check baker output
@@ -893,12 +891,10 @@ BOOST_AUTO_TEST_CASE ( test_simple3D1D )
     OCIO::pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
     OCIO::pystring::splitlines(bout, resvec);
-    BOOST_CHECK_EQUAL(osvec.size(), resvec.size());
+    OIIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
-        BOOST_CHECK_EQUAL(osvec[i], resvec[i]);
+        OIIO_CHECK_EQUAL(osvec[i], resvec[i]);
     
 }
-
-BOOST_AUTO_TEST_SUITE_END()
 
 #endif // OCIO_BUILD_TESTS

--- a/src/core/FileFormatTruelight.cpp
+++ b/src/core/FileFormatTruelight.cpp
@@ -364,9 +364,7 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 #include "UnitTest.h"
 
-BOOST_AUTO_TEST_SUITE( FileFormatTruelight_Unit_Tests )
-
-BOOST_AUTO_TEST_CASE ( test_simple3D )
+OIIO_ADD_TEST(FileFormatTruelight, simpletest3D)
 {
     // This lowers the red channel by 0.5, other channels are unaffected.
     const char * luttext = "# Truelight Cube v2.0\n"
@@ -429,7 +427,5 @@ BOOST_AUTO_TEST_CASE ( test_simple3D )
     
     // TODO: Test the results of truelight loading.
 }
-
-BOOST_AUTO_TEST_SUITE_END()
 
 #endif // OCIO_UNIT_TEST

--- a/src/core/LogOps.cpp
+++ b/src/core/LogOps.cpp
@@ -374,9 +374,7 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 #include "UnitTest.h"
 
-BOOST_AUTO_TEST_SUITE( LogOps_Unit_Tests )
-
-BOOST_AUTO_TEST_CASE ( test_LogOps_LinToLog_Base2 )
+OIIO_ADD_TEST(LogOps, LinToLog_Base2)
 {
     float data[8] = { 4.0f, 2.0f, 1.0f, 1.0f,
                       0.5f, 0.25f, 0.001f, 1.0f, };
@@ -397,11 +395,11 @@ BOOST_AUTO_TEST_CASE ( test_LogOps_LinToLog_Base2 )
     
     for(int i=0; i<8; ++i)
     {
-        BOOST_REQUIRE_CLOSE( data[i], result[i], 1.0e-3 );
+        OIIO_CHECK_CLOSE( data[i], result[i], 1.0e-3 );
     }
 }
 
-BOOST_AUTO_TEST_CASE ( test_LogOps_LogToLin_Base2 )
+OIIO_ADD_TEST(LogOps, LogToLin_Base2)
 {
     float data[8] = { 2.0f, 1.0f, 0.0f, 1.0f,
                       -1.0f, -2.0f, -9.965784284662087f, 1.0f, };
@@ -422,12 +420,11 @@ BOOST_AUTO_TEST_CASE ( test_LogOps_LogToLin_Base2 )
     
     for(int i=0; i<8; ++i)
     {
-        BOOST_REQUIRE_CLOSE( data[i], result[i], 1.0e-3 );
+        OIIO_CHECK_CLOSE( data[i], result[i], 1.0e-3 );
     }
 }
 
-
-BOOST_AUTO_TEST_CASE ( test_LogOps_LinToLog_Base10 )
+OIIO_ADD_TEST(LogOps, LinToLog_Base10)
 {
     float k[3] = { 0.18f, 0.18f, 0.18f };
     float m[3] = { 2.0f, 2.0f, 2.0f };
@@ -461,12 +458,11 @@ BOOST_AUTO_TEST_CASE ( test_LogOps_LinToLog_Base10 )
     
     for(int i=0; i<8; ++i)
     {
-        BOOST_REQUIRE_CLOSE( data[i], result[i], 1.0e-3 );
+        OIIO_CHECK_CLOSE( data[i], result[i], 1.0e-3 );
     }
 }
 
-
-BOOST_AUTO_TEST_CASE ( test_LogOps_LogToLin_Base10 )
+OIIO_ADD_TEST(LogOps, LogToLin_Base10)
 {
     float k[3] = { 0.18f, 0.18f, 0.18f };
     float m[3] = { 2.0f, 2.0f, 2.0f };
@@ -499,11 +495,8 @@ BOOST_AUTO_TEST_CASE ( test_LogOps_LogToLin_Base10 )
     
     for(int i=0; i<8; ++i)
     {
-        BOOST_REQUIRE_CLOSE( data[i], result[i], 1.0e-3 );
+        OIIO_CHECK_CLOSE( data[i], result[i], 1.0e-3 );
     }
 }
-
-
-BOOST_AUTO_TEST_SUITE_END()
 
 #endif // OCIO_UNIT_TEST

--- a/src/core/PathUtils.cpp
+++ b/src/core/PathUtils.cpp
@@ -205,9 +205,7 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 #include "UnitTest.h"
 
-BOOST_AUTO_TEST_SUITE( PathUtils_Unit_Tests )
-
-BOOST_AUTO_TEST_CASE ( test_envexpand )
+OIIO_ADD_TEST(PathUtils, envexpand)
 {
     // build env by hand for unit test
     OCIO::EnvMap env_map; // = OCIO::GetEnvMap();
@@ -221,10 +219,7 @@ BOOST_AUTO_TEST_CASE ( test_envexpand )
     std::string foo = "/a/b/${TEST1}/${TEST1NG}/$TEST1/$TEST1NG/${FOO_${TEST1}}/";
     std::string foo_result = "/a/b/foo.bar/bar.foo/foo.bar/bar.foo/cheese/";
     std::string testresult = OCIO::EnvExpand(foo, env_map);
-    BOOST_CHECK( testresult == foo_result );
-    
+    OIIO_CHECK_ASSERT( testresult == foo_result );
 }
-
-BOOST_AUTO_TEST_SUITE_END()
 
 #endif // OCIO_BUILD_TESTS

--- a/src/core/TruelightTransform.cpp
+++ b/src/core/TruelightTransform.cpp
@@ -261,9 +261,7 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 #include "UnitTest.h"
 
-BOOST_AUTO_TEST_SUITE( Truelight_Unit_Tests )
-
-BOOST_AUTO_TEST_CASE ( test_simpletest )
+OIIO_ADD_TEST(TruelightTransform, simpletest)
 {
     
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
@@ -293,27 +291,26 @@ BOOST_AUTO_TEST_CASE ( test_simpletest )
     OCIO::ConstProcessorRcPtr tolog;
     
 #ifdef OCIO_TRUELIGHT_SUPPORT
-    BOOST_CHECK_NO_THROW(tosrgb = config->getProcessor("log", "sRGB"));
-    BOOST_CHECK_NO_THROW(tolog = config->getProcessor("sRGB", "log"));
+    OIIO_CHECK_NO_THOW(tosrgb = config->getProcessor("log", "sRGB"));
+    OIIO_CHECK_NO_THOW(tolog = config->getProcessor("sRGB", "log"));
 #else
-    BOOST_CHECK_THROW(tosrgb = config->getProcessor("log", "sRGB"), OCIO::Exception);
-    BOOST_CHECK_THROW(tolog = config->getProcessor("sRGB", "log"), OCIO::Exception);
+    OIIO_CHECK_THOW(tosrgb = config->getProcessor("log", "sRGB"), OCIO::Exception);
+    OIIO_CHECK_THOW(tolog = config->getProcessor("sRGB", "log"), OCIO::Exception);
 #endif
     
 #ifdef OCIO_TRUELIGHT_SUPPORT
     float input[3] = {0.5f, 0.5f, 0.5f};
     float output[3] = {0.500098f, 0.500317f, 0.501134f};
-    
-    BOOST_CHECK_NO_THROW(tosrgb->applyRGB(input));
-    BOOST_CHECK_NO_THROW(tolog->applyRGB(input));
-    BOOST_CHECK_CLOSE(input[0], output[0], 1e-4);
-    BOOST_CHECK_CLOSE(input[1], output[1], 1e-4);
-    BOOST_CHECK_CLOSE(input[2], output[2], 1e-4);
+    OIIO_CHECK_NO_THOW(tosrgb->applyRGB(input));
+    OIIO_CHECK_NO_THOW(tolog->applyRGB(input));
+    OIIO_CHECK_CLOSE(input[0], output[0], 1e-4);
+    OIIO_CHECK_CLOSE(input[1], output[1], 1e-4);
+    OIIO_CHECK_CLOSE(input[2], output[2], 1e-4);
 #endif
     
     //
     std::ostringstream os;
-    BOOST_CHECK_NO_THROW(config->serialize(os));
+    OIIO_CHECK_NO_THOW(config->serialize(os));
     
     std::string testconfig =
     "---\n"
@@ -352,17 +349,15 @@ BOOST_AUTO_TEST_CASE ( test_simpletest )
     std::vector<std::string> testconfigvec;
     OCIO::pystring::splitlines(testconfig, testconfigvec);
     
-    BOOST_CHECK_EQUAL(osvec.size(), testconfigvec.size());
+    OIIO_CHECK_EQUAL(osvec.size(), testconfigvec.size());
     for(unsigned int i = 0; i < testconfigvec.size(); ++i)
-        BOOST_CHECK_EQUAL(osvec[i], testconfigvec[i]);
+        OIIO_CHECK_EQUAL(osvec[i], testconfigvec[i]);
     
     std::istringstream is;
     is.str(testconfig);
     OCIO::ConstConfigRcPtr rtconfig;
-    BOOST_CHECK_NO_THROW(rtconfig = OCIO::Config::CreateFromStream(is));
+    OIIO_CHECK_NO_THOW(rtconfig = OCIO::Config::CreateFromStream(is));
     
 }
-
-BOOST_AUTO_TEST_SUITE_END()
 
 #endif // OCIO_BUILD_TESTS

--- a/src/core/UnitTest.cpp
+++ b/src/core/UnitTest.cpp
@@ -31,8 +31,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef OCIO_UNIT_TEST
 #pragma GCC visibility push(default)
-#define BOOST_TEST_MODULE ocio_core
-#include <boost/test/unit_test.hpp>
+#include <unittest.h> # OIIO unit tests header
+OIIO_TEST_APP(OpenColorIO_Core_Unit_Tests)
 #pragma GCC visibility pop
 #endif // OCIO_UNIT_TEST
 

--- a/src/core/UnitTest.h
+++ b/src/core/UnitTest.h
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef OCIO_UNIT_TEST
 #pragma GCC visibility push(default)
-#include <boost/test/unit_test.hpp>
+#include <unittest.h> # OIIO unit tests header
 #pragma GCC visibility pop
 #endif // OCIO_UNIT_TEST
 

--- a/src/core_tests/CMakeLists.txt
+++ b/src/core_tests/CMakeLists.txt
@@ -7,6 +7,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/export/
     ${CMAKE_BINARY_DIR}/export/
     ${YAML_CPP_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/ext/oiio/src/include
     )
 
 set(EXTERNAL_INCLUDE_DIRS)


### PR DESCRIPTION
- replaced BOOST test with OIIO test, added OIIO_TEST_APP, OIIO_TEST_SETUP, OIIO_ADD_TEST, OIIO_CHECK_NO_THOW, OIIO_CHECK_THOW, OIIO_CHECK_CLOSE in an effort to remove boost as a build dependancy
- added a OCIO static target that gets built by default
- added ext/oiio with plans to move argparse and strutil to this location
