### PR TITLE
Make it possible to build OpenColorIO for Windows on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,7 +310,7 @@ endif()
 messageonce("SSE Optimizations: ${OCIO_USE_SSE}")
 
 if(OCIO_USE_SSE)
-    if(WIN32)
+    if(MSVC)
         # SSE instructions are automatically compiled into 64-bit applications so enabling the option is redundant and
         # actually produces an unknown option warning in Visual Studio.
         if(NOT CMAKE_CL_64)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,12 @@ if(NOT DEFINED CMAKE_FIRST_RUN)
     SET(CMAKE_FIRST_RUN 1 CACHE INTERNAL "")
 endif()
 
+if (MSVC)
+    set(PATCH myptch)
+else()
+    set(PATCH patch)
+endif ()
+
 ###############################################################################
 ### GLOBAL ###
 
@@ -183,12 +189,12 @@ else(USE_EXTERNAL_TINYXML)
     endif()
     ExternalProject_Add(tinyxml
         URL ${CMAKE_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.tar.gz
-        PATCH_COMMAND patch -f -p1 < ${CMAKE_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.patch
+        PATCH_COMMAND ${PATCH} --binary -f -p1 < ${CMAKE_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.patch
         BINARY_DIR ext/build/tinyxml
         INSTALL_DIR ext/dist
         CMAKE_ARGS ${TINYXML_CMAKE_ARGS}
     )
-    if(WIN32)
+    if(MSVC)
         set(TINYXML_STATIC_LIBRARIES ${PROJECT_BINARY_DIR}/ext/dist/lib/tinyxml.lib)
     else()
         set(TINYXML_STATIC_LIBRARIES ${PROJECT_BINARY_DIR}/ext/dist/lib/libtinyxml.a)
@@ -252,13 +258,13 @@ else(USE_EXTERNAL_YAML)
     ExternalProject_Add(YAML_CPP_LOCAL
         URL ${CMAKE_SOURCE_DIR}/ext/yaml-cpp-${YAML_CPP_VERSION}.tar.gz
         BINARY_DIR ext/build/yaml-cpp
-        PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/ext/yaml-cpp-${YAML_CPP_VERSION}.patch
+        PATCH_COMMAND ${PATCH} --binary -p1 < ${CMAKE_SOURCE_DIR}/ext/yaml-cpp-${YAML_CPP_VERSION}.patch
         INSTALL_DIR ext/dist
         CMAKE_ARGS ${YAML_CPP_CMAKE_ARGS}
     )
     set(YAML_CPP_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ext/dist/include)
     set(YAML_CPP_LIBRARY_DIRS ${PROJECT_BINARY_DIR}/ext/dist/lib)
-    if(WIN32)
+    if(MSVC)
         set(YAML_CPP_STATIC_DEBUG_LIBRARIES ${PROJECT_BINARY_DIR}/ext/dist/lib/libyaml-cppmdd.lib)
         set(YAML_CPP_STATIC_OPTIMIZED_LIBRARIES ${PROJECT_BINARY_DIR}/ext/dist/lib/libyaml-cppmd.lib)
     else()

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -55,7 +55,7 @@ set(SPHINX_VERSION 1.2b3)
 ExternalProject_Add(Sphinx
     DEPENDS setuptools docutils Jinja2 Pygments
     URL ${CMAKE_SOURCE_DIR}/ext/Sphinx-${SPHINX_VERSION}.tar.gz
-    PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/ext/Sphinx-${SPHINX_VERSION}.patch
+    PATCH_COMMAND patch --binary -p1 < ${CMAKE_SOURCE_DIR}/ext/Sphinx-${SPHINX_VERSION}.patch
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND ${CMAKE_COMMAND} -E make_directory ${EXTDIST_PYTHONPATH}
     BUILD_COMMAND PYTHONPATH=${PYTHONPATH} ${PYTHON} setup.py build

--- a/src/core/Platform.h
+++ b/src/core/Platform.h
@@ -75,7 +75,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #define NOMINMAX 1
 
 // windows - defined for both Win32 and Win64
-#include <Windows.h>
+#include <windows.h>
 #include <malloc.h>
 #include <io.h>
 #include <tchar.h> 


### PR DESCRIPTION
With this patch, it's possible to use the mingw cross-compile toolchain to build opencolorio on Linux for Windows: the #include <Windows.h> becomes #include <windows.h>, all the places where if (WIN32) was used but if (MSVC) was meant are fixed. And on Windows itself, use myptch.exe as a patch command instead of the blocked patch.exe
