### PR TITLE
OCIOYaml: Fixed use of freed const char * on RHS of assignments - issue365

### DIFF
--- a/src/core/OCIOYaml.cpp
+++ b/src/core/OCIOYaml.cpp
@@ -1546,15 +1546,15 @@ OCIO_NAMESPACE_ENTER
                 {
                     std::vector<std::string> display;
                     load(second, display);
-                    const char* displays = JoinStringEnvStyle(display).c_str();
-                    c->setActiveDisplays(displays);
+                    std::string displays = JoinStringEnvStyle(display);
+                    c->setActiveDisplays(displays.c_str());
                 }
                 else if(key == "active_views")
                 {
                     std::vector<std::string> view;
                     load(second, view);
-                    const char* views = JoinStringEnvStyle(view).c_str();
-                    c->setActiveViews(views);
+                    std::string views = JoinStringEnvStyle(view);
+                    c->setActiveViews(views.c_str());
                 }
                 else if(key == "colorspaces")
                 {


### PR DESCRIPTION
Inside OCIOYaml.cpp, there are a few places where the result of std::string::c_str() are stored in a const char *, but the string itself is on the right hand side of the assignment, meaning that it is instantly destructed and the pointer is now looking at freed memory.

This patch fixes these issues.
