### PR TITLE
Add travis-ci.org build file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+# travis-ci.org build file
+
+# As CMake is not officially supported we use erlang VMs
+language: erlang
+
+# Settings to try
+env:
+  - OPTIONS="-DCMAKE_BUILD_TYPE=Release -DOCIO_BUILD_TESTS=yes"
+
+# Make sure CMake is installed
+install:
+ - sudo apt-get install cmake
+
+# Run the Build script
+script:
+ - mkdir _build
+ - cd _build
+ - cmake .. -DCMAKE_INSTALL_PREFIX=../_install $OPTIONS
+ - cmake --build . --target install
+
+# Run Tests
+after_script:
+ - ctest --output-on-failure .


### PR DESCRIPTION
For no particular reason, I wanted to see if I could get OCIO to build on Travis CI (free/open-source CI service thing):

http://travis-ci.org/#!/dbr/OpenColorIO

..which runs cmake/ctest, and reports if it succeeded or not (and can be shown as a fancy little embeddable image, [![Build Status](https://secure.travis-ci.org/dbr/OpenColorIO.png?branch=travis)](http://travis-ci.org/dbr/OpenColorIO))

Not sure how useful it is (it would be nice to have the tests run over a few different platforms, but the service isn't really aimed at that, more for testing against multiple interpreter versions and such) - but figured I'd pull-request it for discussion
