### PR TITLE
Fix issue where loading profiles with yaml-cpp 0.5.x would crash.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,15 +202,44 @@ if(USE_EXTERNAL_YAML)
     # Set minimum yaml version for non-patched sources.
     set(YAML_VERSION_MIN "0.3.0")
     include(FindPkgConfig)
-    pkg_check_modules(YAML_CPP yaml-cpp)
+    pkg_check_modules(PC_YAML_CPP REQUIRED QUIET yaml-cpp)
+    find_path(YAML_CPP_INCLUDE_DIR yaml-cpp/yaml.h
+        HINTS  ${PC_YAML_CPP_INCLUDEDIR} ${PC_YAML_CPP_INCLUDE_DIRS} )
+    find_library(YAML_CPP_LIBRARY LIBRARY_NAMES yaml-cpp libyaml-cpp
+        HINTS ${PC_YAML_CPP_LIBRARY_DIRS} )
+    set(YAML_CPP_LIBRARIES ${YAML_CPP_LIBRARY})
+    set(YAML_CPP_INCLUDE_DIRS ${YAML_CPP_INCLUDE_DIR})
+    set(YAML_CPP_VERSION ${PC_YAML_CPP_VERSION})
+
+    if(YAML_CPP_VERSION VERSION_LESS ${YAML_VERSION_MIN})
+        message(FATAL_ERROR "ERROR: yaml-cpp ${YAML_VERSION_MIN} or greater is required.")
+    endif()
+
+    find_package_handle_standard_args(yaml-cpp
+                                      REQUIRED_VARS YAML_CPP_LIBRARIES YAML_CPP_INCLUDE_DIRS )
+    set(YAML_CPP_FOUND ${YAML-CPP_FOUND})
+    mark_as_advanced(YAML_CPP_INCLUDE_DIR YAML_CPP_LIBRARY YAML-CPP_FOUND)
+
     if(YAML_CPP_FOUND)
-        if(YAML_CPP_VERSION VERSION_EQUAL ${YAML_VERSION_MIN} OR
-           YAML_CPP_VERSION VERSION_GREATER ${YAML_VERSION_MIN})
-            message(STATUS "System yaml-cpp library will be used.")
-            include_directories(BEFORE ${YAML_CPP_INCLUDE_DIRS})
-        else()
-            message(FATAL_ERROR "ERROR: yaml-cpp ${YAML_VERSION_MIN} or greater is required.")
+        if(YAML_CPP_VERSION VERSION_GREATER "0.5.0")
+            # Need to also get the boost headers here, as yaml-cpp 0.5.0+ requires them.
+            # Don't bother doing this step if we are already including the boost headers for shared_ptr
+            if(NOT OCIO_USE_BOOST_PTR)
+                set(Boost_ADDITIONAL_VERSIONS "1.49" "1.45" "1.44" "1.43" "1.43.0" "1.42"
+                                              "1.42.0" "1.41" "1.41.0" "1.40"
+                                              "1.40.0" "1.39" "1.39.0" "1.38"
+                                              "1.38.0" "1.37" "1.37.0" "1.34.1"
+                                              "1_34_1")
+                set(Boost_USE_MULTITHREADED ON)
+                find_package(Boost 1.34)
+                if(NOT Boost_FOUND)
+                    message(FATAL_ERROR "Error: Detected system yaml-cpp version ${YAML_CPP_VERSION} is greater than 0.5.0, and therefore requires boost, but a boost installation could not be found.")
+                endif()
+
+                set(EXTERNAL_INCLUDE_DIRS ${EXTERNAL_INCLUDE_DIRS} ${Boost_INCLUDE_DIR})
+            endif()
         endif()
+        set(EXTERNAL_INCLUDE_DIRS ${EXTERNAL_INCLUDE_DIRS} ${YAML_CPP_INCLUDE_DIRS})
     else(YAML_CPP_FOUND)
         message(FATAL_ERROR "ERROR: System yaml-cpp library was not found. Make sure the library is installed and the pkg-config file exists.")
     endif(YAML_CPP_FOUND)

--- a/src/core/OCIOYaml.cpp
+++ b/src/core/OCIOYaml.cpp
@@ -88,26 +88,36 @@ OCIO_NAMESPACE_ENTER
 #else
         typedef YAML::const_iterator Iterator;
 #endif
-        
+
         // Iterator access
-        
-        inline const YAML::Node& get_first(const Iterator it)
-        {
+        // Note: The ownership semantics have changed between yaml-cpp 0.3.x and 0.5.x .
+        // Returning a const reference to a yaml node screws with the internal yaml-cpp smart ptr 
+        // implementation in the newer version. Luckily, the compiler does not care if we maintain
+        // const YAML::Node & = get_first(iter) syntax at the call site even when returning an actual object
+        // (instead of the reference as expected).
 #ifdef OLDYAML
+        inline const YAML::Node& get_first(const Iterator &it)
+        {
             return it.first();
-#else
-            return it->first;
-#endif
         }
-        
-        inline const YAML::Node& get_second(const Iterator it)
+#else
+        inline YAML::Node get_first(const Iterator &it)
         {
-#ifdef OLDYAML
-            return it.second();
-#else
-            return it->second;
-#endif
+            return it->first;
         }
+#endif
+        
+#ifdef OLDYAML
+        inline const YAML::Node& get_second(const Iterator &it)
+        {
+            return it.second();
+        }
+#else
+        inline YAML::Node get_second(const Iterator &it)
+        {
+            return it->second;
+        }
+#endif
         
         // Basic types
         


### PR DESCRIPTION
There seemed to be a bug when using yaml-cpp 0.5.x. At some point, the code was returning a reference to a temporary object, causing the yaml parser to crash.

This was noticed by the Krita maintainers when using the default internal Raw profile.

Along with this fix, I have improved the CMake code for detecting the system yaml version, as well as adding a check for the relevant boost headers (which yaml-cpp 0.5.x+ requires).
