### PR TITLE
nuke: Toolbar node population no longer conflicts with Foundry

### DIFF
--- a/share/nuke/menu.py
+++ b/share/nuke/menu.py
@@ -14,8 +14,13 @@ def ocio_populate_menu():
     allplugs = nuke.plugins(nuke.ALL | nuke.NODIR, "OCIO*.so", "OCIO*.dylib", "OCIO*.dll")
 
     for fname in allplugs:
-        p = os.path.splitext(fname)[0] # strip .so extension
-        m_ocio.addCommand(p, lambda p=p: nuke.createNode(p))
+        nodeMenu = nodeClass = os.path.splitext(fname)[0] # strip .so extension
+        # Put a space after "OCIO" to match The Foundry's convention (huh?)
+        if nodeMenu.startswith("OCIO"):
+            nodeMenu = nodeMenu.replace("OCIO", "OCIO ", 1)
+        # Only add the item if it doesn't exist
+        if not m_ocio.findItem(nodeMenu):
+            m_ocio.addCommand(nodeMenu, lambda nodeClass=nodeClass: nuke.createNode(nodeClass))
 
     m_utils = m_ocio.addMenu("Utils")
     m_utils.addCommand("Import .ccc to CDL nodes", ocionuke.cdl.import_multiple_from_ccc)


### PR DESCRIPTION
This code was previously creating duplicate entries for most of the OCIO nodes in the OCIO menu that ships with Nuke 6.3v7 and newer. I modified the code to check for these existing entries and to match their menu naming convention.
