### PR TITLE
Fix inclusion of hidden files in documentation install.

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -99,7 +99,8 @@ add_dependencies(doc Sphinx)
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/build-html/
         DESTINATION ${CMAKE_INSTALL_PREFIX}/share/doc/OpenColorIO/html
-        PATTERN .git EXCLUDE)
+        PATTERN .* EXCLUDE
+)
 
 find_package(LATEX)
 if(PDFLATEX_COMPILER)


### PR DESCRIPTION
There were some other hidden files besides git related files making it into the installed doc folder. They looked to be output from some of the doc generation apps.
