### PR TITLE
Add TSC meeting notes from Mark Boorer and Carl Rand

### DIFF
--- a/docs/tsc/meetings/2019-09-16.md
+++ b/docs/tsc/meetings/2019-09-16.md
@@ -1,0 +1,45 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the OpenColorIO Project. -->
+
+September 16, 2019
+
+Host: Doug Walker
+
+Rotating Secretary: Carl Rand
+
+Attendees:
+  * [X] Mark Boorer (_TSC_) - Industrial Light & Magic
+  * [ ] Sean Cooper (_TSC_) - DNEG
+  * [ ] Michael Dolan (_TSC Chair_) - Sony Pictures Imageworks
+  * [X] Larry Gritz (_TSC_) - Sony Pictures Imageworks
+  * [X] Patrick Hodoul (_TSC_) - Autodesk
+  * [ ] John Mertic - Academy Software Foundation / Linux Foundation
+  * [X] Carl Rand (_TSC_) - Foundry
+  * [X] Doug Walker (_TSC Chief Architect_) - Autodesk
+  * [X] Kevin Wheatley (_TSC_) - Framestore
+  * [ ] Bernard Lefebvre - Autodesk
+
+Apologies:
+   Michael Dolan
+
+# **OCIO TSC Meeting Notes**
+
+* Do we need to support GCC 4 and 5 anymore?
+    - Doug raised that pull request #831 removes macros specific to these versions of GCC.
+    - Patrick raised that as we add more C+11 features the more we will be restricted.
+    - Kevin thinks we should definitely drop support for GCC 3.
+    - Patrick thought dropping GCC 3 would be fine and should be done in the master branch.
+
+* Azure CI build
+    - Patrick raised that the communication between Azure and Github is broken.
+    - Even when a pull request passes it still remains highlighted as red.
+    - Because of this an administrator has to sign off each individual pull request which is slowing the whole process down.
+    - It looks like a bug in the Azure side.
+    - We are currently waiting on the Azure team to fix the issue.
+
+* Python bindings
+    - Doug asked if there was a way to use pybind11 in an automatic way due to the destructor being private?
+    - Patrick hasn't been able to find a nicer way to do it without making a major change to the API.
+    - The only way seems to be to change the destructor from private to public.
+    - Making the destructor public might be the best and simplest solution.
+    - Doug thought if we went the public route we would need to document it in the API and explain that no one should really call this themselves.

--- a/docs/tsc/meetings/2019-10-07.md
+++ b/docs/tsc/meetings/2019-10-07.md
@@ -1,0 +1,42 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the OpenColorIO Project. -->
+
+October 7, 2019
+
+Host: Doug Walker
+
+Rotating Secretary: Mark Boorer
+
+Attendees:
+  * [X] Mark Boorer (_TSC_) - Industrial Light & Magic
+  * [X] Sean Cooper (_TSC_) - DNEG
+  * [ ] Michael Dolan (_TSC Chair_) - Sony Pictures Imageworks
+  * [X] Larry Gritz (_TSC_) - Sony Pictures Imageworks
+  * [X] Patrick Hodoul (_TSC_) - Autodesk
+  * [X] John Mertic - Academy Software Foundation / Linux Foundation
+  * [ ] Carl Rand (_TSC_) - Foundry
+  * [X] Doug Walker (_TSC Chief Architect_) - Autodesk
+  * [X] Kevin Wheatley (_TSC_) - Framestore
+  * [X] Michael Min - Netflix
+  * [X] Carol Payne - Netflix
+  * [X] Bernard Lefebvre - Autodesk
+
+Apologies:
+   Michael Dolan
+
+# **OCIO TSC Meeting Notes**
+
+* Question for John re: DCO sign-off process
+  Doug - What happens if the email that people are signing-off with is not the email of their employer (eg @autodesk.com).
+  Lary - The CLA manager can log on and list all the emails that are associated with their employees.
+
+  Only email addresses OK'd by the CLA manager (or domain, github user, etc) will be approved.
+  
+  DCO doesn't tell us /why/ a certain pull request was approved. So potentially a new feature request.
+  John will confirm with the team as to how the DCO sign off will behave when a user has not completed the CLA process correctly, or is a new user.
+
+* No updates on documentation refresh
+
+* Hacktober fest tag work done by Patrick, looking for other volunteers to improve visibility
+
+* No meeting next week (14/10/2019) due to thanksgiving in Canada


### PR DESCRIPTION
Mark and Carl's TSC notes are encountering branch and CLA issues respectively. Since these are just meeting notes I propose we get them in there without lots of runaround. We could then close #843 and #863 if nobody opposes.

Signed-off-by: michdolan <michdolan@gmail.com>