### PR TITLE
Azure Build - Update the 'latest' build to use the latest Yaml.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,6 @@ jobs:
 # ----------------------------------
 # Latest dependency tags (cron only)
 # ----------------------------------
-# TODO: Set yaml-cpp to "latest" when 0.6.x is supported
 
 - job: Latest
   strategy:
@@ -119,7 +118,7 @@ jobs:
   - bash: |
       share/ci/scripts/linux/install_expat.sh latest
       share/ci/scripts/linux/install_lcms2.sh latest
-      share/ci/scripts/linux/install_yaml-cpp.sh 0.3.0
+      share/ci/scripts/linux/install_yaml-cpp.sh latest
       share/ci/scripts/linux/install_pystring.sh latest
       share/ci/scripts/linux/install_openexr.sh latest
       share/ci/scripts/linux/install_oiio.sh latest

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -57,7 +57,7 @@ The basic requirements for building OCIO are:
 
 - cmake >= 3.10
 - \*Expat >= 2.2.5 (XML parser for CDL/CLF/CTF)
-- \*yaml-cpp >= 0.3.0 (YAML parser for Configs)
+- \*yaml-cpp >= 0.6.3 (YAML parser for Configs)
 - \*IlmBase (Half only) >= 2.3.0 (for half domain LUTs)
 - \*pystring >= 1.1.3
 


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

Even if I cannot reproduce the problem with a centOS docker, the problem is around the CentOS 'latest' build (i.e. test OCIO with all the latest code from its third-party dependencies).  So, I changed the Yaml settings to use the latest Yaml code.

Unfortunately, I have no way to test the change and validate if it fixes the problem. But the change is still needed.