### PR TITLE
DisplayTransform looks are no longer automatically applied to 'data'

### DIFF
--- a/src/core/DisplayTransform.cpp
+++ b/src/core/DisplayTransform.cpp
@@ -361,8 +361,14 @@ OCIO_NAMESPACE_ENTER
         
         // Apply a look, if specified
         std::string looks;
-        if(displayTransform.getLooksOverrideEnabled()) looks = displayTransform.getLooksOverride();
-        else looks = config.getDisplayLooks(display.c_str(), view.c_str());
+        if(displayTransform.getLooksOverrideEnabled())
+        {
+            looks = displayTransform.getLooksOverride();
+        }
+        else if(!skipColorSpaceConversions)
+        {
+            looks = config.getDisplayLooks(display.c_str(), view.c_str());
+        }
         
         if(!looks.empty())
         {


### PR DESCRIPTION
DisplayTransform looks are no longer automatically applied to 'data' ('data' being normals, pts, etc). By design, colorspaces tagged as data do not have the display transforms applied, and the fact that the looks _were_
being applied was an oversight. DisplayTransforms that utilize the looksOverride functionality will be unchanged.
