### PR TITLE
Adsk Contrib - Add some missing 'export' keyword in the public API

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -1087,7 +1087,7 @@ namespace OCIO_NAMESPACE
     // ************
     
     //!cpp:class::
-    class CPUProcessor
+    class OCIOEXPORT CPUProcessor
     {
     public:
         //!cpp:function::
@@ -1152,7 +1152,7 @@ namespace OCIO_NAMESPACE
     // ************
     
     //!cpp:class::
-    class GPUProcessor
+    class OCIOEXPORT GPUProcessor
     {
     public:
         //!cpp:function::

--- a/include/OpenColorIO/OpenColorTransforms.h
+++ b/include/OpenColorIO/OpenColorTransforms.h
@@ -37,7 +37,7 @@ namespace OCIO_NAMESPACE
     // * And a list of child sub-elements, which are also objects implementing
     //   FormatMetadata.
     //
-    class FormatMetadata
+    class OCIOEXPORT FormatMetadata
     {
     public:
         //!cpp:function::


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

On Windows platform the symbol export is critical and some classes were not correctly managed.
Refer to [OpenColorABI.h.in](https://github.com/AcademySoftwareFoundation/OpenColorIO/blob/master/include/OpenColorIO/OpenColorABI.h.in#L32) to have the details.