### PR TITLE
Adsk Contrib - Some Yaml cleanup

### DIFF
--- a/share/cmake/modules/FindYamlCpp.cmake
+++ b/share/cmake/modules/FindYamlCpp.cmake
@@ -93,15 +93,17 @@ if(NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL ALL)
     )
 
     # Get version from config if it was found.
-    # Important: The yaml-cpp interface changed between 0.3.0 and 0.5.0. 
-    # OCIO supports both, but relies on YAMLCPP_VERSION to set the OLDYAML
-    # property below, which tells the compiler which to use.
     if(PC_YAMLCPP_VERSION)
         set(YAMLCPP_VERSION "${PC_YAMLCPP_VERSION}")
     elseif(EXISTS "${YAMLCPP_INCLUDE_DIR}/yaml-cpp/iterator.h")
         set(YAMLCPP_VERSION "0.3.0")
+    elseif(EXISTS "${YAMLCPP_INCLUDE_DIR}/yaml-cpp/noncopyable.h")
+        # The version is higher than 0.3.0 but lower than 0.6.3
+        # i.e. the version 0.6.3 removes the file 'yaml-cpp/noncopyable.h.
+        set(YAMLCPP_VERSION "0.5.3")
     else()
-        set(YAMLCPP_VERSION "0.5.0")
+        # The only supported version.
+        set(YAMLCPP_VERSION "0.6.3")
     endif()
 
     # Override REQUIRED if package can be installed

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -227,8 +227,6 @@ OCIO_NAMESPACE_ENTER
         mutable StringMap cacheids_;
         mutable std::string cacheidnocontext_;
         
-        OCIOYaml io_;
-        
         Impl() : 
             majorVersion_(FirstSupportedMajorVersion_),
             minorVersion_(0),
@@ -335,10 +333,8 @@ OCIO_NAMESPACE_ENTER
     {
         std::istringstream istream;
         istream.str(INTERNAL_RAW_PROFILE);
-        
-        ConfigRcPtr config = Config::Create();
-        config->getImpl()->io_.open(istream, config);
-        return config;
+
+        return CreateFromStream(istream);
     }
 
     ConstConfigRcPtr Config::CreateFromEnv()
@@ -364,16 +360,16 @@ OCIO_NAMESPACE_ENTER
             os << "' OCIO profile.";
             throw Exception (os.str().c_str());
         }
-        
+
         ConfigRcPtr config = Config::Create();
-        config->getImpl()->io_.open(istream, config, filename);
+        OCIOYaml::read(istream, config, filename);
         return config;
     }
     
     ConstConfigRcPtr Config::CreateFromStream(std::istream & istream)
     {
         ConfigRcPtr config = Config::Create();
-        config->getImpl()->io_.open(istream, config);
+        OCIOYaml::read(istream, config, nullptr);
         return config;
     }
     
@@ -1624,7 +1620,7 @@ OCIO_NAMESPACE_ENTER
     {
         try
         {
-            getImpl()->io_.write(os, this);
+            OCIOYaml::write(os, this);
         }
         catch( const std::exception & e)
         {

--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -5,57 +5,7 @@
 
 #include <OpenColorIO/OpenColorIO.h>
 
-#ifndef _WIN32
-
-// fwd declare yaml-cpp visibility
-#pragma GCC visibility push(hidden)
-namespace YAML {
-    class Exception;
-    class BadDereference;
-    class RepresentationException;
-    class EmitterException;
-    class ParserException;
-    class InvalidScalar;
-    class KeyNotFound;
-    template <typename T> class TypedKeyNotFound;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::ColorSpace>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::Config>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::Exception>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::GpuShaderDesc>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::ImageDesc>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::Look>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::Processor>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::Transform>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::AllocationTransform>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::CDLTransform>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::ColorSpaceTransform>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::DisplayTransform>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::ExponentTransform>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::ExponentWithLinearTransform>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::ExposureContrastTransform>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::FileTransform>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::FixedFunctionTransform>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::GroupTransform>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::LogAffineTransform>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::LogTransform>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::LookTransform>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::MatrixTransform>;
-    template <> class TypedKeyNotFound<OCIO_NAMESPACE::RangeTransform>;
-}
-#pragma GCC visibility pop
-
-#endif
-
-#ifdef _MSC_VER
-#pragma warning( push )
-#pragma warning( disable: 4146 )
-#endif
-
 #include <yaml-cpp/yaml.h>
-
-#ifdef _MSC_VER
-#pragma warning( pop )
-#endif
 
 #include "Display.h"
 #include "Logging.h"
@@ -2481,7 +2431,7 @@ OCIO_NAMESPACE_ENTER
     
     ///////////////////////////////////////////////////////////////////////////
     
-    void OCIOYaml::open(std::istream& istream, ConfigRcPtr& c, const char* filename) const
+    void OCIOYaml::read(std::istream & istream, ConfigRcPtr & c, const char * filename)
     {
         try
         {
@@ -2498,7 +2448,7 @@ OCIO_NAMESPACE_ENTER
         }
     }
     
-    void OCIOYaml::write(std::ostream& ostream, const Config* c) const
+    void OCIOYaml::write(std::ostream & ostream, const Config * c)
     {
         YAML::Emitter out;
         out.SetDoublePrecision(std::numeric_limits<double>::digits10);

--- a/src/OpenColorIO/OCIOYaml.h
+++ b/src/OpenColorIO/OCIOYaml.h
@@ -9,11 +9,10 @@
 OCIO_NAMESPACE_ENTER
 {
     
-    class OCIOYaml
+    namespace OCIOYaml
     {
-    public:
-        void open(std::istream& istream, ConfigRcPtr& c, const char* filename = NULL) const;
-        void write(std::ostream& ostream, const Config* c) const;
+        void read(std::istream & istream, ConfigRcPtr & c, const char * filename);
+        void write(std::ostream & ostream, const Config * c);
     };
     
 }


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

The pull request removes some 'dead' code around Yaml (refer to [src/OpenColorIO/OCIOYaml.cpp](https://github.com/AcademySoftwareFoundation/OpenColorIO/compare/master...autodesk-forks:adsk_contrib/yaml_cleanup?expand=1#diff-74c88273b31122385791a6a558e04b87L8)) to fix #517. The library does now compile when using an installed Yaml (if the version is higher than 0.6.x).

**Note:**  From an installed Yaml, the version 'detection' is flaky; only 0.3.0 and 0.6.3 can be correctly detected. So, installing any version lower than 0.6.3 will still trigger the download and the build of the Yaml library. 

**Note:**  Refer to #883 for details about the new Yaml support.