### PR TITLE
Fix non portable path warning with clang

### DIFF
--- a/src/core/CDLTransform.cpp
+++ b/src/core/CDLTransform.cpp
@@ -856,7 +856,7 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 
 #include "Platform.h"
-#include "unittest.h"
+#include "UnitTest.h"
 
 
 namespace


### PR DESCRIPTION
Addresses the following warning:

OpenColorIO/src/core/CDLTransform.cpp:859:10: warning: non-portable path to file '"UnitTest.h"'; specified path differs in case from file name on disk [-Wnonportable-include-path]