### PR TITLE
windows build changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ if(UNIX AND NOT APPLE)
     option(USE_EXTERNAL_TINYXML "Use system installed tinyxml library." OFF)
     option(USE_EXTERNAL_LCMS "Use system install lcms2 library." OFF)
 endif()
+if(NOT UNIX)
+	set(OCIO_USE_BOOST_PTR ON CACHE BOOL "Set to ON to enable boost shared_ptr (necessary when tr1 is not available)")
+endif()
 
 # This does not include the SOVERSION override, on purpose, so that the
 # OCIO_VERSION value will be an accurate reflection of the underlying library version.
@@ -91,7 +94,7 @@ endif()
 
 messageonce("Use Boost Ptr: ${OCIO_USE_BOOST_PTR}")
 if(OCIO_USE_BOOST_PTR)
-    set(Boost_ADDITIONAL_VERSIONS "1.45" "1.44" "1.43" "1.43.0" "1.42"
+    set(Boost_ADDITIONAL_VERSIONS "1.49" "1.45" "1.44" "1.43" "1.43.0" "1.42"
                                   "1.42.0" "1.41" "1.41.0" "1.40"
                                   "1.40.0" "1.39" "1.39.0" "1.38"
                                   "1.38.0" "1.37" "1.37.0" "1.34.1"

--- a/src/apps/share/pystring.cpp
+++ b/src/apps/share/pystring.cpp
@@ -41,17 +41,21 @@
 #include <iostream>
 #include <sstream>
 
-OCIO_NAMESPACE_ENTER
-{
-
-namespace pystring
-{
-
 #if defined(_WIN32) || defined(_WIN64) || defined(_WINDOWS) || defined(_MSC_VER)
 #ifndef WINDOWS
 #define WINDOWS
 #endif
 #endif
+
+#ifdef WINDOWS
+#include "BaseTsd.h"
+#endif
+
+OCIO_NAMESPACE_ENTER
+{
+
+namespace pystring
+{
 
 // This definition codes from configure.in in the python src.
 // Strictly speaking this limits us to str sizes of 2**31.
@@ -61,6 +65,10 @@ namespace pystring
 // This must also equal the size used in the end = MAX_32BIT_INT default arg.
 
 typedef int Py_ssize_t;
+
+#ifdef WINDOWS
+typedef SSIZE_T ssize_t;
+#endif
 
 /* helper macro to fixup start/end slice values */
 #define ADJUST_INDICES(start, end, len)         \

--- a/src/core/pystring/pystring.cpp
+++ b/src/core/pystring/pystring.cpp
@@ -41,17 +41,21 @@
 #include <iostream>
 #include <sstream>
 
-OCIO_NAMESPACE_ENTER
-{
-
-namespace pystring
-{
-
 #if defined(_WIN32) || defined(_WIN64) || defined(_WINDOWS) || defined(_MSC_VER)
 #ifndef WINDOWS
 #define WINDOWS
 #endif
 #endif
+
+#ifdef WINDOWS
+#include "BaseTsd.h"
+#endif
+
+OCIO_NAMESPACE_ENTER
+{
+
+namespace pystring
+{
 
 // This definition codes from configure.in in the python src.
 // Strictly speaking this limits us to str sizes of 2**31.
@@ -61,6 +65,10 @@ namespace pystring
 // This must also equal the size used in the end = MAX_32BIT_INT default arg.
 
 typedef int Py_ssize_t;
+
+#ifdef WINDOWS
+typedef SSIZE_T ssize_t;
+#endif
 
 /* helper macro to fixup start/end slice values */
 #define ADJUST_INDICES(start, end, len)         \


### PR DESCRIPTION
- on windows, cmake sets boost pointers to be defaulting ON (tr1 not being available). Also added a later version of boost to the additional versions
- changes in pystring to override ssize_t as the win SSIZE_T equivalent
