### PR TITLE
Add CMAKE_INSTALL_EXEC_PREFIX option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,14 @@ if(NOT OCIO_NAMESPACE)
       FORCE)
 endif(NOT OCIO_NAMESPACE)
 
+# If CMAKE_INSTALL_EXEC_PREFIX is not specified, install binaries
+# directly into the regular install prefix
+if(NOT CMAKE_INSTALL_EXEC_PREFIX)
+    message(STATUS "Exec prefix not specified, defaulting to ${CMAKE_INSTALL_PREFIX}")
+    set(CMAKE_INSTALL_EXEC_PREFIX ${CMAKE_INSTALL_PREFIX})
+endif()
+
+
 # Enable a bunch of compiler warnings...
 # http://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
 set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wshadow -Wconversion -Wcast-qual -Wformat=2")

--- a/export/pkgconfig/OpenColorIO.pc.in
+++ b/export/pkgconfig/OpenColorIO.pc.in
@@ -1,5 +1,5 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}
+exec_prefix=@CMAKE_INSTALL_EXEC_PREFIX@
 includedir=${prefix}/include
 libdir=${exec_prefix}/lib
 

--- a/src/apps/ocio2icc/CMakeLists.txt
+++ b/src/apps/ocio2icc/CMakeLists.txt
@@ -32,4 +32,4 @@ target_link_libraries(ocio2icc
                       ${LCMS_STATIC_LIBRARIES}
                       OpenColorIO)
 
-install(TARGETS ocio2icc DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+install(TARGETS ocio2icc DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/bin)

--- a/src/apps/ociobakelut/CMakeLists.txt
+++ b/src/apps/ociobakelut/CMakeLists.txt
@@ -9,4 +9,4 @@ include_directories(
 
 add_executable(ociobakelut ${share_src_files} main.cpp)
 target_link_libraries(ociobakelut OpenColorIO)
-install(TARGETS ociobakelut DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+install(TARGETS ociobakelut DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/bin)

--- a/src/apps/ociocheck/CMakeLists.txt
+++ b/src/apps/ociocheck/CMakeLists.txt
@@ -14,4 +14,4 @@ target_link_libraries(ociocheck
     OpenColorIO
     )
 
-install(TARGETS ociocheck DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+install(TARGETS ociocheck DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/bin)

--- a/src/apps/ocioconvert/CMakeLists.txt
+++ b/src/apps/ocioconvert/CMakeLists.txt
@@ -8,5 +8,5 @@ if (OIIO_FOUND)
     
     target_link_libraries(ocioconvert ${OIIO_LIBRARIES} OpenColorIO dl)
     
-    install(TARGETS ocioconvert DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+    install(TARGETS ocioconvert DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/bin)
 endif()

--- a/src/apps/ociodisplay/CMakeLists.txt
+++ b/src/apps/ociodisplay/CMakeLists.txt
@@ -8,4 +8,4 @@ include_directories(
 add_executable(ociodisplay main.cpp)
 # set_target_properties(ociodisplay PROPERTIES INSTALL_RPATH ${OIIO_LIBRARIES} )
 target_link_libraries(ociodisplay ${GLEW_LIBRARIES} ${GLUT_LIBRARY} ${OPENGL_LIBRARY} ${OIIO_LIBRARIES} OpenColorIO)
-install(TARGETS ociodisplay DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+install(TARGETS ociodisplay DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/bin)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -26,7 +26,7 @@ set_target_properties(OpenColorIO PROPERTIES
     OUTPUT_NAME OpenColorIO
     COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS}"
     LINK_FLAGS "${EXTERNAL_LINK_FLAGS}")
-install(TARGETS OpenColorIO DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+install(TARGETS OpenColorIO DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/lib)
 
 # STATIC
 
@@ -38,7 +38,7 @@ set_target_properties(OpenColorIO_STATIC PROPERTIES
     OUTPUT_NAME OpenColorIO
     COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS}"
     LINK_FLAGS "${EXTERNAL_LINK_FLAGS}")
-install(TARGETS OpenColorIO_STATIC DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+install(TARGETS OpenColorIO_STATIC DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/lib)
 
 #
 if (SOVERSION)
@@ -62,4 +62,4 @@ message(STATUS "Create OpenColorIO.pc from OpenColorIO.pc.in")
 configure_file(${CMAKE_SOURCE_DIR}/export/pkgconfig/OpenColorIO.pc.in
     ${CMAKE_CURRENT_BINARY_DIR}/OpenColorIO.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenColorIO.pc
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/include/pkgconfig/)
+    DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/include/pkgconfig/)

--- a/src/nuke/CMakeLists.txt
+++ b/src/nuke/CMakeLists.txt
@@ -87,16 +87,16 @@ add_custom_target(Nuke
 )
 
 install(TARGETS NukeOCIOColorSpace
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/nuke${Nuke_DDImageVersion})
+        DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/lib/nuke${Nuke_DDImageVersion})
 
 install(TARGETS NukeOCIODisplay
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/nuke${Nuke_DDImageVersion})
+        DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/lib/nuke${Nuke_DDImageVersion})
 
 install(TARGETS NukeOCIOLogConvert
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/nuke${Nuke_DDImageVersion})
+        DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/lib/nuke${Nuke_DDImageVersion})
 
 install(TARGETS NukeOCIOFileTransform
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/nuke${Nuke_DDImageVersion})
+        DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/lib/nuke${Nuke_DDImageVersion})
 
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/share/nuke
         DESTINATION ${CMAKE_INSTALL_PREFIX}/share/

--- a/src/pyglue/CMakeLists.txt
+++ b/src/pyglue/CMakeLists.txt
@@ -54,6 +54,6 @@ add_custom_target(PyOpenColorIOTest
     VERBATIM
 )
 
-install(TARGETS PyOpenColorIO DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python${PYTHON_VERSION})
+install(TARGETS PyOpenColorIO DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/lib/python${PYTHON_VERSION})
 install(FILES ${CMAKE_SOURCE_DIR}/export/PyOpenColorIO/PyOpenColorIO.h
     DESTINATION ${CMAKE_INSTALL_PREFIX}/include/PyOpenColorIO/)


### PR DESCRIPTION
Add CMAKE_INSTALL_EXEC_PREFIX option, to allow moving arch-specific binaries into dedicated folders.

Defaults to same as CMAKE_INSTALL_PREFIX, so regular behaviour should be untouched.

Allows compiling for multiple platforms without duplicating arch-agnostic code, e.g:

```
arch/
  linux/
    x86_64:
      lib/
        libOpenColorIO.so
      bin/
        ociocheck
  darwin/
    i386/
      lib/
        libOpenColorIO.dylib
      bin/
        ociocheck
include/
  OpenColorIO/
    OpenColorIO.h
share/
  nuke/
    init.py
    menu.py
```
