### PR TITLE
Added the ability to explicitly declare config envvars

### DIFF
--- a/export/OpenColorIO/OpenColorIO.h
+++ b/export/OpenColorIO/OpenColorIO.h
@@ -270,11 +270,24 @@ OCIO_NAMESPACE_ENTER
         ConstContextRcPtr getCurrentContext() const;
         
         //!cpp:function::
+        void addEnvironmentVar(const char * name, const char * defaultValue);
+        //!cpp:function::
+        int getNumEnvironmentVars() const;
+        //!cpp:function::
+        const char * getEnvironmentVarNameByIndex(int index) const;
+        //!cpp:function::
+        const char * getEnvironmentVarDefault(const char * name) const;
+        //!cpp:function::
+        void clearEnvironmentVars();
+        
+        //!cpp:function::
         const char * getSearchPath() const;
+        //!cpp:function::
         void setSearchPath(const char * path);
         
         //!cpp:function::
         const char * getWorkingDir() const;
+        //!cpp:function::
         void setWorkingDir(const char * dirname);
         
         ///////////////////////////////////////////////////////////////////////////
@@ -1195,8 +1208,19 @@ OCIO_NAMESPACE_ENTER
         //!cpp:function::
         const char * getStringVar(const char * name) const;
         
+        //!cpp:function::
         int getNumStringVars() const;
+        //!cpp:function::
         const char * getStringVarNameByIndex(int index) const;
+        
+        //!cpp:function::
+        void clearStringVars();
+        
+        //!cpp:function::
+        void setEnvironmentMode(EnvironmentMode mode);
+        
+        //!cpp:function::
+        EnvironmentMode getEnvironmentMode() const;
         
         //!cpp:function:: Seed all string vars with the current environment.
         void loadEnvironment();

--- a/export/OpenColorIO/OpenColorTypes.h
+++ b/export/OpenColorIO/OpenColorTypes.h
@@ -266,6 +266,13 @@ OCIO_NAMESPACE_ENTER
         GPU_LANGUAGE_GLSL_1_3      ///< OpenGL Shading Language
     };
     
+    //!cpp:type::
+    enum EnvironmentMode
+    {
+        ENV_ENVIRONMENT_UNKNOWN = 0,
+        ENV_ENVIRONMENT_LOAD_PREDEFINED,
+        ENV_ENVIRONMENT_LOAD_ALL
+    };
     
     //!rst::
     // Conversion
@@ -320,6 +327,11 @@ OCIO_NAMESPACE_ENTER
     extern OCIOEXPORT const char * GpuLanguageToString(GpuLanguage language);
     //!cpp:function::
     extern OCIOEXPORT GpuLanguage GpuLanguageFromString(const char * s);
+    
+    //!cpp:function::
+    extern OCIOEXPORT const char * EnvironmentModeToString(EnvironmentMode mode);
+    //!cpp:function::
+    extern OCIOEXPORT EnvironmentMode EnvironmentModeFromString(const char * s);
     
     
     /*!rst::

--- a/src/core/ParseUtils.cpp
+++ b/src/core/ParseUtils.cpp
@@ -220,6 +220,21 @@ OCIO_NAMESPACE_ENTER
     }
     
     
+    const char * EnvironmentModeToString(EnvironmentMode mode)
+    {
+        if(mode == ENV_ENVIRONMENT_LOAD_PREDEFINED) return "loadpredefined";
+        else if(mode == ENV_ENVIRONMENT_LOAD_ALL) return "loadall";
+        return "unknown";
+    }
+    
+    EnvironmentMode EnvironmentModeFromString(const char * s)
+    {
+        std::string str = pystring::lower(s);
+        if(str == "loadpredefined") return ENV_ENVIRONMENT_LOAD_PREDEFINED;
+        else if(str == "loadall") return ENV_ENVIRONMENT_LOAD_ALL;
+        return ENV_ENVIRONMENT_UNKNOWN;
+    }
+    
     const char * ROLE_DEFAULT = "default";
     const char * ROLE_REFERENCE = "reference";
     const char * ROLE_DATA = "data";

--- a/src/core/PathUtils.cpp
+++ b/src/core/PathUtils.cpp
@@ -185,17 +185,31 @@ OCIO_NAMESPACE_ENTER
         const int MAX_PATH_LENGTH = 4096;
     }
     
-    void LoadEnvironment(EnvMap & map)
+    void LoadEnvironment(EnvMap & map, bool update)
     {
         for (char **env = GetEnviron(); *env != NULL; ++env)
         {
+            
             // split environment up into std::map[name] = value
             std::string env_str = (char*)*env;
             int pos = static_cast<int>(env_str.find_first_of('='));
-            map.insert(
-                EnvMap::value_type(env_str.substr(0, pos),
-                env_str.substr(pos+1, env_str.length()))
-            );
+            std::string name = env_str.substr(0, pos);
+            std::string value = env_str.substr(pos+1, env_str.length());
+            
+            if(update)
+            {
+                // update existing key:values that match
+                EnvMap::iterator iter = map.find(name);
+                if(iter != map.end()) iter->second = value;
+            }
+            else
+            {
+                // load the entire env
+                std::string env_str = (char*)*env;
+                int pos = static_cast<int>(env_str.find_first_of('='));
+                map.insert(EnvMap::value_type(name, value));
+            }
+            
         }
     }
     

--- a/src/core/PathUtils.h
+++ b/src/core/PathUtils.h
@@ -74,8 +74,8 @@ OCIO_NAMESPACE_ENTER
     };
     typedef std::map< std::string, std::string, EnvMapKey< std::string > > EnvMap;
     
-    // Get map of current env key = value,
-    void LoadEnvironment(EnvMap & map);
+    // Get map of current env key = value, or update the existing entries
+    void LoadEnvironment(EnvMap & map, bool update = false);
     
     // Expand a string with $VAR, ${VAR} or %VAR% with the keys passed
     // in the EnvMap.

--- a/src/jniglue/CMakeLists.txt
+++ b/src/jniglue/CMakeLists.txt
@@ -30,6 +30,7 @@ set(JNIOCIO_CLASSES
   org.OpenColorIO.BitDepth
   org.OpenColorIO.Allocation
   org.OpenColorIO.GpuLanguage
+  org.OpenColorIO.EnvironmentMode
   # Transforms
   org.OpenColorIO.AllocationTransform
   org.OpenColorIO.CDLTransform

--- a/src/jniglue/JNIConfig.cpp
+++ b/src/jniglue/JNIConfig.cpp
@@ -159,6 +159,51 @@ Java_org_OpenColorIO_Config_getCurrentContext(JNIEnv * env, jobject self)
     OCIO_JNITRY_EXIT(NULL)
 }
 
+JNIEXPORT void JNICALL
+Java_org_OpenColorIO_Config_addEnvironmentVar(JNIEnv * env, jobject self, jstring name, jstring defaultValue)
+{
+    OCIO_JNITRY_ENTER()
+    ConfigRcPtr cfg = GetEditableJOCIO<ConfigRcPtr, ConfigJNI>(env, self);
+    cfg->addEnvironmentVar(GetJStringValue(env, name)(), GetJStringValue(env, defaultValue)());
+    OCIO_JNITRY_EXIT()
+}
+
+JNIEXPORT jint JNICALL
+Java_org_OpenColorIO_Config_getNumEnvironmentVars(JNIEnv * env, jobject self)
+{
+    OCIO_JNITRY_ENTER()
+    ConstConfigRcPtr cfg = GetConstJOCIO<ConstConfigRcPtr, ConfigJNI>(env, self);
+    return (jint)cfg->getNumEnvironmentVars();
+    OCIO_JNITRY_EXIT(0)
+}
+
+JNIEXPORT jstring JNICALL
+Java_org_OpenColorIO_Config_getEnvironmentVarNameByIndex(JNIEnv * env, jobject self, jint index)
+{
+    OCIO_JNITRY_ENTER()
+    ConstConfigRcPtr cfg = GetConstJOCIO<ConstConfigRcPtr, ConfigJNI>(env, self);
+    return env->NewStringUTF(cfg->getEnvironmentVarNameByIndex((int)index));
+    OCIO_JNITRY_EXIT(NULL)
+}
+
+JNIEXPORT jstring JNICALL
+Java_org_OpenColorIO_Config_getEnvironmentVarDefault(JNIEnv * env, jobject self, jstring name)
+{
+    OCIO_JNITRY_ENTER()
+    ConstConfigRcPtr cfg = GetConstJOCIO<ConstConfigRcPtr, ConfigJNI>(env, self);
+    return env->NewStringUTF(cfg->getEnvironmentVarDefault(GetJStringValue(env, name)()));
+    OCIO_JNITRY_EXIT(NULL)
+}
+
+JNIEXPORT void JNICALL
+Java_org_OpenColorIO_Config_clearEnvironmentVars(JNIEnv * env, jobject self)
+{
+    OCIO_JNITRY_ENTER()
+    ConfigRcPtr cfg = GetEditableJOCIO<ConfigRcPtr, ConfigJNI>(env, self);
+    cfg->clearEnvironmentVars();
+    OCIO_JNITRY_EXIT()
+}
+
 JNIEXPORT jstring JNICALL
 Java_org_OpenColorIO_Config_getSearchPath(JNIEnv * env, jobject self)
 {

--- a/src/jniglue/JNIContext.cpp
+++ b/src/jniglue/JNIContext.cpp
@@ -143,6 +143,32 @@ Java_org_OpenColorIO_Context_getStringVarNameByIndex(JNIEnv * env, jobject self,
 }
 
 JNIEXPORT void JNICALL
+Java_org_OpenColorIO_Context_clearStringVars(JNIEnv * env, jobject self)
+{
+    OCIO_JNITRY_ENTER()
+    ContextRcPtr con = GetEditableJOCIO<ContextRcPtr, ContextJNI>(env, self);
+    con->clearStringVars();
+    OCIO_JNITRY_EXIT()
+}
+
+JNIEXPORT void JNICALL
+Java_org_OpenColorIO_Context_setEnvironmentMode(JNIEnv * env, jobject self, jobject mode) {
+    OCIO_JNITRY_ENTER()
+    ContextRcPtr con = GetEditableJOCIO<ContextRcPtr, ContextJNI>(env, self);
+    con->setEnvironmentMode(GetJEnum<EnvironmentMode>(env, mode));
+    OCIO_JNITRY_EXIT()
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_OpenColorIO_Context_getEnvironmentMode(JNIEnv * env, jobject self)
+{
+    OCIO_JNITRY_ENTER()
+    ConstContextRcPtr con = GetConstJOCIO<ConstContextRcPtr, ContextJNI>(env, self);
+    return BuildJEnum(env, "org/OpenColorIO/EnvironmentMode", con->getEnvironmentMode());
+    OCIO_JNITRY_EXIT(NULL)
+}
+
+JNIEXPORT void JNICALL
 Java_org_OpenColorIO_Context_loadEnvironment(JNIEnv * env, jobject self)
 {
     OCIO_JNITRY_ENTER()

--- a/src/jniglue/JNIGlobals.cpp
+++ b/src/jniglue/JNIGlobals.cpp
@@ -415,3 +415,37 @@ Java_org_OpenColorIO_Globals_GpuLanguageFromString(JNIEnv * env, jobject, jstrin
              GpuLanguageFromString(GetJStringValue(env, s)()));
     OCIO_JNITRY_EXIT(NULL)
 }
+
+// EnvironmentMode
+
+JNIEXPORT jstring JNICALL
+Java_org_OpenColorIO_EnvironmentMode_toString(JNIEnv * env, jobject self) {
+    OCIO_JNITRY_ENTER()
+    return env->NewStringUTF(
+      EnvironmentModeToString(GetJEnum<EnvironmentMode>(env, self)));
+    OCIO_JNITRY_EXIT(NULL)
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_OpenColorIO_EnvironmentMode_equals(JNIEnv * env, jobject self, jobject obj) {
+    OCIO_JNITRY_ENTER()
+    return GetJEnum<EnvironmentMode>(env, self)
+        == GetJEnum<EnvironmentMode>(env, obj);
+    OCIO_JNITRY_EXIT(false)
+}
+
+JNIEXPORT jstring JNICALL
+Java_org_OpenColorIO_Globals_EnvironmentModeToString(JNIEnv * env, jobject, jobject mode) {
+    OCIO_JNITRY_ENTER()
+    return env->NewStringUTF(
+      EnvironmentModeToString(GetJEnum<EnvironmentMode>(env, mode)));
+    OCIO_JNITRY_EXIT(NULL)
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_OpenColorIO_Globals_EnvironmentModeFromString(JNIEnv * env, jobject, jstring s) {
+    OCIO_JNITRY_ENTER()
+    return BuildJEnum(env, "org/OpenColorIO/EnvironmentMode",
+             EnvironmentModeFromString(GetJStringValue(env, s)()));
+    OCIO_JNITRY_EXIT(NULL)
+}

--- a/src/jniglue/org/OpenColorIO/Config.java
+++ b/src/jniglue/org/OpenColorIO/Config.java
@@ -47,6 +47,11 @@ public class Config extends LoadLibrary
     public native String getCacheID();
     public native String getCacheID(Context context);
     public native Context getCurrentContext();
+    public native void addEnvironmentVar(String name, String defaultValue);
+    public native int getNumEnvironmentVars();
+    public native String getEnvironmentVarNameByIndex(int index);
+    public native String getEnvironmentVarDefault(String name);
+    public native void clearEnvironmentVars();
     public native String getSearchPath();
     public native void setSearchPath(String path);
     public native String getWorkingDir();

--- a/src/jniglue/org/OpenColorIO/Context.java
+++ b/src/jniglue/org/OpenColorIO/Context.java
@@ -46,6 +46,9 @@ public class Context extends LoadLibrary
     public native String getStringVar(String name);
     public native int getNumStringVars();
     public native String getStringVarNameByIndex(int index);
+    public native void clearStringVars();
+    public native void setEnvironmentMode(EnvironmentMode mode);
+    public native EnvironmentMode getEnvironmentMode();
     public native void loadEnvironment();
     public native String resolveStringVar(String val);
     public native String resolveFileLocation(String filename) throws ExceptionMissingFile;

--- a/src/jniglue/org/OpenColorIO/Globals.java
+++ b/src/jniglue/org/OpenColorIO/Globals.java
@@ -60,6 +60,8 @@ public class Globals extends LoadLibrary
     public native Interpolation InterpolationFromString(String s);
     public native String GpuLanguageToString(GpuLanguage language);
     public native GpuLanguage GpuLanguageFromString(String s);
+    public native String EnvironmentModeToString(EnvironmentMode mode);
+    public native GpuLanguage EnvironmentModeFromString(String s);
     
     // Roles
     public String ROLE_DEFAULT;

--- a/src/jniglue/tests/org/OpenColorIO/ConfigTest.java
+++ b/src/jniglue/tests/org/OpenColorIO/ConfigTest.java
@@ -91,6 +91,19 @@ public class ConfigTest extends TestCase {
         
         Config _cfg = new Config().CreateFromStream(SIMPLE_PROFILE);
         Config _cfge = _cfg.createEditableCopy();
+        _cfge.clearEnvironmentVars();
+        assertEquals(0, _cfge.getNumEnvironmentVars());
+        _cfge.addEnvironmentVar("FOO", "test1");
+        _cfge.addEnvironmentVar("FOO2", "test2${FOO}");
+        assertEquals(2, _cfge.getNumEnvironmentVars());
+        assertEquals("FOO", _cfge.getEnvironmentVarNameByIndex(0));
+        assertEquals("FOO2", _cfge.getEnvironmentVarNameByIndex(1));
+        assertEquals("test1", _cfge.getEnvironmentVarDefault("FOO"));
+        assertEquals("test2${FOO}", _cfge.getEnvironmentVarDefault("FOO2"));
+        assertEquals("test2test1", _cfge.getCurrentContext().resolveStringVar("${FOO2}"));
+        //self.assertEqual({'FOO': 'test1', 'FOO2': 'test2${FOO}'}, _cfge.getEnvironmentVarDefaults())
+        _cfge.clearEnvironmentVars();
+        assertEquals(0, _cfge.getNumEnvironmentVars());
         assertEquals("luts", _cfge.getSearchPath());
         _cfge.setSearchPath("otherdir");
         assertEquals("otherdir", _cfge.getSearchPath());

--- a/src/jniglue/tests/org/OpenColorIO/ContextTest.java
+++ b/src/jniglue/tests/org/OpenColorIO/ContextTest.java
@@ -14,7 +14,7 @@ public class ContextTest extends TestCase {
         Context cont = new Context().Create();
         cont.setSearchPath("testing123");
         cont.setWorkingDir("/dir/123");
-        assertEquals("$af84c0ff921e48843d711a761e05b80f", cont.getCacheID());
+        assertEquals("$4c2d66a612fc25ddd509591e1dead57b", cont.getCacheID());
         assertEquals("testing123", cont.getSearchPath());
         assertEquals("/dir/123", cont.getWorkingDir());
         cont.setStringVar("TeSt", "foobar");
@@ -25,7 +25,12 @@ public class ContextTest extends TestCase {
         assertNotSame(0, cont.getNumStringVars());
         cont.setStringVar("TEST1", "foobar");
         assertEquals("/foo/foobar/bar",
-                     cont.resolveStringVar("/foo/${TEST1}/bar"));
+                cont.resolveStringVar("/foo/${TEST1}/bar"));
+        cont.clearStringVars();
+        assertEquals(0, cont.getNumStringVars());
+        assertEquals(EnvironmentMode.ENV_ENVIRONMENT_LOAD_PREDEFINED, cont.getEnvironmentMode());
+        cont.setEnvironmentMode(EnvironmentMode.ENV_ENVIRONMENT_LOAD_ALL);
+        assertEquals(EnvironmentMode.ENV_ENVIRONMENT_LOAD_ALL, cont.getEnvironmentMode());
         try {
             cont.setSearchPath("testing123");
             String foo = cont.resolveFileLocation("test.lut");

--- a/src/jniglue/tests/org/OpenColorIO/GlobalsTest.java
+++ b/src/jniglue/tests/org/OpenColorIO/GlobalsTest.java
@@ -134,6 +134,14 @@ public class GlobalsTest extends TestCase {
         assertEquals(globals.GpuLanguageToString(GpuLanguage.GPU_LANGUAGE_GLSL_1_3), "glsl_1.3");
         assertEquals(globals.GpuLanguageFromString("glsl_1.3"), GpuLanguage.GPU_LANGUAGE_GLSL_1_3);
         
+        // EnvironmentMode
+        assertEquals(globals.EnvironmentModeToString(EnvironmentMode.ENV_ENVIRONMENT_UNKNOWN), "unknown");
+        assertEquals(globals.EnvironmentModeFromString("unknown"), EnvironmentMode.ENV_ENVIRONMENT_UNKNOWN);
+        assertEquals(globals.EnvironmentModeToString(EnvironmentMode.ENV_ENVIRONMENT_LOAD_PREDEFINED), "loadpredefined");
+        assertEquals(globals.EnvironmentModeFromString("loadpredefined"), EnvironmentMode.ENV_ENVIRONMENT_LOAD_PREDEFINED);
+        assertEquals(globals.EnvironmentModeToString(EnvironmentMode.ENV_ENVIRONMENT_LOAD_ALL), "loadall");
+        assertEquals(globals.EnvironmentModeFromString("loadall"), EnvironmentMode.ENV_ENVIRONMENT_LOAD_ALL);
+        
         // Roles
         assertEquals(globals.ROLE_DEFAULT, "default");
         assertEquals(globals.ROLE_REFERENCE, "reference");

--- a/src/pyglue/DocStrings/Config.py
+++ b/src/pyglue/DocStrings/Config.py
@@ -142,7 +142,37 @@ class Config:
         :rtype: pycontext
         """
         pass
-
+    
+    def addEnvironmentVar(self, name, defaultValue):
+        """
+        """
+        pass
+        
+    def getNumEnvironmentVars(self):
+        """
+        """
+        pass
+        
+    def getEnvironmentVarNameByIndex(self, index):
+        """
+        """
+        pass
+        
+    def getEnvironmentVarDefault(self, name):
+        """
+        """
+        pass
+    
+    def getEnvironmentVarDefaults(self):
+        """
+        """
+        pass
+    
+    def clearEnvironmentVars(self):
+        """
+        """
+        pass
+    
     def getSearchPath(self):
         """
         getSearchPath()

--- a/src/pyglue/DocStrings/Context.py
+++ b/src/pyglue/DocStrings/Context.py
@@ -27,6 +27,12 @@ class Context:
         pass
     def getStringVarNameByIndex(self, index):
         pass
+    def clearStringVars():
+        pass
+    def setEnvironmentMode(self, mode):
+        pass
+    def getEnvironmentMode():
+        pass
     def loadEnvironment(self):
         pass
     def resolveStringVar(self, stringVar):

--- a/src/pyglue/PyConfig.cpp
+++ b/src/pyglue/PyConfig.cpp
@@ -89,6 +89,12 @@ OCIO_NAMESPACE_ENTER
         PyObject * PyOCIO_Config_serialize(PyObject * self);
         PyObject * PyOCIO_Config_getCacheID(PyObject * self, PyObject * args);
         PyObject * PyOCIO_Config_getCurrentContext(PyObject * self);
+        PyObject * PyOCIO_Config_addEnvironmentVar(PyObject * self, PyObject * args);
+        PyObject * PyOCIO_Config_getNumEnvironmentVars(PyObject * self);
+        PyObject * PyOCIO_Config_getEnvironmentVarNameByIndex(PyObject * self, PyObject * args);
+        PyObject * PyOCIO_Config_getEnvironmentVarDefault(PyObject * self, PyObject * args);
+        PyObject * PyOCIO_Config_getEnvironmentVarDefaults(PyObject * self);
+        PyObject * PyOCIO_Config_clearEnvironmentVars(PyObject * self);
         PyObject * PyOCIO_Config_getSearchPath(PyObject * self);
         PyObject * PyOCIO_Config_setSearchPath(PyObject * self, PyObject * args);
         PyObject * PyOCIO_Config_getWorkingDir(PyObject * self);
@@ -159,6 +165,18 @@ OCIO_NAMESPACE_ENTER
             PyOCIO_Config_getCacheID, METH_VARARGS, CONFIG_GETCACHEID__DOC__ },
             { "getCurrentContext",
             (PyCFunction) PyOCIO_Config_getCurrentContext, METH_NOARGS, CONFIG_GETCURRENTCONTEXT__DOC__ },
+            { "addEnvironmentVar",
+            PyOCIO_Config_addEnvironmentVar, METH_VARARGS, CONFIG_ADDENVIRONMENTVAR__DOC__ },
+            { "getNumEnvironmentVars",
+            (PyCFunction)PyOCIO_Config_getNumEnvironmentVars, METH_NOARGS, CONFIG_GETNUMENVIRONMENTVARS__DOC__ },
+            { "getEnvironmentVarNameByIndex",
+            PyOCIO_Config_getEnvironmentVarNameByIndex, METH_VARARGS, CONFIG_GETENVIRONMENTVARNAMEBYINDEX__DOC__ },
+            { "getEnvironmentVarDefault",
+            PyOCIO_Config_getEnvironmentVarDefault, METH_VARARGS, CONFIG_GETENVIRONMENTVARDEFAULT__DOC__ },
+            { "getEnvironmentVarDefaults",
+            (PyCFunction)PyOCIO_Config_getEnvironmentVarDefaults, METH_NOARGS, CONFIG_GETENVIRONMENTVARDEFAULTS__DOC__ },
+            { "clearEnvironmentVars",
+            (PyCFunction)PyOCIO_Config_clearEnvironmentVars, METH_NOARGS, CONFIG_CLEARENVIRONMENTVARS__DOC__ },
             { "getSearchPath",
             (PyCFunction) PyOCIO_Config_getSearchPath, METH_NOARGS, CONFIG_GETSEARCHPATH__DOC__ },
             { "setSearchPath",
@@ -415,6 +433,72 @@ OCIO_NAMESPACE_ENTER
             OCIO_PYTRY_ENTER()
             ConstConfigRcPtr config = GetConstConfig(self, true);
             return BuildConstPyContext(config->getCurrentContext());
+            OCIO_PYTRY_EXIT(NULL)
+        }
+        
+        PyObject * PyOCIO_Config_addEnvironmentVar(PyObject * self, PyObject * args)
+        {
+            OCIO_PYTRY_ENTER()
+            char* name = 0;
+            char* value = 0;
+            if (!PyArg_ParseTuple(args, "ss:addEnvironmentVar",
+                &name, &value)) return NULL;
+            ConfigRcPtr config = GetEditableConfig(self);
+            config->addEnvironmentVar(name, value);
+            Py_RETURN_NONE;
+            OCIO_PYTRY_EXIT(NULL)
+        }
+        
+        PyObject * PyOCIO_Config_getNumEnvironmentVars(PyObject * self)
+        {
+            OCIO_PYTRY_ENTER()
+            ConstConfigRcPtr config = GetConstConfig(self, true);
+            return PyInt_FromLong(config->getNumEnvironmentVars());
+            OCIO_PYTRY_EXIT(NULL)
+        }
+        
+        PyObject * PyOCIO_Config_getEnvironmentVarNameByIndex(PyObject * self, PyObject * args)
+        {
+            OCIO_PYTRY_ENTER()
+            int index = 0;
+            if (!PyArg_ParseTuple(args,"i:getEnvironmentVarNameByIndex",
+                &index)) return NULL;
+            ConstConfigRcPtr config = GetConstConfig(self, true);
+            return PyString_FromString(config->getEnvironmentVarNameByIndex(index));
+            OCIO_PYTRY_EXIT(NULL)
+        }
+        
+        PyObject * PyOCIO_Config_getEnvironmentVarDefault(PyObject * self, PyObject * args)
+        {
+            OCIO_PYTRY_ENTER()
+            char* name = 0;
+            if (!PyArg_ParseTuple(args, "s:getEnvironmentVarDefault",
+                &name)) return NULL;
+            ConstConfigRcPtr config = GetConstConfig(self, true);
+            return PyString_FromString(config->getEnvironmentVarDefault(name));
+            OCIO_PYTRY_EXIT(NULL)
+        }
+        
+        PyObject * PyOCIO_Config_getEnvironmentVarDefaults(PyObject * self)
+        {
+            OCIO_PYTRY_ENTER()
+            std::map<std::string, std::string> data;
+            ConstConfigRcPtr config = GetConstConfig(self, true);
+            for(int i = 0; i < config->getNumEnvironmentVars(); ++i) {
+                const char* name = config->getEnvironmentVarNameByIndex(i);
+                const char* value = config->getEnvironmentVarDefault(name);
+                data.insert(std::pair<std::string, std::string>(name, value));
+            }
+            return CreatePyDictFromStringMap(data);
+            OCIO_PYTRY_EXIT(NULL)
+        }
+        
+        PyObject * PyOCIO_Config_clearEnvironmentVars(PyObject * self)
+        {
+            OCIO_PYTRY_ENTER()
+            ConfigRcPtr config = GetEditableConfig(self);
+            config->clearEnvironmentVars();
+            Py_RETURN_NONE;
             OCIO_PYTRY_EXIT(NULL)
         }
         

--- a/src/pyglue/PyConstants.cpp
+++ b/src/pyglue/PyConstants.cpp
@@ -149,6 +149,13 @@ OCIO_NAMESPACE_ENTER
         PyModule_AddStringConstant(m, "GPU_LANGUAGE_GLSL_1_3",
             const_cast<char*>(GpuLanguageToString(GPU_LANGUAGE_GLSL_1_3)));
         
+        PyModule_AddStringConstant(m, "ENV_ENVIRONMENT_UNKNOWN",
+            const_cast<char*>(EnvironmentModeToString(ENV_ENVIRONMENT_UNKNOWN)));
+        PyModule_AddStringConstant(m, "ENV_ENVIRONMENT_LOAD_PREDEFINED",
+            const_cast<char*>(EnvironmentModeToString(ENV_ENVIRONMENT_LOAD_PREDEFINED)));
+        PyModule_AddStringConstant(m, "ENV_ENVIRONMENT_LOAD_ALL",
+            const_cast<char*>(EnvironmentModeToString(ENV_ENVIRONMENT_LOAD_ALL)));
+        
         PyModule_AddStringConstant(m, "ROLE_DEFAULT", const_cast<char*>(ROLE_DEFAULT));
         PyModule_AddStringConstant(m, "ROLE_REFERENCE", const_cast<char*>(ROLE_REFERENCE));
         PyModule_AddStringConstant(m, "ROLE_DATA", const_cast<char*>(ROLE_DATA));

--- a/src/pyglue/PyContext.cpp
+++ b/src/pyglue/PyContext.cpp
@@ -88,6 +88,9 @@ OCIO_NAMESPACE_ENTER
         PyObject * PyOCIO_Context_setStringVar(PyObject * self, PyObject * args);
         PyObject * PyOCIO_Context_getNumStringVars(PyObject * self, PyObject * args);
         PyObject * PyOCIO_Context_getStringVarNameByIndex(PyObject * self, PyObject * args);
+        PyObject * PyOCIO_Context_clearStringVars(PyObject * self);
+        PyObject * PyOCIO_Context_setEnvironmentMode(PyObject * self, PyObject * args);
+        PyObject * PyOCIO_Context_getEnvironmentMode(PyObject * self);
         PyObject * PyOCIO_Context_loadEnvironment(PyObject * self);
         PyObject * PyOCIO_Context_resolveStringVar(PyObject * self, PyObject * args);
         PyObject * PyOCIO_Context_resolveFileLocation(PyObject * self, PyObject * args);
@@ -118,6 +121,12 @@ OCIO_NAMESPACE_ENTER
             PyOCIO_Context_getNumStringVars, METH_VARARGS, CONTEXT_GETNUMSTRINGVARS__DOC__ },
             { "getStringVarNameByIndex",
             PyOCIO_Context_getStringVarNameByIndex, METH_VARARGS, CONTEXT_GETSTRINGVARNAMEBYINDEX__DOC__ },
+            { "clearStringVars",
+            (PyCFunction) PyOCIO_Context_clearStringVars, METH_NOARGS, CONTEXT_CLEARSTRINGVARS__DOC__ },
+            { "setEnvironmentMode",
+            PyOCIO_Context_setEnvironmentMode, METH_VARARGS, CONTEXT_SETENVIRONMENTMODE__DOC__ },
+            { "getEnvironmentMode",
+            (PyCFunction) PyOCIO_Context_getEnvironmentMode, METH_NOARGS, CONTEXT_GETENVIRONMENTMODE__DOC__ },
             { "loadEnvironment",
             (PyCFunction) PyOCIO_Context_loadEnvironment, METH_NOARGS, CONTEXT_LOADENVIRONMENT__DOC__ },
             { "resolveStringVar",
@@ -295,6 +304,36 @@ OCIO_NAMESPACE_ENTER
                 &index)) return NULL;
             ConstContextRcPtr context = GetConstContext(self, true);
             return PyString_FromString(context->getStringVarNameByIndex(index));
+            OCIO_PYTRY_EXIT(NULL)
+        }
+        
+        PyObject * PyOCIO_Context_clearStringVars(PyObject * self)
+        {
+            OCIO_PYTRY_ENTER()
+            ContextRcPtr context = GetEditableContext(self);
+            context->clearStringVars();
+            Py_RETURN_NONE;
+            OCIO_PYTRY_EXIT(NULL)
+        }
+        
+        PyObject * PyOCIO_Context_setEnvironmentMode(PyObject * self, PyObject * args)
+        {
+            OCIO_PYTRY_ENTER()
+            EnvironmentMode mode;
+            if (!PyArg_ParseTuple(args, "O&:setEnvironmentMode",
+                ConvertPyObjectToEnvironmentMode, &mode)) return NULL;
+            ContextRcPtr context = GetEditableContext(self);
+            context->setEnvironmentMode(mode);
+            Py_RETURN_NONE;
+            OCIO_PYTRY_EXIT(NULL)
+        }
+        
+        PyObject * PyOCIO_Context_getEnvironmentMode(PyObject * self)
+        {
+            OCIO_PYTRY_ENTER()
+            ConstContextRcPtr context = GetConstContext(self, true);
+            EnvironmentMode mode = context->getEnvironmentMode();
+            return PyString_FromString(EnvironmentModeToString(mode));
             OCIO_PYTRY_EXIT(NULL)
         }
         

--- a/src/pyglue/PyUtil.cpp
+++ b/src/pyglue/PyUtil.cpp
@@ -137,7 +137,20 @@ OCIO_NAMESPACE_ENTER
         return 1;
     }
     
-    
+    int ConvertPyObjectToEnvironmentMode(PyObject *object, void *valuePtr)
+    {
+        EnvironmentMode* environmentmodePtr = static_cast<EnvironmentMode*>(valuePtr);
+        
+        if(!PyString_Check(object))
+        {
+            PyErr_SetString(PyExc_ValueError, "Object is not a string.");
+            return 0;
+        }
+        
+        *environmentmodePtr = EnvironmentModeFromString(PyString_AsString( object ));
+        
+        return 1;
+    }
     
     ///////////////////////////////////////////////////////////////////////////
     
@@ -322,6 +335,26 @@ OCIO_NAMESPACE_ENTER
         return returnlist;
     }
     
+    PyObject* CreatePyDictFromStringMap(const std::map<std::string, std::string> &data)
+    {
+        PyObject* returndict = PyDict_New();
+        if(!returndict) return 0;
+        
+        std::map<std::string, std::string>::const_iterator iter;
+        for(iter = data.begin(); iter != data.end(); ++iter)
+        {
+            int ret = PyDict_SetItem(returndict,
+                PyString_FromString(iter->first.c_str()),
+                PyString_FromString(iter->second.c_str()));
+            if(ret)
+            {
+                Py_DECREF(returndict);
+                return NULL;
+            }
+        }
+        
+        return returndict;
+    }
     
     namespace
     {

--- a/src/pyglue/PyUtil.h
+++ b/src/pyglue/PyUtil.h
@@ -32,6 +32,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <PyOpenColorIO/PyOpenColorIO.h>
 
 #include <vector>
+#include <map>
+#include <iostream>
 
 #define OCIO_PYTRY_ENTER() try {
 #define OCIO_PYTRY_EXIT(ret) } catch(...) { OpenColorIO::Python_Handle_Exception(); return ret; }
@@ -146,7 +148,6 @@ OCIO_NAMESPACE_ENTER
     inline PyObject * BuildConstPyOCIO(C ptr, PyTypeObject& type)
     {
         if(!ptr) return Py_INCREF(Py_None), Py_None;
-        //P * obj = PyObject_New(P, type); // (PyTypeObject *)&
         P * obj = (P *)_PyObject_New(&type);
         obj->constcppobj = new C ();
         *obj->constcppobj = ptr;
@@ -159,7 +160,6 @@ OCIO_NAMESPACE_ENTER
     inline PyObject * BuildEditablePyOCIO(T ptr, PyTypeObject& type)
     {
         if(!ptr) return Py_INCREF(Py_None), Py_None;
-        //P * obj = PyObject_New(P, type); // (PyTypeObject *)&
         P * obj = (P *) _PyObject_New(&type);
         obj->constcppobj = new C ();
         obj->cppobj = new T ();
@@ -270,6 +270,7 @@ OCIO_NAMESPACE_ENTER
     int ConvertPyObjectToTransformDirection(PyObject *object, void *valuePtr);
     int ConvertPyObjectToColorSpaceDirection(PyObject *object, void *valuePtr);
     int ConvertPyObjectToGpuLanguage(PyObject *object, void *valuePtr);
+    int ConvertPyObjectToEnvironmentMode(PyObject *object, void *valuePtr);
     
     ///////////////////////////////////////////////////////////////////////////
     
@@ -300,6 +301,7 @@ OCIO_NAMESPACE_ENTER
     PyObject* CreatePyListFromDoubleVector(const std::vector<double> &data);
     PyObject* CreatePyListFromStringVector(const std::vector<std::string> &data);
     PyObject* CreatePyListFromTransformVector(const std::vector<ConstTransformRcPtr> &data);
+    PyObject* CreatePyDictFromStringMap(const std::map<std::string, std::string> &data);
     
     //! Fill the specified vector type from the given pyobject
     //! Return true on success, false on failure.

--- a/src/pyglue/tests/CMakeLists.txt
+++ b/src/pyglue/tests/CMakeLists.txt
@@ -3,7 +3,7 @@
 ### PYTHON UNIT TESTS ###
 
 add_custom_target(PYTests
-                  COMMAND python OpenColorIOTestSuite.py ${CMAKE_BINARY_DIR}
+                  COMMAND ${PYTHON} OpenColorIOTestSuite.py ${CMAKE_BINARY_DIR}
                   DEPENDS PyOpenColorIO
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                   COMMENT "Setting Up and Running PYTHON OCIO UNIT tests")

--- a/src/pyglue/tests/ConstantsTest.py
+++ b/src/pyglue/tests/ConstantsTest.py
@@ -59,6 +59,11 @@ class ConstantsTest(unittest.TestCase):
         self.assertEqual(OCIO.Constants.GPU_LANGUAGE_GLSL_1_0, "glsl_1.0")
         self.assertEqual(OCIO.Constants.GPU_LANGUAGE_GLSL_1_3, "glsl_1.3")
         
+        # EnvironmentMode
+        self.assertEqual(OCIO.Constants.ENV_ENVIRONMENT_UNKNOWN, "unknown")
+        self.assertEqual(OCIO.Constants.ENV_ENVIRONMENT_LOAD_PREDEFINED, "loadpredefined")
+        self.assertEqual(OCIO.Constants.ENV_ENVIRONMENT_LOAD_ALL, "loadall")
+        
         # Roles
         self.assertEqual(OCIO.Constants.ROLE_DEFAULT, "default")
         self.assertEqual(OCIO.Constants.ROLE_REFERENCE, "reference")

--- a/src/pyglue/tests/ContextTest.py
+++ b/src/pyglue/tests/ContextTest.py
@@ -9,7 +9,7 @@ class ContextTest(unittest.TestCase):
         cont = OCIO.Context()
         cont.setSearchPath("testing123")
         cont.setWorkingDir("/dir/123")
-        self.assertEqual("$af84c0ff921e48843d711a761e05b80f", cont.getCacheID())
+        self.assertEqual("$4c2d66a612fc25ddd509591e1dead57b", cont.getCacheID())
         self.assertEqual("testing123", cont.getSearchPath())
         self.assertEqual("/dir/123", cont.getWorkingDir())
         cont.setStringVar("TeSt", "foobar")
@@ -20,10 +20,15 @@ class ContextTest(unittest.TestCase):
         self.assertNotEqual(0, cont.getNumStringVars())
         cont.setStringVar("TEST1", "foobar")
         self.assertEqual("/foo/foobar/bar", cont.resolveStringVar("/foo/${TEST1}/bar"))
+        cont.clearStringVars()
+        self.assertEqual(0, cont.getNumStringVars())
+        self.assertEqual(OCIO.Constants.ENV_ENVIRONMENT_LOAD_PREDEFINED, cont.getEnvironmentMode())
+        cont.setEnvironmentMode(OCIO.Constants.ENV_ENVIRONMENT_LOAD_ALL)
+        self.assertEqual(OCIO.Constants.ENV_ENVIRONMENT_LOAD_ALL, cont.getEnvironmentMode())
         try:
             cont.setSearchPath("testing123")
             foo = cont.resolveFileLocation("test.lut")
-            print foo
-        except OCIO.ExceptionMissingFile, e:
+            print(foo)
+        except OCIO.ExceptionMissingFile as e:
             #print e
             pass

--- a/src/pyglue/tests/OpenColorIOTestSuite.py
+++ b/src/pyglue/tests/OpenColorIOTestSuite.py
@@ -23,6 +23,7 @@ def suite():
     suite.addTest(MainTest("test_interface"))
     suite.addTest(ConstantsTest("test_interface"))
     suite.addTest(ConfigTest("test_interface"))
+    suite.addTest(ConfigTest("test_is_editable"))
     suite.addTest(ContextTest("test_interface"))
     suite.addTest(LookTest("test_interface"))
     suite.addTest(ColorSpaceTest("test_interface"))
@@ -38,7 +39,8 @@ def suite():
 if __name__ == '__main__':
     runner = unittest.TextTestRunner()
     test_suite = suite()
-    runner.run(test_suite)
-
-print "hello world"
+    result = runner.run(test_suite)
+    if result.wasSuccessful() == False:
+        sys.exit(1)
+    sys.exit(0)
 


### PR DESCRIPTION
old profiles are supported which still load the entire environment,
this is disabled as soon as you define an 'environment:' section.

eg.
--snip--
ocio_profile_version: 1
environment:
  SHOW: super
  SHOT: test
  SEQ: foo
  test: bar${cheese}
  cheese: chedder
...
--snip--

ABI Changes:
- added Config::addEnvironmentVar(const char \* name, const char \* defaultValue)
- added Config::getNumEnvironmentVars()
- added Config::getEnvironmentVarNameByIndex(int index)
- added Config::getEnvironmentVarDefault(const char \* name)
- added Config::clearEnvironmentVars()
- added EnvironmentMode enum
- added EnvironmentModeToString(EnvironmentMode mode)
- added EnvironmentModeFromString(const char \* s)
- added Context::clearStringVars()
- added Context::setEnvironmentMode(EnvironmentMode mode)
- added Context::getEnvironmentMode()
