### PR TITLE
ExponentOp collapsing fix

### DIFF
--- a/src/core/MathUtils.cpp
+++ b/src/core/MathUtils.cpp
@@ -43,12 +43,22 @@ OCIO_NAMESPACE_ENTER
     {
         return equalWithAbsError(v, 0.0f, FLTMIN);
     }
-    
+
+    bool IsScalarEqualToZeroFlt(double v)
+    {
+        return equalWithAbsError(float(v), 0.0f, FLTMIN);
+    }
+
     bool IsScalarEqualToOne(float v)
     {
         return equalWithAbsError(v, 1.0f, FLTMIN);
     }
     
+    bool IsScalarEqualToOneFlt(double v)
+    {
+        return equalWithAbsError(float(v), 1.0f, FLTMIN);
+    }
+
     float GetSafeScalarInverse(float v, float defaultValue)
     {
         if(IsScalarEqualToZero(v)) return defaultValue;
@@ -72,7 +82,16 @@ OCIO_NAMESPACE_ENTER
         }
         return true;
     }
-    
+
+    bool IsVecEqualToOneFlt(const double* v, int size)
+    {
+        for(int i=0; i<size; ++i)
+        {
+            if(!IsScalarEqualToOneFlt(v[i])) return false;
+        }
+        return true;
+    }
+
     bool VecContainsZero(const float* v, int size)
     {
         for(int i=0; i<size; ++i)

--- a/src/core/MathUtils.h
+++ b/src/core/MathUtils.h
@@ -110,11 +110,14 @@ OCIO_NAMESPACE_ENTER
     // Checks within fltmin tolerance
     bool IsScalarEqualToZero(float v);
     bool IsScalarEqualToOne(float v);
-    
+    bool IsScalarEqualToZeroFlt(double v);
+    bool IsScalarEqualToOneFlt(double v);
+
     // Are all the vector components the specified value?
     bool IsVecEqualToZero(const float* v, int size);
     bool IsVecEqualToOne(const float* v, int size);
-    
+    bool IsVecEqualToOneFlt(const double* v, int size);
+
     // Is at least one of the specified components equal to 0?
     bool VecContainsZero(const float* v, int size);
     bool VecContainsOne(const float* v, int size);


### PR DESCRIPTION
The exponent op is unique in that the inverse transform is represented by
inverting the exponent, rather than storing an explicit forward/inverse flag.

However, the internal inversion math was done at float precision which meant that
for some exponents a forward / inverse pair would not exactly cancel out.

Example: 1.037289f, 1.019015f, 0.966082f

This fix stores the exponent at double precision, while doing inverse checks at
float precision, allowing accurate collapsing.

This does not impact performance as the actual image processing still works at
float, only the internal exponent coefficients are stored as doubles.
