### PR TITLE
FileFormat registry refactor

### DIFF
--- a/src/core/FileFormat3DL.cpp
+++ b/src/core/FileFormat3DL.cpp
@@ -472,13 +472,11 @@ OCIO_NAMESPACE_ENTER
                 }
             }
         }
-        
-        
-        struct AutoRegister
-        {
-            AutoRegister() { FormatRegistry::GetInstance().registerFileFormat(new LocalFileFormat); }
-        };
-        static AutoRegister registerIt;
+    }
+    
+    FileFormat * CreateFileFormat3DL()
+    {
+        return new LocalFileFormat();
     }
 }
 OCIO_NAMESPACE_EXIT

--- a/src/core/FileFormatCC.cpp
+++ b/src/core/FileFormatCC.cpp
@@ -151,13 +151,11 @@ OCIO_NAMESPACE_ENTER
                         *cachedFile->transform,
                         newDir);
         }
-        
-        
-        struct AutoRegister
-        {
-            AutoRegister() { FormatRegistry::GetInstance().registerFileFormat(new LocalFileFormat); }
-        };
-        static AutoRegister registerIt;
+    }
+    
+    FileFormat * CreateFileFormatCC()
+    {
+        return new LocalFileFormat();
     }
 }
 OCIO_NAMESPACE_EXIT

--- a/src/core/FileFormatCCC.cpp
+++ b/src/core/FileFormatCCC.cpp
@@ -228,13 +228,11 @@ OCIO_NAMESPACE_ENTER
                         *(iter->second),
                         newDir);
         }
-        
-        
-        struct AutoRegister
-        {
-            AutoRegister() { FormatRegistry::GetInstance().registerFileFormat(new LocalFileFormat); }
-        };
-        static AutoRegister registerIt;
+    }
+    
+    FileFormat * CreateFileFormatCCC()
+    {
+        return new LocalFileFormat();
     }
 }
 OCIO_NAMESPACE_EXIT

--- a/src/core/FileFormatCSP.cpp
+++ b/src/core/FileFormatCSP.cpp
@@ -779,11 +779,10 @@ OCIO_NAMESPACE_ENTER
         }
     }
     
-    struct AutoRegister
+    FileFormat * CreateFileFormatCSP()
     {
-        AutoRegister() { FormatRegistry::GetInstance().registerFileFormat(new FileFormatCSP); }
-    };
-    static AutoRegister registerIt;
+        return new FileFormatCSP();
+    }
 }
 OCIO_NAMESPACE_EXIT
 

--- a/src/core/FileFormatHDL.cpp
+++ b/src/core/FileFormatHDL.cpp
@@ -528,14 +528,12 @@ OCIO_NAMESPACE_ENTER
             }
             return;
         }
-        
-        struct AutoRegister
-        {
-            AutoRegister() { FormatRegistry::GetInstance().registerFileFormat(new FileFormatHDL()); }
-        };
-        static AutoRegister registerIt;
     }
     
+    FileFormat * CreateFileFormatHDL()
+    {
+        return new FileFormatHDL();
+    }
 }
 OCIO_NAMESPACE_EXIT
 

--- a/src/core/FileFormatIridas.cpp
+++ b/src/core/FileFormatIridas.cpp
@@ -417,11 +417,10 @@ OCIO_NAMESPACE_ENTER
         }
     }
     
-    struct AutoRegister
+    FileFormat * CreateFileFormatIridas()
     {
-        AutoRegister() { FormatRegistry::GetInstance().registerFileFormat(new LocalFileFormat); }
-    };
-    static AutoRegister registerIt;
+        return new LocalFileFormat();
+    }
 }
 OCIO_NAMESPACE_EXIT
 

--- a/src/core/FileFormatSpi1D.cpp
+++ b/src/core/FileFormatSpi1D.cpp
@@ -244,12 +244,11 @@ OCIO_NAMESPACE_ENTER
                               newDir);
             }
         };
-        
-        struct AutoRegister
-        {
-            AutoRegister() { FormatRegistry::GetInstance().registerFileFormat(new LocalFormat); }
-        };
-        static AutoRegister registerIt;
+    }
+    
+    FileFormat * CreateFileFormatSpi1D()
+    {
+        return new LocalFormat();
     }
 }
 OCIO_NAMESPACE_EXIT

--- a/src/core/FileFormatSpi3D.cpp
+++ b/src/core/FileFormatSpi3D.cpp
@@ -193,12 +193,11 @@ OCIO_NAMESPACE_ENTER
                               newDir);
             }
         };
-        
-        struct AutoRegister
-        {
-            AutoRegister() { FormatRegistry::GetInstance().registerFileFormat(new LocalFormat); }
-        };
-        static AutoRegister registerIt;
+    }
+    
+    FileFormat * CreateFileFormatSpi3D()
+    {
+        return new LocalFormat();
     }
 }
 OCIO_NAMESPACE_EXIT

--- a/src/core/FileFormatSpiMtx.cpp
+++ b/src/core/FileFormatSpiMtx.cpp
@@ -180,12 +180,11 @@ OCIO_NAMESPACE_ENTER
                                      newDir);
             }
         };
-        
-        struct AutoRegister
-        {
-            AutoRegister() { FormatRegistry::GetInstance().registerFileFormat(new LocalFormat); }
-        };
-        static AutoRegister registerIt;
+    }
+    
+    FileFormat * CreateFileFormatSpiMtx()
+    {
+        return new LocalFormat();
     }
 }
 OCIO_NAMESPACE_EXIT

--- a/src/core/FileFormatTruelight.cpp
+++ b/src/core/FileFormatTruelight.cpp
@@ -340,11 +340,10 @@ OCIO_NAMESPACE_ENTER
         }
     }
     
-    struct AutoRegister
+    FileFormat * CreateFileFormatTruelight()
     {
-        AutoRegister() { FormatRegistry::GetInstance().registerFileFormat(new LocalFileFormat); }
-    };
-    static AutoRegister registerIt;
+        return new LocalFileFormat();
+    }
 }
 OCIO_NAMESPACE_EXIT
 

--- a/src/core/FileFormatVF.cpp
+++ b/src/core/FileFormatVF.cpp
@@ -313,11 +313,10 @@ OCIO_NAMESPACE_ENTER
         }
     }
     
-    struct AutoRegister
+    FileFormat * CreateFileFormatVF()
     {
-        AutoRegister() { FormatRegistry::GetInstance().registerFileFormat(new LocalFileFormat); }
-    };
-    static AutoRegister registerIt;
+        return new LocalFileFormat();
+    }
 }
 OCIO_NAMESPACE_EXIT
 

--- a/src/core/FileTransform.cpp
+++ b/src/core/FileTransform.cpp
@@ -174,28 +174,44 @@ OCIO_NAMESPACE_ENTER
     ///////////////////////////////////////////////////////////////////////////
     
     // NOTE: You must be mindful when editing this function.
-    //       FormatRegistry::GetInstance().registerFileFormat(...) is called
-    //       during static initialization, so this full code path
-    //       must be resiliant to the static initialization order 'fiasco'
+    //       to be resiliant to the static initialization order 'fiasco'
     //
     //       See
     //       http://www.parashift.com/c++-faq-lite/ctors.html#faq-10.14
     //       http://stackoverflow.com/questions/335369/finding-c-static-initialization-order-problems
     //       for more info.
-    //
-    //       In our case, we avoid it by only have POD types as statics,
-    //       and constructing on first use.  If we were to do something
-    //       more clever, such as using a static mutex to guard GetInstance(),
-    //       this would be fragile to compilation unit ordering.
+    
+    namespace
+    {
+        FormatRegistry* g_formatRegistry = NULL;
+        Mutex g_formatRegistryLock;
+    }
     
     FormatRegistry & FormatRegistry::GetInstance()
     {
-        static FormatRegistry* g_formatRegistry = new FormatRegistry();
+        AutoMutex lock(g_formatRegistryLock);
+        
+        if(!g_formatRegistry)
+        {
+            g_formatRegistry = new FormatRegistry();
+        }
+        
         return *g_formatRegistry;
     }
     
     FormatRegistry::FormatRegistry()
     {
+        registerFileFormat(CreateFileFormat3DL());
+        registerFileFormat(CreateFileFormatCCC());
+        registerFileFormat(CreateFileFormatCC());
+        registerFileFormat(CreateFileFormatCSP());
+        registerFileFormat(CreateFileFormatHDL());
+        registerFileFormat(CreateFileFormatIridas());
+        registerFileFormat(CreateFileFormatSpi1D());
+        registerFileFormat(CreateFileFormatSpi3D());
+        registerFileFormat(CreateFileFormatSpiMtx());
+        registerFileFormat(CreateFileFormatTruelight());
+        registerFileFormat(CreateFileFormatVF());
     }
     
     FormatRegistry::~FormatRegistry()

--- a/src/core/FileTransform.h
+++ b/src/core/FileTransform.h
@@ -93,6 +93,21 @@ OCIO_NAMESPACE_ENTER
         FileFormat& operator= (const FileFormat &);
     };
     
+    // Registry Builders
+    FileFormat * CreateFileFormat3DL();
+    FileFormat * CreateFileFormatCCC();
+    FileFormat * CreateFileFormatCC();
+    FileFormat * CreateFileFormatCSP();
+    FileFormat * CreateFileFormatHDL();
+    FileFormat * CreateFileFormatIridas();
+    FileFormat * CreateFileFormatSpi1D();
+    FileFormat * CreateFileFormatSpi3D();
+    FileFormat * CreateFileFormatSpiMtx();
+    FileFormat * CreateFileFormatTruelight();
+    FileFormat * CreateFileFormatVF();
+    
+    
+    
     typedef std::map<std::string, FileFormat*> FileFormatMap;
     
     class FormatRegistry
@@ -108,12 +123,12 @@ OCIO_NAMESPACE_ENTER
         
         int getNumFormats(FileFormatFeature feature) const;
         FileFormat* getFormatByIndex(FileFormatFeature feature, int index) const;
-        
-        void registerFileFormat(FileFormat* format);
     
     private:
         FormatRegistry();
         ~FormatRegistry();
+        
+        void registerFileFormat(FileFormat* format);
         
         FileFormatMap m_formatsByName;
         FileFormatMap m_formatsByExtension;


### PR DESCRIPTION
The registration mechanism is now less fragile, using the 'construct on first use' approach rather than relying on static initialization to register each format.  This is a more portable implementation (should work on windows), and also avoid some issues we've been seeing when using gcc debug versions of the library.
