### PR TITLE
Build Nuke stuff into lib/nuke6.2 

### DIFF
--- a/share/cmake/TestForDDImageVersion.cxx
+++ b/share/cmake/TestForDDImageVersion.cxx
@@ -2,6 +2,13 @@
 #include "DDImage/ddImageVersionNumbers.h"
 int main(int, char*[])
 {
-  std::cout << kDDImageVersion;
-  return 0;
+    // Print a Nuke API identifier number, used to make the
+    // lib/nuke${API_NUMBER} directory
+
+    // Nuke aims to maintain API compatibilty between "v" releases, so
+    // compiling for 6.1v1 will work with 6.1v2 etc (but not
+    // 6.2v1). Only exception has been 5.1v5 and 5.1v6 (because it was
+    // supposed to be 5.2v1)
+    std::cout << kDDImageVersionMajorNum << "." << kDDImageVersionMinorNum;
+    return 0;
 }


### PR DESCRIPTION
Comment should explain the change best:

```
// Nuke aims to maintain API compatibilty between "v" releases, so
// compiling for 6.1v1 will work with 6.1v2 etc (but not
// 6.2v1). Only exception has been 5.1v5 and 5.1v6 (because it was
// supposed to be 5.2v1)
```

Mirrors how The Foundry's plugins are supplied (e.g Ocula downloads for 6.1/6.2). The info on 5.1v5-6 was from a message to nuke-dev a while ago.

Combined with the `CMAKE_INSTALL_EXEC_PREFIX` change, OCIO can now compile perfectly into RSP's project deployment/package management stuff \o/
