### PR TITLE
Don't define OIIO namespace

### DIFF
--- a/src/apps/ocioconvert/main.cpp
+++ b/src/apps/ocioconvert/main.cpp
@@ -35,7 +35,6 @@ namespace OCIO = OCIO_NAMESPACE;
 
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/typedesc.h>
-namespace OIIO = OIIO_NAMESPACE;
 
 
 #include "argparse.h"

--- a/src/apps/ociodisplay/main.cpp
+++ b/src/apps/ociodisplay/main.cpp
@@ -53,7 +53,6 @@ namespace OCIO = OCIO_NAMESPACE;
 
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/typedesc.h>
-namespace OIIO = OIIO_NAMESPACE;
 
 GLint g_win = 0;
 int g_winWidth = 0;

--- a/src/apps/ociolutimage/main.cpp
+++ b/src/apps/ociolutimage/main.cpp
@@ -32,7 +32,6 @@ OCIO_NAMESPACE_USING;
 
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/typedesc.h>
-namespace OIIO = OIIO_NAMESPACE;
 
 #include "argparse.h"
 


### PR DESCRIPTION
OpenImageIO now defines the OIIO namespace itself, so trying to build against current oiio breaks.
