### PR TITLE
CSP with no metadata failed at read with MSVC10 64 bits

### DIFF
--- a/src/core/FileFormatCSP.cpp
+++ b/src/core/FileFormatCSP.cpp
@@ -412,7 +412,7 @@ OCIO_NAMESPACE_ENTER
 
             // read meta data block
             std::string metadata;
-            std::streampos curr_pos = istream.tellg ();
+            bool lineUpdateNeeded = false;
             nextline (istream, line);
             if (line == "BEGIN METADATA")
             {
@@ -422,11 +422,9 @@ OCIO_NAMESPACE_ENTER
                     if (line != "END METADATA")
                         metadata += line + "\n";
                 }
-            }
-            else
-            {
-                istream.seekg (curr_pos);
-            }
+                lineUpdateNeeded = true;
+            }// else line update not needed
+            
             
             // Make 3 vectors of prelut inputs + output values
             std::vector<float> prelut_in[3];
@@ -437,7 +435,9 @@ OCIO_NAMESPACE_ENTER
             for (int c = 0; c < 3; ++c)
             {
                 // how many points do we have for this channel
-                nextline (istream, line);
+                if (lineUpdateNeeded)
+                    nextline (istream, line);
+
                 int cpoints = 0;
                 
                 if(!StringToInt(&cpoints, line.c_str()) || cpoints<0)
@@ -493,6 +493,7 @@ OCIO_NAMESPACE_ENTER
                     prelut_out[c].push_back(1.0f);
                     useprelut[c] = false;
                 }
+                lineUpdateNeeded = true;
             }
 
             if (csptype == "1D")


### PR DESCRIPTION
Errors at runtime : 
`The specified transform file '(...)rsr_linear_3D_NoMetadata.csp' could not be loaded. malformed 3D csp lut, couldn't read cube size`
or
`The specified transform file '(...)rsr_linear_1D_NoMetadata.csp' could not be loaded. malformed 1D csp lut`

The problem seems to be related to an msv10 bug with seekg.
See ["std::fstream use 32-bit int as pos_type even on x64 platform"](http://connect.microsoft.com/VisualStudio/feedback/details/627639/std-fstream-use-32-bit-int-as-pos-type-even-on-x64-platform)
(I tried several workarounds to patch msvc10, including the one decribed in the link above, but no one worked for me)

This pull request remove the use of seekg and add a condition to handle the "no metadata case".
