### PR TITLE
resolve ENV var before testing for relative/abs paths

### DIFF
--- a/src/core_tests/CMakeLists.txt
+++ b/src/core_tests/CMakeLists.txt
@@ -2,6 +2,7 @@
 ### CORE UNIT TESTS ###
 
 add_definitions("-DOCIO_UNIT_TEST")
+add_definitions("-DOCIO_SOURCE_DIR=${CMAKE_SOURCE_DIR}")
 
 include_directories(
     ${CMAKE_SOURCE_DIR}/export/


### PR DESCRIPTION
fixed a bug where abs environment vars would not be correctly expanded before checking if they are abs in Context::resolveFileLocation()

this should fix #319
