### PR TITLE
Check fail bit to catch non-writable file paths

### DIFF
--- a/src/apps/ociobakelut/main.cpp
+++ b/src/apps/ociobakelut/main.cpp
@@ -345,6 +345,11 @@ int main (int argc, const char* argv[])
             else
             {
                 std::ofstream f(outputfile.c_str());
+                if(f.fail())
+                {
+                    std::cerr << "ERROR: Non-writable file path " << outputfile << " specified." << std::endl;
+                    return 1;
+                }
                 baker->bake(f);
                 if(verbose)
                     std::cout << "[OpenColorIO INFO]: Wrote '" << outputfile << "'" << std::endl;


### PR DESCRIPTION
Addresses #382: If a non-writable path is specified during the construction of an `std::ofstream`, the `std::fail` bit is set to true. By querying this before attempting to write to the path, we can report the correct error message and return 1.

Tested using the aces.1.0.3 configuration with writable and non-writable paths.