### PR TITLE
Functions to clear shader header/footer for GpuShaderDesc

### DIFF
--- a/export/OpenColorIO/OpenColorIO.h
+++ b/export/OpenColorIO/OpenColorIO.h
@@ -1379,7 +1379,7 @@ OCIO_NAMESPACE_ENTER
         // .. code-block:: cpp
         //    
         //    // All global declarations
-        //    uniform sampled3D tex3;
+        //    uniform sampler3D tex3;
         //
         //    // All helper methods
         //    vec3 computePosition(vec3 color)
@@ -1404,6 +1404,8 @@ OCIO_NAMESPACE_ENTER
         virtual void addToFunctionHeaderShaderCode(const char * shaderCode) = 0;
         virtual void addToFunctionShaderCode(const char * shaderCode) = 0;
         virtual void addToFunctionFooterShaderCode(const char * shaderCode) = 0;
+        virtual void clearHeaderShaderCode() = 0;
+        virtual void clearFooterShaderCode() = 0;
 
         //!cpp:function:: Create the OCIO shader program
         //

--- a/src/core/GpuShader.cpp
+++ b/src/core/GpuShader.cpp
@@ -443,6 +443,16 @@ OCIO_NAMESPACE_ENTER
         getImpl()->functionFooter += (shaderCode && *shaderCode) ? shaderCode : "";
     }
 
+    void LegacyGpuShaderDesc::clearHeaderShaderCode()
+    {
+        getImpl()->functionHeader.resize(0);
+    }
+
+    void LegacyGpuShaderDesc::clearFooterShaderCode()
+    {
+        getImpl()->functionFooter.resize(0);
+    }
+
     void LegacyGpuShaderDesc::createShaderText(
         const char * shaderDeclarations, const char * shaderHelperMethods,
         const char * shaderFunctionHeader, const char * shaderFunctionBody,
@@ -609,6 +619,17 @@ OCIO_NAMESPACE_ENTER
     void GenericGpuShaderDesc::addToFunctionFooterShaderCode(const char * shaderCode)
     {
         getImpl()->functionFooter += (shaderCode && *shaderCode) ? shaderCode : "";
+    }
+
+
+    void GenericGpuShaderDesc::clearHeaderShaderCode()
+    {
+        getImpl()->functionHeader.resize(0);
+    }
+
+    void GenericGpuShaderDesc::clearFooterShaderCode()
+    {
+        getImpl()->functionFooter.resize(0);
     }
 
     void GenericGpuShaderDesc::createShaderText(

--- a/src/core/GpuShader.h
+++ b/src/core/GpuShader.h
@@ -76,6 +76,8 @@ OCIO_NAMESPACE_ENTER
         void addToFunctionHeaderShaderCode(const char * shaderCode);
         void addToFunctionShaderCode(const char * shaderCode);
         void addToFunctionFooterShaderCode(const char * shaderCode);
+        void clearHeaderShaderCode();
+        void clearFooterShaderCode();
 
         // Method called to build the complete shader program
         void createShaderText(const char * shaderDeclarations,
@@ -186,6 +188,8 @@ OCIO_NAMESPACE_ENTER
         void addToFunctionHeaderShaderCode(const char * shaderCode);
         void addToFunctionShaderCode(const char * shaderCode);
         void addToFunctionFooterShaderCode(const char * shaderCode);
+        void clearHeaderShaderCode();
+        void clearFooterShaderCode();
 
         // Method called to build the complete shader program
         void createShaderText(const char * shaderDeclarations, 

--- a/src/core/Processor.cpp
+++ b/src/core/Processor.cpp
@@ -201,6 +201,16 @@ OCIO_NAMESPACE_ENTER
     
     namespace
     {
+        void ClearShaderHeader(GpuShaderDescRcPtr & shaderDesc)
+        {
+            shaderDesc->clearHeaderShaderCode();
+        }
+
+        void ClearShaderFooter(GpuShaderDescRcPtr & shaderDesc)
+        {
+            shaderDesc->clearFooterShaderCode();
+        }
+
         void WriteShaderHeader(GpuShaderDescRcPtr & shaderDesc)
         {
             const std::string fcnName(shaderDesc->getFunctionName());


### PR DESCRIPTION
This is quite a minor issue but:

I'm using the 2.X.X code as the GPU bonuses are spectacular! Thank you! To save on some performance (real time playback is vital) I was attempting to create the `GpuShaderDesc` only once and just have the different processors rewire the shader code.

*Question*: Should the intention be to just create a shader description for each time we change things up? They are pretty inexpensive after all.

If so we can close this, however, if we should be able to just keep injecting, that's where the glitch arises.
```cpp
    void Processor::Impl::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const
    { ...
        WriteShaderHeader(shaderDesc);
        WriteShaderFooter(shaderDesc);
     .... }
```
We have the tooling inject the shader info but it won't clear the header and footer at any time (but it does seem to clear the other bits). If we try to run `processor->extractGpuShaderInfo(m_shaderDesc);` again, it will contain the header and footer twice.

This is a small change that would add utility functions on the shader descriptor to clear the header and footer. Testing it with the same SD, it's happy to be reused again and again with different processors.

```cpp
// ...
if (!m_shaderDescr)
{
    OCIO::GpuShaderDescRcPtr shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
    shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_GLSL_4_0);
    shaderDesc->setFunctionName("OCIODisplay");
    shaderDesc->setResourcePrefix("ocio_");
    m_shaderDescr = shaderDesc; // Assign the active description
}
m_shaderDescr->clearHeaderShaderCode();
m_shaderDescr->clearFooterShaderCode()
processor->extractGpuShaderInfo(m_shaderDescr);
// ...
```
Totally understand if this is a non issue because it's expected of the dev to create it every time.

Cheers,
McCartney
