### PR TITLE
Include <cstddef> to define ptrdiff_t

### DIFF
--- a/export/OpenColorIO/OpenColorIO.h
+++ b/export/OpenColorIO/OpenColorIO.h
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <exception>
 #include <iosfwd>
 #include <string>
+#include <cstddef>
 
 #include "OpenColorABI.h"
 #include "OpenColorTypes.h"


### PR DESCRIPTION
Building OCIO on a 64-bit Fedora 15 box borks with undefined ptrdiff_t unless you include <cstddef>
