### PR TITLE
core,pyglue: fixed misc compile warnings on gcc44

### DIFF
--- a/src/core/Context.cpp
+++ b/src/core/Context.cpp
@@ -298,7 +298,8 @@ namespace
             return iter->second.c_str();
         }
         
-        // Load an absolute file reference
+        // Attempt to load an absolute file reference
+        {
         std::string expandedfullpath = EnvExpand(filename, getImpl()->envMap_);
         if(pystring::os::path::isabs(expandedfullpath))
         {
@@ -311,6 +312,7 @@ namespace
             errortext << "The specified absolute file reference ";
             errortext << "'" << expandedfullpath << "' could not be located. ";
             throw Exception(errortext.str().c_str());
+        }
         }
         
         // Load a relative file reference

--- a/src/core/PathUtils.cpp
+++ b/src/core/PathUtils.cpp
@@ -204,12 +204,8 @@ OCIO_NAMESPACE_ENTER
             }
             else
             {
-                // load the entire env
-                std::string env_str = (char*)*env;
-                int pos = static_cast<int>(env_str.find_first_of('='));
                 map.insert(EnvMap::value_type(name, value));
             }
-            
         }
     }
     

--- a/src/pyglue/CMakeLists.txt
+++ b/src/pyglue/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
     
 if(CMAKE_COMPILER_IS_GNUCXX)
     # Python breaks strict-aliasing rules. Disable the warning here.
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-strict-aliasing")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-strict-aliasing -Wno-missing-field-initializers")
 endif()
 
 if(NOT WIN32)

--- a/src/pyglue/PyBaker.cpp
+++ b/src/pyglue/PyBaker.cpp
@@ -260,7 +260,7 @@ OCIO_NAMESPACE_ENTER
             OCIO_PYTRY_EXIT(NULL)
         }
         
-        PyObject * PyOCIO_Baker_getFormat(PyObject * self, PyObject * args)
+        PyObject * PyOCIO_Baker_getFormat(PyObject * self, PyObject * /*args*/)
         {
             OCIO_PYTRY_ENTER()
             ConstBakerRcPtr baker = GetConstBaker(self);

--- a/src/pyglue/PyCDLTransform.cpp
+++ b/src/pyglue/PyCDLTransform.cpp
@@ -174,7 +174,7 @@ OCIO_NAMESPACE_ENTER
             OCIO_PYTRY_EXIT(-1)
         }
         
-        PyObject * PyOCIO_CDLTransform_CreateFromFile(PyObject * self, PyObject * args)
+        PyObject * PyOCIO_CDLTransform_CreateFromFile(PyObject * /*self*/, PyObject * args)
         {
             OCIO_PYTRY_ENTER()
             const char * src = 0;

--- a/src/pyglue/PyContext.cpp
+++ b/src/pyglue/PyContext.cpp
@@ -288,7 +288,7 @@ OCIO_NAMESPACE_ENTER
             OCIO_PYTRY_EXIT(NULL)
         }
         
-        PyObject * PyOCIO_Context_getNumStringVars(PyObject * self, PyObject * args)
+        PyObject * PyOCIO_Context_getNumStringVars(PyObject * self, PyObject * /*args*/)
         {
             OCIO_PYTRY_ENTER()
             ConstContextRcPtr context = GetConstContext(self, true);

--- a/src/pyglue/PyLook.cpp
+++ b/src/pyglue/PyLook.cpp
@@ -173,7 +173,7 @@ OCIO_NAMESPACE_ENTER
         {
             OCIO_PYTRY_ENTER()
             LookRcPtr ptr = Look::Create();
-            int ret = BuildPyObject<PyOCIO_Look, ConstLookRcPtr, LookRcPtr>(self, ptr);
+            /*int ret =*/ BuildPyObject<PyOCIO_Look, ConstLookRcPtr, LookRcPtr>(self, ptr);
             char* name = NULL;
             char* processSpace = NULL;
             PyObject* pytransform = NULL;

--- a/src/pyglue/PyUtil.h
+++ b/src/pyglue/PyUtil.h
@@ -36,7 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 
 #define OCIO_PYTRY_ENTER() try {
-#define OCIO_PYTRY_EXIT(ret) } catch(...) { OpenColorIO::Python_Handle_Exception(); return ret; }
+#define OCIO_PYTRY_EXIT(ret) } catch(...) { OCIO_NAMESPACE::Python_Handle_Exception(); return ret; }
 
 // Some utilities macros for python 2.5 to 3.3 compatibility
 #if PY_MAJOR_VERSION >= 3


### PR DESCRIPTION
- Fixed a few misc. compile warnings when I tried the latest in the SPI build environment.
- Also fixed a pyglue macro issue when using an alt OCIO build namespace
