### PR TITLE
Added OCIO_VERSION_HEX to public header for easy version comparison

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,6 @@ set(OCIO_VERSION "${OCIO_VERSION_MAJOR}.${OCIO_VERSION_MINOR}.${OCIO_VERSION_PAT
 if(NOT SOVERSION)
     set(SOVERSION ${OCIO_VERSION_MAJOR} CACHE STRING "Set the SO version in the SO name of the output library")
 endif()
-if(NOT ${SOVERSION} STREQUAL ${OCIO_VERSION_MAJOR})
-    set(OCIO_VERSION_MAJOR ${SOVERSION})
-endif()
 
 
 cmake_minimum_required(VERSION 2.8)
@@ -266,7 +263,7 @@ endif()
 ###############################################################################
 ### CPACK ###
 
-set(CPACK_PACKAGE_VERSION_MAJOR ${OCIO_VERSION_MAJOR})
+set(CPACK_PACKAGE_VERSION_MAJOR ${SOVERSION})
 set(CPACK_PACKAGE_VERSION_MINOR ${OCIO_VERSION_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${OCIO_VERSION_PATCH})
 set(CPACK_GENERATOR None)

--- a/export/OpenColorIO/OpenColorABI.h.in
+++ b/export/OpenColorIO/OpenColorABI.h.in
@@ -30,10 +30,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define INCLUDED_OCIO_OPENCOLORABI_H
 
 // Makefile configuration options
-#define OCIO_VERSION "@OCIO_VERSION@"
 #define OCIO_NAMESPACE @OCIO_NAMESPACE@
-#define OCIO_VERSION_NS v@OCIO_VERSION_MAJOR@
 #define OCIO_USE_BOOST_PTR @OCIO_USE_BOOST_PTR@
+#define OCIO_VERSION "@OCIO_VERSION@"
+#define OCIO_VERSION_NS v@SOVERSION@
+
+/* Version as a single 4-byte hex number, e.g. 0x01050200 == 1.5.2
+   Use this for numeric comparisons, e.g. #if OCIO_VERSION_HEX >= ... 
+   Note: in the case where SOVERSION is overridden at compile-time,
+   this will reflect the original API version number.
+   */
+#define OCIO_VERSION_HEX ((@OCIO_VERSION_MAJOR@ << 24) | \
+                          (@OCIO_VERSION_MINOR@ << 16) | \
+                          (@OCIO_VERSION_PATCH@ <<  8))
+
 
 // Namespace / version mojo
 #define OCIO_NAMESPACE_ENTER namespace OCIO_NAMESPACE { namespace OCIO_VERSION_NS

--- a/src/pyglue/PyMain.cpp
+++ b/src/pyglue/PyMain.cpp
@@ -120,4 +120,5 @@ initPyOpenColorIO(void)
     OCIO::AddProcessorObjectToModule( m );
     
     PyModule_AddStringConstant(m, "version", OCIO_VERSION);
+    PyModule_AddIntConstant(m, "hexversion", OCIO_VERSION_HEX);
 }


### PR DESCRIPTION
This exposes a single 4-byte hex number, e.g. 0x01050200 == 1.5.2

Use this for numeric comparisons, e.g. #if OCIO_VERSION_HEX >= ... 
Note: in the case where SOVERSION is overridden at compile-time, this will reflect the original API version number.

Code concept is stolen from cpython source.
