### PR TITLE
nuke: config-dependent knob defaults are preserved

### DIFF
--- a/src/nuke/OCIOColorSpace/OCIOColorSpace.cpp
+++ b/src/nuke/OCIOColorSpace/OCIOColorSpace.cpp
@@ -101,18 +101,22 @@ void OCIOColorSpace::knobs(DD::Image::Knob_Callback f)
     DD::Image::CascadingEnumeration_knob(f,
         &m_inputColorSpaceIndex, &m_inputColorSpaceCstrNames[0], "in_colorspace", "in");
     DD::Image::Tooltip(f, "Input data is taken to be in this color space.");
+    DD::Image::SetFlags(f, DD::Image::Knob::ALWAYS_SAVE);
 
     DD::Image::CascadingEnumeration_knob(f,
         &m_outputColorSpaceIndex, &m_outputColorSpaceCstrNames[0], "out_colorspace", "out");
     DD::Image::Tooltip(f, "Image data is converted to this color space for output.");
+    DD::Image::SetFlags(f, DD::Image::Knob::ALWAYS_SAVE);
 #else
     DD::Image::Enumeration_knob(f,
         &m_inputColorSpaceIndex, &m_inputColorSpaceCstrNames[0], "in_colorspace", "in");
     DD::Image::Tooltip(f, "Input data is taken to be in this color space.");
+    DD::Image::SetFlags(f, DD::Image::Knob::ALWAYS_SAVE);
 
     DD::Image::Enumeration_knob(f,
         &m_outputColorSpaceIndex, &m_outputColorSpaceCstrNames[0], "out_colorspace", "out");
     DD::Image::Tooltip(f, "Image data is converted to this color space for output.");
+    DD::Image::SetFlags(f, DD::Image::Knob::ALWAYS_SAVE);
 #endif
     
 }

--- a/src/nuke/OCIODisplay/OCIODisplay.cpp
+++ b/src/nuke/OCIODisplay/OCIODisplay.cpp
@@ -122,14 +122,17 @@ void OCIODisplay::knobs(DD::Image::Knob_Callback f)
     DD::Image::Enumeration_knob(f,
         &m_colorSpaceIndex, &m_colorSpaceCstrNames[0], "colorspace", "input colorspace");
 #endif
+    DD::Image::SetFlags(f, DD::Image::Knob::ALWAYS_SAVE);
     DD::Image::Tooltip(f, "Input data is taken to be in this colorspace.");
 
     m_displayKnob = DD::Image::Enumeration_knob(f,
         &m_displayIndex, &m_displayCstrNames[0], "display", "display device");
+    DD::Image::SetFlags(f, DD::Image::Knob::ALWAYS_SAVE);
     DD::Image::Tooltip(f, "Display device for output.");
 
     m_viewKnob = DD::Image::Enumeration_knob(f,
         &m_viewIndex, &m_viewCstrNames[0], "view", "view transform");
+    DD::Image::SetFlags(f, DD::Image::Knob::ALWAYS_SAVE);
     DD::Image::Tooltip(f, "Display transform for output.");
     
     DD::Image::Float_knob(f, &m_gain, DD::Image::IRange(1.0 / 64.0f, 64.0f), "gain");

--- a/src/nuke/OCIOLogConvert/OCIOLogConvert.cpp
+++ b/src/nuke/OCIOLogConvert/OCIOLogConvert.cpp
@@ -34,7 +34,7 @@ void OCIOLogConvert::knobs(DD::Image::Knob_Callback f)
 {
 
     Enumeration_knob(f, &modeindex, modes, "operation", "operation");
-    //DD::Image::Tooltip(f, "Input data is taken to be in this colorspace.");
+    DD::Image::SetFlags(f, DD::Image::Knob::ALWAYS_SAVE);
 }
 
 void OCIOLogConvert::_validate(bool for_real)


### PR DESCRIPTION
Previously, the knob value was only saved when set to a non-default value. For
values which are configuration dependent (such as colorspace names) this is not
ideal.

OCIOLogConvert direction is also stored, as we may wish to change the default
value in a future version and this will allow us.

OCIOLookTransform is updated in a different commit.
