### PR TITLE
Review: Further enabled the NukeWrapper for channel swizzling

### DIFF
--- a/src/nuke/OCIOCDLTransform/OCIOCDLTransform.cpp
+++ b/src/nuke/OCIOCDLTransform/OCIOCDLTransform.cpp
@@ -21,7 +21,7 @@ const char* OCIOCDLTransform::dirs[] = { "forward", "inverse", 0 };
 
 OCIOCDLTransform::OCIOCDLTransform(Node *n) : DD::Image::PixelIop(n)
 {
-    layersToProcess = DD::Image::Mask_RGB;
+    layersToProcess = DD::Image::Mask_RGBA;
 
     for (int i = 0; i < 3; i++){
         m_slope[i] = 1.0;
@@ -74,7 +74,7 @@ void OCIOCDLTransform::knobs(DD::Image::Knob_Callback f)
     
     m_cccidKnob = String_knob(f, &m_cccid, "cccid");
     const char * ccchelp = "If the source file is an ASC CDL CCC (color correction collection), "
-    "this specifys the id to lookup. OpenColorIO::Contexts (envvars) are obeyed.";
+    "this specifies the id to lookup. OpenColorIO::Contexts (envvars) are obeyed.";
     DD::Image::Tooltip(f, ccchelp);
     
     /* TODO:
@@ -94,11 +94,6 @@ void OCIOCDLTransform::knobs(DD::Image::Knob_Callback f)
     
     
     DD::Image::Divider(f);
-
-    // Layer selection
-    DD::Image::Input_ChannelSet_knob(f, &layersToProcess, 0, "layer", "layer");
-    DD::Image::SetFlags(f, DD::Image::Knob::NO_CHECKMARKS | DD::Image::Knob::NO_ALPHA_PULLDOWN);
-    DD::Image::Tooltip(f, "Set which layer to process. This should be a layer with rgb data.");
     
     /*
     TODO: One thing thats sucks is that we dont apparently have a mechansism to call refreshKnobEnabledState
@@ -365,9 +360,5 @@ const char* OCIOCDLTransform::node_help() const
 DD::Image::Op* build(Node *node)
 {
     DD::Image::NukeWrapper *op = new DD::Image::NukeWrapper(new OCIOCDLTransform(node));
-    op->noMix();
-    op->noMask();
-    op->noChannels(); // prefer our own channels control without checkboxes / alpha
-    op->noUnpremult();
     return op;
 }

--- a/src/nuke/OCIOFileTransform/OCIOFileTransform.cpp
+++ b/src/nuke/OCIOFileTransform/OCIOFileTransform.cpp
@@ -22,7 +22,7 @@ OCIOFileTransform::OCIOFileTransform(Node *n) : DD::Image::PixelIop(n)
     dirindex = 0;
     interpindex = 1;
     
-    layersToProcess = DD::Image::Mask_RGB;
+    layersToProcess = DD::Image::Mask_RGBA;
 }
 
 OCIOFileTransform::~OCIOFileTransform()
@@ -51,12 +51,6 @@ void OCIOFileTransform::knobs(DD::Image::Knob_Callback f)
     
     Enumeration_knob(f, &interpindex, interp, "interpolation", "interpolation");
     DD::Image::Tooltip(f, "Specify the interpolation method. For files that are not LUTs (mtx, etc) this is ignored.");
-    
-    DD::Image::Divider(f);
-    
-    DD::Image::Input_ChannelSet_knob(f, &layersToProcess, 0, "layer", "layer");
-    DD::Image::SetFlags(f, DD::Image::Knob::NO_CHECKMARKS | DD::Image::Knob::NO_ALPHA_PULLDOWN);
-    DD::Image::Tooltip(f, "Set which layer to process. This should be a layer with rgb data.");
 }
 
 void OCIOFileTransform::_validate(bool for_real)
@@ -267,9 +261,5 @@ const char* OCIOFileTransform::node_help() const
 DD::Image::Op* build(Node *node)
 {
     DD::Image::NukeWrapper *op = new DD::Image::NukeWrapper(new OCIOFileTransform(node));
-    op->noMix();
-    op->noMask();
-    op->noChannels(); // prefer our own channels control without checkboxes / alpha
-    op->noUnpremult();
     return op;
 }

--- a/src/nuke/OCIOLogConvert/OCIOLogConvert.cpp
+++ b/src/nuke/OCIOLogConvert/OCIOLogConvert.cpp
@@ -23,7 +23,7 @@ const char* OCIOLogConvert::modes[] = {
 OCIOLogConvert::OCIOLogConvert(Node *n) : DD::Image::PixelIop(n)
 {
     modeindex = 0;
-    layersToProcess = DD::Image::Mask_RGB;
+    layersToProcess = DD::Image::Mask_RGBA;
 
 }
 
@@ -37,12 +37,6 @@ void OCIOLogConvert::knobs(DD::Image::Knob_Callback f)
 
     Enumeration_knob(f, &modeindex, modes, "operation", "operation");
     //DD::Image::Tooltip(f, "Input data is taken to be in this colorspace.");
-    
-    DD::Image::Divider(f);
-    
-    DD::Image::Input_ChannelSet_knob(f, &layersToProcess, 0, "layer", "layer");
-    DD::Image::SetFlags(f, DD::Image::Knob::NO_CHECKMARKS | DD::Image::Knob::NO_ALPHA_PULLDOWN);
-    DD::Image::Tooltip(f, "Set which layer to process. This should be a layer with rgb data.");
 }
 
 void OCIOLogConvert::_validate(bool for_real)
@@ -185,9 +179,5 @@ const char* OCIOLogConvert::node_help() const
 DD::Image::Op* build(Node *node)
 {
     DD::Image::NukeWrapper *op = new DD::Image::NukeWrapper(new OCIOLogConvert(node));
-    op->noMix();
-    op->noMask();
-    op->noChannels(); // prefer our own channels control without checkboxes / alpha
-    op->noUnpremult();
     return op;
 }


### PR DESCRIPTION
Fixed some misspellings and re-enabled all the NukeWrapper features, redoing the knob layouts.  I did remove some knobs rather than use the ObsoleteKnob.  Wasn't sure if that was necessary yet.  If it is, I can revisit.  It doesn't hurt anything, but it does scare users when Nuke warns them that it can't find a knob for a knob value.
