### PR TITLE
Fix source typo

### DIFF
--- a/src/bindings/python/DocStrings/Config.py
+++ b/src/bindings/python/DocStrings/Config.py
@@ -485,7 +485,7 @@ class Config:
         """
         pass
 
-    def setActiveDisplays(self, dislpays):
+    def setActiveDisplays(self, displays):
         """
         setActiveDisplays(displays)
         


### PR DESCRIPTION
Missed this in previous commit (c7b19a0b121d)