### PR TITLE
Fix macOS CI python install script

### DIFF
--- a/share/ci/scripts/macos/install_python.sh
+++ b/share/ci/scripts/macos/install_python.sh
@@ -6,13 +6,18 @@ set -ex
 
 PYTHON_VERSION="$1"
 
-brew install pyenv openssl
+brew install pyenv openssl xqurtz
 
-# Include openssl, disable nullability warning, to greatly reduce log noise during Python install
+# Greatly reduce log warnings during Python install
+export CFLAGS="-I$(brew --prefix openssl)/include -Wno-nullability-completeness"
+export LDFLAGS="-L$(brew --prefix openssl)/lib $LDFLAGS"
+
+# Make X11 headers available to build tkinter extension
+export CFLAGS="$CFLAGS -I$(brew --prefix xquartz)/include"
+
 # Include macOS SDK headers, required for macOS >= 10.14:
 #   https://apple.stackexchange.com/questions/337940/why-is-usr-include-missing-i-have-xcode-and-command-line-tools-installed-moja
-export CFLAGS="-I$(brew --prefix openssl)/include -Wno-nullability-completeness -isysroot $(xcrun --show-sdk-path)"
-export LDFLAGS="-L$(brew --prefix openssl)/lib $LDFLAGS"
+export CFLAGS="$CFLAGS -isysroot $(xcrun --show-sdk-path)"
 
 echo 'eval "$(pyenv init -)"' >> .bash_profile
 source .bash_profile

--- a/share/ci/scripts/macos/install_python.sh
+++ b/share/ci/scripts/macos/install_python.sh
@@ -6,7 +6,7 @@ set -ex
 
 PYTHON_VERSION="$1"
 
-brew install pyenv openssl xqurtz
+brew install pyenv openssl xquartz
 
 # Greatly reduce log warnings during Python install
 export CFLAGS="-I$(brew --prefix openssl)/include -Wno-nullability-completeness"

--- a/share/ci/scripts/macos/install_python.sh
+++ b/share/ci/scripts/macos/install_python.sh
@@ -6,14 +6,11 @@ set -ex
 
 PYTHON_VERSION="$1"
 
-brew install pyenv openssl xquartz
+brew install pyenv openssl
 
 # Greatly reduce log warnings during Python install
 export CFLAGS="-I$(brew --prefix openssl)/include -Wno-nullability-completeness"
 export LDFLAGS="-L$(brew --prefix openssl)/lib $LDFLAGS"
-
-# Make X11 headers available to build tkinter extension
-export CFLAGS="$CFLAGS -I$(brew --prefix xquartz)/include"
 
 # Include macOS SDK headers, required for macOS >= 10.14:
 #   https://apple.stackexchange.com/questions/337940/why-is-usr-include-missing-i-have-xcode-and-command-line-tools-installed-moja

--- a/share/ci/scripts/macos/install_python.sh
+++ b/share/ci/scripts/macos/install_python.sh
@@ -6,22 +6,12 @@ set -ex
 
 PYTHON_VERSION="$1"
 
-MACOS_MAJOR="$(sw_vers -productVersion | cut -f 1 -d .)"
-MACOS_MINOR="$(sw_vers -productVersion | cut -f 2 -d .)"
-
-# This workaround is needed for building Python on macOS >= 10.14:
-#   https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes
-
-if [[ "$MACOS_MAJOR" -gt 9 && "$MACOS_MINOR" -gt 13 ]]; then
-    sudo installer \
-        -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_${MACOS_MAJOR}.${MACOS_MINOR}.pkg \
-        -target /
-fi
-
 brew install pyenv openssl
 
-# Greatly reduce log warnings during Python install
-export CFLAGS="-I$(brew --prefix openssl)/include -Wno-nullability-completeness"
+# Include openssl, disable nullability warning, to greatly reduce log noise during Python install
+# Include macOS SDK headers, required for macOS >= 10.14:
+#   https://apple.stackexchange.com/questions/337940/why-is-usr-include-missing-i-have-xcode-and-command-line-tools-installed-moja
+export CFLAGS="-I$(brew --prefix openssl)/include -Wno-nullability-completeness -isysroot $(xcrun --show-sdk-path)"
 export LDFLAGS="-L$(brew --prefix openssl)/lib $LDFLAGS"
 
 echo 'eval "$(pyenv init -)"' >> .bash_profile


### PR DESCRIPTION
Implemented fix proposed by @zachlewis , which will hopefully resolve the current macOS 10.14 CI failure, resulting from a macOS hosted agent update.

Signed-off-by: michdolan <michdolan@gmail.com>