### PR TITLE
* fixed visibility when using clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,11 +233,11 @@ endif(USE_EXTERNAL_YAML)
 set(EXTERNAL_INCLUDE_DIRS ${EXTERNAL_INCLUDE_DIRS} ${PROJECT_BINARY_DIR}/ext/dist/include)
 set(EXTERNAL_COMPILE_FLAGS "-DTIXML_USE_STL")
 
-if(CMAKE_COMPILER_IS_GNUCXX)
-    
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(EXTERNAL_COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS} -fPIC -fvisibility-inlines-hidden -fvisibility=hidden")
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
                     OUTPUT_VARIABLE GCC_VERSION)
-                    
     if (GCC_VERSION VERSION_LESS 4.2)
         message(STATUS "GCC Version < 4.2 - symbol visibility hiding disabled")
         set(EXTERNAL_COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS} -fPIC")

--- a/src/pyglue/CMakeLists.txt
+++ b/src/pyglue/CMakeLists.txt
@@ -95,7 +95,11 @@ if(OCIO_PYGLUE_SONAME)
 endif()
 
 if(APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -undefined dynamic_lookup")
+    get_target_property(CURR_LINK_FLAGS PyOpenColorIO LINK_FLAGS)
+    if(NOT CURR_LINK_FLAGS)
+        set(CURR_LINK_FLAGS "")
+    endif()
+    set_target_properties(PyOpenColorIO PROPERTIES LINK_FLAGS "${CURR_LINK_FLAGS} -undefined dynamic_lookup")
 endif()
 
 add_subdirectory(tests)


### PR DESCRIPTION
- fixed unused flag -undefined dynamic_lookup when using clang on OSX with PyOpenColorIO
