### PR TITLE
bugfix for when you don't specify --ch

### DIFF
--- a/src/apps/ocioconvert/main.cpp
+++ b/src/apps/ocioconvert/main.cpp
@@ -147,7 +147,7 @@ int main(int argc, const char **argv)
         
         std::vector<int> kchannels;
         //parse --ch argument
-        if (!StringToVector(&kchannels,keepChannels.c_str()))
+        if (keepChannels != "" && !StringToVector(&kchannels,keepChannels.c_str()))
         {
             std::cerr << "Error: --ch: '" << keepChannels << "' should be comma-seperated integers\n";
             exit(1);


### PR DESCRIPTION
I forgot to test the case where the user does not supply --ch.  Right now, if you do that, it says 

"Error: --ch should be comma-seperated integers"

simple fix!
