### PR TITLE
fix build when using libc++

### DIFF
--- a/export/OpenColorIO/OpenColorABI.h.in
+++ b/export/OpenColorIO/OpenColorABI.h.in
@@ -55,6 +55,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <boost/shared_ptr.hpp>
 #define OCIO_SHARED_PTR boost::shared_ptr
 #define OCIO_DYNAMIC_POINTER_CAST boost::dynamic_pointer_cast
+#elif defined(_LIBCPP_VERSION)
+#include <memory>
+#define OCIO_SHARED_PTR std::shared_ptr
+#define OCIO_DYNAMIC_POINTER_CAST std::dynamic_pointer_cast
 #elif __GNUC__ >= 4
 #include <tr1/memory>
 #define OCIO_SHARED_PTR std::tr1::shared_ptr


### PR DESCRIPTION
Small fix to use std::shared_ptr instead of std::tr1::shared_ptr when building against libc++ from libcxx.llvm.org
