### PR TITLE
Fix AZP macOS dependency install failure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -184,21 +184,16 @@ jobs:
   - template: share/ci/templates/checkout.yml
   - bash: |
       share/ci/scripts/macos/install.sh
+      share/ci/scripts/macos/install_python.sh 2.7.16
     displayName: Install dependencies
-
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '2.7'
-      addToPath: true
-    displayName: Configure Python
 
   - template: share/ci/templates/configure.yml
     parameters:
       buildType: $(buildType)
       cmakeOpts: |
         -DPYTHON_INCLUDE_DIR=$(python-config --prefix)/include/python2.7 \
-        -DPYTHON_LIBRARY=$(python-config --prefix)/lib/libpython2.7.a \
-        -DPYTHON_EXECUTABLE=$(which python)
+        -DPYTHON_LIBRARY=$(python-config --prefix)/lib/libpython2.7.dylib \
+        -DPYTHON_EXECUTABLE=$(which python2)
 
   - template: share/ci/templates/build.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -184,16 +184,19 @@ jobs:
   - template: share/ci/templates/checkout.yml
   - bash: |
       share/ci/scripts/macos/install.sh
-      share/ci/scripts/macos/install_python.sh 2.7.16
     displayName: Install dependencies
+
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '2.7'
+      addToPath: true
+    displayName: Configure Python
 
   - template: share/ci/templates/configure.yml
     parameters:
       buildType: $(buildType)
       cmakeOpts: |
-        -DPYTHON_INCLUDE_DIR=$(python-config --prefix)/include/python2.7 \
-        -DPYTHON_LIBRARY=$(python-config --prefix)/lib/libpython2.7.dylib \
-        -DPYTHON_EXECUTABLE=$(which python2)
+        -DPYTHON_EXECUTABLE=$(which python)
 
   - template: share/ci/templates/build.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -196,6 +196,8 @@ jobs:
     parameters:
       buildType: $(buildType)
       cmakeOpts: |
+        -DPYTHON_INCLUDE_DIR=$(python-config --prefix)/include/python2.7 \
+        -DPYTHON_LIBRARY=$(python-config --prefix)/lib/libpython2.7.a \
         -DPYTHON_EXECUTABLE=$(which python)
 
   - template: share/ci/templates/build.yml

--- a/share/ci/scripts/macos/install.sh
+++ b/share/ci/scripts/macos/install.sh
@@ -5,5 +5,4 @@
 set -ex
 
 brew update
-brew upgrade cmake
 brew install glew

--- a/share/ci/scripts/macos/install_python.sh
+++ b/share/ci/scripts/macos/install_python.sh
@@ -8,13 +8,12 @@ PYTHON_VERSION="$1"
 
 brew install pyenv openssl readline
 
-# Workaround Python build errors:
+# pyenv build dependencies:
 #   https://github.com/pyenv/pyenv/wiki/common-build-problems
 export CFLAGS="$CLFAGS -I$(brew --prefix openssl)/include -I$(brew --prefix readline)/include"
 export LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix readline)/lib $LDFLAGS"
 
-# Include macOS SDK headers, required for macOS >= 10.14:
-#   https://apple.stackexchange.com/questions/337940/why-is-usr-include-missing-i-have-xcode-and-command-line-tools-installed-moja
+# Include macOS SDK headers, required for macOS >= 10.14
 export CFLAGS="$CFLAGS -I$(xcrun --show-sdk-path)/usr/include"
 
 # Silence Python build warnings

--- a/share/ci/scripts/macos/install_python.sh
+++ b/share/ci/scripts/macos/install_python.sh
@@ -6,15 +6,19 @@ set -ex
 
 PYTHON_VERSION="$1"
 
-brew install pyenv openssl
+brew install pyenv openssl readline
 
-# Greatly reduce log warnings during Python install
-export CFLAGS="-I$(brew --prefix openssl)/include -Wno-nullability-completeness"
-export LDFLAGS="-L$(brew --prefix openssl)/lib $LDFLAGS"
+# Workaround Python build errors:
+#   https://github.com/pyenv/pyenv/wiki/common-build-problems
+export CFLAGS="$CLFAGS -I$(brew --prefix openssl)/include -I$(brew --prefix readline)/include"
+export LDFLAGS="-L$(brew --prefix openssl)/lib -L$(brew --prefix readline)/lib $LDFLAGS"
 
 # Include macOS SDK headers, required for macOS >= 10.14:
 #   https://apple.stackexchange.com/questions/337940/why-is-usr-include-missing-i-have-xcode-and-command-line-tools-installed-moja
-export CFLAGS="$CFLAGS -isysroot $(xcrun --show-sdk-path)"
+export CFLAGS="$CFLAGS -I$(xcrun --show-sdk-path)/usr/include"
+
+# Silence Python build warnings
+export CFLAGS="$CLFAGS -Wno-nullability-completeness"
 
 echo 'eval "$(pyenv init -)"' >> .bash_profile
 source .bash_profile


### PR DESCRIPTION
The build failures this fixes appear to be caused by another AZP macOS agent update, related to both CMake and Python. This PR removes our custom install of CMake (since AZP has a compatible version installed already now), and refines the pyenv build dependencies. Both of these were contributing to the dependency install task failing for macOS. 

Signed-off-by: michdolan <michdolan@gmail.com>