### PR TITLE
ociobakelut improvements

### DIFF
--- a/src/core/CDLTransform.cpp
+++ b/src/core/CDLTransform.cpp
@@ -703,8 +703,20 @@ OCIO_NAMESPACE_ENTER
     
     std::ostream& operator<< (std::ostream& os, const CDLTransform& t)
     {
+        float sop[9];
+        t.getSOP(sop);
+        
         os << "<CDLTransform ";
         os << "direction=" << TransformDirectionToString(t.getDirection()) << ", ";
+        os << "sop=";
+        for (unsigned int i=0; i<9; ++i)
+        {
+            if(i!=0) os << " ";
+            os << sop[i];
+        }
+        os << ", ";
+        os << "sat=" << t.getSat() << ",";
+        os << TransformDirectionToString(t.getDirection()) << ", ";
         os << ">\n";
         return os;
     }

--- a/src/core/FileTransform.cpp
+++ b/src/core/FileTransform.cpp
@@ -164,9 +164,9 @@ OCIO_NAMESPACE_ENTER
         os << "<FileTransform ";
         os << "direction=" << TransformDirectionToString(t.getDirection()) << ", ";
         os << "interpolation=" << InterpolationToString(t.getInterpolation()) << ", ";
-        os << "src='" << t.getSrc() << "'";
+        os << "src='" << t.getSrc() << "', ";
         os << "cccid='" << t.getCCCId() << "'";
-        os << ">\n";
+        os << ">";
         
         return os;
     }


### PR DESCRIPTION
Added options for specifying simple color corrections (such as saturation, offsets, etc) in addition to normal lut commands.  Also allow for specification of forward and inverse luts (as supported by the underlying OCIO library- still no inverse 3d luts allowed).

example:  ociobakelut --lut filmlut.3dl --lut calibration.3dl --format flame display.3dl
example:  ociobakelut --lut look.3dl --offset 0.01 -0.02 0.03 --lut display.3dl --format flame display_wlook.3dl

Config-Free LUT Baking
    (all options can be specified multiple times, each is applied in order)
    --lut %s             Specify a LUT (forward direction)
    --invlut %s          Specify a LUT (inverse direction)
    --slope %f %f %f     slope
    --offset %f %f %f    offset (float)
    --offset10 %f %f %f  offset (10-bit)
    --power %f %f %f     power
    --sat %f             saturation (ASC-CDL luma coefficients)
