### PR TITLE
Added configurable delimiters support to Config object

### DIFF
--- a/export/OpenColorIO/OpenColorIO.h
+++ b/export/OpenColorIO/OpenColorIO.h
@@ -341,6 +341,26 @@ OCIO_NAMESPACE_ENTER
         //!cpp:function::
         void setStrictParsingEnabled(bool enabled);
         
+        //!cpp:function:: Returns the number of string delimiters that are
+        // defined
+        int getNumDelimiters() const;
+        //!cpp:function:: Returns the string delimiter at index
+        // .. note::
+        //    This will return null if the specified index is not found.
+        const char * getDelimiterByIndex(int index) const;
+        //!cpp:function:: Add a string delimiter to the config
+        void addDelimiters(const char * str);
+        //!cpp:function:: Remove all the defined delimiters
+        void clearDelimiters();
+        
+        //!cpp:function:: Returns true if str contains the token which is
+        // surrounded by one of the defined delimiters. This function
+        // searches for tokens right to left.
+        // .. note::
+        //    This will also return true for a str that has the token as a
+        //    suffix eg. mystring<delimiter><token>
+        bool containsToken(const char * str, const char * token) const;
+        
         ///////////////////////////////////////////////////////////////////////////
         //!rst:: .. _cfgroles_section:
         // 

--- a/src/core/OCIOYaml.cpp
+++ b/src/core/OCIOYaml.cpp
@@ -1504,6 +1504,20 @@ OCIO_NAMESPACE_ENTER
                     load(second, boolval);
                     c->setStrictParsingEnabled(boolval);
                 }
+                else if(key == "delimiters")
+                {
+                    if(second.Type() != YAML::NodeType::Sequence)
+                    {
+                        std::ostringstream os;
+                        os << "'delimiters' field needs to be a list.";
+                        throw Exception(os.str().c_str());
+                    }
+                    for(unsigned i = 0; i < second.size(); ++i)
+                    {
+                        load(second[i], stringval);
+                        c->addDelimiters(stringval.c_str());
+                    }
+                }
                 else if(key == "description")
                 {
                     load(second, stringval);
@@ -1698,6 +1712,15 @@ OCIO_NAMESPACE_ENTER
             }
             out << YAML::Key << "search_path" << YAML::Value << c->getSearchPath();
             out << YAML::Key << "strictparsing" << YAML::Value << c->isStrictParsingEnabled();
+            
+            if(c->getNumDelimiters() > 0)
+            {
+                out << YAML::Key << "delimiters";
+                out << YAML::Value << YAML::Flow << YAML::BeginSeq;
+                for(unsigned i = 0; i < c->getNumDelimiters(); ++i)
+                    out << c->getDelimiterByIndex(i);
+                out << YAML::EndSeq;
+            }
             
             std::vector<float> luma(3, 0.f);
             c->getDefaultLumaCoefs(&luma[0]);

--- a/src/core/TruelightTransform.cpp
+++ b/src/core/TruelightTransform.cpp
@@ -326,6 +326,7 @@ OIIO_ADD_TEST(TruelightTransform, simpletest)
     "\n"
     "search_path: \"\"\n"
     "strictparsing: true\n"
+    "delimiters: [-, _, /, \\, .]\n"
     "luma: [0.2126, 0.7152, 0.0722]\n"
     "\n"
     "roles:\n"

--- a/src/jniglue/JNIConfig.cpp
+++ b/src/jniglue/JNIConfig.cpp
@@ -182,7 +182,8 @@ Java_org_OpenColorIO_Config_getEnvironmentVarNameByIndex(JNIEnv * env, jobject s
 {
     OCIO_JNITRY_ENTER()
     ConstConfigRcPtr cfg = GetConstJOCIO<ConstConfigRcPtr, ConfigJNI>(env, self);
-    return env->NewStringUTF(cfg->getEnvironmentVarNameByIndex((int)index));
+    std::string name = cfg->getEnvironmentVarNameByIndex((int)index);
+    return env->NewStringUTF(name.c_str());
     OCIO_JNITRY_EXIT(NULL)
 }
 
@@ -191,7 +192,8 @@ Java_org_OpenColorIO_Config_getEnvironmentVarDefault(JNIEnv * env, jobject self,
 {
     OCIO_JNITRY_ENTER()
     ConstConfigRcPtr cfg = GetConstJOCIO<ConstConfigRcPtr, ConfigJNI>(env, self);
-    return env->NewStringUTF(cfg->getEnvironmentVarDefault(GetJStringValue(env, name)()));
+    std::string var = cfg->getEnvironmentVarDefault(GetJStringValue(env, name)());
+    return env->NewStringUTF(var.c_str());
     OCIO_JNITRY_EXIT(NULL)
 }
 
@@ -324,6 +326,52 @@ Java_org_OpenColorIO_Config_setStrictParsingEnabled(JNIEnv * env, jobject self, 
     OCIO_JNITRY_EXIT()
 }
 
+JNIEXPORT jint JNICALL
+Java_org_OpenColorIO_Config_getNumDelimiters(JNIEnv * env, jobject self)
+{
+    OCIO_JNITRY_ENTER()
+    ConstConfigRcPtr cfg = GetConstJOCIO<ConstConfigRcPtr, ConfigJNI>(env, self);
+    return (jint)cfg->getNumDelimiters();
+    OCIO_JNITRY_EXIT(0)
+}
+
+JNIEXPORT jstring JNICALL
+Java_org_OpenColorIO_Config_getDelimiterByIndex(JNIEnv * env, jobject self, jint index)
+{
+    OCIO_JNITRY_ENTER()
+    ConstConfigRcPtr cfg = GetConstJOCIO<ConstConfigRcPtr, ConfigJNI>(env, self);
+    return env->NewStringUTF(cfg->getDelimiterByIndex((int)index));
+    OCIO_JNITRY_EXIT(NULL)
+}
+
+JNIEXPORT void JNICALL
+Java_org_OpenColorIO_Config_addDelimiters(JNIEnv * env, jobject self, jstring str)
+{
+    OCIO_JNITRY_ENTER()
+    ConfigRcPtr cfg = GetEditableJOCIO<ConfigRcPtr, ConfigJNI>(env, self);
+    cfg->addDelimiters(GetJStringValue(env, str)());
+    OCIO_JNITRY_EXIT()
+}
+
+JNIEXPORT void JNICALL
+Java_org_OpenColorIO_Config_clearDelimiters(JNIEnv * env, jobject self)
+{
+    OCIO_JNITRY_ENTER()
+    ConfigRcPtr cfg = GetEditableJOCIO<ConfigRcPtr, ConfigJNI>(env, self);
+    cfg->clearDelimiters();
+    OCIO_JNITRY_EXIT()
+}
+
+JNIEXPORT jboolean JNICALL
+Java_org_OpenColorIO_Config_containsToken(JNIEnv * env, jobject self, jstring str, jstring token)
+{
+    OCIO_JNITRY_ENTER()
+    ConstConfigRcPtr cfg = GetConstJOCIO<ConstConfigRcPtr, ConfigJNI>(env, self);
+    return (jboolean)cfg->containsToken(GetJStringValue(env, str)(),
+                                        GetJStringValue(env, token)());
+    OCIO_JNITRY_EXIT(false)
+}
+
 JNIEXPORT void JNICALL
 Java_org_OpenColorIO_Config_setRole(JNIEnv * env, jobject self, jstring role, jstring colorSpaceName)
 {
@@ -434,8 +482,6 @@ Java_org_OpenColorIO_Config_getDisplayLooks(JNIEnv * env, jobject self, jstring 
     OCIO_JNITRY_EXIT(NULL)
 }
 
-// TODO: seems that 4 string params causes a memory error in the JNI layer?
-/*
 JNIEXPORT void JNICALL
 Java_org_OpenColorIO_Config_addDisplay(JNIEnv * env, jobject self, jstring display, jstring view, jstring colorSpaceName, jstring looks)
 {
@@ -445,10 +491,8 @@ Java_org_OpenColorIO_Config_addDisplay(JNIEnv * env, jobject self, jstring displ
                     GetJStringValue(env, view)(),
                     GetJStringValue(env, colorSpaceName)(),
                     GetJStringValue(env, looks)());
-    
     OCIO_JNITRY_EXIT()
 }
-*/
 
 JNIEXPORT void JNICALL
 Java_org_OpenColorIO_Config_clearDisplays(JNIEnv * env, jobject self)

--- a/src/jniglue/org/OpenColorIO/Config.java
+++ b/src/jniglue/org/OpenColorIO/Config.java
@@ -65,6 +65,11 @@ public class Config extends LoadLibrary
     public native String parseColorSpaceFromString(String str);
     public native boolean isStrictParsingEnabled();
     public native void setStrictParsingEnabled(boolean enabled);
+    public native int getNumDelimiters();
+    public native String getDelimiterByIndex(int index);
+    public native void addDelimiters(String str);
+    public native void clearDelimiters();
+    public native boolean containsToken(String str, String token);
     public native void setRole(String role, String colorSpaceName);
     public native int getNumRoles();
     public native boolean hasRole(String role);
@@ -77,8 +82,7 @@ public class Config extends LoadLibrary
     public native String getView(String display, int index);
     public native String getDisplayColorSpaceName(String display, String view);
     public native String getDisplayLooks(String display, String view);
-    // TODO: seems that 4 string params causes a memory error in the JNI layer?
-    // public native void addDisplay(String display, String view, String colorSpaceName, int looks);
+    public native void addDisplay(String display, String view, String colorSpaceName, String looks);
     public native void clearDisplays();
     public native void setActiveDisplays(String displays);
     public native String getActiveDisplays();

--- a/src/jniglue/org/OpenColorIO/EnvironmentMode.java
+++ b/src/jniglue/org/OpenColorIO/EnvironmentMode.java
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2003-2010 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package org.OpenColorIO;
+import org.OpenColorIO.*;
+
+public class EnvironmentMode extends LoadLibrary
+{
+    private final int m_enum;
+    protected EnvironmentMode(int type) { super(); m_enum = type; }
+    public native String toString();
+    public native boolean equals(Object obj);
+    public static final EnvironmentMode
+      ENV_ENVIRONMENT_UNKNOWN = new EnvironmentMode(0);
+    public static final EnvironmentMode
+      ENV_ENVIRONMENT_LOAD_PREDEFINED = new EnvironmentMode(1);
+    public static final EnvironmentMode
+      ENV_ENVIRONMENT_LOAD_ALL = new EnvironmentMode(2);
+}

--- a/src/jniglue/tests/org/OpenColorIO/BakerTest.java
+++ b/src/jniglue/tests/org/OpenColorIO/BakerTest.java
@@ -91,7 +91,7 @@ public class BakerTest extends TestCase {
         assertEquals(2, bakee.getCubeSize());
         String output = bakee.bake();
         assertEquals(EXPECTED_LUT, output);
-        assertEquals(5, bakee.getNumFormats());
+        assertEquals(6, bakee.getNumFormats());
         assertEquals("cinespace", bakee.getFormatNameByIndex(2));
         assertEquals("3dl", bakee.getFormatExtensionByIndex(1));
     }

--- a/src/jniglue/tests/org/OpenColorIO/ConfigTest.java
+++ b/src/jniglue/tests/org/OpenColorIO/ConfigTest.java
@@ -129,6 +129,18 @@ public class ConfigTest extends TestCase {
         if(_cfg.isStrictParsingEnabled()) fail("strict parsing should be off");
         _cfge.setStrictParsingEnabled(true);
         if(!_cfge.isStrictParsingEnabled()) fail("strict parsing should be on");
+        _cfge.clearDelimiters();
+        assertEquals(_cfge.getNumDelimiters(), 0);
+        _cfge.addDelimiters("-");
+        _cfge.addDelimiters("__");
+        assertEquals(_cfge.getNumDelimiters(), 2);
+        assertEquals(_cfge.containsToken("footestfoo", "test"), false);
+        assertEquals(_cfge.containsToken("foo-test-foo", "test"), true);
+        assertEquals(_cfge.containsToken("foo__test__foo", "test"), true);
+        assertEquals(_cfge.containsToken("foobar-test", "test"), true);
+        assertEquals(_cfge.containsToken("foobar__test", "test"), true);
+        _cfge.clearDelimiters();
+        assertEquals(_cfge.getNumDelimiters(), 0);
         assertEquals(2, _cfge.getNumRoles());
         if(_cfg.hasRole("foo")) fail("shouldn't have role foo");
         _cfge.setRole("foo", "dfadfadf");
@@ -143,10 +155,7 @@ public class ConfigTest extends TestCase {
         assertEquals("Raw", _cfge.getView("sRGB", 1));
         assertEquals("vd8", _cfge.getDisplayColorSpaceName("sRGB", "Film1D"));
         assertEquals("", _cfg.getDisplayLooks("sRGB", "Film1D"));
-        
-        // TODO: seems that 4 string params causes a memory error in the JNI layer?
-        //_cfge.addDisplay("foo", "bar", "foo", 0);
-        
+        _cfge.addDisplay("foo", "bar", "foo", "wee");
         _cfge.clearDisplays();
         _cfge.setActiveDisplays("sRGB");
         assertEquals("sRGB", _cfge.getActiveDisplays());

--- a/src/jniglue/tests/org/OpenColorIO/GlobalsTest.java
+++ b/src/jniglue/tests/org/OpenColorIO/GlobalsTest.java
@@ -9,6 +9,7 @@ public class GlobalsTest extends TestCase {
     + "\n"
     + "search_path: \"\"\n"
     + "strictparsing: false\n"
+    + "delimiters: [-, _, /, \\, .]\n"
     + "luma: [0.2126, 0.7152, 0.0722]\n"
     + "\n"
     + "roles:\n"

--- a/src/jniglue/tests/org/OpenColorIO/TransformsTest.java
+++ b/src/jniglue/tests/org/OpenColorIO/TransformsTest.java
@@ -135,7 +135,7 @@ public class TransformsTest extends TestCase {
         assertEquals("foobar", ft.getCCCId());
         ft.setInterpolation(Interpolation.INTERP_NEAREST);
         assertEquals(Interpolation.INTERP_NEAREST, ft.getInterpolation());
-        assertEquals(16, ft.getNumFormats());
+        assertEquals(17, ft.getNumFormats());
         assertEquals("flame", ft.getFormatNameByIndex(0));
         assertEquals("3dl", ft.getFormatExtensionByIndex(0));
         

--- a/src/pyglue/DocStrings/Config.py
+++ b/src/pyglue/DocStrings/Config.py
@@ -299,6 +299,67 @@ class Config:
     def setStrictParsingEnabled(self, enable):
         pass
 
+    def getNumDelimiters(self):
+        """
+        getNumDelimiters()
+        
+        Returns the number of string delimiters that are defined
+        """
+        pass
+
+    def getDelimiterByIndex(self, index):
+        """
+        getDelimiterByIndex(index)
+        
+        Returns the string delimiter at index.
+        
+        :param index: the delimiter index
+        :type index: int
+        
+        .. note::
+           This will return None if the specified index is not found
+        """
+        pass
+
+    def addDelimiters(self, str):
+        """
+        addDelimiters()
+        
+        Add a string delimiter to the config
+        
+        :param str: the delimiter token
+        :type str: string
+        """
+        pass
+
+    def clearDelimiters(self):
+        """
+        clearDelimiters()
+        
+        Remove all the defined delimiters
+        """
+        pass
+
+    def containsToken(self, str, token):
+        """
+        containsToken(token, str)
+        
+        Returns true if str contains the token which is surrounded by one of
+        the defined delimiters. This function searches for tokens right to
+        left.
+        
+        .. note::
+           This will also return true for a str that has the token as a suffix
+           eg. mystring<delimiter><token>
+        
+        :param str: the string to check
+        :type str: string
+        :param token: the token to search for
+        :type token: string
+        :return: if the token exists
+        :rtype: bool
+        """
+
     def setRole(self, role, csname):
         """
         setRole(role, csname)

--- a/src/pyglue/PyConfig.cpp
+++ b/src/pyglue/PyConfig.cpp
@@ -110,6 +110,11 @@ OCIO_NAMESPACE_ENTER
         PyObject * PyOCIO_Config_parseColorSpaceFromString(PyObject * self, PyObject * args);
         PyObject * PyOCIO_Config_isStrictParsingEnabled(PyObject * self);
         PyObject * PyOCIO_Config_setStrictParsingEnabled(PyObject * self, PyObject * args);
+        PyObject * PyOCIO_Config_getNumDelimiters(PyObject * self);
+        PyObject * PyOCIO_Config_getDelimiterByIndex(PyObject * self, PyObject * args);
+        PyObject * PyOCIO_Config_addDelimiters(PyObject * self, PyObject * args);
+        PyObject * PyOCIO_Config_clearDelimiters(PyObject * self);
+        PyObject * PyOCIO_Config_containsToken(PyObject * self, PyObject * args);
         PyObject * PyOCIO_Config_setRole(PyObject * self, PyObject * args);
         PyObject * PyOCIO_Config_getNumRoles(PyObject * self);
         PyObject * PyOCIO_Config_hasRole(PyObject * self, PyObject * args);
@@ -206,6 +211,16 @@ OCIO_NAMESPACE_ENTER
             (PyCFunction) PyOCIO_Config_isStrictParsingEnabled, METH_NOARGS, CONFIG_ISSTRICTPARSINGENABLED__DOC__ },
             { "setStrictParsingEnabled",
             PyOCIO_Config_setStrictParsingEnabled, METH_VARARGS, CONFIG_SETSTRICTPARSINGENABLED__DOC__ },
+            { "getNumDelimiters",
+            (PyCFunction) PyOCIO_Config_getNumDelimiters, METH_NOARGS, CONFIG_GETNUMDELIMITERS__DOC__ },
+            { "getDelimiterByIndex",
+            PyOCIO_Config_getDelimiterByIndex, METH_VARARGS, CONFIG_GETDELIMITERBYINDEX__DOC__ },
+            { "addDelimiters",
+            PyOCIO_Config_addDelimiters, METH_VARARGS, CONFIG_ADDDELIMITERS__DOC__ },
+            { "clearDelimiters",
+            (PyCFunction) PyOCIO_Config_clearDelimiters, METH_NOARGS, CONFIG_CLEARDELIMITERS__DOC__ },
+            { "containsToken",
+            PyOCIO_Config_containsToken, METH_VARARGS, CONFIG_CONTAINSTOKEN__DOC__ },
             { "setRole",
             PyOCIO_Config_setRole, METH_VARARGS, CONFIG_SETROLE__DOC__ },
             { "getNumRoles",
@@ -663,6 +678,58 @@ OCIO_NAMESPACE_ENTER
             ConfigRcPtr config = GetEditableConfig(self);
             config->setStrictParsingEnabled(enabled);
             Py_RETURN_NONE;
+            OCIO_PYTRY_EXIT(NULL)
+        }
+        
+        PyObject * PyOCIO_Config_getNumDelimiters(PyObject * self)
+        {
+            OCIO_PYTRY_ENTER()
+            ConstConfigRcPtr config = GetConstConfig(self, true);
+            return PyInt_FromLong(config->getNumDelimiters());
+            OCIO_PYTRY_EXIT(NULL)
+        }
+        
+        PyObject * PyOCIO_Config_getDelimiterByIndex(PyObject * self, PyObject * args)
+        {
+            OCIO_PYTRY_ENTER()
+            int index = 0;
+            if (!PyArg_ParseTuple(args,"i:getDelimiterByIndex",
+                &index)) return NULL;
+            ConstConfigRcPtr config = GetConstConfig(self, true);
+            return PyString_FromString(config->getDelimiterByIndex(index));
+            OCIO_PYTRY_EXIT(NULL)
+        }
+        
+        PyObject * PyOCIO_Config_addDelimiters(PyObject * self, PyObject * args)
+        {
+            OCIO_PYTRY_ENTER()
+            ConfigRcPtr config = GetEditableConfig(self);
+            char* delim = 0;
+            if (!PyArg_ParseTuple(args, "s:addDelimiters",
+                &delim)) return NULL;
+            config->addDelimiters(delim);
+            Py_RETURN_NONE;
+            OCIO_PYTRY_EXIT(NULL)
+        }
+        
+        PyObject * PyOCIO_Config_clearDelimiters(PyObject * self)
+        {
+            OCIO_PYTRY_ENTER()
+            ConfigRcPtr config = GetEditableConfig(self);
+            config->clearDelimiters();
+            Py_RETURN_NONE;
+            OCIO_PYTRY_EXIT(NULL)
+        }
+        
+        PyObject * PyOCIO_Config_containsToken(PyObject * self, PyObject * args)
+        {
+            OCIO_PYTRY_ENTER()
+            char* str = 0;
+            char* token = 0;
+            if (!PyArg_ParseTuple(args, "ss:containsToken",
+                &str, &token)) return NULL;
+            ConstConfigRcPtr config = GetConstConfig(self, true);
+            return PyBool_FromLong(config->containsToken(str, token));
             OCIO_PYTRY_EXIT(NULL)
         }
         

--- a/src/pyglue/tests/ConfigTest.py
+++ b/src/pyglue/tests/ConfigTest.py
@@ -9,6 +9,7 @@ class ConfigTest(unittest.TestCase):
 
 search_path: luts
 strictparsing: false
+delimiters: [-, _, /, \\, .]
 luma: [0.2126, 0.7152, 0.0722]
 
 roles:
@@ -143,6 +144,18 @@ return out_pixel;
         self.assertEqual(False, _cfg.isStrictParsingEnabled())
         _cfge.setStrictParsingEnabled(True)
         self.assertEqual(True, _cfge.isStrictParsingEnabled())
+        _cfge.clearDelimiters()
+        self.assertEqual(_cfge.getNumDelimiters(), 0)
+        _cfge.addDelimiters("-")
+        _cfge.addDelimiters("__")
+        self.assertEqual(_cfge.getNumDelimiters(), 2)
+        self.assertEqual(_cfge.containsToken("footestfoo", "test"), False)
+        self.assertEqual(_cfge.containsToken("foo-test-foo", "test"), True)
+        self.assertEqual(_cfge.containsToken("foo__test__foo", "test"), True)
+        self.assertEqual(_cfge.containsToken("foobar-test", "test"), True)
+        self.assertEqual(_cfge.containsToken("foobar__test", "test"), True)
+        _cfge.clearDelimiters()
+        self.assertEqual(_cfge.getNumDelimiters(), 0)
         self.assertEqual(2, _cfge.getNumRoles())
         self.assertEqual(False, _cfg.hasRole("foo")) 
         _cfge.setRole("foo", "vd8")

--- a/src/pyglue/tests/MainTest.py
+++ b/src/pyglue/tests/MainTest.py
@@ -9,6 +9,7 @@ class MainTest(unittest.TestCase):
 
 search_path: \"\"
 strictparsing: false
+delimiters: [-, _, /, \\, .]
 luma: [0.2126, 0.7152, 0.0722]
 
 roles:


### PR DESCRIPTION
Added configurable delimiters support which is a modified version of #381

@mike1158, @shootfast, @mplec and @lgritz can you take a look also
- What do you think colorspace name should be returned from this string "somefile-Gamma22-ACEScg.exr”? Currently we return the longest right most colorspace name e.g. Gamma22 not ACEScg. This is what the old code looked like it did but maybe now with delimiters it should just be the first delimited colorspace found (ACEScg in this example).
- I have set the default delimiters to be [-, _, /, \, .] what are your thoughts?
- Note. To get the old behaviour you just need to add ‘’ to the delimiters list.

-- CHANGES
- added getNumDelimiters()
- added getDelimiterByIndex()
- added addDelimiters()
- added clearDelimiters()
- added containsToken()
- Set default delimiters  [-, _, /, \, .]
- Updated parseColorSpaceFromString to use containsToken()
- Added unit tests for containsToken() and parseColorSpaceFromString()
- Updated pyglue and jinglue bindings
- Added missing EnvironmentMode.java file
