### PR TITLE
Bugfix: OCIODisplay stores enum knob values as strings instead of index

### DIFF
--- a/src/nuke/OCIODisplay/OCIODisplay.cpp
+++ b/src/nuke/OCIODisplay/OCIODisplay.cpp
@@ -100,17 +100,14 @@ void OCIODisplay::knobs(DD::Image::Knob_Callback f)
 {
     DD::Image::Enumeration_knob(f,
         &m_colorSpaceIndex, &m_colorSpaceCstrNames[0], "colorspace", "input colorspace");
-    DD::Image::SetFlags(f, DD::Image::Knob::SAVE_MENU);
     DD::Image::Tooltip(f, "Input data is taken to be in this colorspace.");
 
     m_displayKnob = DD::Image::Enumeration_knob(f,
         &m_displayIndex, &m_displayCstrNames[0], "display", "display device");
-    DD::Image::SetFlags(f, DD::Image::Knob::SAVE_MENU);
     DD::Image::Tooltip(f, "Display device for output.");
 
     m_viewKnob = DD::Image::Enumeration_knob(f,
         &m_viewIndex, &m_viewCstrNames[0], "view", "view transform");
-    DD::Image::SetFlags(f, DD::Image::Knob::SAVE_MENU);
     DD::Image::Tooltip(f, "Display transform for output.");
     
     DD::Image::Float_knob(f, &m_gain, DD::Image::IRange(1.0 / 64.0f, 64.0f), "gain");


### PR DESCRIPTION
This fixes the case where enum menu items differ between nuke
sessions and the index value may not correspond to the appropriate
menu item.
