### PR TITLE
ParseUtils: Strip trailing carriage return in nextline

### DIFF
--- a/src/core/ParseUtils.cpp
+++ b/src/core/ParseUtils.cpp
@@ -359,6 +359,10 @@ OCIO_NAMESPACE_ENTER
         while ( istream.good() )
         {
             std::getline(istream, line);
+            if(line.size() > 0 && line[line.size() - 1] == '\r')
+            {
+                line.resize(line.size() - 1);
+            }
             if(!pystring::strip(line).empty())
             {
                 return true;


### PR DESCRIPTION
This addresses an issue reading LUT files that contain Windows-style line endings. As discussed in the issue thread (#372), this is the "Really Specific Fix" that explicitly checks for a single trailing carriage return after the call to `std::getline`.

I've tested and confirmed that this allows files with Windows line endings to be read by loading a CSP LUT file that contains them using the Python bindings directly (including creating a processor), and also using the `OCIOFileTransform` node in Nuke 8.0v5 (by replacing `libOpenColorIO.so`, `PyOpenColorIO.so`, and all of the Nuke plugin libraries with those built against my bugfix branch).
