### PR TITLE
Fix segfault with ociobakelut --format cinespace

### DIFF
--- a/src/core/FileFormatCSP.cpp
+++ b/src/core/FileFormatCSP.cpp
@@ -697,7 +697,14 @@ OCIO_NAMESPACE_ENTER
                 // our guide
                 
                 ConstColorSpaceRcPtr inputColorSpace = config->getColorSpace(baker.getInputSpace());
-                
+
+                if(!inputColorSpace)
+                {
+                    std::ostringstream os;
+                    os << "Could not find colorspace '" << baker.getInputSpace() << "'";
+                    throw Exception(os.str().c_str());
+                }
+
                 // Let's make an allocation transform for this colorspace
                 AllocationTransformRcPtr allocationTransform = AllocationTransform::Create();
                 std::vector<float> vars(inputColorSpace->getAllocationNumVars());


### PR DESCRIPTION
Null-pointer error if inputspace did not exist, e.g:

```
$ ociobakelut --format cinespace --inputspace nonexistent --outputspace lnf /tmp/out.csp
```
