### PR TITLE
Don't set soversion for python libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ option(OCIO_USE_SSE "Specify whether to enable SSE CPU performance optimizations
 option(OCIO_USE_BOOST_PTR "Set to ON to enable boost shared_ptr (necessary when tr1 is not available)" OFF)
 
 option(OCIO_PYGLUE_RESPECT_ABI "If ON, the Python module install path includes Python UCS version" OFF)
+option(OCIO_PYGLUE_SONAME "If ON, soname/soversion will be set for Python module libraries." OFF)
 
 # This does not include the SOVERSION override, on purpose, so that the
 # OCIO_VERSION value will be an accurate reflection of the underlying library version.

--- a/src/pyglue/CMakeLists.txt
+++ b/src/pyglue/CMakeLists.txt
@@ -92,6 +92,14 @@ endif()
 # We should explore whether this should be built as a normal dylib, instead
 # of as a bundle. See https://github.com/imageworks/OpenColorIO/pull/175
 
+if(OCIO_PYGLUE_SONAME)
+    message(STATUS "Setting PyOCIO SOVERSION to: ${SOVERSION}")
+    set_target_properties(PyOpenColorIO PROPERTIES
+        VERSION ${OCIO_VERSION}
+        SOVERSION ${SOVERSION}
+    )
+endif()
+
 if(APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -undefined dynamic_lookup")
 endif()


### PR DESCRIPTION
Ok, as far as I can tell none of the python libraries in site-packages has a soname/soversion, so now that we're installing directly there instead of /usr/lib{,64} I think we should stop setting it.

Comments?
