### PR TITLE
Add description to Display/View combination

### DIFF
--- a/export/OpenColorIO/OpenColorIO.h
+++ b/export/OpenColorIO/OpenColorIO.h
@@ -392,6 +392,8 @@ OCIO_NAMESPACE_ENTER
         const char * getDisplayColorSpaceName(const char * display, const char * view) const;
         //!cpp:function::
         const char * getDisplayLooks(const char * display, const char * view) const;
+        //!cpp:function::
+        const char * getDisplayDescription(const char * display, const char * view) const;
         
         //!cpp:function:: For the (display,view) combination,
         // specify which colorSpace and look to use.
@@ -400,6 +402,16 @@ OCIO_NAMESPACE_ENTER
         void addDisplay(const char * display, const char * view,
                         const char * colorSpaceName, const char * looks);
         
+        //!cpp:function:: For the (display,view) combination,
+        // specify which colorSpace and look to use.
+        // If a look is not desired, then just pass an empty string.
+        // This version also has a description string.  If a description
+        // is not desired, then just pass an empty string.
+
+        void addDisplay(const char * display, const char * view,
+                        const char * colorSpaceName, const char * looks,
+                        const char * description);
+
         //!cpp:function::
         void clearDisplays();
         

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -1176,14 +1176,38 @@ OCIO_NAMESPACE_ENTER
         return views[index].looks.c_str();
     }
     
+    const char * Config::getDisplayDescription(const char * display, const char * view) const
+    {
+        if(!display || !view) return "";
+        
+        DisplayMap::const_iterator iter = find_display_const(getImpl()->displays_, display);
+        if(iter == getImpl()->displays_.end()) return "";
+        
+        const ViewVec & views = iter->second;
+        int index = find_view(views, view);
+        if(index<0) return "";
+        
+        return views[index].description.c_str();
+    }
+    
     void Config::addDisplay(const char * display, const char * view,
                             const char * colorSpaceName, const char * lookName)
     {
+        addDisplay(display, view, colorSpaceName, lookName, "");
+    }
+
+    void Config::addDisplay(const char * display, const char * view,
+                            const char * colorSpaceName, const char * lookName,
+                            const char * description)
+    {
         
         if(!display || !view || !colorSpaceName || !lookName) return;
+        if(!description) {
+            description = "";
+        }
         
-        AddDisplay(getImpl()->displays_,
-                   display, view, colorSpaceName, lookName);
+        AddDisplay(getImpl()->displays_, display, view, colorSpaceName,
+                   lookName, description);
         getImpl()->displayCache_.clear();
         
         AutoMutex lock(getImpl()->cacheidMutex_);

--- a/src/core/Display.cpp
+++ b/src/core/Display.cpp
@@ -71,13 +71,14 @@ OCIO_NAMESPACE_ENTER
                     const std::string & display,
                     const std::string & view,
                     const std::string & colorspace,
-                    const std::string & looks)
+                    const std::string & looks,
+                    const std::string & description)
     {
         DisplayMap::iterator iter = find_display(displays, display);
         if(iter == displays.end())
         {
             ViewVec views;
-            views.push_back( View(view, colorspace, looks) );
+            views.push_back( View(view, colorspace, looks, description) );
             displays[display] = views;
         }
         else
@@ -86,12 +87,13 @@ OCIO_NAMESPACE_ENTER
             int index = find_view(views, view);
             if(index<0)
             {
-                views.push_back( View(view, colorspace, looks) );
+                views.push_back( View(view, colorspace, looks, description) );
             }
             else
             {
                 views[index].colorspace = colorspace;
                 views[index].looks = looks;
+                views[index].description = description;
             }
         }
     }

--- a/src/core/Display.h
+++ b/src/core/Display.h
@@ -47,15 +47,18 @@ OCIO_NAMESPACE_ENTER
         std::string name;
         std::string colorspace;
         std::string looks;
+        std::string description;
         
         View() { }
         
         View(const std::string & name_,
              const std::string & colorspace_,
-             const std::string & looksList_) :
+             const std::string & looksList_,
+             const std::string & description_) :
                 name(name_),
                 colorspace(colorspace_),
-                looks(looksList_)
+                looks(looksList_),
+                description(description_)
         { }
     };
     
@@ -72,7 +75,8 @@ OCIO_NAMESPACE_ENTER
                     const std::string & display,
                     const std::string & view,
                     const std::string & colorspace,
-                    const std::string & looks);
+                    const std::string & looks,
+                    const std::string & description);
     
     void ComputeDisplays(StringVec & displayCache,
                          const DisplayMap & displays,

--- a/src/core/OCIOYaml.cpp
+++ b/src/core/OCIOYaml.cpp
@@ -275,6 +275,11 @@ OCIO_NAMESPACE_ENTER
                     load(second, stringval);
                     v.looks = stringval;
                 }
+                else if(key == "description")
+                {
+                    load(second, stringval);
+                    v.description = stringval;
+                }
                 else
                 {
                     LogUnknownKeyWarning(node.Tag(), first);
@@ -294,7 +299,7 @@ OCIO_NAMESPACE_ENTER
             }
         }
         
-        inline void save(YAML::Emitter& out, View view)
+        inline void save(YAML::Emitter& out, const View &view)
         {
             out << YAML::VerbatimTag("View");
             out << YAML::Flow;
@@ -302,6 +307,7 @@ OCIO_NAMESPACE_ENTER
             out << YAML::Key << "name" << YAML::Value << view.name;
             out << YAML::Key << "colorspace" << YAML::Value << view.colorspace;
             if(!view.looks.empty()) out << YAML::Key << "looks" << YAML::Value << view.looks;
+            if(!view.description.empty()) out << YAML::Key << "description" << YAML::Value << YAML::DoubleQuoted << view.description;
             out << YAML::EndMap;
         }
         
@@ -1538,7 +1544,9 @@ OCIO_NAMESPACE_ENTER
                             View view;
                             load(dsecond[i], view);
                             c->addDisplay(display.c_str(), view.name.c_str(),
-                                          view.colorspace.c_str(), view.looks.c_str());
+                                          view.colorspace.c_str(),
+                                          view.looks.c_str(),
+                                          view.description.c_str());
                         }
                     }
                 }
@@ -1723,6 +1731,7 @@ OCIO_NAMESPACE_ENTER
                     dview.colorspace = c->getDisplayColorSpaceName(display, dview.name.c_str());
                     if(c->getDisplayLooks(display, dview.name.c_str()) != NULL)
                         dview.looks = c->getDisplayLooks(display, dview.name.c_str());
+                    dview.description = c->getDisplayDescription(display, dview.name.c_str());
                     save(out, dview);
                 
                 }

--- a/src/jniglue/JNIConfig.cpp
+++ b/src/jniglue/JNIConfig.cpp
@@ -434,17 +434,28 @@ Java_org_OpenColorIO_Config_getDisplayLooks(JNIEnv * env, jobject self, jstring 
     OCIO_JNITRY_EXIT(NULL)
 }
 
-// TODO: seems that 4 string params causes a memory error in the JNI layer?
+JNIEXPORT jstring JNICALL
+Java_org_OpenColorIO_Config_getDisplayDescription(JNIEnv * env, jobject self, jstring display, jstring view)
+{
+    OCIO_JNITRY_ENTER()
+    ConstConfigRcPtr cfg = GetConstJOCIO<ConstConfigRcPtr, ConfigJNI>(env, self);
+    return env->NewStringUTF(cfg->getDisplayDescription(GetJStringValue(env, display)(),
+                                                        GetJStringValue(env, view)()));
+    OCIO_JNITRY_EXIT(NULL)
+}
+
+// TODO: seems that 5 string params causes a memory error in the JNI layer?
 /*
 JNIEXPORT void JNICALL
-Java_org_OpenColorIO_Config_addDisplay(JNIEnv * env, jobject self, jstring display, jstring view, jstring colorSpaceName, jstring looks)
+Java_org_OpenColorIO_Config_addDisplay(JNIEnv * env, jobject self, jstring display, jstring view, jstring colorSpaceName, jstring looks, jstring description)
 {
     OCIO_JNITRY_ENTER()
     ConfigRcPtr cfg = GetEditableJOCIO<ConfigRcPtr, ConfigJNI>(env, self);
     cfg->addDisplay(GetJStringValue(env, display)(),
                     GetJStringValue(env, view)(),
                     GetJStringValue(env, colorSpaceName)(),
-                    GetJStringValue(env, looks)());
+                    GetJStringValue(env, looks)(),
+                    GetJStringValue(env, description)());
     
     OCIO_JNITRY_EXIT()
 }

--- a/src/jniglue/org/OpenColorIO/Config.java
+++ b/src/jniglue/org/OpenColorIO/Config.java
@@ -77,8 +77,9 @@ public class Config extends LoadLibrary
     public native String getView(String display, int index);
     public native String getDisplayColorSpaceName(String display, String view);
     public native String getDisplayLooks(String display, String view);
-    // TODO: seems that 4 string params causes a memory error in the JNI layer?
-    // public native void addDisplay(String display, String view, String colorSpaceName, int looks);
+    public native String getDisplayDescription(String display, String view);
+    // TODO: seems that 5 string params causes a memory error in the JNI layer?
+    // public native void addDisplay(String display, String view, String colorSpaceName, String looks, String description);
     public native void clearDisplays();
     public native void setActiveDisplays(String displays);
     public native String getActiveDisplays();

--- a/src/jniglue/tests/org/OpenColorIO/ConfigTest.java
+++ b/src/jniglue/tests/org/OpenColorIO/ConfigTest.java
@@ -18,7 +18,7 @@ public class ConfigTest extends TestCase {
     + "\n"
     + "displays:\n"
     + "  sRGB:\n"
-    + "    - !<View> {name: Film1D, colorspace: vd8}\n"
+    + "    - !<View> {name: Film1D, colorspace: vd8, description: \"sRGB->vd8\"}\n"
     + "    - !<View> {name: Raw, colorspace: raw}\n"
     + "\n"
     + "active_displays: []\n"
@@ -143,6 +143,7 @@ public class ConfigTest extends TestCase {
         assertEquals("Raw", _cfge.getView("sRGB", 1));
         assertEquals("vd8", _cfge.getDisplayColorSpaceName("sRGB", "Film1D"));
         assertEquals("", _cfg.getDisplayLooks("sRGB", "Film1D"));
+        assertEquals("sRGB->vd8", _cfg.getDisplayDescription("sRGB", "Film1D"));
         
         // TODO: seems that 4 string params causes a memory error in the JNI layer?
         //_cfge.addDisplay("foo", "bar", "foo", 0);

--- a/src/pyglue/DocStrings/Config.py
+++ b/src/pyglue/DocStrings/Config.py
@@ -415,9 +415,25 @@ class Config:
         """
         pass
     
-    def addDisplay(self, display, view, csname, looks=None):
+    def getDisplayDescription(self, display, view):
         """
-        addDisplay(display, view, colorSpaceName[, looks])
+        getDisplayDescription(display, view)
+        
+        Returns the description corresponding to the display and view
+        combination in :py:class:`PyOpenColorIO.Config`.
+        
+        :param display: display
+        :type display: string
+        :param view: view
+        :type view: string
+        :return: description
+        :rtype: string
+        """
+        pass
+    
+    def addDisplay(self, display, view, csname, looks=None, description=None):
+        """
+        addDisplay(display, view, colorSpaceName[, looks[, description]])
         
         NEEDS WORK
         
@@ -429,6 +445,8 @@ class Config:
         :type colorSpaceName: string
         :param looks: optional
         :type looks: string
+        :param description: optional
+        :type description: string
         """
         pass
 

--- a/src/pyglue/PyConfig.cpp
+++ b/src/pyglue/PyConfig.cpp
@@ -123,6 +123,7 @@ OCIO_NAMESPACE_ENTER
         PyObject * PyOCIO_Config_getViews(PyObject * self, PyObject * args);
         PyObject * PyOCIO_Config_getDisplayColorSpaceName(PyObject * self, PyObject * args);
         PyObject * PyOCIO_Config_getDisplayLooks(PyObject * self, PyObject * args);
+        PyObject * PyOCIO_Config_getDisplayDescription(PyObject * self, PyObject * args);
         PyObject * PyOCIO_Config_addDisplay(PyObject * self, PyObject * args, PyObject * kwargs);
         PyObject * PyOCIO_Config_clearDisplays(PyObject * self);
         PyObject * PyOCIO_Config_setActiveDisplays(PyObject * self, PyObject * args);
@@ -233,6 +234,8 @@ OCIO_NAMESPACE_ENTER
             PyOCIO_Config_getDisplayColorSpaceName, METH_VARARGS, CONFIG_GETDISPLAYCOLORSPACENAME__DOC__ },
             { "getDisplayLooks",
             PyOCIO_Config_getDisplayLooks, METH_VARARGS, CONFIG_GETDISPLAYLOOKS__DOC__ },
+            { "getDisplayDescription",
+            PyOCIO_Config_getDisplayDescription, METH_VARARGS, CONFIG_GETDISPLAYLOOKS__DOC__ },
             { "addDisplay",
             (PyCFunction) PyOCIO_Config_addDisplay, METH_VARARGS|METH_KEYWORDS, CONFIG_ADDDISPLAY__DOC__ },
             { "clearDisplays",
@@ -809,6 +812,18 @@ OCIO_NAMESPACE_ENTER
             OCIO_PYTRY_EXIT(NULL)
         }
         
+        PyObject * PyOCIO_Config_getDisplayDescription(PyObject * self, PyObject * args)
+        {
+            OCIO_PYTRY_ENTER()
+            char* display = 0;
+            char* view = 0;
+            if (!PyArg_ParseTuple(args, "ss:getDisplayDescription",
+                &display, &view)) return NULL;
+            ConstConfigRcPtr config = GetConstConfig(self, true);
+            return PyString_FromString(config->getDisplayDescription(display, view));
+            OCIO_PYTRY_EXIT(NULL)
+        }
+        
         PyObject * PyOCIO_Config_addDisplay(PyObject * self, PyObject * args, PyObject * kwargs)
         {
             OCIO_PYTRY_ENTER()
@@ -817,14 +832,16 @@ OCIO_NAMESPACE_ENTER
             char* view = 0;
             char* colorSpaceName = 0;
             char* looks = 0;
-            const char * kwlist[] = { "display", "view", "colorSpaceName", "looks",  NULL };
-            if (!PyArg_ParseTupleAndKeywords(args, kwargs, "sss|s",
+            char* description = 0;
+            const char * kwlist[] = { "display", "view", "colorSpaceName", "looks", "description", NULL };
+            if (!PyArg_ParseTupleAndKeywords(args, kwargs, "sss|ss",
                 const_cast<char**>(kwlist),
-                &display, &view, &colorSpaceName, &looks))
+                &display, &view, &colorSpaceName, &looks, &description))
                 return 0;
             std::string lookStr;
             if(looks) lookStr = looks;
-            config->addDisplay(display, view, colorSpaceName, lookStr.c_str());
+            config->addDisplay(display, view, colorSpaceName, lookStr.c_str(),
+                               description);
             Py_RETURN_NONE;
             OCIO_PYTRY_EXIT(NULL)
         }

--- a/src/pyglue/tests/ConfigTest.py
+++ b/src/pyglue/tests/ConfigTest.py
@@ -17,7 +17,7 @@ roles:
 
 displays:
   sRGB:
-    - !<View> {name: Film1D, colorspace: vd8}
+    - !<View> {name: Film1D, colorspace: vd8, description: "sRGB->vd8"}
     - !<View> {name: Raw, colorspace: raw}
 
 active_displays: []
@@ -157,7 +157,8 @@ return out_pixel;
         self.assertEqual("Raw", _cfge.getView("sRGB", 1))
         self.assertEqual("vd8", _cfge.getDisplayColorSpaceName("sRGB", "Film1D"))
         self.assertEqual("", _cfg.getDisplayLooks("sRGB", "Film1D"))
-        _cfge.addDisplay("foo", "bar", "foo", "wee")
+        self.assertEqual("sRGB->vd8", _cfg.getDisplayDescription("sRGB", "Film1D"))
+        _cfge.addDisplay("foo", "bar", "foo", "wee", "woop")
         _cfge.clearDisplays()
         _cfge.setActiveDisplays("sRGB")
         self.assertEqual("sRGB", _cfge.getActiveDisplays())


### PR DESCRIPTION
To be consistent with other objects a description field was added to a display/view combination.  The description field could be used in an UI for pop up help.

It follows in the style of the current API with a new method getDisplayDescription(const char *display, const char *view) method added to the Config object.  A second overloaded addDisplay method was added with a description parameter instead of making a description parameter with a default value.  This should ensure binary compatibility with the current library.
