### PR TITLE
Luts with incorrect file extensions are now correctly loaded

### DIFF
--- a/src/core/FileFormatSpi3D.cpp
+++ b/src/core/FileFormatSpi3D.cpp
@@ -111,7 +111,10 @@ OCIO_NAMESPACE_ENTER
             istream.getline(lineBuffer, MAX_LINE_SIZE);
             if(!pystring::startswith(pystring::lower(lineBuffer), "spilut"))
             {
-                throw Exception("Lut does not appear to be valid spilut format.");
+                std::ostringstream os;
+                os << "Lut does not appear to be valid spilut format. ";
+                os << "Expected 'SPILUT'.  Found, '" << lineBuffer << "'.";
+                throw Exception(os.str().c_str());
             }
 
             // TODO: Assert 2nd line is 3 3

--- a/src/core/FileTransform.cpp
+++ b/src/core/FileTransform.cpp
@@ -444,6 +444,7 @@ OCIO_NAMESPACE_ENTER
                 catch(std::exception & e)
                 {
                     primaryErrorText = e.what();
+                    filestream.clear();
                     filestream.seekg( std::ifstream::beg );
                 }
             }
@@ -468,6 +469,7 @@ OCIO_NAMESPACE_ENTER
                 }
                 catch(std::exception & e)
                 {
+                    filestream.clear();
                     filestream.seekg( std::ifstream::beg );
                 }
             }


### PR DESCRIPTION
This was always the intent, but there was a bug in the
implementation, where were doing seekg on the filestream without clearing
potential error states beforehand.
