### PR TITLE
added op combining for MatrixOffsetOps and ExponentOps

### DIFF
--- a/src/core/ExponentOps.cpp
+++ b/src/core/ExponentOps.cpp
@@ -32,8 +32,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <OpenColorIO/OpenColorIO.h>
 
+#include "ExponentOps.h"
 #include "GpuShaderUtils.h"
-#include "MatrixOps.h"
 #include "MathUtils.h"
 
 OCIO_NAMESPACE_ENTER
@@ -76,6 +76,9 @@ OCIO_NAMESPACE_ENTER
             virtual bool isSameType(const OpRcPtr & op) const;
             virtual bool isInverse(const OpRcPtr & op) const;
             
+            virtual bool canCombineWith(const OpRcPtr & op) const;
+            virtual void combineWith(OpRcPtrVec & ops, const OpRcPtr & secondOp) const;
+            
             virtual bool hasChannelCrosstalk() const;
             virtual void finalize();
             virtual void apply(float* rgbaBuffer, long numPixels) const;
@@ -84,11 +87,6 @@ OCIO_NAMESPACE_ENTER
             virtual void writeGpuShader(std::ostream & shader,
                                         const std::string & pixelName,
                                         const GpuShaderDesc & shaderDesc) const;
-            
-            const float * getExponent() const
-            {
-                return m_exp4;            
-            }
         private:
             float m_exp4[4];
             
@@ -172,6 +170,31 @@ OCIO_NAMESPACE_ENTER
             return IsVecEqualToOne(combined, 4);
         }
         
+        bool ExponentOp::canCombineWith(const OpRcPtr & op) const
+        {
+            return isSameType(op);
+        }
+        
+        
+        void ExponentOp::combineWith(OpRcPtrVec & ops, const OpRcPtr & secondOp) const
+        {
+            ExponentOpRcPtr typedRcPtr = DynamicPtrCast<ExponentOp>(secondOp);
+            if(!typedRcPtr)
+            {
+                std::ostringstream os;
+                os << "ExponentOp can only be combined with other ";
+                os << "ExponentOps.  secondOp:" << secondOp->getInfo();
+                throw Exception(os.str().c_str());
+            }
+            
+            float combined[4] = { m_exp4[0]*typedRcPtr->m_exp4[0],
+                                  m_exp4[1]*typedRcPtr->m_exp4[1],
+                                  m_exp4[2]*typedRcPtr->m_exp4[2],
+                                  m_exp4[3]*typedRcPtr->m_exp4[3] };
+            
+            CreateExponentOp(ops, combined, TRANSFORM_DIR_FORWARD);
+        }
+        
         bool ExponentOp::hasChannelCrosstalk() const
         {
             return false;
@@ -228,30 +251,6 @@ OCIO_NAMESPACE_ENTER
         
         ops.push_back( ExponentOpRcPtr(new ExponentOp(exp4, direction)) );
     }
-    
-    bool IsExponentOp(const OpRcPtr & op)
-    {
-        ExponentOpRcPtr typedRcPtr = DynamicPtrCast<ExponentOp>(op);
-        if(typedRcPtr) return true;
-        return false;
-    }
-    
-    OpRcPtr CreateCombinedExponentOp(const OpRcPtr & op1, const OpRcPtr & op2)
-    {
-        ExponentOpRcPtr typedRcPtr1 = DynamicPtrCast<ExponentOp>(op1);
-        ExponentOpRcPtr typedRcPtr2 = DynamicPtrCast<ExponentOp>(op2);
-        if(!typedRcPtr1 || !typedRcPtr2) return OpRcPtr();
-        
-        const float * exp1 = typedRcPtr1->getExponent();
-        const float * exp2 = typedRcPtr2->getExponent();
-        float newexp[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
-        for(unsigned int i=0; i<4; ++i)
-        {
-            newexp[i] = exp1[i]*exp2[i];
-        }
-        
-        return ExponentOpRcPtr(new ExponentOp(newexp, TRANSFORM_DIR_FORWARD));
-    }
 }
 OCIO_NAMESPACE_EXIT
 
@@ -260,16 +259,17 @@ OCIO_NAMESPACE_EXIT
 
 #ifdef OCIO_UNIT_TEST
 
-namespace OCIO = OCIO_NAMESPACE;
 #include "UnitTest.h"
+
+OCIO_NAMESPACE_USING
 
 OIIO_ADD_TEST(ExponentOps, Value)
 {
     float exp1[4] = { 1.2f, 1.3f, 1.4f, 1.5f };
     
-    OCIO::OpRcPtrVec ops;
-    OCIO::CreateExponentOp(ops, exp1, OCIO::TRANSFORM_DIR_FORWARD);
-    OCIO::CreateExponentOp(ops, exp1, OCIO::TRANSFORM_DIR_INVERSE);
+    OpRcPtrVec ops;
+    CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD);
+    CreateExponentOp(ops, exp1, TRANSFORM_DIR_INVERSE);
     OIIO_CHECK_EQUAL(ops.size(), 2);
     
     for(unsigned int i=0; i<ops.size(); ++i)
@@ -305,12 +305,12 @@ OIIO_ADD_TEST(ExponentOps, Inverse)
     float exp1[4] = { 2.0f, 1.02345f, 5.651321f, 0.12345678910f };
     float exp2[4] = { 2.0f, 2.0f, 2.0f, 2.0f };
     
-    OCIO::OpRcPtrVec ops;
+    OpRcPtrVec ops;
     
-    OCIO::CreateExponentOp(ops, exp1, OCIO::TRANSFORM_DIR_FORWARD);
-    OCIO::CreateExponentOp(ops, exp1, OCIO::TRANSFORM_DIR_INVERSE);
-    OCIO::CreateExponentOp(ops, exp2, OCIO::TRANSFORM_DIR_FORWARD);
-    OCIO::CreateExponentOp(ops, exp2, OCIO::TRANSFORM_DIR_INVERSE);
+    CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD);
+    CreateExponentOp(ops, exp1, TRANSFORM_DIR_INVERSE);
+    CreateExponentOp(ops, exp2, TRANSFORM_DIR_FORWARD);
+    CreateExponentOp(ops, exp2, TRANSFORM_DIR_INVERSE);
     
     OIIO_CHECK_EQUAL(ops.size(), 4);
     
@@ -334,20 +334,13 @@ OIIO_ADD_TEST(ExponentOps, Combining)
     float exp1[4] = { 2.0f, 2.0f, 2.0f, 1.0f };
     float exp2[4] = { 1.2f, 1.2f, 1.2f, 1.0f };
     
-    OCIO::OpRcPtrVec ops;
-    OCIO::CreateExponentOp(ops, exp1, OCIO::TRANSFORM_DIR_FORWARD);
-    OCIO::CreateExponentOp(ops, exp2, OCIO::TRANSFORM_DIR_FORWARD);
+    OpRcPtrVec ops;
+    CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD);
+    CreateExponentOp(ops, exp2, TRANSFORM_DIR_FORWARD);
     OIIO_CHECK_EQUAL(ops.size(), 2);
     
-    for(unsigned int i=0; i<ops.size(); ++i)
-    {
-        ops[i]->finalize();
-    }
-    
     float error = 1e-6f;
-    
     const float source[] = {  0.5f, 0.5f, 0.5f, 0.5f, };
-    
     const float result[] = {  0.18946457081379978f, 0.18946457081379978f,
                                0.18946457081379978f, 0.5f };
     
@@ -361,12 +354,14 @@ OIIO_ADD_TEST(ExponentOps, Combining)
         OIIO_CHECK_CLOSE(tmp[i], result[i], error);
     }
     
-    OCIO::OpRcPtr combined = OCIO::CreateCombinedExponentOp(ops[0],ops[1]);
-    combined->finalize();
+    
+    OpRcPtrVec combined;
+    ops[0]->combineWith(combined, ops[1]);
+    OIIO_CHECK_EQUAL(combined.size(), 1);
     
     float tmp2[4];
     memcpy(tmp2, source, 4*sizeof(float));
-    combined->apply(tmp2, 1);
+    combined[0]->apply(tmp2, 1);
     
     for(unsigned int i=0; i<4; ++i)
     {

--- a/src/core/ExponentOps.h
+++ b/src/core/ExponentOps.h
@@ -39,16 +39,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 OCIO_NAMESPACE_ENTER
 {
     // If the exponent is 1.0, this will return without clamping
-    // Otherwise, will be clamped between [0.0,inf]
+    // Otherwise, will be clamped between [0.0, inf]
     
     void CreateExponentOp(OpRcPtrVec & ops,
                           const float * exponent4,
                           TransformDirection direction);
-    
-    bool IsExponentOp(const OpRcPtr & op);
-    
-    // Will return a nullptr if either input is not an exponent Op
-    OpRcPtr CreateCombinedExponentOp(const OpRcPtr & op1, const OpRcPtr & op2);
 }
 OCIO_NAMESPACE_EXIT
 

--- a/src/core/MatrixOps.h
+++ b/src/core/MatrixOps.h
@@ -69,12 +69,6 @@ OCIO_NAMESPACE_ENTER
                             float sat,
                             const float * lumaCoef3,
                             TransformDirection direction);
-    
-    
-    ////////////////////////////////////////////////////////////////////////////
-    
-    
-    bool IsMatrixOp(const OpRcPtr & op);
 }
 OCIO_NAMESPACE_EXIT
 

--- a/src/core/Op.cpp
+++ b/src/core/Op.cpp
@@ -38,6 +38,20 @@ OCIO_NAMESPACE_ENTER
     Op::~Op()
     { }
     
+    bool Op::canCombineWith(const OpRcPtr & /*op*/) const
+    {
+        return false;
+    }
+    
+    void Op::combineWith(OpRcPtrVec & /*ops*/,
+                         const OpRcPtr & /*secondOp*/) const
+    {
+        std::ostringstream os;
+        os << "Op: " << getInfo() << " cannot be combined. ";
+        os << "A type-specific combining function is not defined.";
+        throw Exception(os.str().c_str());
+    }
+    
     std::ostream& operator<< (std::ostream & os, const Op & op)
     {
         os << op.getInfo();

--- a/src/core/Op.h
+++ b/src/core/Op.h
@@ -79,12 +79,23 @@ OCIO_NAMESPACE_ENTER
             
             //! Is the processing a noop? I.e, does apply do nothing.
             //! (Even no-ops may define Allocation though.)
-            
+            //! This must be implmented in a manner where its valid to call
+            //! *prior* to finalize. (Optimizers may make use of it)
             virtual bool isNoOp() const = 0;
             
             virtual bool isSameType(const OpRcPtr & op) const = 0;
             
             virtual bool isInverse(const OpRcPtr & op) const = 0;
+            
+            virtual bool canCombineWith(const OpRcPtr & op) const;
+            
+            // Return a vector of result ops, which correspond to
+            // THIS combinedWith secondOp.
+            //
+            // If the result is a noOp, it is valid for the resulting opsVec
+            // to be empty.
+            
+            virtual void combineWith(OpRcPtrVec & ops, const OpRcPtr & secondOp) const;
             
             virtual bool hasChannelCrosstalk() const = 0;
             


### PR DESCRIPTION
This means that you when multiple MatrixTransforms (or their equivalents) are used in a row, there will only be the cost incurred for a single operation.   Same for Exponent operations.

We've been looking at going down this route for a long time... #19
