### PR TITLE
Update RB-1.1 repo URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ OpenColorIO
 ===========
 
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
-[![Build Status](https://travis-ci.org/imageworks/OpenColorIO.svg?branch=master)](https://travis-ci.org/imageworks/OpenColorIO)
+[![Build Status](https://travis-ci.org/AcademySoftwareFoundation/OpenColorIO.svg?branch=RB-1.1)](https://travis-ci.org/AcademySoftwareFoundation/OpenColorIO)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/fidyv9jkxeigyd2a/branch/master?svg=true)]()
 
 Introduction

--- a/docs/CompatibleSoftware.rst
+++ b/docs/CompatibleSoftware.rst
@@ -20,7 +20,7 @@ After Effects
 An OpenColorIO plugin is available for use in After Effects.
 
 See `src/aftereffects
-<http://github.com/imageworks/OpenColorIO/tree/master/src/aftereffects>`__
+<http://github.com/AcademySoftwareFoundation/OpenColorIO/tree/master/src/aftereffects>`__
 if you are interested in building your own OCIO plugins.
 
 Pre-built binaries are also available for `download
@@ -145,13 +145,13 @@ C++
 
 The core OpenColorIO API is avaiable for use in C++. See the `export
 directory
-<http://github.com/imageworks/OpenColorIO/tree/master/export/OpenColorIO>`__
+<http://github.com/AcademySoftwareFoundation/OpenColorIO/tree/master/export/OpenColorIO>`__
 for the C++ API headers.  Minimal code examples are also available in
 the source code distribution. Of particular note are
 `src/apps/ocioconvert/
-<https://github.com/imageworks/OpenColorIO/tree/master/src/apps/ocioconvert>`__
+<https://github.com/AcademySoftwareFoundation/OpenColorIO/tree/master/src/apps/ocioconvert>`__
 and `src/apps/ociodisplay/
-<https://github.com/imageworks/OpenColorIO/tree/master/src/apps/ociodisplay>`__
+<https://github.com/AcademySoftwareFoundation/OpenColorIO/tree/master/src/apps/ociodisplay>`__
 
 Also see the :ref:`developer-guide`
 
@@ -251,7 +251,7 @@ the OpenColorIO section of the `RV User Manual
 Java (Beta)
 ***********
 The OpenColorIO API is available for use in Java. See the `jniglue directory
-<http://github.com/imageworks/OpenColorIO/tree/master/src/jniglue>`__
+<http://github.com/AcademySoftwareFoundation/OpenColorIO/tree/master/src/jniglue>`__
 in the codebase.
 
 This integration is currently considered a work in progress, and should not be

--- a/docs/CompatibleSoftware.rst
+++ b/docs/CompatibleSoftware.rst
@@ -20,7 +20,7 @@ After Effects
 An OpenColorIO plugin is available for use in After Effects.
 
 See `src/aftereffects
-<http://github.com/AcademySoftwareFoundation/OpenColorIO/tree/master/src/aftereffects>`__
+<http://github.com/AcademySoftwareFoundation/OpenColorIO/tree/RB-1.1/src/aftereffects>`__
 if you are interested in building your own OCIO plugins.
 
 Pre-built binaries are also available for `download
@@ -145,13 +145,13 @@ C++
 
 The core OpenColorIO API is avaiable for use in C++. See the `export
 directory
-<http://github.com/AcademySoftwareFoundation/OpenColorIO/tree/master/export/OpenColorIO>`__
+<http://github.com/AcademySoftwareFoundation/OpenColorIO/tree/RB-1.1/export/OpenColorIO>`__
 for the C++ API headers.  Minimal code examples are also available in
 the source code distribution. Of particular note are
 `src/apps/ocioconvert/
-<https://github.com/AcademySoftwareFoundation/OpenColorIO/tree/master/src/apps/ocioconvert>`__
+<https://github.com/AcademySoftwareFoundation/OpenColorIO/tree/RB-1.1/src/apps/ocioconvert>`__
 and `src/apps/ociodisplay/
-<https://github.com/AcademySoftwareFoundation/OpenColorIO/tree/master/src/apps/ociodisplay>`__
+<https://github.com/AcademySoftwareFoundation/OpenColorIO/tree/RB-1.1/src/apps/ociodisplay>`__
 
 Also see the :ref:`developer-guide`
 
@@ -251,7 +251,7 @@ the OpenColorIO section of the `RV User Manual
 Java (Beta)
 ***********
 The OpenColorIO API is available for use in Java. See the `jniglue directory
-<http://github.com/AcademySoftwareFoundation/OpenColorIO/tree/master/src/jniglue>`__
+<http://github.com/AcademySoftwareFoundation/OpenColorIO/tree/RB-1.1/src/jniglue>`__
 in the codebase.
 
 This integration is currently considered a work in progress, and should not be

--- a/docs/developers/getting_started.rst
+++ b/docs/developers/getting_started.rst
@@ -6,7 +6,7 @@ Getting started
 Checking Out The Codebase
 *************************
 
-The master code repository is available on Github:  http://github.com/imageworks/OpenColorIO
+The master code repository is available on Github: http://github.com/AcademySoftwareFoundation/OpenColorIO
 
 For those unfamiliar with git, the wonderful part about it is that even though
 only a limited number people have write access to the master repository, anyone
@@ -24,11 +24,11 @@ available at: http://help.github.com/
 
 To check out a read-only version of the repository (no GitHub signup required)::
 
-    git clone git://github.com/imageworks/OpenColorIO.git ocio
+    git clone git://github.com/AcademySoftwareFoundation/OpenColorIO.git ocio
 
 For write-access, you must first register for a GitHub account (free).  Then,
 you must create a local fork of the OpenColorIO repository by visiting
-http://github.com/imageworks/OpenColorIO and clicking the "Fork" icon. If you
+http://github.com/AcademySoftwareFoundation/OpenColorIO and clicking the "Fork" icon. If you
 get hung up on this, further instructions on this process are available at
 http://help.github.com/forking/
 
@@ -48,7 +48,7 @@ as a remote. This will allow you to more easily fetch updates as they become
 available::
 
     cd ocio
-    git remote add upstream git://github.com/imageworks/OpenColorIO.git
+    git remote add upstream git://github.com/AcademySoftwareFoundation/OpenColorIO.git
 
 Optionally, you may then add any additional users who have individual working
 forks (just as you've done).  This will allow you to track, view, and

--- a/docs/developers/internal_architecture.rst
+++ b/docs/developers/internal_architecture.rst
@@ -268,7 +268,7 @@ analyze the op-stream metadata and determine the appropriate allocation to use.
 interserting a forward allocation to the end of the pre-ops, and the inverse
 allocation to the start of the lattice ops.
 
-See https://github.com/imageworks/OpenColorIO/blob/master/src/core/NoOps.cpp#L183
+See https://github.com/AcademySoftwareFoundation/OpenColorIO/blob/master/src/core/NoOps.cpp#L183
 
 #. The 3 lists of ops are then optimized individually, and stored on the processor.
 The Lut3d is computed by applying the gpu-lattice ops, on the CPU, to a lut3d

--- a/docs/developers/issues.rst
+++ b/docs/developers/issues.rst
@@ -1,5 +1,5 @@
 Issues
 ======
 
-Please visit http://github.com/imageworks/OpenColorIO/issues for an up to date
+Please visit http://github.com/AcademySoftwareFoundation/OpenColorIO/issues for an up to date
 listing of bugs, feature requests etc

--- a/docs/developers/submitting_changes.rst
+++ b/docs/developers/submitting_changes.rst
@@ -32,15 +32,15 @@ assistance.
 * cd into the cloned directory
 * Connect your cloned repo to the original upstream repository as a remote::
 
-    git remote add upstream https://github.com/imageworks/OpenColorIO.git
+    git remote add upstream https://github.com/AcademySoftwareFoundation/OpenColorIO.git
 
 * You should now have two remotes::
 
     git remote -v
     origin https://github.com/$USER/OpenColorIO (fetch)
     origin https://github.com/$USER/OpenColorIO (fetch)
-    upstream https://github.com/imageworks/OpenColorIO (fetch)
-    upstream https://github.com/imageworks/OpenColorIO (push)
+    upstream https://github.com/AcademySoftwareFoundation/OpenColorIO (fetch)
+    upstream https://github.com/AcademySoftwareFoundation/OpenColorIO (push)
 
 * Pull the latest changes from upstream::
 

--- a/docs/downloads.rst
+++ b/docs/downloads.rst
@@ -5,8 +5,8 @@ Downloads
 
 * Sample OCIO Configurations -- `.zip <http://github.com/imageworks/OpenColorIO-Configs/zipball/master>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO-Configs/tarball/master>`__
 * Reference Images v1.0v4 -- `.tgz <http://code.google.com/p/opencolorio/downloads/detail?name=ocio-images.1.0v4.tgz>`__
-* Core Library v1.0.9 -- `.zip <http://github.com/imageworks/OpenColorIO/zipball/v1.0.9>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO/tarball/v1.0.9>`__
-* Core Library latest -- `.zip <http://github.com/imageworks/OpenColorIO/zipball/master>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO/tarball/master>`__
+* Core Library v1.0.9 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.0.9>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIOtarball/v1.0.9>`__
+* Core Library latest -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/master>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIOtarball/master>`__
 
 Per-version updates: :ref:`changelog-main`.
 
@@ -23,20 +23,20 @@ Deprecated Downloads
 * Reference Images v1.0v2 `tgz <http://code.google.com/p/opencolorio/downloads/detail?name=ocio-images.1.0v2.tgz>`__
 * Reference Images v1.0v1 `tgz <http://code.google.com/p/opencolorio/downloads/detail?name=ocio-images.1.0v1.tgz>`__
 
-* Core Library v1.0.8 -- `.zip <http://github.com/imageworks/OpenColorIO/zipball/v1.0.8>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO/tarball/v1.0.8>`__
-* Core Library v1.0.7 -- `.zip <http://github.com/imageworks/OpenColorIO/zipball/v1.0.7>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO/tarball/v1.0.7>`__
-* Core Library v1.0.6 -- `.zip <http://github.com/imageworks/OpenColorIO/zipball/v1.0.6>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO/tarball/v1.0.6>`__
-* Core Library v1.0.5 -- `.zip <http://github.com/imageworks/OpenColorIO/zipball/v1.0.5>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO/tarball/v1.0.5>`__
-* Core Library v1.0.4 -- `.zip <http://github.com/imageworks/OpenColorIO/zipball/v1.0.4>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO/tarball/v1.0.4>`__
-* Core Library v1.0.3 -- `.zip <http://github.com/imageworks/OpenColorIO/zipball/v1.0.3>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO/tarball/v1.0.3>`__
-* Core Library v1.0.2 -- `.zip <http://github.com/imageworks/OpenColorIO/zipball/v1.0.2>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO/tarball/v1.0.2>`__
-* Core Library v1.0.1 -- `.zip <http://github.com/imageworks/OpenColorIO/zipball/v1.0.1>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO/tarball/v1.0.1>`__
-* Core Library v1.0.0 -- `.zip <http://github.com/imageworks/OpenColorIO/zipball/v1.0.0>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO/tarball/v1.0.0>`__
+* Core Library v1.0.8 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.0.8>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v1.0.8>`__
+* Core Library v1.0.7 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.0.7>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v1.0.7>`__
+* Core Library v1.0.6 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.0.6>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v1.0.6>`__
+* Core Library v1.0.5 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.0.5>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v1.0.5>`__
+* Core Library v1.0.4 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.0.4>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v1.0.4>`__
+* Core Library v1.0.3 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.0.3>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v1.0.3>`__
+* Core Library v1.0.2 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.0.2>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v1.0.2>`__
+* Core Library v1.0.1 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.0.1>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v1.0.1>`__
+* Core Library v1.0.0 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.0.0>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v1.0.0>`__
 
 * Color Config v0.7v4 `tgz <http://code.google.com/p/opencolorio/downloads/detail?name=ocio-configs.0.7v4.tgz>`__ (OCIO v0.7.6+)
-* Core Library v0.8.7 -- `.zip <http://github.com/imageworks/OpenColorIO/zipball/v0.8.7>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO/tarball/v0.8.7>`__
-* Core Library v0.7.9 -- `.zip <http://github.com/imageworks/OpenColorIO/zipball/v0.7.9>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO/tarball/v0.7.9>`__
-* Core Library v0.6.1 -- `.zip <http://github.com/imageworks/OpenColorIO/zipball/v0.6.1>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO/tarball/v0.6.1>`__
-* Core Library v0.5.16 -- `.zip <http://github.com/imageworks/OpenColorIO/zipball/v0.5.16>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO/tarball/v0.5.16>`__
-* Core Library v0.5.8 -- `.zip <http://github.com/imageworks/OpenColorIO/zipball/v0.5.8>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO/tarball/v0.5.8>`__
+* Core Library v0.8.7 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v0.8.7>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v0.8.7>`__
+* Core Library v0.7.9 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v0.7.9>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v0.7.9>`__
+* Core Library v0.6.1 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v0.6.1>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v0.6.1>`__
+* Core Library v0.5.16 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v0.5.16>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v0.5.16>`__
+* Core Library v0.5.8 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v0.5.8>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v0.5.8>`__
 

--- a/docs/downloads.rst
+++ b/docs/downloads.rst
@@ -5,8 +5,8 @@ Downloads
 
 * Sample OCIO Configurations -- `.zip <http://github.com/imageworks/OpenColorIO-Configs/zipball/master>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO-Configs/tarball/master>`__
 * Reference Images v1.0v4 -- `.tgz <http://code.google.com/p/opencolorio/downloads/detail?name=ocio-images.1.0v4.tgz>`__
-* Core Library v1.0.9 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.0.9>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIOtarball/v1.0.9>`__
-* Core Library latest -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/master>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIOtarball/master>`__
+* Core Library v1.0.9 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.0.9>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v1.0.9>`__
+* Core Library latest -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/master>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/master>`__
 
 Per-version updates: :ref:`changelog-main`.
 

--- a/docs/downloads.rst
+++ b/docs/downloads.rst
@@ -5,7 +5,7 @@ Downloads
 
 * Sample OCIO Configurations -- `.zip <http://github.com/imageworks/OpenColorIO-Configs/zipball/master>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO-Configs/tarball/master>`__
 * Reference Images v1.0v4 -- `.tgz <http://code.google.com/p/opencolorio/downloads/detail?name=ocio-images.1.0v4.tgz>`__
-* Core Library v1.0.9 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.0.9>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v1.0.9>`__
+* Core Library v1.1.1 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.1.1>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v1.1.1>`__
 * Core Library latest -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/master>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/master>`__
 
 Per-version updates: :ref:`changelog-main`.
@@ -16,13 +16,16 @@ Build instructions: :ref:`building-from-source`.
 
 Contributor License Agreements
 ******************************
-Please see the `Imageworks Open Source website <http://opensource.imageworks.com/cla/>`__
+Please see the `OCIO GitHub repository <https://github.com/AcademySoftwareFoundation/OpenColorIO/tree/master/docs/aswf>`__
 
 Deprecated Downloads
 ********************
+* Reference Images v1.0v3 `tgz <http://code.google.com/p/opencolorio/downloads/detail?name=ocio-images.1.0v3.tgz>`__
 * Reference Images v1.0v2 `tgz <http://code.google.com/p/opencolorio/downloads/detail?name=ocio-images.1.0v2.tgz>`__
 * Reference Images v1.0v1 `tgz <http://code.google.com/p/opencolorio/downloads/detail?name=ocio-images.1.0v1.tgz>`__
 
+* Core Library v1.1.0 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.1.0>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v1.1.0>`__
+* Core Library v1.0.9 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.0.9>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v1.0.9>`__
 * Core Library v1.0.8 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.0.8>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v1.0.8>`__
 * Core Library v1.0.7 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.0.7>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v1.0.7>`__
 * Core Library v1.0.6 -- `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/v1.0.6>`__ `.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/v1.0.6>`__

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,10 +57,10 @@ Downloading and Building the Code
 *********************************
 
 Source code is available on Github at
-http://github.com/imageworks/OpenColorIO
+http://github.com/AcademySoftwareFoundation/OpenColorIO
 
-Download a `.zip <http://github.com/imageworks/OpenColorIO/zipball/master>`_ or
-`.tar.gz <http://github.com/imageworks/OpenColorIO/tarball/master>`_ of the
+Download a `.zip <http://github.com/AcademySoftwareFoundation/OpenColorIO/zipball/master>`_ or
+`.tar.gz <http://github.com/AcademySoftwareFoundation/OpenColorIO/tarball/master>`_ of the
 current state of the repository.
 
 Please see the :ref:`developer-guide` for more info, and contact `ocio-dev

--- a/share/nuke/ocionuke/cdl.py
+++ b/share/nuke/ocionuke/cdl.py
@@ -113,7 +113,7 @@ def _cdltransforms_to_xml(allcc):
 def SelectCCCIDPanel(*args, **kwargs):
     # Wrap class definition in a function, so nukescripts.PythonPanel
     # is only accessed when ``SelectCCCIDPanel()`` is called,
-    # https://github.com/imageworks/OpenColorIO/issues/277
+    # https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/277
 
     import nukescripts
 

--- a/src/pyglue/CMakeLists.txt
+++ b/src/pyglue/CMakeLists.txt
@@ -97,7 +97,7 @@ endif()
 #
 # TODO: This wont let the normal shared library symbols work on OSX.
 # We should explore whether this should be built as a normal dylib, instead
-# of as a bundle. See https://github.com/imageworks/OpenColorIO/pull/175
+# of as a bundle. See https://github.com/AcademySoftwareFoundation/OpenColorIO/pull/175
 
 if(OCIO_PYGLUE_SONAME)
     message(STATUS "Setting PyOCIO SOVERSION to: ${SOVERSION}")


### PR DESCRIPTION
Replaces imageworks with ASWF in relevant GH URLs. Also corrects some URLs pointing to non-existent locations in master (pointing them to RB-1.1 tree instead).