### PR TITLE
Document portable parallel build with CMake

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -156,6 +156,10 @@ threads)::
 
     $ make -j8
 
+Starting with CMake 3.12, you can instead run a portable parallel build::
+
+    $ cmake --build . -j 8
+
 This should complete in a few minutes. Finally, install the files into
 the specified location::
 


### PR DESCRIPTION
CMake 3.12 and newer supports parallel build option, document using that instead of make, helps with script portability.

Signed-off-by: Jean-Francois Panisset <panisset@gmail.com>