### PR TITLE
bugfix: pyglue: Fixed bug in error handling for invalid argument checking

### DIFF
--- a/src/pyglue/PyExponentTransform.cpp
+++ b/src/pyglue/PyExponentTransform.cpp
@@ -200,7 +200,7 @@ OCIO_NAMESPACE_ENTER
                     if(!FillFloatVectorFromPySequence(pyvalue, data) || (data.size() != 4))
                     {
                         PyErr_SetString(PyExc_TypeError, "Value argument must be a float array, size 4");
-                        return 0;
+                        return -1;
                     }
                     
                     transform->setValue( &data[0] );

--- a/src/pyglue/PyGroupTransform.cpp
+++ b/src/pyglue/PyGroupTransform.cpp
@@ -219,7 +219,7 @@ OCIO_NAMESPACE_ENTER
                     if(!FillTransformVectorFromPySequence(pytransforms, data))
                     {
                         PyErr_SetString(PyExc_TypeError, "Kwarg 'transforms' must be a transform array.");
-                        return 0;
+                        return -1;
                     }
                     
                     for(unsigned int i=0; i<data.size(); ++i)

--- a/src/pyglue/PyProcessor.cpp
+++ b/src/pyglue/PyProcessor.cpp
@@ -350,6 +350,7 @@ OCIO_NAMESPACE_ENTER
                     std::ostringstream os;
                     os << "First argument must be a float array, size multiple of 4. ";
                     os << "Size: " << data.size() << ".";
+                    PyErr_SetString(PyExc_TypeError, os.str().c_str());
                     return 0;
                 }
                 

--- a/src/testbed/main.py
+++ b/src/testbed/main.py
@@ -31,6 +31,12 @@ print ""
 
 # Create a new config
 
+config = OCIO.GetCurrentConfig()
+processor = config.getProcessor(OCIO.Constants.ROLE_COMPOSITING_LOG, OCIO.Constants.ROLE_SCENE_LINEAR)
+processor.applyRGBA([0,0,0,0]) # works fine
+processor.applyRGBA(1)
+   
+"""
 if True:
     config = OCIO.Config()
     
@@ -55,6 +61,7 @@ if True:
     config.addColorSpace(cs2)
     
     print config.serialize()
+"""
 
 """
 


### PR DESCRIPTION
bugfix: pyglue: Fixed bug in error handling for invalid argument checking.

  processor.applyRGBA(1)

The last line dies with:

   Traceback (most recent call last):
     File "<stdin>", line 1, in <module>
   SystemError: error return without exception set

This fixes the error by properly setting the exception type.  Also fixes two other similar issues in PyExponentTransform + PyGroupTransform.

Addresses issue #121
