### PR TITLE
ocioconvert: pass arbitrary attributes to OIIO

### DIFF
--- a/src/apps/ocioconvert/CMakeLists.txt
+++ b/src/apps/ocioconvert/CMakeLists.txt
@@ -2,9 +2,13 @@ if (OIIO_FOUND)
     include_directories(
         ${CMAKE_SOURCE_DIR}/export/
         ${CMAKE_BINARY_DIR}/export/
+        ${CMAKE_SOURCE_DIR}/src/apps/share/
         ${OIIO_INCLUDES}
     )
-    add_executable(ocioconvert main.cpp)
+    
+    file(GLOB_RECURSE share_src_files "${CMAKE_SOURCE_DIR}/src/apps/share/*.cpp")
+    
+    add_executable(ocioconvert ${share_src_files} main.cpp)
     
     target_link_libraries(ocioconvert ${OIIO_LIBRARIES} OpenColorIO dl)
     


### PR DESCRIPTION
We've had reason to experiment with actually using ocioconvert in our
pipeline, but discovered that we needed to pass attributes to
OpenImageIO, largely to reduce bitdepths/image quality settings from the
maximum.

Submitted on behalf of Peter Hillman.
