### PR TITLE
core: added 'best' interpolation type

### DIFF
--- a/export/OpenColorIO/OpenColorTypes.h
+++ b/export/OpenColorIO/OpenColorTypes.h
@@ -206,12 +206,29 @@ OCIO_NAMESPACE_ENTER
     };
     
     //!cpp:type::
+    //
+    // Specify the interpolation type to use
+    // If the specified interpolation type is not supported in the requested
+    // context (for example, using tetrahedral interpolationon 1D luts)
+    // an exception will be throw.
+    //
+    // INTERP_BEST will choose the best interpolation type for the requested
+    // context:
+    //
+    // Lut1D INTERP_BEST: LINEAR
+    // Lut3D INTERP_BEST: LINEAR
+    //
+    // Note: INTERP_BEST is subject to change in minor releases, so if you
+    // care about locking off on a specific interpolation type, we'd recommend
+    // directly specifying it.
+    
     enum Interpolation
     {
         INTERP_UNKNOWN = 0,
-        INTERP_NEAREST,    //! nearest neighbor in all dimensions
-        INTERP_LINEAR,     //! linear interpolation in all dimensions
-        INTERP_TETRAHEDRAL //! tetrahedral interpolation in all directions
+        INTERP_NEAREST = 1,     //! nearest neighbor in all dimensions
+        INTERP_LINEAR = 2,      //! linear interpolation in all dimensions
+        INTERP_TETRAHEDRAL = 3, //! tetrahedral interpolation in all directions
+        INTERP_BEST = 255       //! the 'best' suitable interpolation type
     };
     
     //!cpp:type::

--- a/src/apps/ociobakelut/main.cpp
+++ b/src/apps/ociobakelut/main.cpp
@@ -403,7 +403,7 @@ parse_luts(int argc, const char *argv[])
             
             OCIO::FileTransformRcPtr t = OCIO::FileTransform::Create();
             t->setSrc(argv[i+1]);
-            t->setInterpolation(OCIO::INTERP_LINEAR);
+            t->setInterpolation(OCIO::INTERP_BEST);
             groupTransform->push_back(t);
             
             i += 1;
@@ -417,7 +417,7 @@ parse_luts(int argc, const char *argv[])
             
             OCIO::FileTransformRcPtr t = OCIO::FileTransform::Create();
             t->setSrc(argv[i+1]);
-            t->setInterpolation(OCIO::INTERP_LINEAR);
+            t->setInterpolation(OCIO::INTERP_BEST);
             t->setDirection(OCIO::TRANSFORM_DIR_INVERSE);
             groupTransform->push_back(t);
             

--- a/src/core/Lut1DOp.cpp
+++ b/src/core/Lut1DOp.cpp
@@ -544,10 +544,27 @@ OCIO_NAMESPACE_ENTER
             {
                 throw Exception("Cannot apply lut1d op, unspecified transform direction.");
             }
-            if(m_interpolation == INTERP_UNKNOWN)
+            
+            // Validate the requested interpolation type
+            switch(m_interpolation)
             {
-                throw Exception("Cannot apply lut1d op, unspecified interpolation.");
+                 // These are the allowed values.
+                case INTERP_NEAREST:
+                case INTERP_LINEAR:
+                    break;
+                case INTERP_BEST:
+                    m_interpolation = INTERP_LINEAR;
+                    break;
+                case INTERP_UNKNOWN:
+                    throw Exception("Cannot apply Lut1DOp, unspecified interpolation.");
+                    break;
+                case INTERP_TETRAHEDRAL:
+                    throw Exception("Cannot apply Lut1DOp, tetrahedral interpolation is not allowed for 1d luts.");
+                    break;
+                default:
+                    throw Exception("Cannot apply Lut1DOp, invalid interpolation specified.");
             }
+            
             if(m_lut->luts[0].empty() || m_lut->luts[1].empty() || m_lut->luts[2].empty())
             {
                 throw Exception("Cannot apply lut1d op, no lut data provided.");

--- a/src/core/Lut3DOp.cpp
+++ b/src/core/Lut3DOp.cpp
@@ -663,9 +663,22 @@ OCIO_NAMESPACE_ENTER
                 throw Exception(os.str().c_str());
             }
             
-            if(m_interpolation == INTERP_UNKNOWN)
+            // Validate the requested interpolation type
+            switch(m_interpolation)
             {
-                throw Exception("Cannot apply Lut3DOp, unspecified interpolation.");
+                 // These are the allowed values.
+                case INTERP_NEAREST:
+                case INTERP_LINEAR:
+                case INTERP_TETRAHEDRAL:
+                    break;
+                case INTERP_BEST:
+                    m_interpolation = INTERP_LINEAR;
+                    break;
+                case INTERP_UNKNOWN:
+                    throw Exception("Cannot apply Lut3DOp, unspecified interpolation.");
+                    break;
+                default:
+                    throw Exception("Cannot apply Lut3DOp, invalid interpolation specified.");
             }
             
             for(int i=0; i<3; ++i)

--- a/src/core/ParseUtils.cpp
+++ b/src/core/ParseUtils.cpp
@@ -188,6 +188,7 @@ OCIO_NAMESPACE_ENTER
         if(interp == INTERP_NEAREST) return "nearest";
         else if(interp == INTERP_LINEAR) return "linear";
         else if(interp == INTERP_TETRAHEDRAL) return "tetrahedral";
+        else if(interp == INTERP_BEST) return "best";
         return "unknown";
     }
     
@@ -197,6 +198,7 @@ OCIO_NAMESPACE_ENTER
         if(str == "nearest") return INTERP_NEAREST;
         else if(str == "linear") return INTERP_LINEAR;
         else if(str == "tetrahedral") return INTERP_TETRAHEDRAL;
+        else if(str == "best") return INTERP_BEST;
         return INTERP_UNKNOWN;
     }
     

--- a/src/jniglue/org/OpenColorIO/Interpolation.java
+++ b/src/jniglue/org/OpenColorIO/Interpolation.java
@@ -41,4 +41,8 @@ public class Interpolation extends LoadLibrary
         INTERP_NEAREST = new Interpolation(1);
     public static final Interpolation
         INTERP_LINEAR = new Interpolation(2);
+    public static final Interpolation
+        INTERP_TETRAHEDRAL = new Interpolation(3);
+    public static final Interpolation
+        INTERP_BEST = new Interpolation(255);
 }

--- a/src/jniglue/tests/org/OpenColorIO/GlobalsTest.java
+++ b/src/jniglue/tests/org/OpenColorIO/GlobalsTest.java
@@ -119,6 +119,10 @@ public class GlobalsTest extends TestCase {
         assertEquals(globals.InterpolationFromString("nearest"), Interpolation.INTERP_NEAREST);
         assertEquals(globals.InterpolationToString(Interpolation.INTERP_LINEAR), "linear");
         assertEquals(globals.InterpolationFromString("linear"), Interpolation.INTERP_LINEAR);
+        assertEquals(globals.InterpolationToString(Interpolation.INTERP_TETRAHEDRAL), "tetrahedral");
+        assertEquals(globals.InterpolationFromString("tetrahedral"), Interpolation.INTERP_TETRAHEDRAL);
+        assertEquals(globals.InterpolationToString(Interpolation.INTERP_BEST), "best");
+        assertEquals(globals.InterpolationFromString("best"), Interpolation.INTERP_BEST);
         
         // GpuLanguage
         assertEquals(globals.GpuLanguageToString(GpuLanguage.GPU_LANGUAGE_UNKNOWN), "unknown");

--- a/src/nuke/OCIOFileTransform/OCIOFileTransform.cpp
+++ b/src/nuke/OCIOFileTransform/OCIOFileTransform.cpp
@@ -31,7 +31,7 @@ OCIOFileTransform::~OCIOFileTransform()
 
 const char* OCIOFileTransform::dirs[] = { "forward", "inverse", 0 };
 
-const char* OCIOFileTransform::interp[] = { "nearest", "linear", "tetrahedral", 0 };
+const char* OCIOFileTransform::interp[] = { "nearest", "linear", "tetrahedral", "best", 0 };
 
 void OCIOFileTransform::knobs(DD::Image::Knob_Callback f)
 {
@@ -81,6 +81,7 @@ void OCIOFileTransform::_validate(bool for_real)
         if(m_interpindex == 0) transform->setInterpolation(OCIO::INTERP_NEAREST);
         else if(m_interpindex == 1) transform->setInterpolation(OCIO::INTERP_LINEAR);
         else if(m_interpindex == 2) transform->setInterpolation(OCIO::INTERP_TETRAHEDRAL);
+        else if(m_interpindex == 3) transform->setInterpolation(OCIO::INTERP_BEST);
         else
         {
             // Should never happen

--- a/src/pyglue/PyConstants.cpp
+++ b/src/pyglue/PyConstants.cpp
@@ -143,6 +143,8 @@ OCIO_NAMESPACE_ENTER
             const_cast<char*>(InterpolationToString(INTERP_LINEAR)));
         PyModule_AddStringConstant(m, "INTERP_TETRAHEDRAL",
             const_cast<char*>(InterpolationToString(INTERP_TETRAHEDRAL)));
+        PyModule_AddStringConstant(m, "INTERP_BEST",
+            const_cast<char*>(InterpolationToString(INTERP_BEST)));
         
         PyModule_AddStringConstant(m, "GPU_LANGUAGE_UNKNOWN",
             const_cast<char*>(GpuLanguageToString(GPU_LANGUAGE_UNKNOWN)));


### PR DESCRIPTION
Also, specifying tetrahedral interpolation for lut1d throws an exception rather
than silently skipping lut application.

Addressed issue #217

The naming for 'BEST' was chosen (instead of alternatives such as HIGHEST or
SMOOTHEST) precisely as the ambiguity allows us a bit of freedom in which
interpolation method to use. Consider a 3d lut. Which is 'smoother'? Tetrahedral
or tri-linear? Both are smoother in certain combinations of input luts / image
content.  Thus, by use the intentially ambigious term 'best' we can punt on
these issues.

Of course, should eventually we add support for a cubic 1d interpolation type,
we will switch 'best' be CUBIC at that time.
