### PR TITLE
Write full precision of float to config file

### DIFF
--- a/ext/yaml-cpp-0.5.1.patch
+++ b/ext/yaml-cpp-0.5.1.patch
@@ -10,3 +10,24 @@ diff -Naur yaml-cpp-0.5.1.orig/CMakeLists.txt yaml-cpp-0.5.1/CMakeLists.txt
  	#
  	add_custom_target(debuggable $(MAKE) clean
  		COMMAND ${CMAKE_COMMAND} -DCMAKE_BUILD_TYPE=Debug ${CMAKE_SOURCE_DIR}
+
+--- src/emitterstate.cpp-orig	2015-01-30 13:53:26.468688052 +0000
++++ src/emitterstate.cpp	2015-01-30 13:53:33.507624388 +0000
+@@ -267,7 +267,7 @@
+ 
+     bool EmitterState::SetFloatPrecision(int value, FMT_SCOPE scope)
+     {
+-        if(value < 0 || value > std::numeric_limits<float>::digits10)
++        if(value < 0 || value > (2 + std::numeric_limits<float>::digits * 3010/10000))
+             return false;
+         _Set(m_floatPrecision, value, scope);
+         return true;
+@@ -275,7 +275,7 @@
+     
+     bool EmitterState::SetDoublePrecision(int value, FMT_SCOPE scope)
+     {
+-        if(value < 0 || value > std::numeric_limits<double>::digits10)
++        if(value < 0 || value > (2 + std::numeric_limits<double>::digits * 3010/10000))
+             return false;
+         _Set(m_doublePrecision, value, scope);
+         return true;

--- a/src/core/OCIOYaml.cpp
+++ b/src/core/OCIOYaml.cpp
@@ -1663,6 +1663,8 @@ OCIO_NAMESPACE_ENTER
         
         inline void save(YAML::Emitter& out, const Config* c)
         {
+            out.SetFloatPrecision(2 + std::numeric_limits<float>::digits * 3010/10000);
+            out.SetDoublePrecision(2 + std::numeric_limits<double>::digits * 3010/10000);
             out << YAML::Block;
             out << YAML::BeginMap;
             out << YAML::Key << "ocio_profile_version" << YAML::Value << 1;

--- a/src/core/ParseUtils.cpp
+++ b/src/core/ParseUtils.cpp
@@ -29,6 +29,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 #include <set>
 #include <sstream>
+#include <limits>
 
 #include <OpenColorIO/OpenColorIO.h>
 
@@ -247,8 +248,8 @@ OCIO_NAMESPACE_ENTER
     
     namespace
     {
-        const int FLOAT_DECIMALS = 7;
-        const int DOUBLE_DECIMALS = 16;
+        const int FLOAT_DECIMALS = 2 + std::numeric_limits<float>::digits * 3010/10000;
+        const int DOUBLE_DECIMALS = 2 + std::numeric_limits<double>::digits * 3010/10000;;
     }
     
     std::string FloatToString(float value)


### PR DESCRIPTION
As this depends on the patch to the yaml code, consider this proof of concept, rather than fully mergable (although it should work).

This avoids issues when (re)writing config files and drifting floating point numbers due to the required precision to exactly store floating point numbers.

For details see http://www2.open-std.org/JTC1/SC22/WG21/docs/papers/2005/n1822.pdf

I have reported the yaml-cpp bug upstream (https://code.google.com/p/yaml-cpp/issues/detail?id=272)
