### PR TITLE
2 out of bounds exception fixes that might be windows specific

### DIFF
--- a/src/core/ColorSpaceTransform.cpp
+++ b/src/core/ColorSpaceTransform.cpp
@@ -199,7 +199,9 @@ OCIO_NAMESPACE_ENTER
         AllocationData srcAllocation;
         srcAllocation.allocation = srcColorSpace->getAllocation();
         srcAllocation.vars.resize( srcColorSpace->getAllocationNumVars());
-        srcColorSpace->getAllocationVars(&srcAllocation.vars[0]);
+
+        if ( srcAllocation.vars.size() > 0 )
+            srcColorSpace->getAllocationVars(&srcAllocation.vars[0]);
         
         CreateGpuAllocationNoOp(ops, srcAllocation);
         
@@ -232,7 +234,9 @@ OCIO_NAMESPACE_ENTER
         AllocationData dstAllocation;
         dstAllocation.allocation = dstColorSpace->getAllocation();
         dstAllocation.vars.resize( dstColorSpace->getAllocationNumVars());
-        dstColorSpace->getAllocationVars(&dstAllocation.vars[0]);
+
+        if ( dstAllocation.vars.size() > 0 )
+            dstColorSpace->getAllocationVars(&dstAllocation.vars[0]);
         
         CreateGpuAllocationNoOp(ops, dstAllocation);
     }

--- a/src/core/pystring/pystring.cpp
+++ b/src/core/pystring/pystring.cpp
@@ -253,58 +253,58 @@ typedef int Py_ssize_t;
     ///
     std::string do_strip( const std::string & str, int striptype, const std::string & chars  )
     {
-        std::string::size_type len = str.size(), i, j, charslen = chars.size();
+        std::string::size_type len = str.size(), i = 0, j = 0, charslen = chars.size();
 
-        if ( charslen == 0 )
+        if ( len > 0 )
         {
-            i = 0;
-            if ( striptype != RIGHTSTRIP )
+            if ( charslen == 0 )
             {
-                while ( i < len && ::isspace( str[i] ) )
+                if ( striptype != RIGHTSTRIP )
                 {
-                    i++;
+                    while ( i < len && ::isspace( str[i] ) )
+                    {
+                        i++;
+                    }
                 }
-            }
 
-            j = len;
-            if ( striptype != LEFTSTRIP )
+                j = len;
+                if ( striptype != LEFTSTRIP )
+                {
+                    do
+                    {
+                        j--;
+                    }
+                    while (j >= i && ::isspace(str[j]));
+
+                    j++;
+                }
+
+
+            }
+            else
             {
-                do
+                const char * sep = chars.c_str();
+
+                if ( striptype != RIGHTSTRIP )
                 {
-                    j--;
+                    while ( i < len && memchr(sep, str[i], charslen) )
+                    {
+                        i++;
+                    }
                 }
-                while (j >= i && ::isspace(str[j]));
 
-                j++;
-            }
-
-
-        }
-        else
-        {
-            const char * sep = chars.c_str();
-
-            i = 0;
-            if ( striptype != RIGHTSTRIP )
-            {
-                while ( i < len && memchr(sep, str[i], charslen) )
+                j = len;
+                if (striptype != LEFTSTRIP)
                 {
-                    i++;
+                    do
+                    {
+                        j--;
+                    }
+                    while (j >= i &&  memchr(sep, str[j], charslen)  );
+                    j++;
                 }
+
             }
-
-            j = len;
-            if (striptype != LEFTSTRIP)
-            {
-                do
-                {
-                    j--;
-                }
-                while (j >= i &&  memchr(sep, str[j], charslen)  );
-                j++;
-            }
-
-
         }
 
         if ( i == 0 && j == len )


### PR DESCRIPTION
exception at isspace(str[k]), as the size_type is an unsigned int, and thus
  j-- would wrap the variable j around (instead of making it -1)

ColorSpaceTransform.cpp: if used with no default config, ( -lut defined in the command line )
  the default color spaces have no allocation variables defined. So you get
  an out of bounds exception at trying to access .vars[0]
