### PR TITLE
Set setup_ocio.sh as executable during installation, link PyImageIO against python on *nix systems.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,7 +321,7 @@ endif()
 configure_file(${CMAKE_SOURCE_DIR}/share/ocio/setup_ocio.sh.in
     ${CMAKE_CURRENT_BINARY_DIR}/share/ocio/setup_ocio.sh @ONLY)
 
-INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/ocio/setup_ocio.sh DESTINATION share/ocio/)
+INSTALL(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/share/ocio/setup_ocio.sh DESTINATION share/ocio/)
 
 ###############################################################################
 ### CPACK ###


### PR DESCRIPTION
Change from INSTALL(FILES... to INSTALL(PROGRAMS... so the shell script is marked executable on installation.

Add FindPythonLibs and fix includes and target link libraries for *nix systems.
