### PR TITLE
AZP configuration updates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,7 +109,7 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   container: $[ variables['containerImage'] ]
-  #condition: in(variables['Build.Reason'], 'Manual', 'Schedule')
+  condition: in(variables['Build.Reason'], 'Manual', 'Schedule')
 
   steps:
   - template: share/ci/templates/checkout.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,9 @@ schedules:
       include:
         - master
 
+variables:
+- group: sonar
+
 jobs:
 
 # ------------------------------------------------------------------------------

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,15 +4,12 @@
 # azure-pipelines build file
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema?view=azure-devops&tabs=schema
 
-# TODO: Add gh-pages deployment on tag trigger
-
 trigger:
   batch: true
   branches:
     include:
     - master
     - RB-*
-    - ci_test
 
 pr:
   autoCancel: true
@@ -21,13 +18,21 @@ pr:
     - master
     - RB-*
 
+# TODO: Replace nightly build with PR SonarCloud check once quality gate is 
+#       passing.
+
 schedules:
   - cron: "0 0 * * 0"
-    displayName: Weekly Sunday build
+    displayName: Full weekly build (always)
     branches:
       include:
         - master
     always: true
+  - cron: "0 0 * * 1-6"
+    displayName: Full nightly build (if changed)
+    branches:
+      include:
+        - master
 
 jobs:
 
@@ -94,11 +99,11 @@ jobs:
   strategy:
     matrix:
       Linux CentOS 7 VFX CY2019:
-        containerImage: aswfstaging/ci-ocio:2019
+        containerImage: aswfstaging/ci-common:1.0
         cxxCompiler: g++
         cCompiler: gcc
       Linux CentOS 7 Clang 7:
-        containerImage: aswfstaging/ci-ocio:2019
+        containerImage: aswfstaging/ci-common:1.0
         cxxCompiler: clang++
         cCompiler: clang
   pool:
@@ -123,12 +128,6 @@ jobs:
       installExtPkgs: NONE
       cxxCompiler: $(cxxCompiler)
       cCompiler: $(cCompiler)
-      cmakeOpts: |
-        -DEXPAT_DIRS="/usr/local" \
-        -DLCMS2_DIRS="/usr/local" \
-        -DYAMLCPP_DIRS="/usr/local" \
-        -DPYSTRING_DIRS="/usr/local" \
-        -DILMBASE_DIRS="/usr/local"
 
   - template: share/ci/templates/build.yml
     parameters:
@@ -202,7 +201,7 @@ jobs:
 # Windows
 # ------------------------------------------------------------------------------
 # TODO: Install pythonXX_d.lib (or work around it being needed) to support Debug
-# build testing with Python bindings and docs enabled.
+#       build testing with Python bindings and docs enabled.
 
 - job: Windows
   strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,11 +99,11 @@ jobs:
   strategy:
     matrix:
       Linux CentOS 7 VFX CY2019:
-        containerImage: aswfstaging/ci-common:1.0
+        containerImage: aswfstaging/ci-base:2019
         cxxCompiler: g++
         cCompiler: gcc
       Linux CentOS 7 Clang 7:
-        containerImage: aswfstaging/ci-common:1.0
+        containerImage: aswfstaging/ci-base:2019
         cxxCompiler: clang++
         cCompiler: clang
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -149,7 +149,7 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   container: $[ variables['containerImage'] ]
-  #condition: in(variables['Build.Reason'], 'Manual', 'Schedule')
+  condition: in(variables['Build.Reason'], 'Manual', 'Schedule')
 
   steps:
   - template: share/ci/templates/checkout.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,7 +109,7 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   container: $[ variables['containerImage'] ]
-  condition: in(variables['Build.Reason'], 'Manual', 'Schedule')
+  #condition: in(variables['Build.Reason'], 'Manual', 'Schedule')
 
   steps:
   - template: share/ci/templates/checkout.yml
@@ -146,7 +146,7 @@ jobs:
   pool:
     vmImage: 'ubuntu-16.04'
   container: $[ variables['containerImage'] ]
-  condition: in(variables['Build.Reason'], 'Manual', 'Schedule')
+  #condition: in(variables['Build.Reason'], 'Manual', 'Schedule')
 
   steps:
   - template: share/ci/templates/checkout.yml

--- a/share/ci/scripts/macos/install_python.sh
+++ b/share/ci/scripts/macos/install_python.sh
@@ -20,8 +20,8 @@ fi
 
 brew install pyenv openssl 
 
-CFLAGS="-I/usr/local/Cellar/openssl/1.0.2s/include"
-LDFLAGS="-L/usr/local/Cellar/openssl/1.0.2s/lib"
+CFLAGS="-I$(brew --prefix openssl)/include"
+LDFLAGS="-L$(brew --prefix openssl)/lib $LDFLAGS"
 
 echo 'eval "$(pyenv init -)"' >> .bash_profile
 source .bash_profile

--- a/share/ci/scripts/macos/install_python.sh
+++ b/share/ci/scripts/macos/install_python.sh
@@ -18,8 +18,9 @@ if [[ "$MACOS_MAJOR" -gt 9 && "$MACOS_MINOR" -gt 13 ]]; then
         -target /
 fi
 
-brew install pyenv openssl 
+brew install pyenv openssl
 
+# Greatly reduce log warnings during Python install
 export CFLAGS="-I$(brew --prefix openssl)/include -Wno-nullability-completeness"
 export LDFLAGS="-L$(brew --prefix openssl)/lib $LDFLAGS"
 

--- a/share/ci/scripts/macos/install_python.sh
+++ b/share/ci/scripts/macos/install_python.sh
@@ -20,8 +20,8 @@ fi
 
 brew install pyenv openssl 
 
-CFLAGS="-I$(brew --prefix openssl)/include"
-LDFLAGS="-L$(brew --prefix openssl)/lib $LDFLAGS"
+export CFLAGS="-I$(brew --prefix openssl)/include -Wno-nullability-completeness"
+export LDFLAGS="-L$(brew --prefix openssl)/lib $LDFLAGS"
 
 echo 'eval "$(pyenv init -)"' >> .bash_profile
 source .bash_profile

--- a/share/ci/scripts/macos/install_python.sh
+++ b/share/ci/scripts/macos/install_python.sh
@@ -21,7 +21,7 @@ fi
 brew install pyenv openssl
 
 # Greatly reduce log warnings during Python install
-export CFLAGS="-I$(brew --prefix openssl)/include"
+export CFLAGS="-I$(brew --prefix openssl)/include -Wno-nullability-completeness"
 export LDFLAGS="-L$(brew --prefix openssl)/lib $LDFLAGS"
 
 echo 'eval "$(pyenv init -)"' >> .bash_profile

--- a/share/ci/scripts/macos/install_python.sh
+++ b/share/ci/scripts/macos/install_python.sh
@@ -21,7 +21,7 @@ fi
 brew install pyenv openssl
 
 # Greatly reduce log warnings during Python install
-export CFLAGS="-I$(brew --prefix openssl)/include -Wno-nullability-completeness"
+export CFLAGS="-I$(brew --prefix openssl)/include"
 export LDFLAGS="-L$(brew --prefix openssl)/lib $LDFLAGS"
 
 echo 'eval "$(pyenv init -)"' >> .bash_profile

--- a/share/ci/scripts/macos/install_python.sh
+++ b/share/ci/scripts/macos/install_python.sh
@@ -18,7 +18,10 @@ if [[ "$MACOS_MAJOR" -gt 9 && "$MACOS_MINOR" -gt 13 ]]; then
         -target /
 fi
 
-brew install pyenv
+brew install pyenv openssl 
+
+CFLAGS="-I/usr/local/Cellar/openssl/1.0.2s/include"
+LDFLAGS="-L/usr/local/Cellar/openssl/1.0.2s/lib"
 
 echo 'eval "$(pyenv init -)"' >> .bash_profile
 source .bash_profile

--- a/share/ci/templates/build_sonar.yml
+++ b/share/ci/templates/build_sonar.yml
@@ -30,6 +30,4 @@ steps:
   displayName: Generate code coverage report
 
 - bash: sonar-scanner -X -Dsonar.login=$SONAR_TOKEN
-  env:
-    SONAR_TOKEN: $(tokens.sonarCloud)
   displayName: Run sonar-scanner

--- a/share/ci/templates/build_sonar.yml
+++ b/share/ci/templates/build_sonar.yml
@@ -10,9 +10,6 @@ parameters:
   cxxCompiler: ''
   cCompiler: ''
 
-variables:
-- group: sonar
-
 steps:
 - bash: |
     if [ "$CXXCOMPILER" ]; then

--- a/share/ci/templates/build_sonar.yml
+++ b/share/ci/templates/build_sonar.yml
@@ -29,5 +29,5 @@ steps:
 - bash: share/ci/scripts/linux/run_gcov.sh
   displayName: Generate code coverage report
 
-- bash: sonar-scanner -X -Dsonar.login=$(sonar.SONAR_TOKEN)
+- bash: sonar-scanner -X -Dsonar.login=$(SONAR_TOKEN)
   displayName: Run sonar-scanner

--- a/share/ci/templates/build_sonar.yml
+++ b/share/ci/templates/build_sonar.yml
@@ -10,6 +10,9 @@ parameters:
   cxxCompiler: ''
   cCompiler: ''
 
+variables:
+- group: sonar
+
 steps:
 - bash: |
     if [ "$CXXCOMPILER" ]; then
@@ -29,5 +32,5 @@ steps:
 - bash: share/ci/scripts/linux/run_gcov.sh
   displayName: Generate code coverage report
 
-- bash: sonar-scanner -X -Dsonar.login=$SONAR_TOKEN
+- bash: sonar-scanner -X -Dsonar.login=$(sonar.SONAR_TOKEN)
   displayName: Run sonar-scanner


### PR DESCRIPTION
Currently we have a forced CI cron build every Sunday. With this PR, Monday-Saturday now have a full CI build too IF code has been changed. This will update static analysis more regularly, until we get the quality gate to a place where it can be enabled as a PR check.

I also moved the "latest" builds to use the ci-common Docker image and removed explicit lib paths from their cmake overrides. They pointed to the default install location for each lib, so weren't necessary.

Implemented macOS python install improvement suggested by Christina Tempelaar-Lietz (OpenEXR). This removes a lot of warnings from the install log, potentially speeding up mac builds.