### PR TITLE
Adsk Contrib - remove namespace tabulation

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -21,26 +21,26 @@ C++ API
 **Usage Example:** *Compositing plugin that converts from "log" to "lin"*
 
 .. code-block:: cpp
-   
+
    #include <OpenColorIO/OpenColorIO.h>
    namespace OCIO = OCIO_NAMESPACE;
-   
+
    try
    {
        // Get the global OpenColorIO config
        // This will auto-initialize (using $OCIO) on first use
        OCIO::ConstConfigRcPtr config = OCIO::GetCurrentConfig();
-       
+
        // Get the processor corresponding to this transform.
        OCIO::ConstProcessorRcPtr processor = config->getProcessor(OCIO::ROLE_COMPOSITING_LOG,
                                                                   OCIO::ROLE_SCENE_LINEAR);
 
        // Get the corresponding CPU processor for 32-bit float image processing.
        OCIO::ConstCPUProcessorRcPtr cpuProcessor = processor->getDefaultCPUProcessor();
-    
+
        // Wrap the image in a light-weight ImageDescription
        OCIO::PackedImageDesc img(imageData, w, h, 4);
-       
+
        // Apply the color transformation (in place)
        cpuProcessor->apply(img);
    }
@@ -53,2010 +53,2006 @@ C++ API
 
 namespace OCIO_NAMESPACE
 {
+///////////////////////////////////////////////////////////////////////////
+//!rst::
+// Exceptions
+// **********
+
+//!cpp:class:: An exception class to throw for errors detected at
+// runtime.
+//
+// .. warning::
+//    All functions in the Config class can potentially throw this exception.
+class OCIOEXPORT Exception : public std::runtime_error
+{
+public:
+    //!cpp:function:: Constructor that takes a string as the exception message.
+    explicit Exception(const char *);
+    //!cpp:function:: Constructor that takes an existing exception.
+    Exception(const Exception &);
+
+    ~Exception();
+
+private:
+    Exception();
+    Exception & operator= (const Exception &);
+};
+
+//!cpp:class:: An exception class for errors detected at
+// runtime, thrown when OCIO cannot find a file that is expected to
+// exist. This is provided as a custom type to
+// distinguish cases where one wants to continue looking for
+// missing files, but wants to properly fail
+// for other error conditions.
+
+class OCIOEXPORT ExceptionMissingFile : public Exception
+{
+public:
+    //!cpp:function:: Constructor that takes a string as the exception message.
+    explicit ExceptionMissingFile(const char *);
+    //!cpp:function:: Constructor that takes an existing exception.
+    ExceptionMissingFile(const ExceptionMissingFile &);
+
+    ~ExceptionMissingFile();
+
+private:
+    ExceptionMissingFile();
+    ExceptionMissingFile & operator= (const ExceptionMissingFile &);
+};
+
+///////////////////////////////////////////////////////////////////////////
+//!rst::
+// Global
+// ******
+
+//!cpp:function::
+// OpenColorIO, during normal usage, tends to cache certain information
+// (such as the contents of LUTs on disk, intermediate results, etc.).
+// Calling this function will flush all such information.
+// Under normal usage, this is not necessary, but it can be helpful in particular instances,
+// such as designing OCIO profiles, and wanting to re-read luts without
+// restarting.
+extern OCIOEXPORT void ClearAllCaches();
+
+//!cpp:function:: Get the version number for the library, as a
+// dot-delimited string (e.g., "1.0.0"). This is also available
+// at compile time as OCIO_VERSION.
+extern OCIOEXPORT const char * GetVersion();
+
+//!cpp:function:: Get the version number for the library, as a
+// single 4-byte hex number (e.g., 0x01050200 for "1.5.2"), to be used
+// for numeric comparisons. This is also available
+// at compile time as OCIO_VERSION_HEX.
+extern OCIOEXPORT int GetVersionHex();
+
+//!cpp:function:: Get the global logging level.
+// You can override this at runtime using the :envvar:`OCIO_LOGGING_LEVEL`
+// environment variable. The client application that sets this should use
+// :cpp:func:`SetLoggingLevel`, and not the environment variable. The default value is INFO.
+extern OCIOEXPORT LoggingLevel GetLoggingLevel();
+
+//!cpp:function:: Set the global logging level.
+extern OCIOEXPORT void SetLoggingLevel(LoggingLevel level);
+
+//!cpp:function:: Set the logging function to use; otherwise, use the default (i.e. std::cerr).
+// Note that the logging mechanism is thread-safe.
+extern OCIOEXPORT void SetLoggingFunction(LoggingFunction logFunction);
+//!cpp:function::
+extern OCIOEXPORT void ResetToDefaultLoggingFunction();
+//!cpp:function:: Log a message using the library logging function.
+extern OCIOEXPORT void LogMessage(LoggingLevel level, const char * message);
+
+//
+// Note that the following env. variable access methods are not thread safe.
+//
+
+//!cpp:function:: Another call modifies the string obtained from a previous call
+// as the method always uses the same memory buffer.
+extern OCIOEXPORT const char * GetEnvVariable(const char * name);
+//!cpp:function::
+extern OCIOEXPORT void SetEnvVariable(const char * name, const char * value);
+
+
+///////////////////////////////////////////////////////////////////////////
+//!rst::
+// Config
+// ******
+//
+// A config defines all the color spaces to be available at runtime.
+//
+// The color configuration (:cpp:class:`Config`) is the main object for
+// interacting with this library. It encapsulates all of the information
+// necessary to use customized :cpp:class:`ColorSpaceTransform` and
+// :cpp:class:`DisplayTransform` operations.
+//
+// See the :ref:`user-guide` for more information on
+// selecting, creating, and working with custom color configurations.
+//
+// For applications interested in using only one color config at
+// a time (this is the vast majority of apps), their API would
+// traditionally get the global configuration and use that, as opposed to
+// creating a new one. This simplifies the use case for
+// plugins and bindings, as it alleviates the need to pass around configuration
+// handles.
+//
+// An example of an application where this would not be sufficient would be
+// a multi-threaded image proxy server (daemon), which wished to handle
+// multiple show configurations in a single process concurrently. This
+// app would need to keep multiple configurations alive, and to manage them
+// appropriately.
+//
+// Roughly speaking, a novice user should select a
+// default configuration that most closely approximates the use case
+// (animation, visual effects, etc.), and set the :envvar:`OCIO` environment
+// variable to point at the root of that configuration.
+//
+// .. note::
+//    Initialization using environment variables is typically preferable in
+//    a multi-app ecosystem, as it allows all applications to be
+//    consistently configured.
+//
+// See :ref:`developers-usageexamples`
+
+//!cpp:function:: Get the current configuration.
+
+extern OCIOEXPORT ConstConfigRcPtr GetCurrentConfig();
+
+//!cpp:function:: Set the current configuration. This will then store a copy of the specified config.
+extern OCIOEXPORT void SetCurrentConfig(const ConstConfigRcPtr & config);
+
+
+//!cpp:class::
+class OCIOEXPORT Config
+{
+public:
+
     ///////////////////////////////////////////////////////////////////////////
-    //!rst::
-    // Exceptions
-    // **********
-    
-    //!cpp:class:: An exception class to throw for errors detected at
-    // runtime.
-    //
-    // .. warning:: 
-    //    All functions in the Config class can potentially throw this exception.
-    class OCIOEXPORT Exception : public std::runtime_error
-    {
-    public:
-        //!cpp:function:: Constructor that takes a string as the exception message.
-        explicit Exception(const char *);
-        //!cpp:function:: Constructor that takes an existing exception.
-        Exception(const Exception &);
+    //!rst:: .. _cfginit_section:
+    // 
+    // Initialization
+    // ^^^^^^^^^^^^^^
 
-        ~Exception();
+    //!cpp:function:: Create a default empty configuration.
+    static ConfigRcPtr Create();
+    //!cpp:function:: Create a fall-back config.  This may be useful to allow client apps
+    // to launch in cases when the supplied config path is not loadable.
+    static ConstConfigRcPtr CreateRaw();
+    //!cpp:function:: Create a configuration using the OCIO environment variable.  If the
+    // variable is missing or empty, returns the same result as :cpp:func:`Config::CreateRaw`.
+    static ConstConfigRcPtr CreateFromEnv();
+    //!cpp:function:: Create a configuration using a specific config file.
+    static ConstConfigRcPtr CreateFromFile(const char * filename);
+    //!cpp:function:: Create a configuration using a stream.
+    static ConstConfigRcPtr CreateFromStream(std::istream & istream);
 
-    private:
-        Exception();
-        Exception & operator= (const Exception &);
-    };
-    
-    //!cpp:class:: An exception class for errors detected at
-    // runtime, thrown when OCIO cannot find a file that is expected to
-    // exist. This is provided as a custom type to
-    // distinguish cases where one wants to continue looking for
-    // missing files, but wants to properly fail
-    // for other error conditions.
-    
-    class OCIOEXPORT ExceptionMissingFile : public Exception
-    {
-    public:
-        //!cpp:function:: Constructor that takes a string as the exception message.
-        explicit ExceptionMissingFile(const char *);
-        //!cpp:function:: Constructor that takes an existing exception.
-        ExceptionMissingFile(const ExceptionMissingFile &);
-
-        ~ExceptionMissingFile();
-
-    private:
-        ExceptionMissingFile();
-        ExceptionMissingFile & operator= (const ExceptionMissingFile &);
-    };
-    
-    ///////////////////////////////////////////////////////////////////////////
-    //!rst::
-    // Global
-    // ******
-    
     //!cpp:function::
-    // OpenColorIO, during normal usage, tends to cache certain information
-    // (such as the contents of LUTs on disk, intermediate results, etc.).
-    // Calling this function will flush all such information.
-    // Under normal usage, this is not necessary, but it can be helpful in particular instances,
-    // such as designing OCIO profiles, and wanting to re-read luts without
-    // restarting.
-    
-    extern OCIOEXPORT void ClearAllCaches();
-    
-    //!cpp:function:: Get the version number for the library, as a
-    // dot-delimited string (e.g., "1.0.0"). This is also available
-    // at compile time as OCIO_VERSION.
-    
-    extern OCIOEXPORT const char * GetVersion();
-    
-    //!cpp:function:: Get the version number for the library, as a
-    // single 4-byte hex number (e.g., 0x01050200 for "1.5.2"), to be used
-    // for numeric comparisons. This is also available
-    // at compile time as OCIO_VERSION_HEX.
-    
-    extern OCIOEXPORT int GetVersionHex();
-    
-    //!cpp:function:: Get the global logging level.
-    // You can override this at runtime using the :envvar:`OCIO_LOGGING_LEVEL`
-    // environment variable. The client application that sets this should use
-    // :cpp:func:`SetLoggingLevel`, and not the environment variable. The default value is INFO.
-    
-    extern OCIOEXPORT LoggingLevel GetLoggingLevel();
-    
-    //!cpp:function:: Set the global logging level.
-    extern OCIOEXPORT void SetLoggingLevel(LoggingLevel level);
+    ConfigRcPtr createEditableCopy() const;
 
-    //!cpp:function:: Set the logging function to use; otherwise, use the default (i.e. std::cerr).
-    // Note that the logging mechanism is thread-safe.
-    extern OCIOEXPORT void SetLoggingFunction(LoggingFunction logFunction);
+    //!cpp:function:: Get the configuration major version
+    unsigned int getMajorVersion() const;
+
+    //!cpp:function:: Set the configuration major version
+    void setMajorVersion(unsigned int major);
+
+    //!cpp:function:: Get the configuration minor version
+    unsigned int getMinorVersion() const;
+
+    //!cpp:function:: Set the configuration minor version
+    void setMinorVersion(unsigned int minor);
+
     //!cpp:function::
-    extern OCIOEXPORT void ResetToDefaultLoggingFunction();
-    //!cpp:function:: Log a message using the library logging function.
-    extern OCIOEXPORT void LogMessage(LoggingLevel level, const char * message);
+    // This will throw an exception if the config is malformed. The most
+    // common error occurs when references are made to colorspaces that do not
+    // exist.
+    void sanityCheck() const;
 
-    //
-    // Note that the following env. variable access methods are not thread safe.
-    //
-
-    //!cpp:function:: Another call modifies the string obtained from a previous call
-    // as the method always uses the same memory buffer.
-    extern OCIOEXPORT const char * GetEnvVariable(const char * name);
     //!cpp:function::
-    extern OCIOEXPORT void SetEnvVariable(const char * name, const char * value);
+    const char * getDescription() const;
+    //!cpp:function::
+    void setDescription(const char * description);
 
+    //!cpp:function::
+    // Returns the string representation of the Config in YAML text form.
+    // This is typically stored on disk in a file with the extension .ocio.
+    void serialize(std::ostream & os) const;
+
+    //!cpp:function::
+    // This will produce a hash of the all colorspace definitions, etc.
+    // All external references, such as files used in FileTransforms, etc.,
+    // will be incorporated into the cacheID. While the contents of
+    // the files are not read, the file system is queried for relevant
+    // information (mtime, inode) so that the config's cacheID will
+    // change when the underlying luts are updated.
+    // If a context is not provided, the current Context will be used.
+    // If a null context is provided, file references will not be taken into
+    // account (this is essentially a hash of Config::serialize).
+    const char * getCacheID() const;
+    //!cpp:function::
+    const char * getCacheID(const ConstContextRcPtr & context) const;
 
     ///////////////////////////////////////////////////////////////////////////
-    //!rst::
-    // Config
-    // ******
+    //!rst:: .. _cfgresource_section:
+    // 
+    // Resources
+    // ^^^^^^^^^
+    // Given a lut src name, where should we find it?
+
+    //!cpp:function::
+    ConstContextRcPtr getCurrentContext() const;
+
+    //!cpp:function::
+    void addEnvironmentVar(const char * name, const char * defaultValue);
+    //!cpp:function::
+    int getNumEnvironmentVars() const;
+    //!cpp:function::
+    const char * getEnvironmentVarNameByIndex(int index) const;
+    //!cpp:function::
+    const char * getEnvironmentVarDefault(const char * name) const;
+    //!cpp:function::
+    void clearEnvironmentVars();
+    //!cpp:function::
+    void setEnvironmentMode(EnvironmentMode mode);
+    //!cpp:function::
+    EnvironmentMode getEnvironmentMode() const;
+    //!cpp:function::
+    void loadEnvironment();
+
+    //!cpp:function::
+    const char * getSearchPath() const;
+    //!cpp:function:: Set all search paths as a concatenated string, using
+    // ':' to separate the paths.  See addSearchPath for a more robust and
+    // platform-agnostic method of setting the search paths.
+    void setSearchPath(const char * path);
+
+    //!cpp:function::
+    int getNumSearchPaths() const;
+    //!cpp:function:: Get a search path from the list. The paths are in the
+    // order they will be searched (that is, highest to lowest priority).
+    const char * getSearchPath(int index) const;
+    //!cpp:function::
+    void clearSearchPaths();
+    //!cpp:function:: Add a single search path to the end of the list.
+    // Paths may be either absolute or relative. Relative paths are
+    // relative to the working directory. Forward slashes will be
+    // normalized to reverse for Windows. Environment (context) variables
+    // may be used in paths.
+    void addSearchPath(const char * path);
+
+    //!cpp:function::
+    const char * getWorkingDir() const;
+    //!cpp:function:: The working directory defaults to the location of the
+    // config file. It is used to convert any relative paths to absolute.
+    // If no search paths have been set, the working directory will be used
+    // as the fallback search path. No environment (context) variables may
+    // be used in the working directory.
+    void setWorkingDir(const char * dirname);
+
+    ///////////////////////////////////////////////////////////////////////////
+    //!rst:: .. _cfgcolorspaces_section:
+    // 
+    // ColorSpaces
+    // ^^^^^^^^^^^
+
+    //!cpp:function:: Get all active color spaces having a specific category
+    // in the order they appear in the config file.
     //
-    // A config defines all the color spaces to be available at runtime.
-    // 
-    // The color configuration (:cpp:class:`Config`) is the main object for
-    // interacting with this library. It encapsulates all of the information
-    // necessary to use customized :cpp:class:`ColorSpaceTransform` and
-    // :cpp:class:`DisplayTransform` operations.
-    // 
-    // See the :ref:`user-guide` for more information on
-    // selecting, creating, and working with custom color configurations.
-    // 
-    // For applications interested in using only one color config at
-    // a time (this is the vast majority of apps), their API would
-    // traditionally get the global configuration and use that, as opposed to
-    // creating a new one. This simplifies the use case for
-    // plugins and bindings, as it alleviates the need to pass around configuration
-    // handles.
-    // 
-    // An example of an application where this would not be sufficient would be
-    // a multi-threaded image proxy server (daemon), which wished to handle
-    // multiple show configurations in a single process concurrently. This
-    // app would need to keep multiple configurations alive, and to manage them
-    // appropriately.
-    // 
-    // Roughly speaking, a novice user should select a
-    // default configuration that most closely approximates the use case
-    // (animation, visual effects, etc.), and set the :envvar:`OCIO` environment
-    // variable to point at the root of that configuration.
-    // 
     // .. note::
-    //    Initialization using environment variables is typically preferable in
-    //    a multi-app ecosystem, as it allows all applications to be
-    //    consistently configured.
+    //    If the category is null or empty, the method returns
+    //    all the active color spaces like :cpp:func:`Config::getNumColorSpaces`
+    //    and :cpp:func:`Config::getColorSpaceNameByIndex` do.
     //
-    // See :ref:`developers-usageexamples`
-    
-    //!cpp:function:: Get the current configuration.
-    
-    extern OCIOEXPORT ConstConfigRcPtr GetCurrentConfig();
-    
-    //!cpp:function:: Set the current configuration. This will then store a copy of the specified config.
-    extern OCIOEXPORT void SetCurrentConfig(const ConstConfigRcPtr & config);
-    
-    
-    //!cpp:class::
-    class OCIOEXPORT Config
-    {
-    public:
-        
-        ///////////////////////////////////////////////////////////////////////////
-        //!rst:: .. _cfginit_section:
-        // 
-        // Initialization
-        // ^^^^^^^^^^^^^^
-        
-        //!cpp:function:: Create a default empty configuration.
-        static ConfigRcPtr Create();
-        //!cpp:function:: Create a fall-back config.  This may be useful to allow client apps 
-        // to launch in cases when the supplied config path is not loadable.
-        static ConstConfigRcPtr CreateRaw();
-        //!cpp:function:: Create a configuration using the OCIO environment variable.  If the 
-        // variable is missing or empty, returns the same result as :cpp:func:`Config::CreateRaw`.
-        static ConstConfigRcPtr CreateFromEnv();
-        //!cpp:function:: Create a configuration using a specific config file.
-        static ConstConfigRcPtr CreateFromFile(const char * filename);
-        //!cpp:function:: Create a configuration using a stream.
-        static ConstConfigRcPtr CreateFromStream(std::istream & istream);
-        
-        //!cpp:function::
-        ConfigRcPtr createEditableCopy() const;
-
-        //!cpp:function:: Get the configuration major version
-        unsigned int getMajorVersion() const;
-
-        //!cpp:function:: Set the configuration major version
-        void setMajorVersion(unsigned int major);
-
-        //!cpp:function:: Get the configuration minor version
-        unsigned int getMinorVersion() const;
-        
-        //!cpp:function:: Set the configuration minor version
-        void setMinorVersion(unsigned int minor);
-
-        //!cpp:function::
-        // This will throw an exception if the config is malformed. The most
-        // common error occurs when references are made to colorspaces that do not
-        // exist.
-        void sanityCheck() const;
-        
-        //!cpp:function::
-        const char * getDescription() const;
-        //!cpp:function::
-        void setDescription(const char * description);
-        
-        //!cpp:function::
-        // Returns the string representation of the Config in YAML text form.
-        // This is typically stored on disk in a file with the extension .ocio.
-        void serialize(std::ostream & os) const;
-        
-        //!cpp:function::
-        // This will produce a hash of the all colorspace definitions, etc.
-        // All external references, such as files used in FileTransforms, etc.,
-        // will be incorporated into the cacheID. While the contents of
-        // the files are not read, the file system is queried for relevant
-        // information (mtime, inode) so that the config's cacheID will
-        // change when the underlying luts are updated.
-        // If a context is not provided, the current Context will be used.
-        // If a null context is provided, file references will not be taken into
-        // account (this is essentially a hash of Config::serialize).
-        const char * getCacheID() const;
-        //!cpp:function::
-        const char * getCacheID(const ConstContextRcPtr & context) const;
-        
-        ///////////////////////////////////////////////////////////////////////////
-        //!rst:: .. _cfgresource_section:
-        // 
-        // Resources
-        // ^^^^^^^^^
-        // Given a lut src name, where should we find it?
-        
-        //!cpp:function::
-        ConstContextRcPtr getCurrentContext() const;
-        
-        //!cpp:function::
-        void addEnvironmentVar(const char * name, const char * defaultValue);
-        //!cpp:function::
-        int getNumEnvironmentVars() const;
-        //!cpp:function::
-        const char * getEnvironmentVarNameByIndex(int index) const;
-        //!cpp:function::
-        const char * getEnvironmentVarDefault(const char * name) const;
-        //!cpp:function::
-        void clearEnvironmentVars();
-        //!cpp:function::
-        void setEnvironmentMode(EnvironmentMode mode);
-        //!cpp:function::
-        EnvironmentMode getEnvironmentMode() const;
-        //!cpp:function::
-        void loadEnvironment();
-        
-        //!cpp:function::
-        const char * getSearchPath() const;
-        //!cpp:function:: Set all search paths as a concatenated string, using
-        // ':' to separate the paths.  See addSearchPath for a more robust and
-        // platform-agnostic method of setting the search paths.
-        void setSearchPath(const char * path);
-        
-        //!cpp:function::
-        int getNumSearchPaths() const;
-        //!cpp:function:: Get a search path from the list. The paths are in the
-        // order they will be searched (that is, highest to lowest priority).
-        const char * getSearchPath(int index) const;
-        //!cpp:function::
-        void clearSearchPaths();
-        //!cpp:function:: Add a single search path to the end of the list.
-        // Paths may be either absolute or relative. Relative paths are
-        // relative to the working directory. Forward slashes will be
-        // normalized to reverse for Windows. Environment (context) variables
-        // may be used in paths.
-        void addSearchPath(const char * path);
-
-        //!cpp:function::
-        const char * getWorkingDir() const;
-        //!cpp:function:: The working directory defaults to the location of the
-        // config file. It is used to convert any relative paths to absolute.
-        // If no search paths have been set, the working directory will be used
-        // as the fallback search path. No environment (context) variables may
-        // be used in the working directory.
-        void setWorkingDir(const char * dirname);
-        
-        ///////////////////////////////////////////////////////////////////////////
-        //!rst:: .. _cfgcolorspaces_section:
-        // 
-        // ColorSpaces
-        // ^^^^^^^^^^^
-
-        //!cpp:function:: Get all active color spaces having a specific category 
-        // in the order they appear in the config file.
-        //
-        // .. note::
-        //    If the category is null or empty, the method returns 
-        //    all the active color spaces like :cpp:func:`Config::getNumColorSpaces` 
-        //    and :cpp:func:`Config::getColorSpaceNameByIndex` do.
-        //
-        // .. note::
-        //    It's worth noticing that the method returns a copy of the 
-        //    selected color spaces decoupling the result from the config. 
-        //    Hence, any changes on the config do not affect the existing 
-        //    color space sets, and vice-versa.
-        //
-        ColorSpaceSetRcPtr getColorSpaces(const char * category) const;
-
-        //!cpp:function:: Work on the color spaces selected by the visibility.
-        int getNumColorSpaces(ColorSpaceVisibility visibility) const;
-        //!cpp:function:: Work on the color spaces selected by the visibility (active or inactive)
-        // and return null for invalid index.
-        const char * getColorSpaceNameByIndex(ColorSpaceVisibility visibility, int index) const;
-
-        //!cpp:function:: Get the color space from all the color spaces 
-        // (i.e. active and inactive) and return null if the name is not found.
-        //
-        // .. note::
-        //    The fcn accepts either a color space OR role name.
-        //    (Color space names take precedence over roles.)
-        ConstColorSpaceRcPtr getColorSpace(const char * name) const;
-
-        // The following three methods only work from the list of active color spaces.
-
-        //!cpp:function:: Work on the active color spaces only.
-        int getNumColorSpaces() const;
-
-        //!cpp:function:: Work on the active color spaces only and return null for invalid index.
-        const char * getColorSpaceNameByIndex(int index) const;
-
-        //!cpp:function:: Get an index from the active color spaces only
-        // and return -1 if the name is not found.
-        //
-        // .. note::
-        //    The fcn accepts either a color space OR role name.
-        //    (Color space names take precedence over roles.)
-        int getIndexForColorSpace(const char * name) const;
-
-        //!cpp:function:: Add a color space to the configuration.
-        //
-        // .. note::
-        //    If another color space is already present with the same name,
-        //    this will overwrite it. This stores a copy of the specified
-        //    color space.
-        // .. note::
-        //    Adding a color space to a :cpp:class:`Config` does not affect any 
-        //    :cpp:class:`ColorSpaceSet`s that have already been created.
-        void addColorSpace(const ConstColorSpaceRcPtr & cs);
-
-        //!cpp:function:: Remove a color space from the configuration.
-        //
-        // .. note::
-        //    It does not throw an exception if the color space is not present
-        //    or used by an existing role.  Role name arguments are ignored.
-        // .. note::
-        //    Removing a color space to a :cpp:class:`Config` does not affect any 
-        //    :cpp:class:`ColorSpaceSet`s that have already been created.
-        void removeColorSpace(const char * name);
-
-        //!cpp:function:: Remove all the color spaces from the configuration.
-        //
-        // .. note::
-        //    Removing color spaces from a :cpp:class:`Config` does not affect 
-        //    any :cpp:class:`ColorSpaceSet`s that have already been created.
-        void clearColorSpaces();
-        
-        //!cpp:function:: Given the specified string, get the longest,
-        // right-most, colorspace substring that appears.
-        //
-        // * If strict parsing is enabled, and no color space is found, return
-        //   an empty string.
-        // * If strict parsing is disabled, return ROLE_DEFAULT (if defined).
-        // * If the default role is not defined, return an empty string.
-        const char * parseColorSpaceFromString(const char * str) const;
-        
-        //!cpp:function::
-        bool isStrictParsingEnabled() const;
-        //!cpp:function::
-        void setStrictParsingEnabled(bool enabled);
-        
-        //!cpp:function:: Set/get a list of inactive color space names.
-        //
-        // * The inactive spaces are color spaces that should not appear in application menus.
-        // * These color spaces will still work in :cpp:function:`getProcessor` calls.
-        // * The argument is a comma-delimited string.  A null or empty string empties the list.
-        // * The environment variable OCIO_INACTIVE_COLORSPACES may also be used to set the 
-        //   inactive color space list.
-        // * The env. var. takes precedence over the inactive_colorspaces list in the config file.
-        // * Setting the list via the API takes precedence over either the env. var. or the 
-        //   config file list.
-        // * Roles may not be used.
-        void setInactiveColorSpaces(const char * inactiveColorSpaces);
-        //!cpp:function::
-        const char * getInactiveColorSpaces() const;
-
-
-        ///////////////////////////////////////////////////////////////////////////
-        //!rst:: .. _cfgroles_section:
-        // 
-        // Roles
-        // ^^^^^
-        // A role is like an alias for a colorspace. You can query the colorspace
-        // corresponding to a role using the normal getColorSpace fcn.
-        
-        //!cpp:function::
-        // .. note::
-        //    Setting the ``colorSpaceName`` name to a null string unsets it.
-        void setRole(const char * role, const char * colorSpaceName);
-        //!cpp:function::
-        int getNumRoles() const;
-        //!cpp:function:: Return true if the role has been defined.
-        bool hasRole(const char * role) const;
-        //!cpp:function:: Get the role name at index, this will return values
-        // like 'scene_linear', 'compositing_log'.
-        // Return empty string if index is out of range.
-        const char * getRoleName(int index) const;
-        
-        
-        
-        ///////////////////////////////////////////////////////////////////////////
-        //!rst:: .. _cfgdisplayview_section:
-        // 
-        // Display/View Registration
-        // ^^^^^^^^^^^^^^^^^^^^^^^^^
-        //
-        // Looks is a potentially comma (or colon) delimited list of lookNames,
-        // Where +/- prefixes are optionally allowed to denote forward/inverse
-        // look specification. (And forward is assumed in the absence of either)
-        
-        //!cpp:function::
-        const char * getDefaultDisplay() const;
-        //!cpp:function::
-        int getNumDisplays() const;
-        //!cpp:function::
-        const char * getDisplay(int index) const;
-        
-        //!cpp:function::
-        const char * getDefaultView(const char * display) const;
-        //!cpp:function::
-        int getNumViews(const char * display) const;
-        //!cpp:function::
-        const char * getView(const char * display, int index) const;
-        
-        //!cpp:function::
-        const char * getDisplayColorSpaceName(const char * display, const char * view) const;
-        //!cpp:function::
-        const char * getDisplayLooks(const char * display, const char * view) const;
-        
-        //!cpp:function:: For the (display,view) combination,
-        // specify which colorSpace and look to use.
-        // If a look is not desired, then just pass an empty string
-        
-        void addDisplay(const char * display, const char * view,
-                        const char * colorSpaceName, const char * looks);
-        
-        //!cpp:function::
-        void clearDisplays();
-        
-        // $OCIO_ACTIVE_DISPLAYS envvar can, at runtime, optionally override the allowed displays.
-        // It is a comma or colon delimited list.
-        // Active displays that are not in the specified profile will be ignored, and the
-        // left-most defined display will be the default.
-        
-        //!cpp:function:: Comma-delimited list of display names.
-        // .. note:: The setter does not override the envvar.  The getter does not take into 
-        // account the envvar value and thus may not represent what the user is seeing.
-        void setActiveDisplays(const char * displays);
-        //!cpp:function::
-        const char * getActiveDisplays() const;
-        
-        // $OCIO_ACTIVE_VIEWS envvar can, at runtime, optionally override the allowed views.
-        // It is a comma or colon delimited list.
-        // Active views that are not in the specified profile will be ignored, and the
-        // left-most defined view will be the default.
-        
-        //!cpp:function:: Comma-delimited list of view names.
-        // .. note:: The setter does not override the envvar.  The getter does not take into 
-        // account the envvar value and thus may not represent what the user is seeing.
-        void setActiveViews(const char * views);
-        //!cpp:function::
-        const char * getActiveViews() const;
-        
-        
-        ///////////////////////////////////////////////////////////////////////////
-        //!rst:: .. _cfgluma_section:
-        // 
-        // Luma
-        // ^^^^
-        //
-        // Get the default coefficients for computing luma.
-        //
-        // .. note::
-        //    There is no "1 size fits all" set of luma coefficients. (The
-        //    values are typically different for each colorspace, and the
-        //    application of them may be nonsensical depending on the
-        //    intensity coding anyways). Thus, the 'right' answer is to make
-        //    these functions on the :cpp:class:`Config` class. However, it's
-        //    often useful to have a config-wide default so here it is. We will
-        //    add the colorspace specific luma call if/when another client is
-        //    interesting in using it.
-        
-        //!cpp:function::
-        void getDefaultLumaCoefs(double * rgb) const;
-        //!cpp:function:: These should be normalized (sum to 1.0 exactly).
-        void setDefaultLumaCoefs(const double * rgb);
-        
-        
-        ///////////////////////////////////////////////////////////////////////////
-        //!rst:: .. _cflooka_section:
-        // 
-        // Look
-        // ^^^^
-        //
-        // Manager per-shot look settings.
-        //
-        
-        //!cpp:function::
-        ConstLookRcPtr getLook(const char * name) const;
-        
-        //!cpp:function::
-        int getNumLooks() const;
-        
-        //!cpp:function::
-        const char * getLookNameByIndex(int index) const;
-        
-        //!cpp:function::
-        void addLook(const ConstLookRcPtr & look);
-        
-        //!cpp:function::
-        void clearLooks();
-        
-        
-        ///////////////////////////////////////////////////////////////////////////
-        //!rst:: .. _cfgprocessors_section:
-        // 
-        // Processors
-        // ^^^^^^^^^^
-        //
-        // Create a :cpp:class:`Processor` to assemble a transformation between two 
-        // color spaces.  It may then be used to create a :cpp:class:`CPUProcessor` 
-        // or :cpp:class:`GPUProcessor` to process/convert pixels.
-
-        //!cpp:function::
-        ConstProcessorRcPtr getProcessor(const ConstContextRcPtr & context,
-                                         const ConstColorSpaceRcPtr & srcColorSpace,
-                                         const ConstColorSpaceRcPtr & dstColorSpace) const;
-        //!cpp:function::
-        ConstProcessorRcPtr getProcessor(const ConstColorSpaceRcPtr & srcColorSpace,
-                                         const ConstColorSpaceRcPtr & dstColorSpace) const;
-        
-        //!cpp:function::
-        // .. note::
-        //    Names can be colorspace name, role name, or a combination of both.
-        ConstProcessorRcPtr getProcessor(const char * srcName,
-                                         const char * dstName) const;
-        //!cpp:function::
-        ConstProcessorRcPtr getProcessor(const ConstContextRcPtr & context,
-                                         const char * srcName,
-                                         const char * dstName) const;
-        
-        //!rst:: Get the processor for the specified transform.
-        //
-        // Not often needed, but will allow for the re-use of atomic OCIO
-        // functionality (such as to apply an individual LUT file).
-        
-        //!cpp:function::
-        ConstProcessorRcPtr getProcessor(const ConstTransformRcPtr& transform) const;
-        //!cpp:function::
-        ConstProcessorRcPtr getProcessor(const ConstTransformRcPtr& transform,
-                                         TransformDirection direction) const;
-        //!cpp:function::
-        ConstProcessorRcPtr getProcessor(const ConstContextRcPtr & context,
-                                         const ConstTransformRcPtr& transform,
-                                         TransformDirection direction) const;
-
-    private:
-        Config();
-        ~Config();
-        
-        Config(const Config &);
-        Config& operator= (const Config &);
-        
-        static void deleter(Config* c);
-        
-        class Impl;
-        friend class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
-    
-    extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const Config&);
-    
-    
-    ///////////////////////////////////////////////////////////////////////////
-    //!rst:: .. _colorspace_section:
-    // 
-    // ColorSpace
-    // **********
-    // The *ColorSpace* is the state of an image with respect to colorimetry
-    // and color encoding. Transforming images between different
-    // *ColorSpaces* is the primary motivation for this library.
-    //
-    // While a complete discussion of color spaces is beyond the scope of
-    // header documentation, traditional uses would be to have *ColorSpaces*
-    // corresponding to: physical capture devices (known cameras, scanners),
-    // and internal 'convenience' spaces (such as scene linear, logarithmic).
-    //
-    // *ColorSpaces* are specific to a particular image precision (float32,
-    // uint8, etc.), and the set of ColorSpaces that provide equivalent mappings
-    // (at different precisions) are referred to as a 'family'.
-    
-    //!cpp:class::
-    class OCIOEXPORT ColorSpace
-    {
-    public:
-        //!cpp:function::
-        static ColorSpaceRcPtr Create();
-        
-        //!cpp:function::
-        ColorSpaceRcPtr createEditableCopy() const;
-        
-        //!cpp:function::
-        const char * getName() const noexcept;
-        //!cpp:function::
-        void setName(const char * name);
-        
-        //!cpp:function::Get the family, for use in user interfaces (optional)
-        // The family string could use a '/' separator to indicate levels to be used
-        // by hierarchical menus.
-        const char * getFamily() const noexcept;
-        //!cpp:function::Set the family, for use in user interfaces (optional)
-        void setFamily(const char * family);
-        
-        //!cpp:function::Get the ColorSpace group name (used for equality comparisons)
-        // This allows no-op transforms between different colorspaces.
-        // If an equalityGroup is not defined (an empty string), it will be considered
-        // unique (i.e., it will not compare as equal to other ColorSpaces with an
-        // empty equality group).  This is often, though not always, set to the
-        // same value as 'family'.
-        const char * getEqualityGroup() const noexcept;
-        //!cpp:function::
-        void setEqualityGroup(const char * equalityGroup);
-        
-        //!cpp:function::
-        const char * getDescription() const noexcept;
-        //!cpp:function::
-        void setDescription(const char * description);
-        
-        //!cpp:function::
-        BitDepth getBitDepth() const noexcept;
-        //!cpp:function::
-        void setBitDepth(BitDepth bitDepth);
-
-        ///////////////////////////////////////////////////////////////////////////
-        //!rst::
-        // Categories
-        // ^^^^^^^^^^
-        // A category is used to allow applications to filter the list of color spaces 
-        // they display in menus based on what that color space is used for.
-        //
-        // Here is an example config entry that could appear under a ColorSpace:
-        // categories: [input, rendering]
-        //
-        // The example contains two categories: 'input' and 'rendering'. 
-        // Category strings are not case-sensitive and the order is not significant.
-        // There is no limit imposed on length or number. Although users may add 
-        // their own categories, the strings will typically come from a fixed set 
-        // listed in the documentation (similar to roles).
-
-        //!cpp:function:: Return true if the category is present.
-        bool hasCategory(const char * category) const;
-        //!cpp:function:: Add a single category.
-        // .. note:: Will do nothing if the category already exists.
-        void addCategory(const char * category);
-        //!cpp:function:: Remove a category.
-        // .. note:: Will do nothing if the category is missing.
-        void removeCategory(const char * category);
-        //!cpp:function:: Get the number of categories.
-        int getNumCategories() const;
-        //!cpp:function:: Return the category name using its index
-        // .. note:: Will be null if the index is invalid.
-        const char * getCategory(int index) const;
-        // Clear all the categories.
-        void clearCategories();
-
-        ///////////////////////////////////////////////////////////////////////////
-        //!rst::
-        // Data
-        // ^^^^
-        // ColorSpaces that are data are treated a bit special. Basically, any
-        // colorspace transforms you try to apply to them are ignored. (Think
-        // of applying a gamut mapping transform to an ID pass). Also, the
-        // :cpp:class:`DisplayTransform` process obeys special 'data min' and
-        // 'data max' args.
-        //
-        // This is traditionally used for pixel data that represents non-color
-        // pixel data, such as normals, point positions, ID information, etc.
-        
-        //!cpp:function::
-        bool isData() const;
-        //!cpp:function::
-        void setIsData(bool isData);
-        
-        ///////////////////////////////////////////////////////////////////////////
-        //!rst::
-        // Allocation
-        // ^^^^^^^^^^
-        // If this colorspace needs to be transferred to a limited dynamic
-        // range coding space (such as during display with a GPU path), use this
-        // allocation to maximize bit efficiency.
-        
-        //!cpp:function::
-        Allocation getAllocation() const;
-        //!cpp:function::
-        void setAllocation(Allocation allocation);
-        
-        //!rst::
-        // Specify the optional variable values to configure the allocation.
-        // If no variables are specified, the defaults are used.
-        //
-        // ALLOCATION_UNIFORM::
-        //    
-        //    2 vars: [min, max]
-        //
-        // ALLOCATION_LG2::
-        //    
-        //    2 vars: [lg2min, lg2max]
-        //    3 vars: [lg2min, lg2max, linear_offset]
-        
-        //!cpp:function::
-        int getAllocationNumVars() const;
-        //!cpp:function::
-        void getAllocationVars(float * vars) const;
-        //!cpp:function::
-        void setAllocationVars(int numvars, const float * vars);
-        
-        ///////////////////////////////////////////////////////////////////////////
-        //!rst::
-        // Transform
-        // ^^^^^^^^^
-        
-        //!cpp:function::
-        // If a transform in the specified direction has been specified,
-        // return it. Otherwise return a null ConstTransformRcPtr
-        ConstTransformRcPtr getTransform(ColorSpaceDirection dir) const;
-        //!cpp:function::
-        // Specify the transform for the appropriate direction.
-        // Setting the transform to null will clear it.
-        void setTransform(const ConstTransformRcPtr & transform,
-                          ColorSpaceDirection dir);
-    
-    private:
-        ColorSpace();
-        ~ColorSpace();
-        
-        ColorSpace(const ColorSpace &);
-        ColorSpace& operator= (const ColorSpace &);
-        
-        static void deleter(ColorSpace* c);
-        
-        class Impl;
-        friend class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
-    
-    extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const ColorSpace&);
-    
-    
-    
-    
-    ///////////////////////////////////////////////////////////////////////////
-    //!rst:: .. _colorspaceset_section:
-    // 
-    // ColorSpaceSet
-    // *************
-    // The *ColorSpaceSet* is a set of color spaces (i.e. no color space duplication) 
-    // which could be the result of :cpp:func:`Config::getColorSpaces`
-    // or built from scratch.
-    // 
     // .. note::
-    //    The color spaces are decoupled from the config ones, i.e., any 
-    //    changes to the set itself or to its color spaces do not affect the 
-    //    original color spaces from the configuration.  If needed, 
-    //    use :cpp:func:`Config::addColorSpace` to update the configuration.
+    //    It's worth noticing that the method returns a copy of the
+    //    selected color spaces decoupling the result from the config.
+    //    Hence, any changes on the config do not affect the existing
+    //    color space sets, and vice-versa.
+    //
+    ColorSpaceSetRcPtr getColorSpaces(const char * category) const;
 
-    //!cpp:class::
-    class OCIOEXPORT ColorSpaceSet
-    {
-    public:
-        //!cpp:function:: Create an empty set of color spaces.
-        static ColorSpaceSetRcPtr Create();
+    //!cpp:function:: Work on the color spaces selected by the visibility.
+    int getNumColorSpaces(ColorSpaceVisibility visibility) const;
+    //!cpp:function:: Work on the color spaces selected by the visibility (active or inactive)
+    // and return null for invalid index.
+    const char * getColorSpaceNameByIndex(ColorSpaceVisibility visibility, int index) const;
 
-        //!cpp:function:: Create a set containing a copy of all the color spaces.
-        ColorSpaceSetRcPtr createEditableCopy() const;
-
-        //!cpp:function:: Return true if the two sets are equal.
-        // .. note:: The comparison is done on the color space names (not a deep comparison).
-        bool operator==(const ColorSpaceSet & css) const;
-        //!cpp:function:: Return true if the two sets are different.
-        bool operator!=(const ColorSpaceSet & css) const;
-
-        //!cpp:function:: Return the number of color spaces.
-        int getNumColorSpaces() const;
-        //!cpp:function:: Return the color space name using its index.
-        // This will be null if an invalid index is specified.
-        const char * getColorSpaceNameByIndex(int index) const;
-        //!cpp:function:: Return the color space using its index.
-        // This will be empty if an invalid index is specified.
-        ConstColorSpaceRcPtr getColorSpaceByIndex(int index) const;
-
-        //!rst::
-        // .. note::
-        //    These fcns only accept color space names (i.e. no role name).
-
-        //!cpp:function:: Will return null if the name is not found.
-        ConstColorSpaceRcPtr getColorSpace(const char * name) const;
-        //!cpp:function:: Will return -1 if the name is not found.
-        int getIndexForColorSpace(const char * name) const;
-
-        //!cpp:function:: Add color space(s).
-        //
-        // .. note::
-        //    If another color space is already registered with the same name,
-        //    this will overwrite it. This stores a copy of the specified
-        //    color space(s).
-        void addColorSpace(const ConstColorSpaceRcPtr & cs);
-        void addColorSpaces(const ConstColorSpaceSetRcPtr & cs);
-
-        //!cpp:function:: Remove color space(s) using color space names (i.e. no role name).
-        //
-        // .. note::
-        //    The removal of a missing color space does nothing.
-        void removeColorSpace(const char * name);
-        void removeColorSpaces(const ConstColorSpaceSetRcPtr & cs);
-
-        //!cpp:function:: Clear all color spaces.
-        void clearColorSpaces();
-
-    private:
-        ColorSpaceSet();
-        ~ColorSpaceSet();
-        
-        ColorSpaceSet(const ColorSpaceSet &);
-        ColorSpaceSet & operator= (const ColorSpaceSet &);
-        
-        static void deleter(ColorSpaceSet * c);
-        
-        class Impl;
-        friend class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
-
-
+    //!cpp:function:: Get the color space from all the color spaces
+    // (i.e. active and inactive) and return null if the name is not found.
+    //
     // .. note::
-    //    All these fcns provide some operations on two color space sets 
-    //    where the result contains copied color spaces and no duplicates.
+    //    The fcn accepts either a color space OR role name.
+    //    (Color space names take precedence over roles.)
+    ConstColorSpaceRcPtr getColorSpace(const char * name) const;
 
-    //!cpp:function:: Perform the union of two sets.
-    extern OCIOEXPORT ConstColorSpaceSetRcPtr operator||(const ConstColorSpaceSetRcPtr & lcss, 
-                                                         const ConstColorSpaceSetRcPtr & rcss);
-    //!cpp:function:: Perform the intersection of two sets.
-    extern OCIOEXPORT ConstColorSpaceSetRcPtr operator&&(const ConstColorSpaceSetRcPtr & lcss, 
-                                                         const ConstColorSpaceSetRcPtr & rcss);
-    //!cpp:function:: Perform the difference of two sets.
-    extern OCIOEXPORT ConstColorSpaceSetRcPtr operator-(const ConstColorSpaceSetRcPtr & lcss, 
-                                                        const ConstColorSpaceSetRcPtr & rcss);
+    // The following three methods only work from the list of active color spaces.
 
+    //!cpp:function:: Work on the active color spaces only.
+    int getNumColorSpaces() const;
+
+    //!cpp:function:: Work on the active color spaces only and return null for invalid index.
+    const char * getColorSpaceNameByIndex(int index) const;
+
+    //!cpp:function:: Get an index from the active color spaces only
+    // and return -1 if the name is not found.
+    //
+    // .. note::
+    //    The fcn accepts either a color space OR role name.
+    //    (Color space names take precedence over roles.)
+    int getIndexForColorSpace(const char * name) const;
+
+    //!cpp:function:: Add a color space to the configuration.
+    //
+    // .. note::
+    //    If another color space is already present with the same name,
+    //    this will overwrite it. This stores a copy of the specified
+    //    color space.
+    // .. note::
+    //    Adding a color space to a :cpp:class:`Config` does not affect any
+    //    :cpp:class:`ColorSpaceSet`s that have already been created.
+    void addColorSpace(const ConstColorSpaceRcPtr & cs);
+
+    //!cpp:function:: Remove a color space from the configuration.
+    //
+    // .. note::
+    //    It does not throw an exception if the color space is not present
+    //    or used by an existing role.  Role name arguments are ignored.
+    // .. note::
+    //    Removing a color space to a :cpp:class:`Config` does not affect any
+    //    :cpp:class:`ColorSpaceSet`s that have already been created.
+    void removeColorSpace(const char * name);
+
+    //!cpp:function:: Remove all the color spaces from the configuration.
+    //
+    // .. note::
+    //    Removing color spaces from a :cpp:class:`Config` does not affect
+    //    any :cpp:class:`ColorSpaceSet`s that have already been created.
+    void clearColorSpaces();
+
+    //!cpp:function:: Given the specified string, get the longest,
+    // right-most, colorspace substring that appears.
+    //
+    // * If strict parsing is enabled, and no color space is found, return
+    //   an empty string.
+    // * If strict parsing is disabled, return ROLE_DEFAULT (if defined).
+    // * If the default role is not defined, return an empty string.
+    const char * parseColorSpaceFromString(const char * str) const;
+
+    //!cpp:function::
+    bool isStrictParsingEnabled() const;
+    //!cpp:function::
+    void setStrictParsingEnabled(bool enabled);
+
+    //!cpp:function:: Set/get a list of inactive color space names.
+    //
+    // * The inactive spaces are color spaces that should not appear in application menus.
+    // * These color spaces will still work in :cpp:function:`getProcessor` calls.
+    // * The argument is a comma-delimited string.  A null or empty string empties the list.
+    // * The environment variable OCIO_INACTIVE_COLORSPACES may also be used to set the
+    //   inactive color space list.
+    // * The env. var. takes precedence over the inactive_colorspaces list in the config file.
+    // * Setting the list via the API takes precedence over either the env. var. or the
+    //   config file list.
+    // * Roles may not be used.
+    void setInactiveColorSpaces(const char * inactiveColorSpaces);
+    //!cpp:function::
+    const char * getInactiveColorSpaces() const;
+
+
+    ///////////////////////////////////////////////////////////////////////////
+    //!rst:: .. _cfgroles_section:
+    //
+    // Roles
+    // ^^^^^
+    // A role is like an alias for a colorspace. You can query the colorspace
+    // corresponding to a role using the normal getColorSpace fcn.
+
+    //!cpp:function::
+    // .. note::
+    //    Setting the ``colorSpaceName`` name to a null string unsets it.
+    void setRole(const char * role, const char * colorSpaceName);
+    //!cpp:function::
+    int getNumRoles() const;
+    //!cpp:function:: Return true if the role has been defined.
+    bool hasRole(const char * role) const;
+    //!cpp:function:: Get the role name at index, this will return values
+    // like 'scene_linear', 'compositing_log'.
+    // Return empty string if index is out of range.
+    const char * getRoleName(int index) const;
 
 
 
     ///////////////////////////////////////////////////////////////////////////
-    //!rst:: .. _look_section:
+    //!rst:: .. _cfgdisplayview_section:
+    //
+    // Display/View Registration
+    // ^^^^^^^^^^^^^^^^^^^^^^^^^
+    //
+    // Looks is a potentially comma (or colon) delimited list of lookNames,
+    // Where +/- prefixes are optionally allowed to denote forward/inverse
+    // look specification. (And forward is assumed in the absence of either)
+
+    //!cpp:function::
+    const char * getDefaultDisplay() const;
+    //!cpp:function::
+    int getNumDisplays() const;
+    //!cpp:function::
+    const char * getDisplay(int index) const;
+
+    //!cpp:function::
+    const char * getDefaultView(const char * display) const;
+    //!cpp:function::
+    int getNumViews(const char * display) const;
+    //!cpp:function::
+    const char * getView(const char * display, int index) const;
+
+    //!cpp:function::
+    const char * getDisplayColorSpaceName(const char * display, const char * view) const;
+    //!cpp:function::
+    const char * getDisplayLooks(const char * display, const char * view) const;
+
+    //!cpp:function:: For the (display,view) combination,
+    // specify which colorSpace and look to use.
+    // If a look is not desired, then just pass an empty string
+
+    void addDisplay(const char * display, const char * view,
+                    const char * colorSpaceName, const char * looks);
+
+    //!cpp:function::
+    void clearDisplays();
+
+    // $OCIO_ACTIVE_DISPLAYS envvar can, at runtime, optionally override the allowed displays.
+    // It is a comma or colon delimited list.
+    // Active displays that are not in the specified profile will be ignored, and the
+    // left-most defined display will be the default.
+
+    //!cpp:function:: Comma-delimited list of display names.
+    // .. note:: The setter does not override the envvar.  The getter does not take into
+    // account the envvar value and thus may not represent what the user is seeing.
+    void setActiveDisplays(const char * displays);
+    //!cpp:function::
+    const char * getActiveDisplays() const;
+
+    // $OCIO_ACTIVE_VIEWS envvar can, at runtime, optionally override the allowed views.
+    // It is a comma or colon delimited list.
+    // Active views that are not in the specified profile will be ignored, and the
+    // left-most defined view will be the default.
+
+    //!cpp:function:: Comma-delimited list of view names.
+    // .. note:: The setter does not override the envvar.  The getter does not take into
+    // account the envvar value and thus may not represent what the user is seeing.
+    void setActiveViews(const char * views);
+    //!cpp:function::
+    const char * getActiveViews() const;
+
+
+    ///////////////////////////////////////////////////////////////////////////
+    //!rst:: .. _cfgluma_section:
+    // 
+    // Luma
+    // ^^^^
+    //
+    // Get the default coefficients for computing luma.
+    //
+    // .. note::
+    //    There is no "1 size fits all" set of luma coefficients. (The
+    //    values are typically different for each colorspace, and the
+    //    application of them may be nonsensical depending on the
+    //    intensity coding anyways). Thus, the 'right' answer is to make
+    //    these functions on the :cpp:class:`Config` class. However, it's
+    //    often useful to have a config-wide default so here it is. We will
+    //    add the colorspace specific luma call if/when another client is
+    //    interesting in using it.
+
+    //!cpp:function::
+    void getDefaultLumaCoefs(double * rgb) const;
+    //!cpp:function:: These should be normalized (sum to 1.0 exactly).
+    void setDefaultLumaCoefs(const double * rgb);
+
+
+    ///////////////////////////////////////////////////////////////////////////
+    //!rst:: .. _cflooka_section:
     // 
     // Look
-    // ****
-    // The *Look* is an 'artistic' image modification, in a specified image
-    // state.
-    // The processSpace defines the ColorSpace the image is required to be
-    // in, for the math to apply correctly.
-    
-    //!cpp:class::
-    class OCIOEXPORT Look
-    {
-    public:
-        //!cpp:function::
-        static LookRcPtr Create();
-        
-        //!cpp:function::
-        LookRcPtr createEditableCopy() const;
-        
-        //!cpp:function::
-        const char * getName() const;
-        //!cpp:function::
-        void setName(const char * name);
-        
-        //!cpp:function::
-        const char * getProcessSpace() const;
-        //!cpp:function::
-        void setProcessSpace(const char * processSpace);
-        
-        //!cpp:function::
-        ConstTransformRcPtr getTransform() const;
-        //!cpp:function:: Setting a transform to a non-null call makes it allowed.
-        void setTransform(const ConstTransformRcPtr & transform);
-        
-        //!cpp:function::
-        ConstTransformRcPtr getInverseTransform() const;
-        //!cpp:function:: Setting a transform to a non-null call makes it allowed.
-        void setInverseTransform(const ConstTransformRcPtr & transform);
-
-        //!cpp:function::
-        const char * getDescription() const;
-        //!cpp:function::
-        void setDescription(const char * description);
-    private:
-        Look();
-        ~Look();
-        
-        Look(const Look &);
-        Look& operator= (const Look &);
-        
-        static void deleter(Look* c);
-        
-        class Impl;
-        friend class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
-    
-    extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const Look&);
-    
-    
-    ///////////////////////////////////////////////////////////////////////////
-    //!rst::
-    // Processor
-    // *********
-    // The *Processor* represents a specific color transformation which is 
-    // the result of :cpp:func:`Config::getProcessor`.
-
-    //!cpp:class::
-    class OCIOEXPORT Processor
-    {
-    public:
-        //!cpp:function::
-        bool isNoOp() const;
-        
-        //!cpp:function:: True if the image transformation is non-separable.
-        // For example, if a change in red may also cause a change in green or blue.
-        bool hasChannelCrosstalk() const;
-        
-        //!cpp:function:: The ProcessorMetadata contains technical information
-        //                such as the number of files and looks used in the processor.
-        ConstProcessorMetadataRcPtr getProcessorMetadata() const;
-
-        //!cpp:function:: Get a FormatMetadata containing the top level metadata
-        //                for the processor.  For a processor from a CLF file,
-        //                this corresponds to the ProcessList metadata.
-        const FormatMetadata & getFormatMetadata() const;
-
-        //!cpp:function:: Get the number of transforms that comprise the processor.
-        //                Each transform has a (potentially empty) FormatMetadata.
-        int getNumTransforms() const;
-        //!cpp:function:: Get a FormatMetadata containing the metadata for a
-        //                transform within the processor. For a processor from
-        //                a CLF file, this corresponds to the metadata associated
-        //                with an individual process node.
-        const FormatMetadata & getTransformFormatMetadata(int index) const;
-
-        //!cpp:function:: Return a cpp:class:`GroupTransform` that contains a
-        //                copy of the transforms that comprise the processor.
-        //                (Changes to it will not modify the original processor.)
-        GroupTransformRcPtr createGroupTransform() const;
-
-        //!cpp:function:: Write the transforms comprising the processor to the stream.
-        //                Writing (as opposed to Baking) is a lossless process.
-        //                An exception is thrown if the processor cannot be
-        //                losslessly written to the specified file format.
-        void write(const char * formatName, std::ostream & os) const;
-
-        //!cpp:function:: Get the number of writers.
-        static int getNumWriteFormats();
-
-        //!cpp:function:: Get the writer at index, return empty string if
-        //                an invalid index is specified.
-        static const char * getFormatNameByIndex(int index);
-        static const char * getFormatExtensionByIndex(int index);
-
-        // TODO: Revisit the dynamic property access.
-        //!cpp:function::
-        DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const;
-        bool hasDynamicProperty(DynamicPropertyType type) const;
-
-        //!cpp:function:: 
-        const char * getCacheID() const;
-
-        ///////////////////////////////////////////////////////////////////////////
-        //!rst::
-        // GPU Renderer
-        // ^^^^^^^^^^^^
-        // Get an optimized :cpp:class:`GPUProcessor` instance.
-
-        //!cpp:function::        
-        ConstGPUProcessorRcPtr getDefaultGPUProcessor() const;
-        //!cpp:function::        
-        ConstGPUProcessorRcPtr getOptimizedGPUProcessor(OptimizationFlags oFlags) const;
-        
-        ///////////////////////////////////////////////////////////////////////////
-        //!rst::
-        // CPU Renderer
-        // ^^^^^^^^^^^^
-        // Get an optimized :cpp:class:`CPUProcessor` instance.
-        //        
-        // .. note::
-        //    This may provide higher fidelity than anticipated due to internal
-        //    optimizations. For example, if the inputColorSpace and the
-        //    outputColorSpace are members of the same family, no conversion
-        //    will be applied, even though strictly speaking quantization
-        //    should be added.
-
-
-        // .. note::
-        //    The typical use case to apply color processing to an image is:
-        // 
-        // .. code-block:: cpp
-        //
-        //     OCIO::ConstConfigRcPtr config = OCIO::GetCurrentConfig();
-        // 
-        //     OCIO::ConstProcessorRcPtr processor 
-        //         = config->getProcessor(colorSpace1, colorSpace2);
-        //
-        //     OCIO::ConstCPUProcessorRcPtr cpuProcessor
-        //         = processor->getDefaultCPUProcessor();
-        //
-        //     OCIO::PackedImageDesc img(imgDataPtr, imgWidth, imgHeight, imgChannels);
-        //     cpuProcessor->apply(img);
-        //     
-
-        //!cpp:function::        
-        ConstCPUProcessorRcPtr getDefaultCPUProcessor() const;
-        //!cpp:function::        
-        ConstCPUProcessorRcPtr getOptimizedCPUProcessor(OptimizationFlags oFlags) const;
-        //!cpp:function::        
-        ConstCPUProcessorRcPtr getOptimizedCPUProcessor(BitDepth inBitDepth,
-                                                        BitDepth outBitDepth,
-                                                        OptimizationFlags oFlags) const;
-
-    private:
-        Processor();
-        ~Processor();
-        
-        Processor(const Processor &);
-        Processor& operator= (const Processor &);
-        
-        static ProcessorRcPtr Create();
-        
-        static void deleter(Processor* c);
-        
-        friend class Config;
-        
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
-    
-    
-    ///////////////////////////////////////////////////////////////////////////
-    //!rst::
-    // CPUProcessor
-    // ************
-    
-    //!cpp:class::
-    class OCIOEXPORT CPUProcessor
-    {
-    public:
-        //!cpp:function::
-        const char * getCacheID() const;
-
-        //!cpp:function::
-        bool hasChannelCrosstalk() const;
-
-        //!cpp:function:: Bit-depth of the input pixel buffer.
-        BitDepth getInputBitDepth() const;
-        //!cpp:function:: Bit-depth of the output pixel buffer.
-        BitDepth getOutputBitDepth() const;
-
-        //!cpp:function:: Refer to :cpp:func:`GPUProcessor::getDynamicProperty`.
-        DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const;
-
-        ///////////////////////////////////////////////////////////////////////////
-        //!rst::
-        // Apply to an image with any kind of channel ordering while respecting 
-        // the input and output bit-depths.
-
-        //!cpp:function:: 
-        void apply(ImageDesc & imgDesc) const;
-        //!cpp:function:: 
-        void apply(const ImageDesc & srcImgDesc, ImageDesc & dstImgDesc) const;
-
-        //!rst::
-        // Apply to a single pixel respecting that the input and output bit-depths
-        // be 32-bit float and the image buffer be packed RGB/RGBA.
-        // 
-        // .. note::
-        //    This is not as efficient as applying to an entire image at once.
-        //    If you are processing multiple pixels, and have the flexibility,
-        //    use the above function instead.
-
-        //!cpp:function:: 
-        void applyRGB(float * pixel) const;
-        //!cpp:function:: 
-        void applyRGBA(float * pixel) const;
-
-    private:
-        CPUProcessor();
-        ~CPUProcessor();
-        
-        CPUProcessor(const CPUProcessor &);
-        CPUProcessor& operator= (const CPUProcessor &);
-        
-        static void deleter(CPUProcessor * c);
-
-        friend class Processor;
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
-    
-
-    ///////////////////////////////////////////////////////////////////////////
-    //!rst::
-    // GPUProcessor
-    // ************
-    
-    //!cpp:class::
-    class OCIOEXPORT GPUProcessor
-    {
-    public:
-        //!cpp:function::
-        bool isNoOp() const;
-        
-        //!cpp:function::
-        const char * getCacheID() const;
-
-        //!cpp:function::
-        bool hasChannelCrosstalk() const;
-
-        //!cpp:function:: The returned pointer may be used to set the value of any
-        //                dynamic properties of the requested type.  Throws if the
-        //                requested property is not found.  Note that if the
-        //                processor contains several ops that support the
-        //                requested property, only ones for which dynamic has
-        //                been enabled will be controlled.
-        //
-        // .. note:: 
-        //    The dynamic properties in this object are decoupled from the ones 
-        //    in the :cpp:class:`Processor` it was generated from.
-        //
-        DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const;
-
-        //!cpp:function:: Extract the shader information to implement the color processing.
-        void extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const;
-
-    private:
-        GPUProcessor();
-        ~GPUProcessor();
-        
-        GPUProcessor(const GPUProcessor &);
-        GPUProcessor& operator= (const GPUProcessor &);
-        
-        static void deleter(GPUProcessor * c);
-
-        friend class Processor;
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
-    
-
-    //!cpp:class::
-    // This class contains meta information about the process that generated
-    // this processor.  The results of these functions do not
-    // impact the pixel processing.
-    
-    class OCIOEXPORT ProcessorMetadata
-    {
-    public:
-        //!cpp:function::
-        static ProcessorMetadataRcPtr Create();
-        
-        //!cpp:function::
-        int getNumFiles() const;
-        //!cpp:function::
-        const char * getFile(int index) const;
-        
-        //!cpp:function::
-        int getNumLooks() const;
-        //!cpp:function::
-        const char * getLook(int index) const;
-        
-        //!cpp:function::
-        void addFile(const char * fname);
-        //!cpp:function::
-        void addLook(const char * look);
-    private:
-        ProcessorMetadata();
-        ~ProcessorMetadata();
-        ProcessorMetadata(const ProcessorMetadata &);
-        ProcessorMetadata& operator= (const ProcessorMetadata &);
-        
-        static void deleter(ProcessorMetadata* c);
-        
-        class Impl;
-        friend class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
-    
-    
-    
-    ///////////////////////////////////////////////////////////////////////////
-    //!rst::
-    // Baker
-    // *****
-    // 
-    // In certain situations it is necessary to serialize transforms into a variety
-    // of application specific LUT formats. Note that not all file formats that may
-    // be read also support baking.
-    // 
-    // **Usage Example:** *Bake a CSP sRGB viewer LUT*
-    // 
-    // .. code-block:: cpp
-    //    
-    //    OCIO::ConstConfigRcPtr config = OCIO::Config::CreateFromEnv();
-    //    OCIO::BakerRcPtr baker = OCIO::Baker::Create();
-    //    baker->setConfig(config);
-    //    baker->setFormat("csp");
-    //    baker->setInputSpace("lnf");
-    //    baker->setShaperSpace("log");
-    //    baker->setTargetSpace("sRGB");
-    //    auto & metadata = baker->getFormatMetadata();
-    //    metadata.addChildElement(OCIO::METADATA_DESCRIPTION, "A first comment");
-    //    metadata.addChildElement(OCIO::METADATA_DESCRIPTION, "A second comment");
-    //    std::ostringstream out;
-    //    baker->bake(out); // fresh bread anyone!
-    //    std::cout << out.str();
-    
-    class OCIOEXPORT Baker
-    {
-    public:
-        //!cpp:function:: Create a new Baker.
-        static BakerRcPtr Create();
-
-        //!cpp:function:: Create a copy of this Baker.
-        BakerRcPtr createEditableCopy() const;
-
-        //!cpp:function::
-        ConstConfigRcPtr getConfig() const;
-        //!cpp:function:: Set the config to use.
-        void setConfig(const ConstConfigRcPtr & config);
-
-        //!cpp:function::
-        const char * getFormat() const;
-        //!cpp:function:: Set the LUT output format.
-        void setFormat(const char * formatName);
-
-
-        //!cpp:function::
-        const FormatMetadata & getFormatMetadata() const;
-        //!cpp:function:: Get editable *optional* format metadata. The metadata that will be used
-        // varies based on the capability of the given file format.  Formats such as CSP,
-        // IridasCube, and ResolveCube will create comments in the file header using the value of
-        // any first-level children elements of the formatMetadata.  The CLF/CTF formats will make
-        // use of the top-level "id" and "name" attributes and children elements "Description",
-        // "InputDescriptor", "OutputDescriptor", and "Info".
-        FormatMetadata & getFormatMetadata();
-
-        //!cpp:function::
-        const char * getInputSpace() const;
-        //!cpp:function:: Set the input ColorSpace that the LUT will be applied to.
-        void setInputSpace(const char * inputSpace);
-
-        //!cpp:function::
-        const char * getShaperSpace() const;
-        //!cpp:function:: Set an *optional* ColorSpace to be used to shape / transfer the input
-        // colorspace. This is mostly used to allocate an HDR luminance range into an LDR one.
-        // If a shaper space is not explicitly specified, and the file format supports one, the
-        // ColorSpace Allocation will be used (not implemented for all formats).
-        void setShaperSpace(const char * shaperSpace);
-
-        //!cpp:function::
-        const char * getLooks() const;
-        //!cpp:function:: Set the looks to be applied during baking. Looks is a potentially comma
-        // (or colon) delimited list of lookNames, where +/- prefixes are optionally allowed to
-        // denote forward/inverse look specification. (And forward is assumed in the absence of
-        // either).
-        void setLooks(const char * looks);
-
-        //!cpp:function::
-        const char * getTargetSpace() const;
-        //!cpp:function:: Set the target device colorspace for the LUT.
-        void setTargetSpace(const char * targetSpace);
-
-        //!cpp:function::
-        int getShaperSize() const;
-        //!cpp:function:: Override the default shaper LUT size. Default value is -1, which allows
-        // each format to use its own most appropriate size. For the CLF format, the default uses
-        // a half-domain LUT1D (which is ideal for scene-linear inputs).
-        void setShaperSize(int shapersize);
-
-        //!cpp:function::
-        int getCubeSize() const;
-        //!cpp:function:: Override the default cube sample size.
-        // default: <format specific>
-        void setCubeSize(int cubesize);
-
-        //!cpp:function:: Bake the LUT into the output stream.
-        void bake(std::ostream & os) const;
-
-        //!cpp:function:: Get the number of LUT bakers.
-        static int getNumFormats();
-
-        //!cpp:function:: Get the LUT baker format name at index, return empty string if an invalid
-        // index is specified.
-        static const char * getFormatNameByIndex(int index);
-        //!cpp:function:: Get the LUT baker format extension at index, return empty string if an
-        // invalid index is specified.
-        static const char * getFormatExtensionByIndex(int index);
-
-    private:
-        Baker();
-        ~Baker();
-
-        Baker(const Baker &);
-        Baker& operator= (const Baker &);
-
-        static void deleter(Baker* o);
-
-        class Impl;
-        friend class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
-    
-    
-    ///////////////////////////////////////////////////////////////////////////
-    //!rst::
-    // ImageDesc
-    // *********
-    
-    //!rst::
-    // .. c:var:: const ptrdiff_t AutoStride
-    //    
-    //    AutoStride
-    const ptrdiff_t AutoStride = std::numeric_limits<ptrdiff_t>::min();
-    
-    //!cpp:class::
-    // This is a light-weight wrapper around an image, that provides a context
-    // for pixel access. This does NOT claim ownership of the pixels or copy
-    // image data.
-    
-    class OCIOEXPORT ImageDesc
-    {
-    public:
-        //!cpp:function::
-        ImageDesc();
-        //!cpp:function::
-        virtual ~ImageDesc();
-
-        //!cpp:function:: Get a pointer to the red channel of the first pixel.
-        virtual void * getRData() const = 0;
-        //!cpp:function:: Get a pointer to the green channel of the first pixel.
-        virtual void * getGData() const = 0;
-        //!cpp:function:: Get a pointer to the blue channel of the first pixel.
-        virtual void * getBData() const = 0;
-        //!cpp:function:: Get a pointer to the alpha channel of the first pixel
-        // or null as alpha channel is optional.
-        virtual void * getAData() const = 0;
-
-        //!cpp:function:: Get the bit-depth.
-        virtual BitDepth getBitDepth() const = 0;
-
-        //!cpp:function:: Get the width to process (where x position starts at 0 and ends at width-1).
-        virtual long getWidth() const = 0;
-        //!cpp:function:: Get the height to process (where y position starts at 0 and ends at height-1).
-        virtual long getHeight() const = 0;
-
-        //!cpp:function:: Get the step in bytes to find the same color channel of the next pixel.
-        virtual ptrdiff_t getXStrideBytes() const = 0;
-        //!cpp:function:: Get the step in bytes to find the same color channel 
-        // of the pixel at the same position in the next line.
-        virtual ptrdiff_t getYStrideBytes() const = 0;
-
-        //!cpp:function:: Is the image buffer in packed mode with the 4 color channels?
-        // ("Packed" here means that XStrideBytes is 4x the bytes per channel, so it is more specific 
-        // than simply any PackedImageDesc.)
-        virtual bool isRGBAPacked() const = 0;
-        //!cpp:function:: Is the image buffer 32-bit float?
-        virtual bool isFloat() const = 0;
-
-    private:
-        ImageDesc(const ImageDesc &);
-        ImageDesc & operator= (const ImageDesc &);
-    };
-    
-    extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const ImageDesc&);
-    
-    
-    ///////////////////////////////////////////////////////////////////////////
-    //!rst::
-    // PackedImageDesc
-    // ^^^^^^^^^^^^^^^
-
-    //!cpp:class::
-    class OCIOEXPORT PackedImageDesc : public ImageDesc
-    {
-    public:
-
-        //!rst::
-        // All the constructors expect a pointer to packed image data (such as 
-        // rgbrgbrgb or rgbargbargba) starting at the first color channel of 
-        // the first pixel to process (which does not need to be the first pixel 
-        // of the image). The number of channels must be greater than or equal to 3.
-        // If a 4th channel is specified, it is assumed to be alpha
-        // information.  Channels > 4 will be ignored.
-        //
-        // .. note:: 
-        // The methods assume the CPUProcessor bit-depth type for the data pointer.
-
-        //!cpp:function::
-        //
-        // .. note:: 
-        //    numChannels must be 3 (RGB) or 4 (RGBA).
-        PackedImageDesc(void * data,
-                        long width, long height,
-                        long numChannels);
-
-        //!cpp:function::
-        //
-        // .. note:: 
-        //    numChannels smust be 3 (RGB) or 4 (RGBA).
-        PackedImageDesc(void * data,
-                        long width, long height,
-                        long numChannels,  // must be 3 (RGB) or 4 (RGBA)
-                        BitDepth bitDepth,
-                        ptrdiff_t chanStrideBytes,
-                        ptrdiff_t xStrideBytes,
-                        ptrdiff_t yStrideBytes);
-
-        //!cpp:function::
-        PackedImageDesc(void * data,
-                        long width, long height,
-                        ChannelOrdering chanOrder);
-
-        //!cpp:function::
-        PackedImageDesc(void * data,
-                        long width, long height,
-                        ChannelOrdering chanOrder,
-                        BitDepth bitDepth,
-                        ptrdiff_t chanStrideBytes,
-                        ptrdiff_t xStrideBytes,
-                        ptrdiff_t yStrideBytes);
-
-        //!cpp:function::
-        virtual ~PackedImageDesc();
-
-        //!cpp:function:: Get the channel ordering of all the pixels.
-        ChannelOrdering getChannelOrder() const;
-
-        //!cpp:function:: Get the bit-depth.
-        BitDepth getBitDepth() const override;
-
-        //!cpp:function:: Get a pointer to the first color channel of the first pixel.
-        void * getData() const;
-
-        //!cpp:function::
-        void * getRData() const override;
-        //!cpp:function::
-        void * getGData() const override;
-        //!cpp:function::
-        void * getBData() const override;
-        //!cpp:function::
-        void * getAData() const override;
-
-        //!cpp:function::
-        long getWidth() const override;
-        //!cpp:function::
-        long getHeight() const override;
-        //!cpp:function::
-        long getNumChannels() const;
-
-        //!cpp:function::
-        ptrdiff_t getChanStrideBytes() const;
-        //!cpp:function::
-        ptrdiff_t getXStrideBytes() const override;
-        //!cpp:function::
-        ptrdiff_t getYStrideBytes() const override;
-
-        //!cpp:function::
-        bool isRGBAPacked() const override;
-        //!cpp:function::
-        bool isFloat() const override;
-
-    private:
-        struct Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-        
-        PackedImageDesc();
-        PackedImageDesc(const PackedImageDesc &);
-        PackedImageDesc& operator= (const PackedImageDesc &);
-    };
-    
-    
-    ///////////////////////////////////////////////////////////////////////////
-    //!rst::
-    // PlanarImageDesc
-    // ^^^^^^^^^^^^^^^
-    
-    //!cpp:class::
-    class OCIOEXPORT PlanarImageDesc : public ImageDesc
-    {
-    public:
-
-        //!rst::
-        // All the constructors expect pointers to the specified image planes 
-        // (i.e. rrrr gggg bbbb) starting at the first color channel of the 
-        // first pixel to process (which need not be the first pixel of the image).
-        // Pass NULL for aData if no alpha exists (r/g/bData must not be NULL).
-        //
-        // .. note:: 
-        // The methods assume the CPUProcessor bit-depth type for the R/G/B/A data pointers.
-
-        //!cpp:function::
-        PlanarImageDesc(void * rData, void * gData, void * bData, void * aData,
-                        long width, long height);
-
-        //!cpp:function::
-        // Note that although PlanarImageDesc is powerful enough to also describe 
-        // all :cpp:class:`PackedImageDesc` scenarios, it is recommended to use 
-        // a PackedImageDesc where possible since that allows for additional
-        // optimizations.
-        PlanarImageDesc(void * rData, void * gData, void * bData, void * aData,
-                        long width, long height,
-                        BitDepth bitDepth,
-                        ptrdiff_t xStrideBytes,
-                        ptrdiff_t yStrideBytes);
-
-        //!cpp:function::
-        virtual ~PlanarImageDesc();
-
-        //!cpp:function::
-        void * getRData() const override;
-        //!cpp:function::
-        void * getGData() const override;
-        //!cpp:function::
-        void * getBData() const override;
-        //!cpp:function::
-        void * getAData() const override;
-
-        //!cpp:function:: Get the bit-depth.
-        BitDepth getBitDepth() const override;
-
-        //!cpp:function::
-        long getWidth() const override;
-        //!cpp:function::
-        long getHeight() const override;
-
-        //!cpp:function::
-        ptrdiff_t getXStrideBytes() const override;
-        //!cpp:function::
-        ptrdiff_t getYStrideBytes() const override;
-
-        //!cpp:function::
-        bool isRGBAPacked() const override;
-        //!cpp:function::
-        bool isFloat() const override;
-
-    private:
-        struct Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-        
-        PlanarImageDesc();
-        PlanarImageDesc(const PlanarImageDesc &);
-        PlanarImageDesc& operator= (const PlanarImageDesc &);
-    };
-    
-    
-    ///////////////////////////////////////////////////////////////////////////
-    //!rst::
-    // GpuShaderDesc
-    // *************
-    // This class holds the GPU-related information needed to build a shader program
-    // from a specific processor.
+    // ^^^^
     //
-    // This class defines the interface and there are two implementations provided.
-    // The "legacy" mode implements the OCIO v1 approach of baking certain ops
-    // in order to have at most one 3D-LUT.  The "generic" mode is the v2 default and 
-    // allows all the ops to be processed as-is, without baking, like the CPU renderer.
-    // Custom implementations could be written to accommodate the GPU needs of a 
-    // specific client app.
+    // Manager per-shot look settings.
     //
+
+    //!cpp:function::
+    ConstLookRcPtr getLook(const char * name) const;
+
+    //!cpp:function::
+    int getNumLooks() const;
+
+    //!cpp:function::
+    const char * getLookNameByIndex(int index) const;
+
+    //!cpp:function::
+    void addLook(const ConstLookRcPtr & look);
+
+    //!cpp:function::
+    void clearLooks();
+
+
+    ///////////////////////////////////////////////////////////////////////////
+    //!rst:: .. _cfgprocessors_section:
     //
-    // The complete fragment shader program is decomposed in two main parts:
-    // the OCIO shader program for the color processing and the client shader 
-    // program which consumes the pixel color processing.
-    //    
-    // The OCIO shader program is fully described by the GpuShaderDesc
-    // independently from the client shader program. The only critical 
-    // point is the agreement on the OCIO function shader name.
+    // Processors
+    // ^^^^^^^^^^
     //
-    // To summarize, the complete shader program is:
-    //    
-    // .. code-block:: cpp
-    //  
-    //  ////////////////////////////////////////////////////////////////////////
-    //  //                                                                    //
-    //  //               The complete fragment shader program                 //
-    //  //                                                                    //
-    //  ////////////////////////////////////////////////////////////////////////
-    //  //                                                                    //
-    //  //   //////////////////////////////////////////////////////////////   //
-    //  //   //                                                          //   // 
-    //  //   //               The OCIO shader program                    //   //
-    //  //   //                                                          //   //
-    //  //   //////////////////////////////////////////////////////////////   //
-    //  //   //                                                          //   //
-    //  //   //   // All global declarations                             //   //
-    //  //   //   uniform sampled3D tex3;                                //   //
-    //  //   //                                                          //   //
-    //  //   //   // All helper methods                                  //   //
-    //  //   //   vec3 computePos(vec3 color)                            //   //
-    //  //   //   {                                                      //   //
-    //  //   //      vec3 coords = color;                                //   //
-    //  //   //      ...                                                 //   //
-    //  //   //      return coords;                                      //   //
-    //  //   //   }                                                      //   //
-    //  //   //                                                          //   //
-    //  //   //   // The OCIO shader function                            //   //
-    //  //   //   vec4 OCIODisplay(in vec4 inColor)                      //   //
-    //  //   //   {                                                      //   //
-    //  //   //      vec4 outColor = inColor;                            //   //
-    //  //   //      ...                                                 //   //
-    //  //   //      outColor.rbg                                        //   //
-    //  //   //         = texture3D(tex3, computePos(inColor.rgb)).rgb;  //   //
-    //  //   //      ...                                                 //   //
-    //  //   //      return outColor;                                    //   //
-    //  //   //   }                                                      //   //
-    //  //   //                                                          //   //
-    //  //   //////////////////////////////////////////////////////////////   //
-    //  //                                                                    //
-    //  //   //////////////////////////////////////////////////////////////   //
-    //  //   //                                                          //   // 
-    //  //   //             The client shader program                    //   //
-    //  //   //                                                          //   //
-    //  //   //////////////////////////////////////////////////////////////   //
-    //  //   //                                                          //   //
-    //  //   //   uniform sampler2D image;                               //   //
-    //  //   //                                                          //   //
-    //  //   //   void main()                                            //   //
-    //  //   //   {                                                      //   //
-    //  //   //      vec4 inColor = texture2D(image, gl_TexCoord[0].st); //   //
-    //  //   //      ...                                                 //   //
-    //  //   //      vec4 outColor = OCIODisplay(inColor);               //   //
-    //  //   //      ...                                                 //   //
-    //  //   //      gl_FragColor = outColor;                            //   //
-    //  //   //   }                                                      //   //
-    //  //   //                                                          //   //
-    //  //   //////////////////////////////////////////////////////////////   //
-    //  //                                                                    //
-    //  ////////////////////////////////////////////////////////////////////////
+    // Create a :cpp:class:`Processor` to assemble a transformation between two
+    // color spaces.  It may then be used to create a :cpp:class:`CPUProcessor`
+    // or :cpp:class:`GPUProcessor` to process/convert pixels.
+
+    //!cpp:function::
+    ConstProcessorRcPtr getProcessor(const ConstContextRcPtr & context,
+                                        const ConstColorSpaceRcPtr & srcColorSpace,
+                                        const ConstColorSpaceRcPtr & dstColorSpace) const;
+    //!cpp:function::
+    ConstProcessorRcPtr getProcessor(const ConstColorSpaceRcPtr & srcColorSpace,
+                                        const ConstColorSpaceRcPtr & dstColorSpace) const;
+
+    //!cpp:function::
+    // .. note::
+    //    Names can be colorspace name, role name, or a combination of both.
+    ConstProcessorRcPtr getProcessor(const char * srcName,
+                                        const char * dstName) const;
+    //!cpp:function::
+    ConstProcessorRcPtr getProcessor(const ConstContextRcPtr & context,
+                                        const char * srcName,
+                                        const char * dstName) const;
+
+    //!rst:: Get the processor for the specified transform.
     //
+    // Not often needed, but will allow for the re-use of atomic OCIO
+    // functionality (such as to apply an individual LUT file).
+
+    //!cpp:function::
+    ConstProcessorRcPtr getProcessor(const ConstTransformRcPtr& transform) const;
+    //!cpp:function::
+    ConstProcessorRcPtr getProcessor(const ConstTransformRcPtr& transform,
+                                        TransformDirection direction) const;
+    //!cpp:function::
+    ConstProcessorRcPtr getProcessor(const ConstContextRcPtr & context,
+                                        const ConstTransformRcPtr& transform,
+                                        TransformDirection direction) const;
+
+private:
+    Config();
+    ~Config();
+
+    Config(const Config &);
+    Config& operator= (const Config &);
+
+    static void deleter(Config* c);
+
+    class Impl;
+    friend class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const Config&);
+
+
+///////////////////////////////////////////////////////////////////////////
+//!rst:: .. _colorspace_section:
+//
+// ColorSpace
+// **********
+// The *ColorSpace* is the state of an image with respect to colorimetry
+// and color encoding. Transforming images between different
+// *ColorSpaces* is the primary motivation for this library.
+//
+// While a complete discussion of color spaces is beyond the scope of
+// header documentation, traditional uses would be to have *ColorSpaces*
+// corresponding to: physical capture devices (known cameras, scanners),
+// and internal 'convenience' spaces (such as scene linear, logarithmic).
+//
+// *ColorSpaces* are specific to a particular image precision (float32,
+// uint8, etc.), and the set of ColorSpaces that provide equivalent mappings
+// (at different precisions) are referred to as a 'family'.
+
+//!cpp:class::
+class OCIOEXPORT ColorSpace
+{
+public:
+    //!cpp:function::
+    static ColorSpaceRcPtr Create();
+
+    //!cpp:function::
+    ColorSpaceRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    const char * getName() const noexcept;
+    //!cpp:function::
+    void setName(const char * name);
+
+    //!cpp:function::Get the family, for use in user interfaces (optional)
+    // The family string could use a '/' separator to indicate levels to be used
+    // by hierarchical menus.
+    const char * getFamily() const noexcept;
+    //!cpp:function::Set the family, for use in user interfaces (optional)
+    void setFamily(const char * family);
+
+    //!cpp:function::Get the ColorSpace group name (used for equality comparisons)
+    // This allows no-op transforms between different colorspaces.
+    // If an equalityGroup is not defined (an empty string), it will be considered
+    // unique (i.e., it will not compare as equal to other ColorSpaces with an
+    // empty equality group).  This is often, though not always, set to the
+    // same value as 'family'.
+    const char * getEqualityGroup() const noexcept;
+    //!cpp:function::
+    void setEqualityGroup(const char * equalityGroup);
+
+    //!cpp:function::
+    const char * getDescription() const noexcept;
+    //!cpp:function::
+    void setDescription(const char * description);
+
+    //!cpp:function::
+    BitDepth getBitDepth() const noexcept;
+    //!cpp:function::
+    void setBitDepth(BitDepth bitDepth);
+
+    ///////////////////////////////////////////////////////////////////////////
+    //!rst::
+    // Categories
+    // ^^^^^^^^^^
+    // A category is used to allow applications to filter the list of color spaces
+    // they display in menus based on what that color space is used for.
     //
-    // **Usage Example:** *Building a GPU shader*
+    // Here is an example config entry that could appear under a ColorSpace:
+    // categories: [input, rendering]
     //
-    //   This example is based on the code in: src/apps/ociodisplay/main.cpp 
+    // The example contains two categories: 'input' and 'rendering'.
+    // Category strings are not case-sensitive and the order is not significant.
+    // There is no limit imposed on length or number. Although users may add
+    // their own categories, the strings will typically come from a fixed set
+    // listed in the documentation (similar to roles).
+
+    //!cpp:function:: Return true if the category is present.
+    bool hasCategory(const char * category) const;
+    //!cpp:function:: Add a single category.
+    // .. note:: Will do nothing if the category already exists.
+    void addCategory(const char * category);
+    //!cpp:function:: Remove a category.
+    // .. note:: Will do nothing if the category is missing.
+    void removeCategory(const char * category);
+    //!cpp:function:: Get the number of categories.
+    int getNumCategories() const;
+    //!cpp:function:: Return the category name using its index
+    // .. note:: Will be null if the index is invalid.
+    const char * getCategory(int index) const;
+    // Clear all the categories.
+    void clearCategories();
+
+    ///////////////////////////////////////////////////////////////////////////
+    //!rst::
+    // Data
+    // ^^^^
+    // ColorSpaces that are data are treated a bit special. Basically, any
+    // colorspace transforms you try to apply to them are ignored. (Think
+    // of applying a gamut mapping transform to an ID pass). Also, the
+    // :cpp:class:`DisplayTransform` process obeys special 'data min' and
+    // 'data max' args.
+    //
+    // This is traditionally used for pixel data that represents non-color
+    // pixel data, such as normals, point positions, ID information, etc.
+
+    //!cpp:function::
+    bool isData() const;
+    //!cpp:function::
+    void setIsData(bool isData);
+
+    ///////////////////////////////////////////////////////////////////////////
+    //!rst::
+    // Allocation
+    // ^^^^^^^^^^
+    // If this colorspace needs to be transferred to a limited dynamic
+    // range coding space (such as during display with a GPU path), use this
+    // allocation to maximize bit efficiency.
+
+    //!cpp:function::
+    Allocation getAllocation() const;
+    //!cpp:function::
+    void setAllocation(Allocation allocation);
+
+    //!rst::
+    // Specify the optional variable values to configure the allocation.
+    // If no variables are specified, the defaults are used.
+    //
+    // ALLOCATION_UNIFORM::
+    //
+    //    2 vars: [min, max]
+    //
+    // ALLOCATION_LG2::
+    //
+    //    2 vars: [lg2min, lg2max]
+    //    3 vars: [lg2min, lg2max, linear_offset]
+
+    //!cpp:function::
+    int getAllocationNumVars() const;
+    //!cpp:function::
+    void getAllocationVars(float * vars) const;
+    //!cpp:function::
+    void setAllocationVars(int numvars, const float * vars);
+
+    ///////////////////////////////////////////////////////////////////////////
+    //!rst::
+    // Transform
+    // ^^^^^^^^^
+
+    //!cpp:function::
+    // If a transform in the specified direction has been specified,
+    // return it. Otherwise return a null ConstTransformRcPtr
+    ConstTransformRcPtr getTransform(ColorSpaceDirection dir) const;
+    //!cpp:function::
+    // Specify the transform for the appropriate direction.
+    // Setting the transform to null will clear it.
+    void setTransform(const ConstTransformRcPtr & transform,
+                        ColorSpaceDirection dir);
+
+private:
+    ColorSpace();
+    ~ColorSpace();
+
+    ColorSpace(const ColorSpace &);
+    ColorSpace& operator= (const ColorSpace &);
+
+    static void deleter(ColorSpace* c);
+
+    class Impl;
+    friend class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const ColorSpace&);
+
+
+
+
+///////////////////////////////////////////////////////////////////////////
+//!rst:: .. _colorspaceset_section:
+//
+// ColorSpaceSet
+// *************
+// The *ColorSpaceSet* is a set of color spaces (i.e. no color space duplication)
+// which could be the result of :cpp:func:`Config::getColorSpaces`
+// or built from scratch.
+//
+// .. note::
+//    The color spaces are decoupled from the config ones, i.e., any
+//    changes to the set itself or to its color spaces do not affect the
+//    original color spaces from the configuration.  If needed,
+//    use :cpp:func:`Config::addColorSpace` to update the configuration.
+
+//!cpp:class::
+class OCIOEXPORT ColorSpaceSet
+{
+public:
+    //!cpp:function:: Create an empty set of color spaces.
+    static ColorSpaceSetRcPtr Create();
+
+    //!cpp:function:: Create a set containing a copy of all the color spaces.
+    ColorSpaceSetRcPtr createEditableCopy() const;
+
+    //!cpp:function:: Return true if the two sets are equal.
+    // .. note:: The comparison is done on the color space names (not a deep comparison).
+    bool operator==(const ColorSpaceSet & css) const;
+    //!cpp:function:: Return true if the two sets are different.
+    bool operator!=(const ColorSpaceSet & css) const;
+
+    //!cpp:function:: Return the number of color spaces.
+    int getNumColorSpaces() const;
+    //!cpp:function:: Return the color space name using its index.
+    // This will be null if an invalid index is specified.
+    const char * getColorSpaceNameByIndex(int index) const;
+    //!cpp:function:: Return the color space using its index.
+    // This will be empty if an invalid index is specified.
+    ConstColorSpaceRcPtr getColorSpaceByIndex(int index) const;
+
+    //!rst::
+    // .. note::
+    //    These fcns only accept color space names (i.e. no role name).
+
+    //!cpp:function:: Will return null if the name is not found.
+    ConstColorSpaceRcPtr getColorSpace(const char * name) const;
+    //!cpp:function:: Will return -1 if the name is not found.
+    int getIndexForColorSpace(const char * name) const;
+
+    //!cpp:function:: Add color space(s).
+    //
+    // .. note::
+    //    If another color space is already registered with the same name,
+    //    this will overwrite it. This stores a copy of the specified
+    //    color space(s).
+    void addColorSpace(const ConstColorSpaceRcPtr & cs);
+    void addColorSpaces(const ConstColorSpaceSetRcPtr & cs);
+
+    //!cpp:function:: Remove color space(s) using color space names (i.e. no role name).
+    //
+    // .. note::
+    //    The removal of a missing color space does nothing.
+    void removeColorSpace(const char * name);
+    void removeColorSpaces(const ConstColorSpaceSetRcPtr & cs);
+
+    //!cpp:function:: Clear all color spaces.
+    void clearColorSpaces();
+
+private:
+    ColorSpaceSet();
+    ~ColorSpaceSet();
+
+    ColorSpaceSet(const ColorSpaceSet &);
+    ColorSpaceSet & operator= (const ColorSpaceSet &);
+
+    static void deleter(ColorSpaceSet * c);
+
+    class Impl;
+    friend class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+
+// .. note::
+//    All these fcns provide some operations on two color space sets
+//    where the result contains copied color spaces and no duplicates.
+
+//!cpp:function:: Perform the union of two sets.
+extern OCIOEXPORT ConstColorSpaceSetRcPtr operator||(const ConstColorSpaceSetRcPtr & lcss,
+                                                        const ConstColorSpaceSetRcPtr & rcss);
+//!cpp:function:: Perform the intersection of two sets.
+extern OCIOEXPORT ConstColorSpaceSetRcPtr operator&&(const ConstColorSpaceSetRcPtr & lcss,
+                                                        const ConstColorSpaceSetRcPtr & rcss);
+//!cpp:function:: Perform the difference of two sets.
+extern OCIOEXPORT ConstColorSpaceSetRcPtr operator-(const ConstColorSpaceSetRcPtr & lcss,
+                                                    const ConstColorSpaceSetRcPtr & rcss);
+
+
+
+
+///////////////////////////////////////////////////////////////////////////
+//!rst:: .. _look_section:
+//
+// Look
+// ****
+// The *Look* is an 'artistic' image modification, in a specified image
+// state.
+// The processSpace defines the ColorSpace the image is required to be
+// in, for the math to apply correctly.
+
+//!cpp:class::
+class OCIOEXPORT Look
+{
+public:
+    //!cpp:function::
+    static LookRcPtr Create();
+
+    //!cpp:function::
+    LookRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    const char * getName() const;
+    //!cpp:function::
+    void setName(const char * name);
+
+    //!cpp:function::
+    const char * getProcessSpace() const;
+    //!cpp:function::
+    void setProcessSpace(const char * processSpace);
+
+    //!cpp:function::
+    ConstTransformRcPtr getTransform() const;
+    //!cpp:function:: Setting a transform to a non-null call makes it allowed.
+    void setTransform(const ConstTransformRcPtr & transform);
+
+    //!cpp:function::
+    ConstTransformRcPtr getInverseTransform() const;
+    //!cpp:function:: Setting a transform to a non-null call makes it allowed.
+    void setInverseTransform(const ConstTransformRcPtr & transform);
+
+    //!cpp:function::
+    const char * getDescription() const;
+    //!cpp:function::
+    void setDescription(const char * description);
+private:
+    Look();
+    ~Look();
+
+    Look(const Look &);
+    Look& operator= (const Look &);
+
+    static void deleter(Look* c);
+
+    class Impl;
+    friend class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const Look&);
+
+
+///////////////////////////////////////////////////////////////////////////
+//!rst::
+// Processor
+// *********
+// The *Processor* represents a specific color transformation which is 
+// the result of :cpp:func:`Config::getProcessor`.
+
+//!cpp:class::
+class OCIOEXPORT Processor
+{
+public:
+    //!cpp:function::
+    bool isNoOp() const;
+
+    //!cpp:function:: True if the image transformation is non-separable.
+    // For example, if a change in red may also cause a change in green or blue.
+    bool hasChannelCrosstalk() const;
+
+    //!cpp:function:: The ProcessorMetadata contains technical information
+    //                such as the number of files and looks used in the processor.
+    ConstProcessorMetadataRcPtr getProcessorMetadata() const;
+
+    //!cpp:function:: Get a FormatMetadata containing the top level metadata
+    //                for the processor.  For a processor from a CLF file,
+    //                this corresponds to the ProcessList metadata.
+    const FormatMetadata & getFormatMetadata() const;
+
+    //!cpp:function:: Get the number of transforms that comprise the processor.
+    //                Each transform has a (potentially empty) FormatMetadata.
+    int getNumTransforms() const;
+    //!cpp:function:: Get a FormatMetadata containing the metadata for a
+    //                transform within the processor. For a processor from
+    //                a CLF file, this corresponds to the metadata associated
+    //                with an individual process node.
+    const FormatMetadata & getTransformFormatMetadata(int index) const;
+
+    //!cpp:function:: Return a cpp:class:`GroupTransform` that contains a
+    //                copy of the transforms that comprise the processor.
+    //                (Changes to it will not modify the original processor.)
+    GroupTransformRcPtr createGroupTransform() const;
+
+    //!cpp:function:: Write the transforms comprising the processor to the stream.
+    //                Writing (as opposed to Baking) is a lossless process.
+    //                An exception is thrown if the processor cannot be
+    //                losslessly written to the specified file format.
+    void write(const char * formatName, std::ostream & os) const;
+
+    //!cpp:function:: Get the number of writers.
+    static int getNumWriteFormats();
+
+    //!cpp:function:: Get the writer at index, return empty string if
+    //                an invalid index is specified.
+    static const char * getFormatNameByIndex(int index);
+    static const char * getFormatExtensionByIndex(int index);
+
+    // TODO: Revisit the dynamic property access.
+    //!cpp:function::
+    DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const;
+    bool hasDynamicProperty(DynamicPropertyType type) const;
+
+    //!cpp:function:: 
+    const char * getCacheID() const;
+
+    ///////////////////////////////////////////////////////////////////////////
+    //!rst::
+    // GPU Renderer
+    // ^^^^^^^^^^^^
+    // Get an optimized :cpp:class:`GPUProcessor` instance.
+
+    //!cpp:function::
+    ConstGPUProcessorRcPtr getDefaultGPUProcessor() const;
+    //!cpp:function::
+    ConstGPUProcessorRcPtr getOptimizedGPUProcessor(OptimizationFlags oFlags) const;
+
+    ///////////////////////////////////////////////////////////////////////////
+    //!rst::
+    // CPU Renderer
+    // ^^^^^^^^^^^^
+    // Get an optimized :cpp:class:`CPUProcessor` instance.
+    //
+    // .. note::
+    //    This may provide higher fidelity than anticipated due to internal
+    //    optimizations. For example, if the inputColorSpace and the
+    //    outputColorSpace are members of the same family, no conversion
+    //    will be applied, even though strictly speaking quantization
+    //    should be added.
+
+
+    // .. note::
+    //    The typical use case to apply color processing to an image is:
     //
     // .. code-block:: cpp
     //
-    //    // Get the processor
-    //    //
-    //    OCIO::ConstConfigRcPtr config = OCIO::Config::CreateFromEnv();
-    //    OCIO::ConstProcessorRcPtr processor 
-    //       = config->getProcessor("ACES - ACEScg", "Output - sRGB");
+    //     OCIO::ConstConfigRcPtr config = OCIO::GetCurrentConfig();
     //
-    //    // Step 1: Create a GPU shader description
-    //    //
-    //    // The three potential scenarios are:
-    //    //
-    //    //   1. Instantiate the legacy shader description.  The color processor
-    //    //      is baked down to contain at most one 3D LUT and no 1D LUTs.
-    //    //
-    //    //      This is the v1 behavior and will remain part of OCIO v2
-    //    //      for backward compatibility.
-    //    //
-    //    OCIO::GpuShaderDescRcPtr shaderDesc
-    //          = OCIO::GpuShaderDesc::CreateLegacyShaderDesc(LUT3D_EDGE_SIZE);
-    //    //
-    //    //   2. Instantiate the generic shader description.  The color processor 
-    //    //      is used as-is (i.e. without any baking step) and could contain 
-    //    //      any number of 1D & 3D luts.
-    //    //
-    //    //      This is the default OCIO v2 behavior and allows a much better
-    //    //      match between the CPU and GPU renderers.
-    //    //
-    //    OCIO::GpuShaderDescRcPtr shaderDesc = OCIO::GpuShaderDesc::Create();
-    //    //
-    //    //   3. Instantiate a custom shader description.
-    //    //
-    //    //      Writing a custom shader description is a way to tailor the shaders
-    //    //      to the needs of a given client program.  This involves writing a
-    //    //      new class inheriting from the pure virtual class GpuShaderDesc.
-    //    //
-    //    //      Please refer to the GenericGpuShaderDesc class for an example.
-    //    //
-    //    OCIO::GpuShaderDescRcPtr shaderDesc = MyCustomGpuShader::Create();
+    //     OCIO::ConstProcessorRcPtr processor
+    //         = config->getProcessor(colorSpace1, colorSpace2);
     //
-    //    shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_GLSL_1_3);
-    //    shaderDesc->setFunctionName("OCIODisplay");
+    //     OCIO::ConstCPUProcessorRcPtr cpuProcessor
+    //         = processor->getDefaultCPUProcessor();
     //
-    //    // Step 2: Collect the shader program information for a specific processor
-    //    //
-    //    processor->extractGpuShaderInfo(shaderDesc);
-    //
-    //    // Step 3: Create a helper to build the shader. Here we use a helper for
-    //    //         OpenGL but there will also be helpers for other languages.
-    //    //
-    //    OpenGLBuilderRcPtr oglBuilder = OpenGLBuilder::Create(shaderDesc);
-    //
-    //    // Step 4: Allocate & upload all the LUTs
-    //    //
-    //    oglBuilder->allocateAllTextures();
-    //
-    //    // Step 5: Build the complete fragment shader program using 
-    //    //         g_fragShaderText which is the client shader program.
-    //    //
-    //    g_programId = oglBuilder->buildProgram(g_fragShaderText);
-    //
-    //    // Step 6: Enable the fragment shader program, and all needed textures
-    //    //
-    //    glUseProgram(g_programId);
-    //    glUniform1i(glGetUniformLocation(g_programId, "tex1"), 1);  // image texture
-    //    oglBuilder->useAllTextures(g_programId);                    // LUT textures
+    //     OCIO::PackedImageDesc img(imgDataPtr, imgWidth, imgHeight, imgChannels);
+    //     cpuProcessor->apply(img);
     //
 
-    //!cpp:class::
-    class OCIOEXPORT GpuShaderDesc
-    {
-    public:
+    //!cpp:function::
+    ConstCPUProcessorRcPtr getDefaultCPUProcessor() const;
+    //!cpp:function::
+    ConstCPUProcessorRcPtr getOptimizedCPUProcessor(OptimizationFlags oFlags) const;
+    //!cpp:function::
+    ConstCPUProcessorRcPtr getOptimizedCPUProcessor(BitDepth inBitDepth,
+                                                    BitDepth outBitDepth,
+                                                    OptimizationFlags oFlags) const;
 
-        //!cpp:function:: Create the legacy shader description
-        static GpuShaderDescRcPtr CreateLegacyShaderDesc(unsigned edgelen);
+private:
+    Processor();
+    ~Processor();
 
-        //!cpp:function:: Create the default shader description
-        static GpuShaderDescRcPtr CreateShaderDesc();
+    Processor(const Processor &);
+    Processor& operator= (const Processor &);
 
-        //!cpp:function:: Set the shader program language
-        void setLanguage(GpuLanguage lang);
-        //!cpp:function::
-        GpuLanguage getLanguage() const;
-        
-        //!cpp:function:: Set the function name of the shader program 
-        void setFunctionName(const char * name);
-        //!cpp:function::
-        const char * getFunctionName() const;
+    static ProcessorRcPtr Create();
 
-        //!cpp:function:: Set the pixel name variable holding the color values
-        void setPixelName(const char * name);
-        //!cpp:function::
-        const char * getPixelName() const;
+    static void deleter(Processor* c);
 
-        //!cpp:function::  Set a prefix to the resource name
-        //
-        // .. note::
-        //   Some applications require that textures, uniforms, 
-        //   and helper methods be uniquely named because several 
-        //   processor instances could coexist.
-        //
-        void setResourcePrefix(const char * prefix);
-        //!cpp:function:: 
-        const char * getResourcePrefix() const;
+    friend class Config;
 
-        //!cpp:function::
-        virtual const char * getCacheID() const;
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
 
-    public:
 
-        enum TextureType
-        {
-            TEXTURE_RED_CHANNEL, // Only use the red channel of the texture
-            TEXTURE_RGB_CHANNEL
-        };
+///////////////////////////////////////////////////////////////////////////
+//!rst::
+// CPUProcessor
+// ************
 
-        //!cpp:function:: Dynamic Property related methods.
-        virtual unsigned getNumUniforms() const = 0;
-        virtual void getUniform(unsigned index, const char *& name, 
-                                DynamicPropertyRcPtr & value) const = 0;
-        virtual bool addUniform(const char * name, 
-                                const DynamicPropertyRcPtr & value) = 0;
+//!cpp:class::
+class OCIOEXPORT CPUProcessor
+{
+public:
+    //!cpp:function::
+    const char * getCacheID() const;
 
-        //!cpp:function:: 1D lut related methods
-        virtual unsigned getTextureMaxWidth() const = 0;
-        virtual void setTextureMaxWidth(unsigned maxWidth) = 0;
-        virtual unsigned getNumTextures() const = 0;
-        virtual void addTexture(const char * name, const char * id, 
-                                unsigned width, unsigned height,
-                                TextureType channel, Interpolation interpolation,
-                                const float * values) = 0;
-        virtual void getTexture(unsigned index, const char *& name, const char *& id, 
-                                unsigned & width, unsigned & height,
-                                TextureType & channel, Interpolation & interpolation) const = 0;
-        virtual void getTextureValues(unsigned index, const float *& values) const = 0;
+    //!cpp:function::
+    bool hasChannelCrosstalk() const;
 
-        //!cpp:function:: 3D lut related methods
-        virtual unsigned getNum3DTextures() const = 0;
-        virtual void add3DTexture(const char * name, const char * id, unsigned edgelen, 
-                                  Interpolation interpolation, const float * values) = 0;
-        virtual void get3DTexture(unsigned index, const char *& name, const char *& id, 
-                                  unsigned & edgelen, Interpolation & interpolation) const = 0;
-        virtual void get3DTextureValues(unsigned index, const float *& values) const = 0;
+    //!cpp:function:: Bit-depth of the input pixel buffer.
+    BitDepth getInputBitDepth() const;
+    //!cpp:function:: Bit-depth of the output pixel buffer.
+    BitDepth getOutputBitDepth() const;
 
-        //!cpp:function:: Methods to specialize parts of a OCIO shader program
-        //
-        // **An OCIO shader program could contain:**
-        // 
-        // 1. A declaration part  e.g., uniform sampled3D tex3;
-        // 
-        // 2. Some helper methods
-        // 
-        // 3. The OCIO shader function may be broken down as:
-        // 
-        //    1. The function header  e.g., void OCIODisplay(in vec4 inColor) {
-        //    2. The function body    e.g.,   vec4 outColor.rgb = texture3D(tex3, inColor.rgb).rgb;
-        //    3. The function footer  e.g.,   return outColor; }
-        // 
-        // 
-        // **Usage Example:**
-        // 
-        // Below is a code snippet to highlight the different parts of the OCIO shader program.
-        // 
-        // .. code-block:: cpp
-        //    
-        //    // All global declarations
-        //    uniform sampled3D tex3;
-        //
-        //    // All helper methods
-        //    vec3 computePosition(vec3 color)
-        //    {
-        //       vec3 coords = color;
-        //       // Some processing...
-        //       return coords;
-        //    }
-        // 
-        //    // The shader function
-        //    vec4 OCIODisplay(in vec4 inColor)     //
-        //    {                                     // Function Header
-        //       vec4 outColor = inColor;           //
-        // 
-        //       outColor.rgb = texture3D(tex3, computePosition(inColor.rgb)).rgb;
-        // 
-        //       return outColor;                   // Function Footer
-        //    }                                     //
-        // 
-        virtual void addToDeclareShaderCode(const char * shaderCode) = 0;
-        virtual void addToHelperShaderCode(const char * shaderCode) = 0;
-        virtual void addToFunctionHeaderShaderCode(const char * shaderCode) = 0;
-        virtual void addToFunctionShaderCode(const char * shaderCode) = 0;
-        virtual void addToFunctionFooterShaderCode(const char * shaderCode) = 0;
+    //!cpp:function:: Refer to :cpp:func:`GPUProcessor::getDynamicProperty`.
+    DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const;
 
-        //!cpp:function:: Create the OCIO shader program
-        //
-        // .. note::
-        // 
-        //   The OCIO shader program is decomposed to allow a specific implementation
-        //   to change some parts. Some product integrations add the color processing
-        //   within a client shader program, imposing constraints requiring this flexibility.
-        //
-        virtual void createShaderText(
-            const char * shaderDeclarations, const char * shaderHelperMethods,
-            const char * shaderFunctionHeader, const char * shaderFunctionBody,
-            const char * shaderFunctionFooter) = 0;
-
-        //!cpp:function:: Get the complete OCIO shader program
-        virtual const char * getShaderText() const = 0;
-
-        //!cpp:function::
-        virtual void finalize() = 0;
-
-    protected:
-        //!cpp:function::
-        GpuShaderDesc();
-        //!cpp:function::
-        virtual ~GpuShaderDesc();
-
-    private:
-        
-        GpuShaderDesc(const GpuShaderDesc &);
-        GpuShaderDesc& operator= (const GpuShaderDesc &);
-        
-        class Impl;
-        friend class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-   };
-    
-    
     ///////////////////////////////////////////////////////////////////////////
     //!rst::
-    // Context
-    // *******
-    
-    //!cpp:class::
-    class OCIOEXPORT Context
-    {
-    public:
-        //!cpp:function::
-        static ContextRcPtr Create();
-        
-        //!cpp:function::
-        ContextRcPtr createEditableCopy() const;
-        
-        //!cpp:function:: 
-        const char * getCacheID() const;
-        
-        //!cpp:function::
-        void setSearchPath(const char * path);
-        //!cpp:function::
-        const char * getSearchPath() const;
-        
-        //!cpp:function::
-        int getNumSearchPaths() const;
-        //!cpp:function::
-        const char * getSearchPath(int index) const;
-        //!cpp:function::
-        void clearSearchPaths();
-        //!cpp:function::
-        void addSearchPath(const char * path);
+    // Apply to an image with any kind of channel ordering while respecting
+    // the input and output bit-depths.
 
-        //!cpp:function::
-        void setWorkingDir(const char * dirname);
-        //!cpp:function::
-        const char * getWorkingDir() const;
-        
-        //!cpp:function::
-        void setStringVar(const char * name, const char * value);
-        //!cpp:function::
-        const char * getStringVar(const char * name) const;
-        
-        //!cpp:function::
-        int getNumStringVars() const;
-        //!cpp:function::
-        const char * getStringVarNameByIndex(int index) const;
-        
-        //!cpp:function::
-        void clearStringVars();
-        
-        //!cpp:function::
-        void setEnvironmentMode(EnvironmentMode mode);
-        
-        //!cpp:function::
-        EnvironmentMode getEnvironmentMode() const;
-        
-        //!cpp:function:: Seed all string vars with the current environment.
-        void loadEnvironment();
-        
-        //! Do a string lookup.
-        //!cpp:function:: Do a file lookup.
-        // 
-        // Evaluate the specified variable (as needed). Will not throw exceptions.
-        const char * resolveStringVar(const char * val) const;
-        
-        //! Do a file lookup.
-        //!cpp:function:: Do a file lookup.
-        // 
-        // Evaluate all variables (as needed).
-        // Also, walk the full search path until the file is found.
-        // If the filename cannot be found, an exception will be thrown.
-        const char * resolveFileLocation(const char * filename) const;
-    
-    private:
-        Context();
-        ~Context();
-        
-        Context(const Context &);
-        Context& operator= (const Context &);
-        
-        static void deleter(Context* c);
-        
-        class Impl;
-        friend class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
+    //!cpp:function::
+    void apply(ImageDesc & imgDesc) const;
+    //!cpp:function::
+    void apply(const ImageDesc & srcImgDesc, ImageDesc & dstImgDesc) const;
+
+    //!rst::
+    // Apply to a single pixel respecting that the input and output bit-depths
+    // be 32-bit float and the image buffer be packed RGB/RGBA.
+    //
+    // .. note::
+    //    This is not as efficient as applying to an entire image at once.
+    //    If you are processing multiple pixels, and have the flexibility,
+    //    use the above function instead.
+
+    //!cpp:function::
+    void applyRGB(float * pixel) const;
+    //!cpp:function::
+    void applyRGBA(float * pixel) const;
+
+private:
+    CPUProcessor();
+    ~CPUProcessor();
+
+    CPUProcessor(const CPUProcessor &);
+    CPUProcessor& operator= (const CPUProcessor &);
+
+    static void deleter(CPUProcessor * c);
+
+    friend class Processor;
+
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+
+///////////////////////////////////////////////////////////////////////////
+//!rst::
+// GPUProcessor
+// ************
+
+//!cpp:class::
+class OCIOEXPORT GPUProcessor
+{
+public:
+    //!cpp:function::
+    bool isNoOp() const;
+
+    //!cpp:function::
+    const char * getCacheID() const;
+
+    //!cpp:function::
+    bool hasChannelCrosstalk() const;
+
+    //!cpp:function:: The returned pointer may be used to set the value of any
+    //                dynamic properties of the requested type.  Throws if the
+    //                requested property is not found.  Note that if the
+    //                processor contains several ops that support the
+    //                requested property, only ones for which dynamic has
+    //                been enabled will be controlled.
+    //
+    // .. note::
+    //    The dynamic properties in this object are decoupled from the ones
+    //    in the :cpp:class:`Processor` it was generated from.
+    //
+    DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const;
+
+    //!cpp:function:: Extract the shader information to implement the color processing.
+    void extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const;
+
+private:
+    GPUProcessor();
+    ~GPUProcessor();
+
+    GPUProcessor(const GPUProcessor &);
+    GPUProcessor& operator= (const GPUProcessor &);
+
+    static void deleter(GPUProcessor * c);
+
+    friend class Processor;
+
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+
+//!cpp:class::
+// This class contains meta information about the process that generated
+// this processor.  The results of these functions do not
+// impact the pixel processing.
+
+class OCIOEXPORT ProcessorMetadata
+{
+public:
+    //!cpp:function::
+    static ProcessorMetadataRcPtr Create();
+
+    //!cpp:function::
+    int getNumFiles() const;
+    //!cpp:function::
+    const char * getFile(int index) const;
+
+    //!cpp:function::
+    int getNumLooks() const;
+    //!cpp:function::
+    const char * getLook(int index) const;
+
+    //!cpp:function::
+    void addFile(const char * fname);
+    //!cpp:function::
+    void addLook(const char * look);
+private:
+    ProcessorMetadata();
+    ~ProcessorMetadata();
+    ProcessorMetadata(const ProcessorMetadata &);
+    ProcessorMetadata& operator= (const ProcessorMetadata &);
+
+    static void deleter(ProcessorMetadata* c);
+
+    class Impl;
+    friend class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+
+
+///////////////////////////////////////////////////////////////////////////
+//!rst::
+// Baker
+// *****
+// 
+// In certain situations it is necessary to serialize transforms into a variety
+// of application specific LUT formats. Note that not all file formats that may
+// be read also support baking.
+//
+// **Usage Example:** *Bake a CSP sRGB viewer LUT*
+//
+// .. code-block:: cpp
+//
+//    OCIO::ConstConfigRcPtr config = OCIO::Config::CreateFromEnv();
+//    OCIO::BakerRcPtr baker = OCIO::Baker::Create();
+//    baker->setConfig(config);
+//    baker->setFormat("csp");
+//    baker->setInputSpace("lnf");
+//    baker->setShaperSpace("log");
+//    baker->setTargetSpace("sRGB");
+//    auto & metadata = baker->getFormatMetadata();
+//    metadata.addChildElement(OCIO::METADATA_DESCRIPTION, "A first comment");
+//    metadata.addChildElement(OCIO::METADATA_DESCRIPTION, "A second comment");
+//    std::ostringstream out;
+//    baker->bake(out); // fresh bread anyone!
+//    std::cout << out.str();
+
+class OCIOEXPORT Baker
+{
+public:
+    //!cpp:function:: Create a new Baker.
+    static BakerRcPtr Create();
+
+    //!cpp:function:: Create a copy of this Baker.
+    BakerRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    ConstConfigRcPtr getConfig() const;
+    //!cpp:function:: Set the config to use.
+    void setConfig(const ConstConfigRcPtr & config);
+
+    //!cpp:function::
+    const char * getFormat() const;
+    //!cpp:function:: Set the LUT output format.
+    void setFormat(const char * formatName);
+
+
+    //!cpp:function::
+    const FormatMetadata & getFormatMetadata() const;
+    //!cpp:function:: Get editable *optional* format metadata. The metadata that will be used
+    // varies based on the capability of the given file format.  Formats such as CSP,
+    // IridasCube, and ResolveCube will create comments in the file header using the value of
+    // any first-level children elements of the formatMetadata.  The CLF/CTF formats will make
+    // use of the top-level "id" and "name" attributes and children elements "Description",
+    // "InputDescriptor", "OutputDescriptor", and "Info".
+    FormatMetadata & getFormatMetadata();
+
+    //!cpp:function::
+    const char * getInputSpace() const;
+    //!cpp:function:: Set the input ColorSpace that the LUT will be applied to.
+    void setInputSpace(const char * inputSpace);
+
+    //!cpp:function::
+    const char * getShaperSpace() const;
+    //!cpp:function:: Set an *optional* ColorSpace to be used to shape / transfer the input
+    // colorspace. This is mostly used to allocate an HDR luminance range into an LDR one.
+    // If a shaper space is not explicitly specified, and the file format supports one, the
+    // ColorSpace Allocation will be used (not implemented for all formats).
+    void setShaperSpace(const char * shaperSpace);
+
+    //!cpp:function::
+    const char * getLooks() const;
+    //!cpp:function:: Set the looks to be applied during baking. Looks is a potentially comma
+    // (or colon) delimited list of lookNames, where +/- prefixes are optionally allowed to
+    // denote forward/inverse look specification. (And forward is assumed in the absence of
+    // either).
+    void setLooks(const char * looks);
+
+    //!cpp:function::
+    const char * getTargetSpace() const;
+    //!cpp:function:: Set the target device colorspace for the LUT.
+    void setTargetSpace(const char * targetSpace);
+
+    //!cpp:function::
+    int getShaperSize() const;
+    //!cpp:function:: Override the default shaper LUT size. Default value is -1, which allows
+    // each format to use its own most appropriate size. For the CLF format, the default uses
+    // a half-domain LUT1D (which is ideal for scene-linear inputs).
+    void setShaperSize(int shapersize);
+
+    //!cpp:function::
+    int getCubeSize() const;
+    //!cpp:function:: Override the default cube sample size.
+    // default: <format specific>
+    void setCubeSize(int cubesize);
+
+    //!cpp:function:: Bake the LUT into the output stream.
+    void bake(std::ostream & os) const;
+
+    //!cpp:function:: Get the number of LUT bakers.
+    static int getNumFormats();
+
+    //!cpp:function:: Get the LUT baker format name at index, return empty string if an invalid
+    // index is specified.
+    static const char * getFormatNameByIndex(int index);
+    //!cpp:function:: Get the LUT baker format extension at index, return empty string if an
+    // invalid index is specified.
+    static const char * getFormatExtensionByIndex(int index);
+
+private:
+    Baker();
+    ~Baker();
+
+    Baker(const Baker &);
+    Baker& operator= (const Baker &);
+
+    static void deleter(Baker* o);
+
+    class Impl;
+    friend class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+
+///////////////////////////////////////////////////////////////////////////
+//!rst::
+// ImageDesc
+// *********
+
+//!rst::
+// .. c:var:: const ptrdiff_t AutoStride
+//
+//    AutoStride
+const ptrdiff_t AutoStride = std::numeric_limits<ptrdiff_t>::min();
+
+//!cpp:class::
+// This is a light-weight wrapper around an image, that provides a context
+// for pixel access. This does NOT claim ownership of the pixels or copy
+// image data.
+
+class OCIOEXPORT ImageDesc
+{
+public:
+    //!cpp:function::
+    ImageDesc();
+    //!cpp:function::
+    virtual ~ImageDesc();
+
+    //!cpp:function:: Get a pointer to the red channel of the first pixel.
+    virtual void * getRData() const = 0;
+    //!cpp:function:: Get a pointer to the green channel of the first pixel.
+    virtual void * getGData() const = 0;
+    //!cpp:function:: Get a pointer to the blue channel of the first pixel.
+    virtual void * getBData() const = 0;
+    //!cpp:function:: Get a pointer to the alpha channel of the first pixel
+    // or null as alpha channel is optional.
+    virtual void * getAData() const = 0;
+
+    //!cpp:function:: Get the bit-depth.
+    virtual BitDepth getBitDepth() const = 0;
+
+    //!cpp:function:: Get the width to process (where x position starts at 0 and ends at width-1).
+    virtual long getWidth() const = 0;
+    //!cpp:function:: Get the height to process (where y position starts at 0 and ends at height-1).
+    virtual long getHeight() const = 0;
+
+    //!cpp:function:: Get the step in bytes to find the same color channel of the next pixel.
+    virtual ptrdiff_t getXStrideBytes() const = 0;
+    //!cpp:function:: Get the step in bytes to find the same color channel
+    // of the pixel at the same position in the next line.
+    virtual ptrdiff_t getYStrideBytes() const = 0;
+
+    //!cpp:function:: Is the image buffer in packed mode with the 4 color channels?
+    // ("Packed" here means that XStrideBytes is 4x the bytes per channel, so it is more specific
+    // than simply any PackedImageDesc.)
+    virtual bool isRGBAPacked() const = 0;
+    //!cpp:function:: Is the image buffer 32-bit float?
+    virtual bool isFloat() const = 0;
+
+private:
+    ImageDesc(const ImageDesc &);
+    ImageDesc & operator= (const ImageDesc &);
+};
+
+extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const ImageDesc&);
+
+
+///////////////////////////////////////////////////////////////////////////
+//!rst::
+// PackedImageDesc
+// ^^^^^^^^^^^^^^^
+
+//!cpp:class::
+class OCIOEXPORT PackedImageDesc : public ImageDesc
+{
+public:
+
+    //!rst::
+    // All the constructors expect a pointer to packed image data (such as
+    // rgbrgbrgb or rgbargbargba) starting at the first color channel of
+    // the first pixel to process (which does not need to be the first pixel
+    // of the image). The number of channels must be greater than or equal to 3.
+    // If a 4th channel is specified, it is assumed to be alpha
+    // information.  Channels > 4 will be ignored.
+    //
+    // .. note::
+    // The methods assume the CPUProcessor bit-depth type for the data pointer.
+
+    //!cpp:function::
+    //
+    // .. note::
+    //    numChannels must be 3 (RGB) or 4 (RGBA).
+    PackedImageDesc(void * data,
+                    long width, long height,
+                    long numChannels);
+
+    //!cpp:function::
+    //
+    // .. note::
+    //    numChannels smust be 3 (RGB) or 4 (RGBA).
+    PackedImageDesc(void * data,
+                    long width, long height,
+                    long numChannels,  // must be 3 (RGB) or 4 (RGBA)
+                    BitDepth bitDepth,
+                    ptrdiff_t chanStrideBytes,
+                    ptrdiff_t xStrideBytes,
+                    ptrdiff_t yStrideBytes);
+
+    //!cpp:function::
+    PackedImageDesc(void * data,
+                    long width, long height,
+                    ChannelOrdering chanOrder);
+
+    //!cpp:function::
+    PackedImageDesc(void * data,
+                    long width, long height,
+                    ChannelOrdering chanOrder,
+                    BitDepth bitDepth,
+                    ptrdiff_t chanStrideBytes,
+                    ptrdiff_t xStrideBytes,
+                    ptrdiff_t yStrideBytes);
+
+    //!cpp:function::
+    virtual ~PackedImageDesc();
+
+    //!cpp:function:: Get the channel ordering of all the pixels.
+    ChannelOrdering getChannelOrder() const;
+
+    //!cpp:function:: Get the bit-depth.
+    BitDepth getBitDepth() const override;
+
+    //!cpp:function:: Get a pointer to the first color channel of the first pixel.
+    void * getData() const;
+
+    //!cpp:function::
+    void * getRData() const override;
+    //!cpp:function::
+    void * getGData() const override;
+    //!cpp:function::
+    void * getBData() const override;
+    //!cpp:function::
+    void * getAData() const override;
+
+    //!cpp:function::
+    long getWidth() const override;
+    //!cpp:function::
+    long getHeight() const override;
+    //!cpp:function::
+    long getNumChannels() const;
+
+    //!cpp:function::
+    ptrdiff_t getChanStrideBytes() const;
+    //!cpp:function::
+    ptrdiff_t getXStrideBytes() const override;
+    //!cpp:function::
+    ptrdiff_t getYStrideBytes() const override;
+
+    //!cpp:function::
+    bool isRGBAPacked() const override;
+    //!cpp:function::
+    bool isFloat() const override;
+
+private:
+    struct Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+
+    PackedImageDesc();
+    PackedImageDesc(const PackedImageDesc &);
+    PackedImageDesc& operator= (const PackedImageDesc &);
+};
+
+
+///////////////////////////////////////////////////////////////////////////
+//!rst::
+// PlanarImageDesc
+// ^^^^^^^^^^^^^^^
+
+//!cpp:class::
+class OCIOEXPORT PlanarImageDesc : public ImageDesc
+{
+public:
+
+    //!rst::
+    // All the constructors expect pointers to the specified image planes
+    // (i.e. rrrr gggg bbbb) starting at the first color channel of the
+    // first pixel to process (which need not be the first pixel of the image).
+    // Pass NULL for aData if no alpha exists (r/g/bData must not be NULL).
+    //
+    // .. note::
+    // The methods assume the CPUProcessor bit-depth type for the R/G/B/A data pointers.
+
+    //!cpp:function::
+    PlanarImageDesc(void * rData, void * gData, void * bData, void * aData,
+                    long width, long height);
+
+    //!cpp:function::
+    // Note that although PlanarImageDesc is powerful enough to also describe
+    // all :cpp:class:`PackedImageDesc` scenarios, it is recommended to use
+    // a PackedImageDesc where possible since that allows for additional
+    // optimizations.
+    PlanarImageDesc(void * rData, void * gData, void * bData, void * aData,
+                    long width, long height,
+                    BitDepth bitDepth,
+                    ptrdiff_t xStrideBytes,
+                    ptrdiff_t yStrideBytes);
+
+    //!cpp:function::
+    virtual ~PlanarImageDesc();
+
+    //!cpp:function::
+    void * getRData() const override;
+    //!cpp:function::
+    void * getGData() const override;
+    //!cpp:function::
+    void * getBData() const override;
+    //!cpp:function::
+    void * getAData() const override;
+
+    //!cpp:function:: Get the bit-depth.
+    BitDepth getBitDepth() const override;
+
+    //!cpp:function::
+    long getWidth() const override;
+    //!cpp:function::
+    long getHeight() const override;
+
+    //!cpp:function::
+    ptrdiff_t getXStrideBytes() const override;
+    //!cpp:function::
+    ptrdiff_t getYStrideBytes() const override;
+
+    //!cpp:function::
+    bool isRGBAPacked() const override;
+    //!cpp:function::
+    bool isFloat() const override;
+
+private:
+    struct Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+
+    PlanarImageDesc();
+    PlanarImageDesc(const PlanarImageDesc &);
+    PlanarImageDesc& operator= (const PlanarImageDesc &);
+};
+
+
+///////////////////////////////////////////////////////////////////////////
+//!rst::
+// GpuShaderDesc
+// *************
+// This class holds the GPU-related information needed to build a shader program
+// from a specific processor.
+//
+// This class defines the interface and there are two implementations provided.
+// The "legacy" mode implements the OCIO v1 approach of baking certain ops
+// in order to have at most one 3D-LUT.  The "generic" mode is the v2 default and
+// allows all the ops to be processed as-is, without baking, like the CPU renderer.
+// Custom implementations could be written to accommodate the GPU needs of a
+// specific client app.
+//
+//
+// The complete fragment shader program is decomposed in two main parts:
+// the OCIO shader program for the color processing and the client shader
+// program which consumes the pixel color processing.
+//
+// The OCIO shader program is fully described by the GpuShaderDesc
+// independently from the client shader program. The only critical
+// point is the agreement on the OCIO function shader name.
+//
+// To summarize, the complete shader program is:
+//
+// .. code-block:: cpp
+//
+//  ////////////////////////////////////////////////////////////////////////
+//  //                                                                    //
+//  //               The complete fragment shader program                 //
+//  //                                                                    //
+//  ////////////////////////////////////////////////////////////////////////
+//  //                                                                    //
+//  //   //////////////////////////////////////////////////////////////   //
+//  //   //                                                          //   //
+//  //   //               The OCIO shader program                    //   //
+//  //   //                                                          //   //
+//  //   //////////////////////////////////////////////////////////////   //
+//  //   //                                                          //   //
+//  //   //   // All global declarations                             //   //
+//  //   //   uniform sampled3D tex3;                                //   //
+//  //   //                                                          //   //
+//  //   //   // All helper methods                                  //   //
+//  //   //   vec3 computePos(vec3 color)                            //   //
+//  //   //   {                                                      //   //
+//  //   //      vec3 coords = color;                                //   //
+//  //   //      ...                                                 //   //
+//  //   //      return coords;                                      //   //
+//  //   //   }                                                      //   //
+//  //   //                                                          //   //
+//  //   //   // The OCIO shader function                            //   //
+//  //   //   vec4 OCIODisplay(in vec4 inColor)                      //   //
+//  //   //   {                                                      //   //
+//  //   //      vec4 outColor = inColor;                            //   //
+//  //   //      ...                                                 //   //
+//  //   //      outColor.rbg                                        //   //
+//  //   //         = texture3D(tex3, computePos(inColor.rgb)).rgb;  //   //
+//  //   //      ...                                                 //   //
+//  //   //      return outColor;                                    //   //
+//  //   //   }                                                      //   //
+//  //   //                                                          //   //
+//  //   //////////////////////////////////////////////////////////////   //
+//  //                                                                    //
+//  //   //////////////////////////////////////////////////////////////   //
+//  //   //                                                          //   //
+//  //   //             The client shader program                    //   //
+//  //   //                                                          //   //
+//  //   //////////////////////////////////////////////////////////////   //
+//  //   //                                                          //   //
+//  //   //   uniform sampler2D image;                               //   //
+//  //   //                                                          //   //
+//  //   //   void main()                                            //   //
+//  //   //   {                                                      //   //
+//  //   //      vec4 inColor = texture2D(image, gl_TexCoord[0].st); //   //
+//  //   //      ...                                                 //   //
+//  //   //      vec4 outColor = OCIODisplay(inColor);               //   //
+//  //   //      ...                                                 //   //
+//  //   //      gl_FragColor = outColor;                            //   //
+//  //   //   }                                                      //   //
+//  //   //                                                          //   //
+//  //   //////////////////////////////////////////////////////////////   //
+//  //                                                                    //
+//  ////////////////////////////////////////////////////////////////////////
+//
+//
+// **Usage Example:** *Building a GPU shader*
+//
+//   This example is based on the code in: src/apps/ociodisplay/main.cpp
+//
+// .. code-block:: cpp
+//
+//    // Get the processor
+//    //
+//    OCIO::ConstConfigRcPtr config = OCIO::Config::CreateFromEnv();
+//    OCIO::ConstProcessorRcPtr processor
+//       = config->getProcessor("ACES - ACEScg", "Output - sRGB");
+//
+//    // Step 1: Create a GPU shader description
+//    //
+//    // The three potential scenarios are:
+//    //
+//    //   1. Instantiate the legacy shader description.  The color processor
+//    //      is baked down to contain at most one 3D LUT and no 1D LUTs.
+//    //
+//    //      This is the v1 behavior and will remain part of OCIO v2
+//    //      for backward compatibility.
+//    //
+//    OCIO::GpuShaderDescRcPtr shaderDesc
+//          = OCIO::GpuShaderDesc::CreateLegacyShaderDesc(LUT3D_EDGE_SIZE);
+//    //
+//    //   2. Instantiate the generic shader description.  The color processor
+//    //      is used as-is (i.e. without any baking step) and could contain
+//    //      any number of 1D & 3D luts.
+//    //
+//    //      This is the default OCIO v2 behavior and allows a much better
+//    //      match between the CPU and GPU renderers.
+//    //
+//    OCIO::GpuShaderDescRcPtr shaderDesc = OCIO::GpuShaderDesc::Create();
+//    //
+//    //   3. Instantiate a custom shader description.
+//    //
+//    //      Writing a custom shader description is a way to tailor the shaders
+//    //      to the needs of a given client program.  This involves writing a
+//    //      new class inheriting from the pure virtual class GpuShaderDesc.
+//    //
+//    //      Please refer to the GenericGpuShaderDesc class for an example.
+//    //
+//    OCIO::GpuShaderDescRcPtr shaderDesc = MyCustomGpuShader::Create();
+//
+//    shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_GLSL_1_3);
+//    shaderDesc->setFunctionName("OCIODisplay");
+//
+//    // Step 2: Collect the shader program information for a specific processor
+//    //
+//    processor->extractGpuShaderInfo(shaderDesc);
+//
+//    // Step 3: Create a helper to build the shader. Here we use a helper for
+//    //         OpenGL but there will also be helpers for other languages.
+//    //
+//    OpenGLBuilderRcPtr oglBuilder = OpenGLBuilder::Create(shaderDesc);
+//
+//    // Step 4: Allocate & upload all the LUTs
+//    //
+//    oglBuilder->allocateAllTextures();
+//
+//    // Step 5: Build the complete fragment shader program using
+//    //         g_fragShaderText which is the client shader program.
+//    //
+//    g_programId = oglBuilder->buildProgram(g_fragShaderText);
+//
+//    // Step 6: Enable the fragment shader program, and all needed textures
+//    //
+//    glUseProgram(g_programId);
+//    glUniform1i(glGetUniformLocation(g_programId, "tex1"), 1);  // image texture
+//    oglBuilder->useAllTextures(g_programId);                    // LUT textures
+//
+
+//!cpp:class::
+class OCIOEXPORT GpuShaderDesc
+{
+public:
+
+    //!cpp:function:: Create the legacy shader description
+    static GpuShaderDescRcPtr CreateLegacyShaderDesc(unsigned edgelen);
+
+    //!cpp:function:: Create the default shader description
+    static GpuShaderDescRcPtr CreateShaderDesc();
+
+    //!cpp:function:: Set the shader program language
+    void setLanguage(GpuLanguage lang);
+    //!cpp:function::
+    GpuLanguage getLanguage() const;
+
+    //!cpp:function:: Set the function name of the shader program
+    void setFunctionName(const char * name);
+    //!cpp:function::
+    const char * getFunctionName() const;
+
+    //!cpp:function:: Set the pixel name variable holding the color values
+    void setPixelName(const char * name);
+    //!cpp:function::
+    const char * getPixelName() const;
+
+    //!cpp:function::  Set a prefix to the resource name
+    //
+    // .. note::
+    //   Some applications require that textures, uniforms,
+    //   and helper methods be uniquely named because several
+    //   processor instances could coexist.
+    //
+    void setResourcePrefix(const char * prefix);
+    //!cpp:function::
+    const char * getResourcePrefix() const;
+
+    //!cpp:function::
+    virtual const char * getCacheID() const;
+
+public:
+
+    enum TextureType
+    {
+        TEXTURE_RED_CHANNEL, // Only use the red channel of the texture
+        TEXTURE_RGB_CHANNEL
     };
-    
-    extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const Context&);
+
+    //!cpp:function:: Dynamic Property related methods.
+    virtual unsigned getNumUniforms() const = 0;
+    virtual void getUniform(unsigned index, const char *& name,
+                            DynamicPropertyRcPtr & value) const = 0;
+    virtual bool addUniform(const char * name,
+                            const DynamicPropertyRcPtr & value) = 0;
+
+    //!cpp:function:: 1D lut related methods
+    virtual unsigned getTextureMaxWidth() const = 0;
+    virtual void setTextureMaxWidth(unsigned maxWidth) = 0;
+    virtual unsigned getNumTextures() const = 0;
+    virtual void addTexture(const char * name, const char * id,
+                            unsigned width, unsigned height,
+                            TextureType channel, Interpolation interpolation,
+                            const float * values) = 0;
+    virtual void getTexture(unsigned index, const char *& name, const char *& id,
+                            unsigned & width, unsigned & height,
+                            TextureType & channel, Interpolation & interpolation) const = 0;
+    virtual void getTextureValues(unsigned index, const float *& values) const = 0;
+
+    //!cpp:function:: 3D lut related methods
+    virtual unsigned getNum3DTextures() const = 0;
+    virtual void add3DTexture(const char * name, const char * id, unsigned edgelen,
+                                Interpolation interpolation, const float * values) = 0;
+    virtual void get3DTexture(unsigned index, const char *& name, const char *& id,
+                                unsigned & edgelen, Interpolation & interpolation) const = 0;
+    virtual void get3DTextureValues(unsigned index, const float *& values) const = 0;
+
+    //!cpp:function:: Methods to specialize parts of a OCIO shader program
+    //
+    // **An OCIO shader program could contain:**
+    //
+    // 1. A declaration part  e.g., uniform sampled3D tex3;
+    //
+    // 2. Some helper methods
+    //
+    // 3. The OCIO shader function may be broken down as:
+    //
+    //    1. The function header  e.g., void OCIODisplay(in vec4 inColor) {
+    //    2. The function body    e.g.,   vec4 outColor.rgb = texture3D(tex3, inColor.rgb).rgb;
+    //    3. The function footer  e.g.,   return outColor; }
+    //
+    //
+    // **Usage Example:**
+    //
+    // Below is a code snippet to highlight the different parts of the OCIO shader program.
+    //
+    // .. code-block:: cpp
+    //
+    //    // All global declarations
+    //    uniform sampled3D tex3;
+    //
+    //    // All helper methods
+    //    vec3 computePosition(vec3 color)
+    //    {
+    //       vec3 coords = color;
+    //       // Some processing...
+    //       return coords;
+    //    }
+    //
+    //    // The shader function
+    //    vec4 OCIODisplay(in vec4 inColor)     //
+    //    {                                     // Function Header
+    //       vec4 outColor = inColor;           //
+    //
+    //       outColor.rgb = texture3D(tex3, computePosition(inColor.rgb)).rgb;
+    //
+    //       return outColor;                   // Function Footer
+    //    }                                     //
+    //
+    virtual void addToDeclareShaderCode(const char * shaderCode) = 0;
+    virtual void addToHelperShaderCode(const char * shaderCode) = 0;
+    virtual void addToFunctionHeaderShaderCode(const char * shaderCode) = 0;
+    virtual void addToFunctionShaderCode(const char * shaderCode) = 0;
+    virtual void addToFunctionFooterShaderCode(const char * shaderCode) = 0;
+
+    //!cpp:function:: Create the OCIO shader program
+    //
+    // .. note::
+    //
+    //   The OCIO shader program is decomposed to allow a specific implementation
+    //   to change some parts. Some product integrations add the color processing
+    //   within a client shader program, imposing constraints requiring this flexibility.
+    //
+    virtual void createShaderText(
+        const char * shaderDeclarations, const char * shaderHelperMethods,
+        const char * shaderFunctionHeader, const char * shaderFunctionBody,
+        const char * shaderFunctionFooter) = 0;
+
+    //!cpp:function:: Get the complete OCIO shader program
+    virtual const char * getShaderText() const = 0;
+
+    //!cpp:function::
+    virtual void finalize() = 0;
+
+protected:
+    //!cpp:function::
+    GpuShaderDesc();
+    //!cpp:function::
+    virtual ~GpuShaderDesc();
+
+private:
+
+    GpuShaderDesc(const GpuShaderDesc &);
+    GpuShaderDesc& operator= (const GpuShaderDesc &);
+
+    class Impl;
+    friend class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+
+///////////////////////////////////////////////////////////////////////////
+//!rst::
+// Context
+// *******
+
+//!cpp:class::
+class OCIOEXPORT Context
+{
+public:
+    //!cpp:function::
+    static ContextRcPtr Create();
+
+    //!cpp:function::
+    ContextRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    const char * getCacheID() const;
+
+    //!cpp:function::
+    void setSearchPath(const char * path);
+    //!cpp:function::
+    const char * getSearchPath() const;
+
+    //!cpp:function::
+    int getNumSearchPaths() const;
+    //!cpp:function::
+    const char * getSearchPath(int index) const;
+    //!cpp:function::
+    void clearSearchPaths();
+    //!cpp:function::
+    void addSearchPath(const char * path);
+
+    //!cpp:function::
+    void setWorkingDir(const char * dirname);
+    //!cpp:function::
+    const char * getWorkingDir() const;
+
+    //!cpp:function::
+    void setStringVar(const char * name, const char * value);
+    //!cpp:function::
+    const char * getStringVar(const char * name) const;
+
+    //!cpp:function::
+    int getNumStringVars() const;
+    //!cpp:function::
+    const char * getStringVarNameByIndex(int index) const;
+
+    //!cpp:function::
+    void clearStringVars();
+
+    //!cpp:function::
+    void setEnvironmentMode(EnvironmentMode mode);
+
+    //!cpp:function::
+    EnvironmentMode getEnvironmentMode() const;
+
+    //!cpp:function:: Seed all string vars with the current environment.
+    void loadEnvironment();
+
+    //! Do a string lookup.
+    //!cpp:function:: Do a file lookup.
+    //
+    // Evaluate the specified variable (as needed). Will not throw exceptions.
+    const char * resolveStringVar(const char * val) const;
+
+    //! Do a file lookup.
+    //!cpp:function:: Do a file lookup.
+    //
+    // Evaluate all variables (as needed).
+    // Also, walk the full search path until the file is found.
+    // If the filename cannot be found, an exception will be thrown.
+    const char * resolveFileLocation(const char * filename) const;
+
+private:
+    Context();
+    ~Context();
+
+    Context(const Context &);
+    Context& operator= (const Context &);
+
+    static void deleter(Context* c);
+
+    class Impl;
+    friend class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const Context&);
 
 } // namespace OCIO_NAMESPACE
 

--- a/include/OpenColorIO/OpenColorTransforms.h
+++ b/include/OpenColorIO/OpenColorTransforms.h
@@ -22,1491 +22,1491 @@ namespace OCIO_NAMESPACE
 {
 
 
-    //!rst:: //////////////////////////////////////////////////////////////////
+//!rst:: //////////////////////////////////////////////////////////////////
 
-    //!cpp:class:: The FormatMetadata class is intended to be a generic
-    // container to hold metadata from various file formats.
-    //
-    // This class provides a hierarchical metadata container.
-    // A metadata object is similar to an element in XML.
-    // It contains:
-    //
-    // * A name string (e.g. "Description").
-    // * A value string (e.g. "updated viewing LUT").
-    // * A list of attributes (name, value) string pairs (e.g. "version", "1.5").
-    // * And a list of child sub-elements, which are also objects implementing
-    //   FormatMetadata.
-    //
-    class OCIOEXPORT FormatMetadata
-    {
-    public:
-        //!cpp:function::
-        virtual const char * getName() const = 0;
-        //!cpp:function::
-        virtual void setName(const char *) = 0;
-
-        //!cpp:function::
-        virtual const char * getValue() const = 0;
-        //!cpp:function::
-        virtual void setValue(const char *) = 0;
-
-        //!cpp:function::
-        virtual int getNumAttributes() const = 0;
-        //!cpp:function::
-        virtual const char * getAttributeName(int i) const = 0;
-        //!cpp:function::
-        virtual const char * getAttributeValue(int i) const = 0;
-        //!cpp:function:: Add an attribute with a given name and value. If an
-        // attribute with the same name already exists, the value is replaced.
-        virtual void addAttribute(const char * name, const char * value) = 0;
-
-        //!cpp:function::
-        virtual int getNumChildrenElements() const = 0;
-        //!cpp:function::
-        virtual const FormatMetadata & getChildElement(int i) const = 0;
-        //!cpp:function::
-        virtual FormatMetadata & getChildElement(int i) = 0;
-
-        //!cpp:function:: Add a child element with a given name and value. Name has to be
-        // non-empty. Value may be empty, particularly if this element will have children.
-        // Return a reference to the added element.
-        virtual FormatMetadata & addChildElement(const char * name, const char * value) = 0;
-
-        //!cpp:function::
-        virtual void clear() = 0;
-        //!cpp:function::
-        virtual FormatMetadata & operator=(const FormatMetadata & rhs) = 0;
-
-    protected:
-        FormatMetadata();
-        virtual ~FormatMetadata();
-
-    private:
-        FormatMetadata(const FormatMetadata & rhs) = delete;
-    };
-
-    //!rst:: //////////////////////////////////////////////////////////////////
-
-    //!cpp:class:: Base class for all the transform classes
-    class OCIOEXPORT Transform
-    {
-    public:
-        virtual TransformRcPtr createEditableCopy() const = 0;
-
-        virtual TransformDirection getDirection() const = 0;
-        //!cpp:function::
-        virtual void setDirection(TransformDirection dir) = 0;
-
-        //!cpp:function:: Will throw if data is not valid.
-        virtual void validate() const;
-
-    protected:
-        Transform() = default;
-        virtual ~Transform() = default;
-
-    private:
-        Transform(const Transform &) = delete;
-        Transform & operator= (const Transform &) = delete;
-    };
+//!cpp:class:: The FormatMetadata class is intended to be a generic
+// container to hold metadata from various file formats.
+//
+// This class provides a hierarchical metadata container.
+// A metadata object is similar to an element in XML.
+// It contains:
+//
+// * A name string (e.g. "Description").
+// * A value string (e.g. "updated viewing LUT").
+// * A list of attributes (name, value) string pairs (e.g. "version", "1.5").
+// * And a list of child sub-elements, which are also objects implementing
+//   FormatMetadata.
+//
+class OCIOEXPORT FormatMetadata
+{
+public:
+    //!cpp:function::
+    virtual const char * getName() const = 0;
+    //!cpp:function::
+    virtual void setName(const char *) = 0;
 
     //!cpp:function::
-    extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const Transform&);
-
-
-    //!rst:: //////////////////////////////////////////////////////////////////
-
-    //!cpp:class:: Forward direction wraps the 'expanded' range into the
-    // specified, often compressed, range.
-    class OCIOEXPORT AllocationTransform : public Transform
-    {
-    public:
-        //!cpp:function::
-        static AllocationTransformRcPtr Create();
-
-        //!cpp:function::
-        virtual TransformRcPtr createEditableCopy() const;
-
-        //!cpp:function::
-        virtual TransformDirection getDirection() const;
-        //!cpp:function::
-        virtual void setDirection(TransformDirection dir);
-
-        //!cpp:function:: Will throw if data is not valid.
-        virtual void validate() const;
-
-        //!cpp:function::
-        Allocation getAllocation() const;
-        //!cpp:function::
-        void setAllocation(Allocation allocation);
-
-        //!cpp:function::
-        int getNumVars() const;
-        //!cpp:function::
-        void getVars(float * vars) const;
-        //!cpp:function::
-        void setVars(int numvars, const float * vars);
-
-    private:
-        AllocationTransform();
-        AllocationTransform(const AllocationTransform &);
-        virtual ~AllocationTransform();
-
-        AllocationTransform & operator= (const AllocationTransform &);
-
-        static void deleter(AllocationTransform * t);
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
+    virtual const char * getValue() const = 0;
+    //!cpp:function::
+    virtual void setValue(const char *) = 0;
 
     //!cpp:function::
-    extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const AllocationTransform&);
+    virtual int getNumAttributes() const = 0;
+    //!cpp:function::
+    virtual const char * getAttributeName(int i) const = 0;
+    //!cpp:function::
+    virtual const char * getAttributeValue(int i) const = 0;
+    //!cpp:function:: Add an attribute with a given name and value. If an
+    // attribute with the same name already exists, the value is replaced.
+    virtual void addAttribute(const char * name, const char * value) = 0;
+
+    //!cpp:function::
+    virtual int getNumChildrenElements() const = 0;
+    //!cpp:function::
+    virtual const FormatMetadata & getChildElement(int i) const = 0;
+    //!cpp:function::
+    virtual FormatMetadata & getChildElement(int i) = 0;
+
+    //!cpp:function:: Add a child element with a given name and value. Name has to be
+    // non-empty. Value may be empty, particularly if this element will have children.
+    // Return a reference to the added element.
+    virtual FormatMetadata & addChildElement(const char * name, const char * value) = 0;
+
+    //!cpp:function::
+    virtual void clear() = 0;
+    //!cpp:function::
+    virtual FormatMetadata & operator=(const FormatMetadata & rhs) = 0;
+
+protected:
+    FormatMetadata();
+    virtual ~FormatMetadata();
+
+private:
+    FormatMetadata(const FormatMetadata & rhs) = delete;
+};
+
+//!rst:: //////////////////////////////////////////////////////////////////
+
+//!cpp:class:: Base class for all the transform classes
+class OCIOEXPORT Transform
+{
+public:
+    virtual TransformRcPtr createEditableCopy() const = 0;
+
+    virtual TransformDirection getDirection() const = 0;
+    //!cpp:function::
+    virtual void setDirection(TransformDirection dir) = 0;
+
+    //!cpp:function:: Will throw if data is not valid.
+    virtual void validate() const;
+
+protected:
+    Transform() = default;
+    virtual ~Transform() = default;
+
+private:
+    Transform(const Transform &) = delete;
+    Transform & operator= (const Transform &) = delete;
+};
+
+//!cpp:function::
+extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const Transform&);
 
 
-    //!rst:: //////////////////////////////////////////////////////////////////
+//!rst:: //////////////////////////////////////////////////////////////////
 
-    //!cpp:class:: An implementation of the ASC CDL Transfer Functions and
-    // Interchange - Syntax (Based on the version 1.2 document)
+//!cpp:class:: Forward direction wraps the 'expanded' range into the
+// specified, often compressed, range.
+class OCIOEXPORT AllocationTransform : public Transform
+{
+public:
+    //!cpp:function::
+    static AllocationTransformRcPtr Create();
+
+    //!cpp:function::
+    virtual TransformRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    virtual TransformDirection getDirection() const;
+    //!cpp:function::
+    virtual void setDirection(TransformDirection dir);
+
+    //!cpp:function:: Will throw if data is not valid.
+    virtual void validate() const;
+
+    //!cpp:function::
+    Allocation getAllocation() const;
+    //!cpp:function::
+    void setAllocation(Allocation allocation);
+
+    //!cpp:function::
+    int getNumVars() const;
+    //!cpp:function::
+    void getVars(float * vars) const;
+    //!cpp:function::
+    void setVars(int numvars, const float * vars);
+
+private:
+    AllocationTransform();
+    AllocationTransform(const AllocationTransform &);
+    virtual ~AllocationTransform();
+
+    AllocationTransform & operator= (const AllocationTransform &);
+
+    static void deleter(AllocationTransform * t);
+
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+//!cpp:function::
+extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const AllocationTransform&);
+
+
+//!rst:: //////////////////////////////////////////////////////////////////
+
+//!cpp:class:: An implementation of the ASC CDL Transfer Functions and
+// Interchange - Syntax (Based on the version 1.2 document)
+//
+// .. note::
+//    the clamping portion of the CDL is only applied if a non-identity
+//    power is specified.
+class OCIOEXPORT CDLTransform : public Transform
+{
+public:
+    //!cpp:function::
+    static CDLTransformRcPtr Create();
+
+    //!cpp:function:: Load the CDL from the src .cc or .ccc file.
+    // If a .ccc is used, the cccid must also be specified
+    // src must be an absolute path reference, no relative directory
+    // or envvar resolution is performed.
+    static CDLTransformRcPtr CreateFromFile(const char * src, const char * cccid);
+
+    //!cpp:function::
+    virtual TransformRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    virtual TransformDirection getDirection() const;
+    //!cpp:function::
+    virtual void setDirection(TransformDirection dir);
+
+    //!cpp:function:: Will throw if data is not valid.
+    virtual void validate() const;
+
+    //!cpp:function::
+    FormatMetadata & getFormatMetadata();
+    //!cpp:function::
+    const FormatMetadata & getFormatMetadata() const;
+
+    //!cpp:function::
+    bool equals(const ConstCDLTransformRcPtr & other) const;
+
+    //!cpp:function::
+    const char * getXML() const;
+    //!cpp:function::
+    void setXML(const char * xml);
+
+    //!rst:: **ASC_SOP**
+    //
+    // Slope, offset, power::
+    //
+    //    out = clamp( (in * slope) + offset ) ^ power
+
+    //!cpp:function::
+    void getSlope(double * rgb) const;
+    //!cpp:function::
+    void setSlope(const double * rgb);
+
+    //!cpp:function::
+    void getOffset(double * rgb) const;
+    //!cpp:function::
+    void setOffset(const double * rgb);
+
+    //!cpp:function::
+    void getPower(double * rgb) const;
+    //!cpp:function::
+    void setPower(const double * rgb);
+
+    //!cpp:function::
+    void getSOP(double * vec9) const;
+    //!cpp:function::
+    void setSOP(const double * vec9);
+
+    //!rst:: **ASC_SAT**
+    //
+
+    //!cpp:function::
+    double getSat() const;
+    //!cpp:function::
+    void setSat(double sat);
+
+    //!cpp:function:: These are hard-coded, by spec, to r709.
+    void getSatLumaCoefs(double * rgb) const;
+
+    //!rst:: **Metadata**
+    //
+    // These do not affect the image processing, but
+    // are often useful for pipeline purposes and are
+    // included in the serialization.
+
+    //!cpp:function:: Unique Identifier for this correction.
+    const char * getID() const;
+    //!cpp:function::
+    void setID(const char * id);
+
+    //!cpp:function:: Deprecated. Use `getFormatMetadata`.
+    // First textual description of color correction (stored
+    // on the SOP). If there is already a description, the setter will
+    // replace it with the supplied text.
+    const char * getDescription() const;
+    //!cpp:function:: Deprecated. Use `getFormatMetadata`.
+    void setDescription(const char * desc);
+
+private:
+    CDLTransform();
+    CDLTransform(const CDLTransform &);
+    virtual ~CDLTransform();
+
+    CDLTransform & operator=(const CDLTransform &);
+
+    static void deleter(CDLTransform * t);
+
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+//!cpp:function::
+extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const CDLTransform &);
+
+
+//!rst:: //////////////////////////////////////////////////////////////////
+
+//!cpp:class::
+class OCIOEXPORT ColorSpaceTransform : public Transform
+{
+public:
+    //!cpp:function::
+    static ColorSpaceTransformRcPtr Create();
+
+    //!cpp:function::
+    virtual TransformRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    virtual TransformDirection getDirection() const;
+    //!cpp:function::
+    virtual void setDirection(TransformDirection dir);
+
+    //!cpp:function:: Will throw if data is not valid.
+    virtual void validate() const;
+
+    //!cpp:function::
+    const char * getSrc() const;
+    //!cpp:function::
+    void setSrc(const char * src);
+
+    //!cpp:function::
+    const char * getDst() const;
+    //!cpp:function::
+    void setDst(const char * dst);
+
+private:
+    ColorSpaceTransform();
+    ColorSpaceTransform(const ColorSpaceTransform &);
+    virtual ~ColorSpaceTransform();
+
+    ColorSpaceTransform & operator=(const ColorSpaceTransform &);
+
+    static void deleter(ColorSpaceTransform * t);
+
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+//!cpp:function::
+extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const ColorSpaceTransform &);
+
+
+//!rst:: //////////////////////////////////////////////////////////////////
+
+//!cpp:class::
+class OCIOEXPORT DisplayTransform : public Transform
+{
+public:
+    //!cpp:function::
+    static DisplayTransformRcPtr Create();
+
+    //!cpp:function::
+    virtual TransformRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    virtual TransformDirection getDirection() const;
+    //!cpp:function::
+    virtual void setDirection(TransformDirection dir);
+
+    //!cpp:function:: Will throw if data is not valid.
+    virtual void validate() const;
+
+    //!cpp:function::
+    const char * getInputColorSpaceName() const;
+    //!cpp:function:: Step 0. Specify the incoming color space.
+    void setInputColorSpaceName(const char * name);
+
+    //!cpp:function::
+    ConstTransformRcPtr getLinearCC() const;
+    //!cpp:function:: Step 1: Apply a Color Correction, in ROLE_SCENE_LINEAR.
+    void setLinearCC(const ConstTransformRcPtr & cc);
+
+    //!cpp:function::
+    ConstTransformRcPtr getColorTimingCC() const;
+    //!cpp:function:: Step 2: Apply a color correction, in ROLE_COLOR_TIMING.
+    void setColorTimingCC(const ConstTransformRcPtr & cc);
+
+    //!cpp:function::
+    ConstTransformRcPtr getChannelView() const;
+    //!cpp:function:: Step 3: Apply the Channel Viewing Swizzle (mtx).
+    void setChannelView(const ConstTransformRcPtr & transform);
+
+    //!cpp:function::
+    const char * getDisplay() const;
+    //!cpp:function:: Step 4: Apply the output display transform
+    // This is controlled by the specification of (display, view)
+    void setDisplay(const char * display);
+
+    //!cpp:function::
+    const char * getView() const;
+    //!cpp:function:: Specify which view transform to use
+    void setView(const char * view);
+
+    //!cpp:function::
+    ConstTransformRcPtr getDisplayCC() const;
+    //!cpp:function:: Step 5: Apply a post display transform color correction
+    void setDisplayCC(const ConstTransformRcPtr & cc);
+
+
+
+    //!cpp:function::
+    const char * getLooksOverride() const;
+    //!cpp:function:: A user can optionally override the looks that are,
+    // by default, used with the expected display / view combination.
+    // A common use case for this functionality is in an image viewing
+    // app, where per-shot looks are supported.  If for some reason
+    // a per-shot look is not defined for the current Context, the
+    // Config::getProcessor fcn will not succeed by default.  Thus,
+    // with this mechanism the viewing app could override to looks = "",
+    // and this will allow image display to continue (though hopefully)
+    // the interface would reflect this fallback option.)
+    //
+    // Looks is a potentially comma (or colon) delimited list of lookNames,
+    // Where +/- prefixes are optionally allowed to denote forward/inverse
+    // look specification. (And forward is assumed in the absence of either)
+    void setLooksOverride(const char * looks);
+
+    //!cpp:function::
+    bool getLooksOverrideEnabled() const;
+    //!cpp:function:: Specify whether the lookOverride should be used,
+    // or not. This is a separate flag, as it's often useful to override
+    // "looks" to an empty string.
+    void setLooksOverrideEnabled(bool enabled);
+
+private:
+    DisplayTransform();
+    DisplayTransform(const DisplayTransform &);
+    virtual ~DisplayTransform();
+
+    DisplayTransform & operator=(const DisplayTransform &);
+
+    static void deleter(DisplayTransform * t);
+
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+//!cpp:function::
+extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const DisplayTransform &);
+
+
+//!rst:: //////////////////////////////////////////////////////////////////
+
+//!cpp:class:: Allows transform parameter values to be set on-the-fly
+// (after finalization).  For example, to modify the exposure in a viewport.
+class OCIOEXPORT DynamicProperty
+{
+public:
+
+    //!cpp:function::
+    virtual DynamicPropertyType getType() const = 0;
+
+    //!cpp:function::
+    virtual DynamicPropertyValueType getValueType() const = 0;
+
+    //!cpp:function::
+    virtual double getDoubleValue() const = 0;
+    //!cpp:function::
+    virtual void setValue(double value) = 0;
+
+    //!cpp:function::
+    virtual bool isDynamic() const = 0;
+
+protected:
+
+    DynamicProperty();
+    DynamicProperty(const DynamicProperty &);
+    virtual ~DynamicProperty();
+
+    DynamicProperty & operator=(const DynamicProperty &);
+};
+
+//!rst:: //////////////////////////////////////////////////////////////////
+
+//!cpp:class:: Represents exponent transform: pow( clamp(color), value)
+//
+// For configs with version == 1: If the exponent is 1.0, this will not clamp.
+// Otherwise, the input color will be clamped between [0.0, inf].
+// For configs with version > 1: Negative values are always clamped.
+class OCIOEXPORT ExponentTransform : public Transform
+{
+public:
+    //!cpp:function::
+    static ExponentTransformRcPtr Create();
+
+    //!cpp:function::
+    virtual TransformRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    virtual TransformDirection getDirection() const;
+    //!cpp:function::
+    virtual void setDirection(TransformDirection dir);
+
+    //!cpp:function:: Will throw if data is not valid.
+    virtual void validate() const;
+
+    //!cpp:function::
+    const FormatMetadata & getFormatMetadata() const;
+    //!cpp:function::
+    FormatMetadata & getFormatMetadata();
+
+    //!cpp:function::
+    void getValue(double(&vec4)[4]) const;
+    //!cpp:function::
+    void setValue(const double(&vec4)[4]);
+
+private:
+    ExponentTransform();
+    ExponentTransform(const ExponentTransform &);
+    virtual ~ExponentTransform();
+
+    ExponentTransform & operator=(const ExponentTransform &);
+
+    static void deleter(ExponentTransform * t);
+
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+//!cpp:function::
+extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const ExponentTransform &);
+
+
+//!rst:: //////////////////////////////////////////////////////////////////
+
+//!cpp:class:: Represents power functions with a linear section in the shadows
+// such as sRGB and L*.
+//
+// The basic formula is::
+//
+//   pow( (x + offset)/(1 + offset), gamma )
+//   with the breakpoint at offset/(gamma - 1).
+//
+// Negative values are never clamped.
+class OCIOEXPORT ExponentWithLinearTransform : public Transform
+{
+public:
+    //!cpp:function::
+    static ExponentWithLinearTransformRcPtr Create();
+
+    //!cpp:function::
+    virtual TransformRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    virtual TransformDirection getDirection() const;
+    //!cpp:function::
+    virtual void setDirection(TransformDirection dir);
+
+    //!cpp:function:: Validate the transform and throw if invalid.
+    virtual void validate() const;
+
+    //!cpp:function::
+    const FormatMetadata & getFormatMetadata() const;
+    //!cpp:function::
+    FormatMetadata & getFormatMetadata();
+
+    //!cpp:function::
+    void getGamma(double(&values)[4]) const;
+    //!cpp:function:: Set the exponent value for the power function for R, G, B, A.
     //
     // .. note::
-    //    the clamping portion of the CDL is only applied if a non-identity
-    //    power is specified.
-    class OCIOEXPORT CDLTransform : public Transform
-    {
-    public:
-        //!cpp:function::
-        static CDLTransformRcPtr Create();
-
-        //!cpp:function:: Load the CDL from the src .cc or .ccc file.
-        // If a .ccc is used, the cccid must also be specified
-        // src must be an absolute path reference, no relative directory
-        // or envvar resolution is performed.
-        static CDLTransformRcPtr CreateFromFile(const char * src, const char * cccid);
-
-        //!cpp:function::
-        virtual TransformRcPtr createEditableCopy() const;
-
-        //!cpp:function::
-        virtual TransformDirection getDirection() const;
-        //!cpp:function::
-        virtual void setDirection(TransformDirection dir);
-
-        //!cpp:function:: Will throw if data is not valid.
-        virtual void validate() const;
-
-        //!cpp:function::
-        FormatMetadata & getFormatMetadata();
-        //!cpp:function::
-        const FormatMetadata & getFormatMetadata() const;
-
-        //!cpp:function::
-        bool equals(const ConstCDLTransformRcPtr & other) const;
-
-        //!cpp:function::
-        const char * getXML() const;
-        //!cpp:function::
-        void setXML(const char * xml);
-
-        //!rst:: **ASC_SOP**
-        //
-        // Slope, offset, power::
-        //
-        //    out = clamp( (in * slope) + offset ) ^ power
-
-        //!cpp:function::
-        void getSlope(double * rgb) const;
-        //!cpp:function::
-        void setSlope(const double * rgb);
-
-        //!cpp:function::
-        void getOffset(double * rgb) const;
-        //!cpp:function::
-        void setOffset(const double * rgb);
-
-        //!cpp:function::
-        void getPower(double * rgb) const;
-        //!cpp:function::
-        void setPower(const double * rgb);
-
-        //!cpp:function::
-        void getSOP(double * vec9) const;
-        //!cpp:function::
-        void setSOP(const double * vec9);
-
-        //!rst:: **ASC_SAT**
-        //
-
-        //!cpp:function::
-        double getSat() const;
-        //!cpp:function::
-        void setSat(double sat);
-
-        //!cpp:function:: These are hard-coded, by spec, to r709.
-        void getSatLumaCoefs(double * rgb) const;
-
-        //!rst:: **Metadata**
-        //
-        // These do not affect the image processing, but
-        // are often useful for pipeline purposes and are
-        // included in the serialization.
-
-        //!cpp:function:: Unique Identifier for this correction.
-        const char * getID() const;
-        //!cpp:function::
-        void setID(const char * id);
-
-        //!cpp:function:: Deprecated. Use `getFormatMetadata`.
-        // First textual description of color correction (stored
-        // on the SOP). If there is already a description, the setter will
-        // replace it with the supplied text.
-        const char * getDescription() const;
-        //!cpp:function:: Deprecated. Use `getFormatMetadata`.
-        void setDescription(const char * desc);
-
-    private:
-        CDLTransform();
-        CDLTransform(const CDLTransform &);
-        virtual ~CDLTransform();
-
-        CDLTransform & operator=(const CDLTransform &);
-
-        static void deleter(CDLTransform * t);
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
+    //    The gamma values must be in the range of [1, 10]. Set the transform direction
+    //    to inverse to obtain the effect of values less than 1.
+    void setGamma(const double(&values)[4]);
 
     //!cpp:function::
-    extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const CDLTransform &);
-
-
-    //!rst:: //////////////////////////////////////////////////////////////////
-
-    //!cpp:class::
-    class OCIOEXPORT ColorSpaceTransform : public Transform
-    {
-    public:
-        //!cpp:function::
-        static ColorSpaceTransformRcPtr Create();
-
-        //!cpp:function::
-        virtual TransformRcPtr createEditableCopy() const;
-
-        //!cpp:function::
-        virtual TransformDirection getDirection() const;
-        //!cpp:function::
-        virtual void setDirection(TransformDirection dir);
-
-        //!cpp:function:: Will throw if data is not valid.
-        virtual void validate() const;
-
-        //!cpp:function::
-        const char * getSrc() const;
-        //!cpp:function::
-        void setSrc(const char * src);
-
-        //!cpp:function::
-        const char * getDst() const;
-        //!cpp:function::
-        void setDst(const char * dst);
-
-    private:
-        ColorSpaceTransform();
-        ColorSpaceTransform(const ColorSpaceTransform &);
-        virtual ~ColorSpaceTransform();
-
-        ColorSpaceTransform & operator=(const ColorSpaceTransform &);
-
-        static void deleter(ColorSpaceTransform * t);
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
-
-    //!cpp:function::
-    extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const ColorSpaceTransform &);
-
-
-    //!rst:: //////////////////////////////////////////////////////////////////
-
-    //!cpp:class::
-    class OCIOEXPORT DisplayTransform : public Transform
-    {
-    public:
-        //!cpp:function::
-        static DisplayTransformRcPtr Create();
-
-        //!cpp:function::
-        virtual TransformRcPtr createEditableCopy() const;
-
-        //!cpp:function::
-        virtual TransformDirection getDirection() const;
-        //!cpp:function::
-        virtual void setDirection(TransformDirection dir);
-
-        //!cpp:function:: Will throw if data is not valid.
-        virtual void validate() const;
-
-        //!cpp:function::
-        const char * getInputColorSpaceName() const;
-        //!cpp:function:: Step 0. Specify the incoming color space.
-        void setInputColorSpaceName(const char * name);
-
-        //!cpp:function::
-        ConstTransformRcPtr getLinearCC() const;
-        //!cpp:function:: Step 1: Apply a Color Correction, in ROLE_SCENE_LINEAR.
-        void setLinearCC(const ConstTransformRcPtr & cc);
-
-        //!cpp:function::
-        ConstTransformRcPtr getColorTimingCC() const;
-        //!cpp:function:: Step 2: Apply a color correction, in ROLE_COLOR_TIMING.
-        void setColorTimingCC(const ConstTransformRcPtr & cc);
-
-        //!cpp:function::
-        ConstTransformRcPtr getChannelView() const;
-        //!cpp:function:: Step 3: Apply the Channel Viewing Swizzle (mtx).
-        void setChannelView(const ConstTransformRcPtr & transform);
-
-        //!cpp:function::
-        const char * getDisplay() const;
-        //!cpp:function:: Step 4: Apply the output display transform
-        // This is controlled by the specification of (display, view)
-        void setDisplay(const char * display);
-
-        //!cpp:function::
-        const char * getView() const;
-        //!cpp:function:: Specify which view transform to use
-        void setView(const char * view);
-
-        //!cpp:function::
-        ConstTransformRcPtr getDisplayCC() const;
-        //!cpp:function:: Step 5: Apply a post display transform color correction
-        void setDisplayCC(const ConstTransformRcPtr & cc);
-
-
-
-        //!cpp:function::
-        const char * getLooksOverride() const;
-        //!cpp:function:: A user can optionally override the looks that are,
-        // by default, used with the expected display / view combination.
-        // A common use case for this functionality is in an image viewing
-        // app, where per-shot looks are supported.  If for some reason
-        // a per-shot look is not defined for the current Context, the
-        // Config::getProcessor fcn will not succeed by default.  Thus,
-        // with this mechanism the viewing app could override to looks = "",
-        // and this will allow image display to continue (though hopefully)
-        // the interface would reflect this fallback option.)
-        //
-        // Looks is a potentially comma (or colon) delimited list of lookNames,
-        // Where +/- prefixes are optionally allowed to denote forward/inverse
-        // look specification. (And forward is assumed in the absence of either) 
-        void setLooksOverride(const char * looks);
-
-        //!cpp:function::
-        bool getLooksOverrideEnabled() const;
-        //!cpp:function:: Specify whether the lookOverride should be used,
-        // or not. This is a separate flag, as it's often useful to override
-        // "looks" to an empty string.
-        void setLooksOverrideEnabled(bool enabled);
-
-    private:
-        DisplayTransform();
-        DisplayTransform(const DisplayTransform &);
-        virtual ~DisplayTransform();
-
-        DisplayTransform & operator=(const DisplayTransform &);
-
-        static void deleter(DisplayTransform * t);
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
-
-    //!cpp:function::
-    extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const DisplayTransform &);
-
-
-    //!rst:: //////////////////////////////////////////////////////////////////
-
-    //!cpp:class:: Allows transform parameter values to be set on-the-fly
-    // (after finalization).  For example, to modify the exposure in a viewport.
-    class OCIOEXPORT DynamicProperty
-    {
-    public:
-
-        //!cpp:function::
-        virtual DynamicPropertyType getType() const = 0;
-
-        //!cpp:function::
-        virtual DynamicPropertyValueType getValueType() const = 0;
-
-        //!cpp:function::
-        virtual double getDoubleValue() const = 0;
-        //!cpp:function::
-        virtual void setValue(double value) = 0;
-
-        //!cpp:function::
-        virtual bool isDynamic() const = 0;
-
-    protected:
-
-        DynamicProperty();
-        DynamicProperty(const DynamicProperty &);
-        virtual ~DynamicProperty();
-
-        DynamicProperty & operator=(const DynamicProperty &);
-    };
-
-    //!rst:: //////////////////////////////////////////////////////////////////
-
-    //!cpp:class:: Represents exponent transform: pow( clamp(color), value)
+    void getOffset(double(&values)[4]) const;
+    //!cpp:function:: Set the offset value for the power function for R, G, B, A.
     //
-    // For configs with version == 1: If the exponent is 1.0, this will not clamp.
-    // Otherwise, the input color will be clamped between [0.0, inf].
-    // For configs with version > 1: Negative values are always clamped.
-    class OCIOEXPORT ExponentTransform : public Transform
-    {
-    public:
-        //!cpp:function::
-        static ExponentTransformRcPtr Create();
+    // .. note::
+    //    The offset values must be in the range [0, 0.9].
+    void setOffset(const double(&values)[4]);
 
-        //!cpp:function::
-        virtual TransformRcPtr createEditableCopy() const;
+private:
+    ExponentWithLinearTransform();
+    ExponentWithLinearTransform(const ExponentWithLinearTransform &);
+    virtual ~ExponentWithLinearTransform();
 
-        //!cpp:function::
-        virtual TransformDirection getDirection() const;
-        //!cpp:function::
-        virtual void setDirection(TransformDirection dir);
+    ExponentWithLinearTransform & operator=(const ExponentWithLinearTransform &);
 
-        //!cpp:function:: Will throw if data is not valid.
-        virtual void validate() const;
+    static void deleter(ExponentWithLinearTransform * t);
 
-        //!cpp:function::
-        const FormatMetadata & getFormatMetadata() const;
-        //!cpp:function::
-        FormatMetadata & getFormatMetadata();
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
 
-        //!cpp:function::
-        void getValue(double(&vec4)[4]) const;
-        //!cpp:function::
-        void setValue(const double(&vec4)[4]);
+//!cpp:function::
+extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const ExponentWithLinearTransform &);
 
-    private:
-        ExponentTransform();
-        ExponentTransform(const ExponentTransform &);
-        virtual ~ExponentTransform();
+//!rst:: //////////////////////////////////////////////////////////////////
 
-        ExponentTransform & operator=(const ExponentTransform &);
-
-        static void deleter(ExponentTransform * t);
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
+//!cpp:class:: Applies exposure, gamma, and pivoted contrast adjustments.
+// Adjusts the math to be appropriate for linear, logarithmic, or video
+// color spaces.
+class OCIOEXPORT ExposureContrastTransform : public Transform
+{
+public:
+    //!cpp:function::
+    static ExposureContrastTransformRcPtr Create();
 
     //!cpp:function::
-    extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const ExponentTransform &);
+    virtual TransformRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    virtual TransformDirection getDirection() const;
+    //!cpp:function::
+    virtual void setDirection(TransformDirection dir);
+
+    //!cpp:function:: Will throw if data is not valid.
+    virtual void validate() const;
+
+    //!cpp:function::
+    const FormatMetadata & getFormatMetadata() const;
+    //!cpp:function::
+    FormatMetadata & getFormatMetadata();
+
+    //!cpp:function::
+    ExposureContrastStyle getStyle() const;
+    //!cpp:function:: Select the algorithm for linear, video
+    // or log color spaces.
+    void setStyle(ExposureContrastStyle style);
+
+    //!cpp:function::
+    double getExposure() const;
+    //!cpp:function:: Applies an exposure adjustment.  The value is in
+    // units of stops (regardless of style), for example, a value of -1
+    // would be equivalent to reducing the lighting by one half.
+    void setExposure(double exposure);
+    //!cpp:function::
+    bool isExposureDynamic() const;
+    //!cpp:function::
+    void makeExposureDynamic();
+
+    //!cpp:function::
+    double getContrast() const;
+    //!cpp:function:: Applies a contrast/gamma adjustment around a pivot
+    // point.  The contrast and gamma are mathematically the same, but two
+    // controls are provided to enable the use of separate dynamic
+    // parameters.  Contrast is usually a scene-referred adjustment that
+    // pivots around gray whereas gamma is usually a display-referred
+    // adjustment that pivots around white.
+    void setContrast(double contrast);
+    //!cpp:function::
+    bool isContrastDynamic() const;
+    //!cpp:function::
+    void makeContrastDynamic();
+    //!cpp:function::
+    double getGamma() const;
+    //!cpp:function::
+    void setGamma(double gamma);
+    //!cpp:function::
+    bool isGammaDynamic() const;
+    //!cpp:function::
+    void makeGammaDynamic();
+
+    //!cpp:function::
+    double getPivot() const;
+    //!cpp:function:: Set the pivot point around which the contrast
+    // and gamma controls will work. Regardless of whether
+    // linear/video/log-style is being used, the pivot is always expressed
+    // in linear. In other words, a pivot of 0.18 is always mid-gray.
+    void setPivot(double pivot);
+
+    //!cpp:function:: 
+    double getLogExposureStep() const;
+    //!cpp:function:: Set the increment needed to move one stop for
+    // the log-style algorithm. For example, ACEScct is 0.057, LogC is
+    // roughly 0.074, and Cineon is roughly 90/1023 = 0.088.
+    // The default value is 0.088.
+    void setLogExposureStep(double logExposureStep);
+
+    //!cpp:function:: 
+    double getLogMidGray() const;
+    //!cpp:function:: Set the position of 18% gray for use by the
+    // log-style algorithm. For example, ACEScct is about 0.41, LogC is
+    // about 0.39, and ADX10 is 445/1023 = 0.435.
+    // The default value is 0.435.
+    void setLogMidGray(double logMidGray);
+
+private:
+    ExposureContrastTransform();
+    ExposureContrastTransform(const ExposureContrastTransform &);
+    virtual ~ExposureContrastTransform();
+
+    ExposureContrastTransform & operator=(const ExposureContrastTransform &);
+
+    static void deleter(ExposureContrastTransform * t);
+
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+//!cpp:function::
+extern OCIOEXPORT std::ostream & operator<<(std::ostream &,
+                                            const ExposureContrastTransform &);
+
+//!rst:: //////////////////////////////////////////////////////////////////
+
+//!cpp:class::
+class OCIOEXPORT FileTransform : public Transform
+{
+public:
+    //!cpp:function::
+    static FileTransformRcPtr Create();
+
+    //!cpp:function::
+    virtual TransformRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    virtual TransformDirection getDirection() const;
+    //!cpp:function::
+    virtual void setDirection(TransformDirection dir);
+
+    //!cpp:function:: Will throw if data is not valid.
+    virtual void validate() const;
+
+    //!cpp:function::
+    const char * getSrc() const;
+    //!cpp:function::
+    void setSrc(const char * src);
+
+    //!cpp:function::
+    const char * getCCCId() const;
+    //!cpp:function::
+    void setCCCId(const char * id);
+
+    //!cpp:function::
+    Interpolation getInterpolation() const;
+    //!cpp:function::
+    void setInterpolation(Interpolation interp);
+
+    //!cpp:function:: Get the number of LUT readers.
+    static int getNumFormats();
+    //!cpp:function:: Get the LUT readers at index, return empty string if
+    // an invalid index is specified.
+    static const char * getFormatNameByIndex(int index);
+
+    //!cpp:function:: Get the LUT reader extension at index, return empty string if
+    // an invalid index is specified.
+    static const char * getFormatExtensionByIndex(int index);
+
+private:
+    FileTransform();
+    FileTransform(const FileTransform &);
+    virtual ~FileTransform();
+
+    FileTransform & operator=(const FileTransform &);
+
+    static void deleter(FileTransform * t);
+
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+//!cpp:function::
+extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const FileTransform &);
 
 
-    //!rst:: //////////////////////////////////////////////////////////////////
+//!rst:: //////////////////////////////////////////////////////////////////
 
-    //!cpp:class:: Represents power functions with a linear section in the shadows 
-    // such as sRGB and L*.
+//!cpp:class:: Provides a set of hard-coded algorithmic building blocks
+// that are needed to accurately implement various common color transformations.
+class OCIOEXPORT FixedFunctionTransform : public Transform
+{
+public:
+    //!cpp:function::
+    static FixedFunctionTransformRcPtr Create();
+
+    //!cpp:function::
+    virtual TransformRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    virtual TransformDirection getDirection() const;
+    //!cpp:function::
+    virtual void setDirection(TransformDirection dir);
+
+    //!cpp:function:: Will throw if data is not valid.
+    virtual void validate() const;
+
+    //!cpp:function::
+    const FormatMetadata & getFormatMetadata() const;
+    //!cpp:function::
+    FormatMetadata & getFormatMetadata();
+
+    //!cpp:function::
+    FixedFunctionStyle getStyle() const;
+    //!cpp:function:: Select which algorithm to use.
+    void setStyle(FixedFunctionStyle style);
+
+    //!cpp:function::
+    size_t getNumParams() const;
+    //!cpp:function::
+    void getParams(double * params) const;
+    //!cpp:function:: Set the parameters (for functions that require them).
+    void setParams(const double * params, size_t num);
+
+private:
+    FixedFunctionTransform();
+    FixedFunctionTransform(const FixedFunctionTransform &);
+    virtual ~FixedFunctionTransform();
+
+    FixedFunctionTransform & operator=(const FixedFunctionTransform &);
+
+    static void deleter(FixedFunctionTransform * t);
+
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+//!cpp:function::
+extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const FixedFunctionTransform &);
+
+
+//!rst:: //////////////////////////////////////////////////////////////////
+
+//!cpp:class::
+class OCIOEXPORT GroupTransform : public Transform
+{
+public:
+    //!cpp:function::
+    static GroupTransformRcPtr Create();
+
+    //!cpp:function::
+    virtual TransformRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    virtual TransformDirection getDirection() const;
+    //!cpp:function::
+    virtual void setDirection(TransformDirection dir);
+
+    //!cpp:function:: Will throw if data is not valid.
+    virtual void validate() const;
+
+    //!cpp:function::
+    virtual const FormatMetadata & getFormatMetadata() const;
+    //!cpp:function::
+    virtual FormatMetadata & getFormatMetadata();
+
+    //!cpp:function::
+    ConstTransformRcPtr getTransform(int index) const;
+
+    //!cpp:function::
+    TransformRcPtr & getTransform(int index);
+
+    //!cpp:function::
+    int getNumTransforms() const;
+    //!cpp:function:: Adds a pointer to the transform to the end of the group.
+    void appendTransform(TransformRcPtr transform);
+
+private:
+    GroupTransform();
+    GroupTransform(const GroupTransform &);
+    virtual ~GroupTransform();
+
+    GroupTransform & operator=(const GroupTransform &);
+
+    static void deleter(GroupTransform * t);
+
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+//!cpp:function::
+extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const GroupTransform &);
+
+
+//!rst:: //////////////////////////////////////////////////////////////////
+
+//!cpp:class::  Applies a logarithm with an affine transform before and after.
+// Represents the Cineon lin-to-log type transforms::
+//
+//   logSideSlope * log( linSideSlope * color + linSideOffset, base) + logSideOffset
+//
+// * Default values are: 1. * log( 1. * color + 0., 2.) + 0.
+// * The alpha channel is not affected.
+class OCIOEXPORT LogAffineTransform : public Transform
+{
+public:
+    //!cpp:function::
+    static LogAffineTransformRcPtr Create();
+
+    //!cpp:function::
+    virtual TransformRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    virtual TransformDirection getDirection() const;
+    //!cpp:function::
+    virtual void setDirection(TransformDirection dir);
+
+    //!cpp:function:: Will throw if data is not valid.
+    virtual void validate() const;
+
+    //!cpp:function::
+    const FormatMetadata & getFormatMetadata() const;
+    //!cpp:function::
+    FormatMetadata & getFormatMetadata();
+
+    //!cpp:function::
+    double getBase() const;
+    //!cpp:function::
+    void setBase(double base);
+
+    //!rst:: **Get/Set values for the R, G, B components**
     //
-    // The basic formula is::
+
+    //!cpp:function::
+    void getLogSideSlopeValue(double(&values)[3]) const;
+    //!cpp:function::
+    void setLogSideSlopeValue(const double(&values)[3]);
+    //!cpp:function::
+    void getLogSideOffsetValue(double(&values)[3]) const;
+    //!cpp:function::
+    void setLogSideOffsetValue(const double(&values)[3]);
+    //!cpp:function::
+    void getLinSideSlopeValue(double(&values)[3]) const;
+    //!cpp:function::
+    void setLinSideSlopeValue(const double(&values)[3]);
+    //!cpp:function::
+    void getLinSideOffsetValue(double(&values)[3]) const;
+    //!cpp:function::
+    void setLinSideOffsetValue(const double(&values)[3]);
+
+private:
+    LogAffineTransform();
+    LogAffineTransform(const LogAffineTransform &);
+    virtual ~LogAffineTransform();
+
+    LogAffineTransform & operator=(const LogAffineTransform &);
+
+    static void deleter(LogAffineTransform * t);
+
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+//!cpp:function::
+extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const LogAffineTransform &);
+
+
+//!rst:: //////////////////////////////////////////////////////////////////
+
+//!cpp:class:: Represents log transform: log(color, base)
+//
+// * The input will be clamped for negative numbers.
+// * Default base is 2.0.
+// * The alpha channel is not affected.
+class OCIOEXPORT LogTransform : public Transform
+{
+public:
+    //!cpp:function::
+    static LogTransformRcPtr Create();
+
+    //!cpp:function::
+    virtual TransformRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    virtual TransformDirection getDirection() const;
+    //!cpp:function::
+    virtual void setDirection(TransformDirection dir);
+
+    //!cpp:function:: Will throw if data is not valid.
+    virtual void validate() const;
+
+    //!cpp:function::
+    const FormatMetadata & getFormatMetadata() const;
+    //!cpp:function::
+    FormatMetadata & getFormatMetadata();
+
+    //!cpp:function::
+    double getBase() const;
+    //!cpp:function::
+    void setBase(double val);
+
+private:
+    LogTransform();
+    LogTransform(const LogTransform &);
+    virtual ~LogTransform();
+
+    LogTransform & operator=(const LogTransform &);
+
+    static void deleter(LogTransform * t);
+
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+//!cpp:function::
+extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const LogTransform &);
+
+
+//!rst:: //////////////////////////////////////////////////////////////////
+
+//!cpp:class::
+class OCIOEXPORT LookTransform : public Transform
+{
+public:
+    //!cpp:function::
+    static LookTransformRcPtr Create();
+
+    //!cpp:function::
+    virtual TransformRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    virtual TransformDirection getDirection() const;
+    //!cpp:function::
+    virtual void setDirection(TransformDirection dir);
+
+    //!cpp:function:: Will throw if data is not valid.
+    virtual void validate() const;
+
+    //!cpp:function::
+    const char * getSrc() const;
+    //!cpp:function::
+    void setSrc(const char * src);
+
+    //!cpp:function::
+    const char * getDst() const;
+    //!cpp:function::
+    void setDst(const char * dst);
+
+    //!cpp:function::
+    const char * getLooks() const;
+    //!cpp:function:: Specify looks to apply.
+    // Looks is a potentially comma (or colon) delimited list of look names,
+    // Where +/- prefixes are optionally allowed to denote forward/inverse
+    // look specification. (And forward is assumed in the absence of either)
+    void setLooks(const char * looks);
+
+private:
+    LookTransform();
+    LookTransform(const LookTransform &);
+    virtual ~LookTransform();
+
+    LookTransform & operator=(const LookTransform &);
+
+    static void deleter(LookTransform * t);
+
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+//!cpp:function::
+extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const LookTransform &);
+
+
+//!rst:: //////////////////////////////////////////////////////////////////
+
+//!cpp:class:: Represents a 1D-LUT transform.
+class OCIOEXPORT LUT1DTransform : public Transform
+{
+public:
+    //!cpp:function:: Create an identity 1D-LUT of length two.
+    static LUT1DTransformRcPtr Create();
+
+    //!cpp:function:: Create an identity 1D-LUT with specific length and
+    // half-domain setting. Will throw for lengths longer than 1024x1024.
+    static LUT1DTransformRcPtr Create(unsigned long length,
+                                        bool isHalfDomain);
+
+    //!cpp:function::
+    virtual TransformRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    virtual TransformDirection getDirection() const;
+    //!cpp:function:: Set the direction the 1D-LUT should be evaluated in.
+    // Note that this only affects the evaluation and not the values
+    // stored in the object.
+    virtual void setDirection(TransformDirection dir);
+
+    //!cpp:function:: Will throw if data is not valid.
+    virtual void validate() const;
+
+    //!cpp:function::
+    BitDepth getFileOutputBitDepth() const;
+    //!cpp:function:: Get the bit-depth associated with the LUT values read
+    // from a file or set the bit-depth of values to be written to a file
+    // (for file formats such as CLF that support multiple bit-depths).
+    // However, note that the values stored in the object are always
+    // normalized.
+    void setFileOutputBitDepth(BitDepth bitDepth);
+
+    //!cpp:function::
+    const FormatMetadata & getFormatMetadata() const;
+    //!cpp:function::
+    FormatMetadata & getFormatMetadata();
+
+    //!cpp:function::
+    unsigned long getLength() const;
+    //!cpp:function:: Changing the length will reset the LUT to identity.
+    // Will throw for lengths longer than 1024x1024.
+    void setLength(unsigned long length);
+
+    //!cpp:function::
+    void getValue(unsigned long index, float & r, float & g, float & b) const;
+    //!cpp:function:: Set the values of a LUT1D.  Will throw if the index
+    // is outside of the range from 0 to (length-1).
     //
-    //   pow( (x + offset)/(1 + offset), gamma )
-    //   with the breakpoint at offset/(gamma - 1).
+    // These values are normalized relative to what may be stored in any
+    // given LUT files. For example in a CLF file using a "10i" output
+    // depth, a value of 1023 in the file is normalized to 1.0. The
+    // values here are unclamped and may extend outside [0,1].
     //
-    // Negative values are never clamped.
-    class OCIOEXPORT ExponentWithLinearTransform : public Transform
-    {
-    public:
-        //!cpp:function::
-        static ExponentWithLinearTransformRcPtr Create();
-
-        //!cpp:function::
-        virtual TransformRcPtr createEditableCopy() const;
-
-        //!cpp:function::
-        virtual TransformDirection getDirection() const;
-        //!cpp:function::
-        virtual void setDirection(TransformDirection dir);
-
-        //!cpp:function:: Validate the transform and throw if invalid.
-        virtual void validate() const;
-
-        //!cpp:function::
-        const FormatMetadata & getFormatMetadata() const;
-        //!cpp:function::
-        FormatMetadata & getFormatMetadata();
-
-        //!cpp:function::
-        void getGamma(double(&values)[4]) const;
-        //!cpp:function:: Set the exponent value for the power function for R, G, B, A.
-        //
-        // .. note::
-        //    The gamma values must be in the range of [1, 10]. Set the transform direction 
-        //    to inverse to obtain the effect of values less than 1.
-        void setGamma(const double(&values)[4]);
-
-        //!cpp:function::
-        void getOffset(double(&values)[4]) const;
-        //!cpp:function:: Set the offset value for the power function for R, G, B, A.
-        //
-        // .. note::
-        //    The offset values must be in the range [0, 0.9].
-        void setOffset(const double(&values)[4]);
-
-    private:
-        ExponentWithLinearTransform();
-        ExponentWithLinearTransform(const ExponentWithLinearTransform &);
-        virtual ~ExponentWithLinearTransform();
-
-        ExponentWithLinearTransform & operator=(const ExponentWithLinearTransform &);
-
-        static void deleter(ExponentWithLinearTransform * t);
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
+    // LUTs in various file formats may only provide values for one
+    // channel where R, G, B are the same. Even in that case, you should
+    // provide three equal values to the setter.
+    void setValue(unsigned long index, float r, float g, float b);
 
     //!cpp:function::
-    extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const ExponentWithLinearTransform &);
-
-    //!rst:: //////////////////////////////////////////////////////////////////
-
-    //!cpp:class:: Applies exposure, gamma, and pivoted contrast adjustments.
-    // Adjusts the math to be appropriate for linear, logarithmic, or video
-    // color spaces.
-    class OCIOEXPORT ExposureContrastTransform : public Transform
-    {
-    public:
-        //!cpp:function::
-        static ExposureContrastTransformRcPtr Create();
-
-        //!cpp:function::
-        virtual TransformRcPtr createEditableCopy() const;
-
-        //!cpp:function::
-        virtual TransformDirection getDirection() const;
-        //!cpp:function::
-        virtual void setDirection(TransformDirection dir);
-
-        //!cpp:function:: Will throw if data is not valid.
-        virtual void validate() const;
-
-        //!cpp:function::
-        const FormatMetadata & getFormatMetadata() const;
-        //!cpp:function::
-        FormatMetadata & getFormatMetadata();
-
-        //!cpp:function::
-        ExposureContrastStyle getStyle() const;
-        //!cpp:function:: Select the algorithm for linear, video
-        // or log color spaces.
-        void setStyle(ExposureContrastStyle style);
-
-        //!cpp:function::
-        double getExposure() const;
-        //!cpp:function:: Applies an exposure adjustment.  The value is in
-        // units of stops (regardless of style), for example, a value of -1
-        // would be equivalent to reducing the lighting by one half.
-        void setExposure(double exposure);
-        //!cpp:function::
-        bool isExposureDynamic() const;
-        //!cpp:function::
-        void makeExposureDynamic();
-
-        //!cpp:function::
-        double getContrast() const;
-        //!cpp:function:: Applies a contrast/gamma adjustment around a pivot
-        // point.  The contrast and gamma are mathematically the same, but two
-        // controls are provided to enable the use of separate dynamic
-        // parameters.  Contrast is usually a scene-referred adjustment that
-        // pivots around gray whereas gamma is usually a display-referred
-        // adjustment that pivots around white.
-        void setContrast(double contrast);
-        //!cpp:function::
-        bool isContrastDynamic() const;
-        //!cpp:function::
-        void makeContrastDynamic();
-        //!cpp:function::
-        double getGamma() const;
-        //!cpp:function::
-        void setGamma(double gamma);
-        //!cpp:function::
-        bool isGammaDynamic() const;
-        //!cpp:function::
-        void makeGammaDynamic();
-
-        //!cpp:function::
-        double getPivot() const;
-        //!cpp:function:: Set the pivot point around which the contrast
-        // and gamma controls will work. Regardless of whether
-        // linear/video/log-style is being used, the pivot is always expressed
-        // in linear. In other words, a pivot of 0.18 is always mid-gray.
-        void setPivot(double pivot);
-
-        //!cpp:function:: 
-        double getLogExposureStep() const;
-        //!cpp:function:: Set the increment needed to move one stop for
-        // the log-style algorithm. For example, ACEScct is 0.057, LogC is
-        // roughly 0.074, and Cineon is roughly 90/1023 = 0.088.
-        // The default value is 0.088.
-        void setLogExposureStep(double logExposureStep);
-
-        //!cpp:function:: 
-        double getLogMidGray() const;
-        //!cpp:function:: Set the position of 18% gray for use by the
-        // log-style algorithm. For example, ACEScct is about 0.41, LogC is
-        // about 0.39, and ADX10 is 445/1023 = 0.435.
-        // The default value is 0.435.
-        void setLogMidGray(double logMidGray);
-
-    private:
-        ExposureContrastTransform();
-        ExposureContrastTransform(const ExposureContrastTransform &);
-        virtual ~ExposureContrastTransform();
-
-        ExposureContrastTransform & operator=(const ExposureContrastTransform &);
-
-        static void deleter(ExposureContrastTransform * t);
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
+    bool getInputHalfDomain() const;
+    //!cpp:function:: In a half-domain LUT, the contents of the LUT specify
+    // the desired value of the function for each half-float value.
+    // Therefore, the length of the LUT must be 65536 entries or else
+    // validate() will throw.
+    void setInputHalfDomain(bool isHalfDomain);
 
     //!cpp:function::
-    extern OCIOEXPORT std::ostream & operator<<(std::ostream &,
-                                                const ExposureContrastTransform &);
-
-    //!rst:: //////////////////////////////////////////////////////////////////
-
-    //!cpp:class::
-    class OCIOEXPORT FileTransform : public Transform
-    {
-    public:
-        //!cpp:function::
-        static FileTransformRcPtr Create();
-
-        //!cpp:function::
-        virtual TransformRcPtr createEditableCopy() const;
-
-        //!cpp:function::
-        virtual TransformDirection getDirection() const;
-        //!cpp:function::
-        virtual void setDirection(TransformDirection dir);
-
-        //!cpp:function:: Will throw if data is not valid.
-        virtual void validate() const;
-
-        //!cpp:function::
-        const char * getSrc() const;
-        //!cpp:function::
-        void setSrc(const char * src);
-
-        //!cpp:function::
-        const char * getCCCId() const;
-        //!cpp:function::
-        void setCCCId(const char * id);
-
-        //!cpp:function::
-        Interpolation getInterpolation() const;
-        //!cpp:function::
-        void setInterpolation(Interpolation interp);
-
-        //!cpp:function:: Get the number of LUT readers.
-        static int getNumFormats();
-        //!cpp:function:: Get the LUT readers at index, return empty string if
-        // an invalid index is specified.
-        static const char * getFormatNameByIndex(int index);
-
-        //!cpp:function:: Get the LUT reader extension at index, return empty string if
-        // an invalid index is specified.
-        static const char * getFormatExtensionByIndex(int index);
-
-    private:
-        FileTransform();
-        FileTransform(const FileTransform &);
-        virtual ~FileTransform();
-
-        FileTransform & operator=(const FileTransform &);
-
-        static void deleter(FileTransform * t);
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
+    bool getOutputRawHalfs() const;
+    //!cpp:function:: Set OutputRawHalfs to true if you want to output the
+    // LUT contents as 16-bit floating point values expressed as unsigned
+    // 16-bit integers representing the equivalent bit pattern.
+    // For example, the value 1.0 would be written as the integer 15360
+    // because it has the same bit-pattern.  Note that this implies the
+    // values will be quantized to a 16-bit float.  Note that this setting
+    // only controls the output formatting (where supported) and not the 
+    // values for getValue/setValue.  The only file formats that currently
+    // support this are CLF and CTF.
+    void setOutputRawHalfs(bool isRawHalfs);
 
     //!cpp:function::
-    extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const FileTransform &);
-
-
-    //!rst:: //////////////////////////////////////////////////////////////////
-
-    //!cpp:class:: Provides a set of hard-coded algorithmic building blocks
-    // that are needed to accurately implement various common color transformations.
-    class OCIOEXPORT FixedFunctionTransform : public Transform
-    {
-    public:
-        //!cpp:function::
-        static FixedFunctionTransformRcPtr Create();
-
-        //!cpp:function::
-        virtual TransformRcPtr createEditableCopy() const;
-
-        //!cpp:function::
-        virtual TransformDirection getDirection() const;
-        //!cpp:function::
-        virtual void setDirection(TransformDirection dir);
-
-        //!cpp:function:: Will throw if data is not valid.
-        virtual void validate() const;
-
-        //!cpp:function::
-        const FormatMetadata & getFormatMetadata() const;
-        //!cpp:function::
-        FormatMetadata & getFormatMetadata();
-
-        //!cpp:function::
-        FixedFunctionStyle getStyle() const;
-        //!cpp:function:: Select which algorithm to use.
-        void setStyle(FixedFunctionStyle style);
-
-        //!cpp:function::
-        size_t getNumParams() const;
-        //!cpp:function::
-        void getParams(double * params) const;
-        //!cpp:function:: Set the parameters (for functions that require them).
-        void setParams(const double * params, size_t num);
-
-    private:
-        FixedFunctionTransform();
-        FixedFunctionTransform(const FixedFunctionTransform &);
-        virtual ~FixedFunctionTransform();
-
-        FixedFunctionTransform & operator=(const FixedFunctionTransform &);
-
-        static void deleter(FixedFunctionTransform * t);
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
+    LUT1DHueAdjust getHueAdjust() const;
+    //!cpp:function:: The 1D-LUT transform optionally supports a hue adjustment
+    // feature that was used in some versions of ACES.  This adjusts the hue
+    // of the result to approximately match the input.
+    void setHueAdjust(LUT1DHueAdjust algo);
 
     //!cpp:function::
-    extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const FixedFunctionTransform &);
+    Interpolation getInterpolation() const;
+    //!cpp:function::
+    void setInterpolation(Interpolation algo);
 
+private:
+    LUT1DTransform();
+    LUT1DTransform(unsigned long length,
+                    bool isHalfDomain);
+    LUT1DTransform(const LUT1DTransform &);
+    virtual ~LUT1DTransform();
 
-    //!rst:: //////////////////////////////////////////////////////////////////
+    LUT1DTransform& operator= (const LUT1DTransform &);
 
-    //!cpp:class::
-    class OCIOEXPORT GroupTransform : public Transform
-    {
-    public:
-        //!cpp:function::
-        static GroupTransformRcPtr Create();
+    static void deleter(LUT1DTransform* t);
 
-        //!cpp:function::
-        virtual TransformRcPtr createEditableCopy() const;
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
 
-        //!cpp:function::
-        virtual TransformDirection getDirection() const;
-        //!cpp:function::
-        virtual void setDirection(TransformDirection dir);
+//!cpp:function::
+extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const LUT1DTransform&);
 
-        //!cpp:function:: Will throw if data is not valid.
-        virtual void validate() const;
+//!rst:: //////////////////////////////////////////////////////////////////
 
-        //!cpp:function::
-        virtual const FormatMetadata & getFormatMetadata() const;
-        //!cpp:function::
-        virtual FormatMetadata & getFormatMetadata();
+//!cpp:class:: Represents a 3D-LUT transform.
+class OCIOEXPORT LUT3DTransform : public Transform
+{
+public:
+    //!cpp:function:: Create an identity 3D-LUT of size 2x2x2.
+    static LUT3DTransformRcPtr Create();
 
-        //!cpp:function::
-        ConstTransformRcPtr getTransform(int index) const;
-
-        //!cpp:function::
-        TransformRcPtr & getTransform(int index);
-
-        //!cpp:function::
-        int getNumTransforms() const;
-        //!cpp:function:: Adds a pointer to the transform to the end of the group.
-        void appendTransform(TransformRcPtr transform);
-
-    private:
-        GroupTransform();
-        GroupTransform(const GroupTransform &);
-        virtual ~GroupTransform();
-
-        GroupTransform & operator=(const GroupTransform &);
-
-        static void deleter(GroupTransform * t);
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
+    //!cpp:function:: Create an identity 3D-LUT with specific grid size.
+    // Will throw for grid size larger than 129.
+    static LUT3DTransformRcPtr Create(unsigned long gridSize);
 
     //!cpp:function::
-    extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const GroupTransform &);
+    virtual TransformRcPtr createEditableCopy() const;
 
+    //!cpp:function::
+    virtual TransformDirection getDirection() const;
+    //!cpp:function:: Set the direction the 3D-LUT should be evaluated in.
+    // Note that this only affects the evaluation and not the values
+    // stored in the object.
+    virtual void setDirection(TransformDirection dir);
 
-    //!rst:: //////////////////////////////////////////////////////////////////
+    //!cpp:function:: Will throw if data is not valid.
+    virtual void validate() const;
 
-    //!cpp:class::  Applies a logarithm with an affine transform before and after.
-    // Represents the Cineon lin-to-log type transforms::
+    //!cpp:function::
+    BitDepth getFileOutputBitDepth() const;
+    //!cpp:function:: Get the bit-depth associated with the LUT values read
+    // from a file or set the bit-depth of values to be written to a file
+    // (for file formats such as CLF that support multiple bit-depths).
+    // However, note that the values stored in the object are always
+    // normalized.
+    void setFileOutputBitDepth(BitDepth bitDepth);
+
+    //!cpp:function::
+    const FormatMetadata & getFormatMetadata() const;
+    //!cpp:function::
+    FormatMetadata & getFormatMetadata();
+
+    //!cpp:function::
+    unsigned long getGridSize() const;
+    //!cpp:function:: Changing the grid size will reset the LUT to identity.
+    // Will throw for grid sizes larger than 129.
+    void setGridSize(unsigned long gridSize);
+
+    //!cpp:function::
+    void getValue(unsigned long indexR,
+                    unsigned long indexG,
+                    unsigned long indexB,
+                    float & r, float & g, float & b) const;
+    //!cpp:function:: Set the values of a 3D-LUT. Will throw if an index is
+    // outside of the range from 0 to (gridSize-1).
     //
-    //   logSideSlope * log( linSideSlope * color + linSideOffset, base) + logSideOffset
+    // These values are normalized relative to what may be stored in any
+    // given LUT files. For example in a CLF file using a "10i" output
+    // depth, a value of 1023 in the file is normalized to 1.0. The values
+    // here are unclamped and may extend outside [0,1].
+    void setValue(unsigned long indexR,
+                    unsigned long indexG,
+                    unsigned long indexB,
+                    float r, float g, float b);
+
+    //!cpp:function::
+    Interpolation getInterpolation() const;
+    //!cpp:function::
+    void setInterpolation(Interpolation algo);
+
+private:
+    LUT3DTransform();
+    explicit LUT3DTransform(unsigned long gridSize);
+
+    LUT3DTransform(const LUT3DTransform &);
+    virtual ~LUT3DTransform();
+
+    LUT3DTransform& operator= (const LUT3DTransform &);
+
+    static void deleter(LUT3DTransform* t);
+
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+//!cpp:function::
+extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const LUT3DTransform&);
+
+//!rst:: //////////////////////////////////////////////////////////////////
+
+//!cpp:class:: Represents an MX+B Matrix transform
+class OCIOEXPORT MatrixTransform : public Transform
+{
+public:
+    //!cpp:function::
+    static MatrixTransformRcPtr Create();
+
+    //!cpp:function::
+    virtual TransformRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    virtual TransformDirection getDirection() const;
+    //!cpp:function:: Set the direction the matrix should be evaluated in.
+    // Note that this only affects the evaluation and not the values
+    // stored in the object.
     //
-    // * Default values are: 1. * log( 1. * color + 0., 2.) + 0.
-    // * The alpha channel is not affected.
-    class OCIOEXPORT LogAffineTransform : public Transform
-    {
-    public:
-        //!cpp:function::
-        static LogAffineTransformRcPtr Create();
+    // For singular matrices, an inverse direction will throw an
+    // exception during finalization
+    virtual void setDirection(TransformDirection dir);
 
-        //!cpp:function::
-        virtual TransformRcPtr createEditableCopy() const;
-
-        //!cpp:function::
-        virtual TransformDirection getDirection() const;
-        //!cpp:function::
-        virtual void setDirection(TransformDirection dir);
-
-        //!cpp:function:: Will throw if data is not valid.
-        virtual void validate() const;
-
-        //!cpp:function::
-        const FormatMetadata & getFormatMetadata() const;
-        //!cpp:function::
-        FormatMetadata & getFormatMetadata();
-
-        //!cpp:function::
-        double getBase() const;
-        //!cpp:function::
-        void setBase(double base);
-
-        //!rst:: **Get/Set values for the R, G, B components**
-        //
-
-        //!cpp:function::
-        void getLogSideSlopeValue(double(&values)[3]) const;
-        //!cpp:function::
-        void setLogSideSlopeValue(const double(&values)[3]);
-        //!cpp:function::
-        void getLogSideOffsetValue(double(&values)[3]) const;
-        //!cpp:function::
-        void setLogSideOffsetValue(const double(&values)[3]);
-        //!cpp:function::
-        void getLinSideSlopeValue(double(&values)[3]) const;
-        //!cpp:function::
-        void setLinSideSlopeValue(const double(&values)[3]);
-        //!cpp:function::
-        void getLinSideOffsetValue(double(&values)[3]) const;
-        //!cpp:function::
-        void setLinSideOffsetValue(const double(&values)[3]);
-
-    private:
-        LogAffineTransform();
-        LogAffineTransform(const LogAffineTransform &);
-        virtual ~LogAffineTransform();
-
-        LogAffineTransform & operator=(const LogAffineTransform &);
-
-        static void deleter(LogAffineTransform * t);
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
+    //!cpp:function:: Will throw if data is not valid.
+    virtual void validate() const;
 
     //!cpp:function::
-    extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const LogAffineTransform &);
+    const FormatMetadata & getFormatMetadata() const;
+    //!cpp:function::
+    FormatMetadata & getFormatMetadata();
 
+    //!cpp:function:: Checks if this exactly equals other.
+    bool equals(const MatrixTransform & other) const;
 
-    //!rst:: //////////////////////////////////////////////////////////////////
-
-    //!cpp:class:: Represents log transform: log(color, base)
+    //!cpp:function::
+    void getMatrix(double * m44) const;
+    //!cpp:function:: Get or set the values of a Matrix. Expects 16 values,
+    // where the first four are the coefficients to generate the R output
+    // channel from R, G, B, A input channels.
     //
-    // * The input will be clamped for negative numbers.
-    // * Default base is 2.0.
-    // * The alpha channel is not affected.
-    class OCIOEXPORT LogTransform : public Transform
-    {
-    public:
-        //!cpp:function::
-        static LogTransformRcPtr Create();
-
-        //!cpp:function::
-        virtual TransformRcPtr createEditableCopy() const;
-
-        //!cpp:function::
-        virtual TransformDirection getDirection() const;
-        //!cpp:function::
-        virtual void setDirection(TransformDirection dir);
-
-        //!cpp:function:: Will throw if data is not valid.
-        virtual void validate() const;
-
-        //!cpp:function::
-        const FormatMetadata & getFormatMetadata() const;
-        //!cpp:function::
-        FormatMetadata & getFormatMetadata();
-
-        //!cpp:function::
-        double getBase() const;
-        //!cpp:function::
-        void setBase(double val);
-
-    private:
-        LogTransform();
-        LogTransform(const LogTransform &);
-        virtual ~LogTransform();
-
-        LogTransform & operator=(const LogTransform &);
-
-        static void deleter(LogTransform * t);
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
+    // These values are normalized relative to what may be stored in
+    // file formats such as CLF. For example in a CLF file using a "32f"
+    // input depth and "10i" output depth, a value of 1023 in the file
+    // is normalized to 1.0. The values here are unclamped and may
+    // extend outside [0,1].
+    void setMatrix(const double * m44);
 
     //!cpp:function::
-    extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const LogTransform &);
-
-
-    //!rst:: //////////////////////////////////////////////////////////////////
-
-    //!cpp:class::
-    class OCIOEXPORT LookTransform : public Transform
-    {
-    public:
-        //!cpp:function::
-        static LookTransformRcPtr Create();
-
-        //!cpp:function::
-        virtual TransformRcPtr createEditableCopy() const;
-
-        //!cpp:function::
-        virtual TransformDirection getDirection() const;
-        //!cpp:function::
-        virtual void setDirection(TransformDirection dir);
-
-        //!cpp:function:: Will throw if data is not valid.
-        virtual void validate() const;
-
-        //!cpp:function::
-        const char * getSrc() const;
-        //!cpp:function::
-        void setSrc(const char * src);
-
-        //!cpp:function::
-        const char * getDst() const;
-        //!cpp:function::
-        void setDst(const char * dst);
-
-        //!cpp:function::
-        const char * getLooks() const;
-        //!cpp:function:: Specify looks to apply.
-        // Looks is a potentially comma (or colon) delimited list of look names,
-        // Where +/- prefixes are optionally allowed to denote forward/inverse
-        // look specification. (And forward is assumed in the absence of either)
-        void setLooks(const char * looks);
-
-    private:
-        LookTransform();
-        LookTransform(const LookTransform &);
-        virtual ~LookTransform();
-
-        LookTransform & operator=(const LookTransform &);
-
-        static void deleter(LookTransform * t);
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
-
-    //!cpp:function::
-    extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const LookTransform &);
-
-
-    //!rst:: //////////////////////////////////////////////////////////////////
-
-    //!cpp:class:: Represents a 1D-LUT transform.
-    class OCIOEXPORT LUT1DTransform : public Transform
-    {
-    public:
-        //!cpp:function:: Create an identity 1D-LUT of length two.
-        static LUT1DTransformRcPtr Create();
-
-        //!cpp:function:: Create an identity 1D-LUT with specific length and
-        // half-domain setting. Will throw for lengths longer than 1024x1024.
-        static LUT1DTransformRcPtr Create(unsigned long length,
-                                          bool isHalfDomain);
-
-        //!cpp:function::
-        virtual TransformRcPtr createEditableCopy() const;
-
-        //!cpp:function::
-        virtual TransformDirection getDirection() const;
-        //!cpp:function:: Set the direction the 1D-LUT should be evaluated in.
-        // Note that this only affects the evaluation and not the values
-        // stored in the object.
-        virtual void setDirection(TransformDirection dir);
-
-        //!cpp:function:: Will throw if data is not valid.
-        virtual void validate() const;
-
-        //!cpp:function::
-        BitDepth getFileOutputBitDepth() const;
-        //!cpp:function:: Get the bit-depth associated with the LUT values read
-        // from a file or set the bit-depth of values to be written to a file
-        // (for file formats such as CLF that support multiple bit-depths).
-        // However, note that the values stored in the object are always
-        // normalized.
-        void setFileOutputBitDepth(BitDepth bitDepth);
-
-        //!cpp:function::
-        const FormatMetadata & getFormatMetadata() const;
-        //!cpp:function::
-        FormatMetadata & getFormatMetadata();
-
-        //!cpp:function::
-        unsigned long getLength() const;
-        //!cpp:function:: Changing the length will reset the LUT to identity.
-        // Will throw for lengths longer than 1024x1024.
-        void setLength(unsigned long length);
-
-        //!cpp:function::
-        void getValue(unsigned long index, float & r, float & g, float & b) const;
-        //!cpp:function:: Set the values of a LUT1D.  Will throw if the index
-        // is outside of the range from 0 to (length-1).
-        //
-        // These values are normalized relative to what may be stored in any
-        // given LUT files. For example in a CLF file using a "10i" output
-        // depth, a value of 1023 in the file is normalized to 1.0. The
-        // values here are unclamped and may extend outside [0,1].
-        //
-        // LUTs in various file formats may only provide values for one
-        // channel where R, G, B are the same. Even in that case, you should
-        // provide three equal values to the setter.
-        void setValue(unsigned long index, float r, float g, float b);
-
-        //!cpp:function::
-        bool getInputHalfDomain() const;
-        //!cpp:function:: In a half-domain LUT, the contents of the LUT specify
-        // the desired value of the function for each half-float value.
-        // Therefore, the length of the LUT must be 65536 entries or else
-        // validate() will throw.
-        void setInputHalfDomain(bool isHalfDomain);
-
-        //!cpp:function::
-        bool getOutputRawHalfs() const;
-        //!cpp:function:: Set OutputRawHalfs to true if you want to output the
-        // LUT contents as 16-bit floating point values expressed as unsigned
-        // 16-bit integers representing the equivalent bit pattern.
-        // For example, the value 1.0 would be written as the integer 15360 
-        // because it has the same bit-pattern.  Note that this implies the 
-        // values will be quantized to a 16-bit float.  Note that this setting
-        // only controls the output formatting (where supported) and not the 
-        // values for getValue/setValue.  The only file formats that currently
-        // support this are CLF and CTF.
-        void setOutputRawHalfs(bool isRawHalfs);
-
-        //!cpp:function::
-        LUT1DHueAdjust getHueAdjust() const;
-        //!cpp:function:: The 1D-LUT transform optionally supports a hue adjustment
-        // feature that was used in some versions of ACES.  This adjusts the hue
-        // of the result to approximately match the input.
-        void setHueAdjust(LUT1DHueAdjust algo);
-
-        //!cpp:function::
-        Interpolation getInterpolation() const;
-        //!cpp:function::
-        void setInterpolation(Interpolation algo);
-
-    private:
-        LUT1DTransform();
-        LUT1DTransform(unsigned long length,
-                       bool isHalfDomain);
-        LUT1DTransform(const LUT1DTransform &);
-        virtual ~LUT1DTransform();
-
-        LUT1DTransform& operator= (const LUT1DTransform &);
-
-        static void deleter(LUT1DTransform* t);
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
-
-    //!cpp:function::
-    extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const LUT1DTransform&);
-
-    //!rst:: //////////////////////////////////////////////////////////////////
-
-    //!cpp:class:: Represents a 3D-LUT transform.
-    class OCIOEXPORT LUT3DTransform : public Transform
-    {
-    public:
-        //!cpp:function:: Create an identity 3D-LUT of size 2x2x2.
-        static LUT3DTransformRcPtr Create();
-
-        //!cpp:function:: Create an identity 3D-LUT with specific grid size.
-        // Will throw for grid size larger than 129.
-        static LUT3DTransformRcPtr Create(unsigned long gridSize);
-
-        //!cpp:function::
-        virtual TransformRcPtr createEditableCopy() const;
-
-        //!cpp:function::
-        virtual TransformDirection getDirection() const;
-        //!cpp:function:: Set the direction the 3D-LUT should be evaluated in.
-        // Note that this only affects the evaluation and not the values
-        // stored in the object.
-        virtual void setDirection(TransformDirection dir);
-
-        //!cpp:function:: Will throw if data is not valid.
-        virtual void validate() const;
-
-        //!cpp:function::
-        BitDepth getFileOutputBitDepth() const;
-        //!cpp:function:: Get the bit-depth associated with the LUT values read
-        // from a file or set the bit-depth of values to be written to a file
-        // (for file formats such as CLF that support multiple bit-depths).
-        // However, note that the values stored in the object are always
-        // normalized.
-        void setFileOutputBitDepth(BitDepth bitDepth);
-
-        //!cpp:function::
-        const FormatMetadata & getFormatMetadata() const;
-        //!cpp:function::
-        FormatMetadata & getFormatMetadata();
-
-        //!cpp:function::
-        unsigned long getGridSize() const;
-        //!cpp:function:: Changing the grid size will reset the LUT to identity.
-        // Will throw for grid sizes larger than 129.
-        void setGridSize(unsigned long gridSize);
-
-        //!cpp:function::
-        void getValue(unsigned long indexR,
-                      unsigned long indexG,
-                      unsigned long indexB,
-                      float & r, float & g, float & b) const;
-        //!cpp:function:: Set the values of a 3D-LUT. Will throw if an index is
-        // outside of the range from 0 to (gridSize-1).
-        //
-        // These values are normalized relative to what may be stored in any
-        // given LUT files. For example in a CLF file using a "10i" output
-        // depth, a value of 1023 in the file is normalized to 1.0. The values
-        // here are unclamped and may extend outside [0,1].
-        void setValue(unsigned long indexR,
-                      unsigned long indexG,
-                      unsigned long indexB,
-                      float r, float g, float b);
-
-        //!cpp:function::
-        Interpolation getInterpolation() const;
-        //!cpp:function::
-        void setInterpolation(Interpolation algo);
-
-    private:
-        LUT3DTransform();
-        explicit LUT3DTransform(unsigned long gridSize);
-
-        LUT3DTransform(const LUT3DTransform &);
-        virtual ~LUT3DTransform();
-
-        LUT3DTransform& operator= (const LUT3DTransform &);
-
-        static void deleter(LUT3DTransform* t);
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
-
-    //!cpp:function::
-    extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const LUT3DTransform&);
-
-    //!rst:: //////////////////////////////////////////////////////////////////
-
-    //!cpp:class:: Represents an MX+B Matrix transform
-    class OCIOEXPORT MatrixTransform : public Transform
-    {
-    public:
-        //!cpp:function::
-        static MatrixTransformRcPtr Create();
-
-        //!cpp:function::
-        virtual TransformRcPtr createEditableCopy() const;
-
-        //!cpp:function::
-        virtual TransformDirection getDirection() const;
-        //!cpp:function:: Set the direction the matrix should be evaluated in.
-        // Note that this only affects the evaluation and not the values
-        // stored in the object.
-        //
-        // For singular matrices, an inverse direction will throw an
-        // exception during finalization
-        virtual void setDirection(TransformDirection dir);
-
-        //!cpp:function:: Will throw if data is not valid.
-        virtual void validate() const;
-
-        //!cpp:function::
-        const FormatMetadata & getFormatMetadata() const;
-        //!cpp:function::
-        FormatMetadata & getFormatMetadata();
-
-        //!cpp:function:: Checks if this exactly equals other.
-        bool equals(const MatrixTransform & other) const;
-
-        //!cpp:function::
-        void getMatrix(double * m44) const;
-        //!cpp:function:: Get or set the values of a Matrix. Expects 16 values,
-        // where the first four are the coefficients to generate the R output
-        // channel from R, G, B, A input channels.
-        //
-        // These values are normalized relative to what may be stored in
-        // file formats such as CLF. For example in a CLF file using a "32f"
-        // input depth and "10i" output depth, a value of 1023 in the file
-        // is normalized to 1.0. The values here are unclamped and may
-        // extend outside [0,1].
-        void setMatrix(const double * m44);
-
-        //!cpp:function::
-        void getOffset(double * offset4) const;
-        //!cpp:function:: Get or set the R, G, B, A offsets to be applied
-        // after the matrix.
-        //
-        // These values are normalized relative to what may be stored in
-        // file formats such as CLF. For example, in a CLF file using a
-        // "10i" output depth, a value of 1023 in the file is normalized
-        // to 1.0. The values here are unclamped and may extend
-        // outside [0,1].
-        void setOffset(const double * offset4);
-
-        //!rst:: **File bit-depth**
-        //
-        // Get the bit-depths associated with the matrix values read from a
-        // file or set the bit-depths of values to be written to a file
-        // (for file formats such as CLF that support multiple bit-depths).
-        //
-        // In a format such as CLF, the matrix values are scaled to take
-        // pixels at the specified inBitDepth to pixels at the specified
-        // outBitDepth.  This complicates the interpretation of the matrix
-        // values and so this object always holds normalized values and
-        // scaling is done on the way from or to file formats such as CLF.
-
-        //!cpp:function::
-        BitDepth getFileInputBitDepth() const;
-        //!cpp:function::
-        void setFileInputBitDepth(BitDepth bitDepth);
-        //!cpp:function::
-        BitDepth getFileOutputBitDepth() const;
-        //!cpp:function::
-        void setFileOutputBitDepth(BitDepth bitDepth);
-
-        //!rst:: **Convenience functions**
-        //
-        // Build the matrix and offset corresponding to higher-level concepts.
-        // 
-        // .. note::
-        //    These can throw an exception if for any component
-        //    ``oldmin == oldmax. (divide by 0)``
-
-        //!cpp:function::
-        static void Fit(double * m44, double* offset4,
-                        const double * oldmin4, const double * oldmax4,
-                        const double * newmin4, const double * newmax4);
-
-        //!cpp:function::
-        static void Identity(double * m44, double * offset4);
-
-        //!cpp:function::
-        static void Sat(double * m44, double * offset4,
-                        double sat, const double * lumaCoef3);
-
-        //!cpp:function::
-        static void Scale(double * m44, double * offset4,
-                          const double * scale4);
-
-        //!cpp:function::
-        static void View(double * m44, double * offset4,
-                         int * channelHot4,
-                         const double * lumaCoef3);
-    private:
-        MatrixTransform();
-        MatrixTransform(const MatrixTransform &);
-        virtual ~MatrixTransform();
-
-        MatrixTransform & operator=(const MatrixTransform &);
-
-        static void deleter(MatrixTransform * t);
-
-        class Impl;
-        Impl * m_impl;
-        Impl * getImpl() { return m_impl; }
-        const Impl * getImpl() const { return m_impl; }
-    };
-
-    //!cpp:function::
-    extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const MatrixTransform &);
-
-    //!rst:: //////////////////////////////////////////////////////////////////
-
-    //!cpp:class:: Represents a range transform
+    void getOffset(double * offset4) const;
+    //!cpp:function:: Get or set the R, G, B, A offsets to be applied
+    // after the matrix.
     //
-    // The Range is used to apply an affine transform (scale & offset) and
-    // clamps values to min/max bounds on all color components except the alpha.
-    // The scale and offset values are computed from the input and output bounds.
+    // These values are normalized relative to what may be stored in
+    // file formats such as CLF. For example, in a CLF file using a
+    // "10i" output depth, a value of 1023 in the file is normalized
+    // to 1.0. The values here are unclamped and may extend
+    // outside [0,1].
+    void setOffset(const double * offset4);
+
+    //!rst:: **File bit-depth**
+    //
+    // Get the bit-depths associated with the matrix values read from a
+    // file or set the bit-depths of values to be written to a file
+    // (for file formats such as CLF that support multiple bit-depths).
+    //
+    // In a format such as CLF, the matrix values are scaled to take
+    // pixels at the specified inBitDepth to pixels at the specified
+    // outBitDepth.  This complicates the interpretation of the matrix
+    // values and so this object always holds normalized values and
+    // scaling is done on the way from or to file formats such as CLF.
+
+    //!cpp:function::
+    BitDepth getFileInputBitDepth() const;
+    //!cpp:function::
+    void setFileInputBitDepth(BitDepth bitDepth);
+    //!cpp:function::
+    BitDepth getFileOutputBitDepth() const;
+    //!cpp:function::
+    void setFileOutputBitDepth(BitDepth bitDepth);
+
+    //!rst:: **Convenience functions**
+    //
+    // Build the matrix and offset corresponding to higher-level concepts.
     // 
-    // Refer to section 7.2.4 in specification S-2014-006 "A Common File Format
-    // for Look-Up Tables" from the Academy of Motion Picture Arts and Sciences
-    // and the American Society of Cinematographers.
-    //
-    // The "noClamp" style described in the specification S-2014-006 becomes a
-    // MatrixOp at the processor level.
-    class OCIOEXPORT RangeTransform : public Transform
-    {
-    public:
-        //!cpp:function:: Creates an instance of RangeTransform.
-        static RangeTransformRcPtr Create();
-
-        //!cpp:function:: Creates a copy of this.
-        virtual TransformRcPtr createEditableCopy() const = 0;
-
-        //!cpp:function::
-        virtual TransformDirection getDirection() const = 0;
-        //!cpp:function:: Set the direction the Range should be evaluated in.
-        // Note that this only affects the evaluation and not the values stored
-        // in the object.
-        virtual void setDirection(TransformDirection dir) = 0;
-
-        //!cpp:function::
-        virtual RangeStyle getStyle() const = 0;
-        //!cpp:function:: Set the Range style to clamp or not input values.
-        virtual void setStyle(RangeStyle style) = 0;
-
-        //!cpp:function:: Will throw if data is not valid.
-        virtual void validate() const = 0;
-
-        //!cpp:function::
-        virtual const FormatMetadata & getFormatMetadata() const = 0;
-        //!cpp:function::
-        virtual FormatMetadata & getFormatMetadata() = 0;
-
-        //!cpp:function:: Checks if this equals other.
-        virtual bool equals(const RangeTransform & other) const = 0;
-
-        //!rst:: **File bit-depth**
-        //
-        // Get the bit-depths associated with the range values read from a file
-        // or set the bit-depths of values to be written to a file (for file
-        // formats such as CLF that support multiple bit-depths).
-        //
-        // In a format such as CLF, the range values are scaled to take
-        // pixels at the specified inBitDepth to pixels at the specified
-        // outBitDepth. This complicates the interpretation of the range
-        // values and so this object always holds normalized values and
-        // scaling is done on the way from or to file formats such as CLF.
-
-        //!cpp:function::
-        virtual BitDepth getFileInputBitDepth() const = 0;
-        //!cpp:function::
-        virtual void setFileInputBitDepth(BitDepth bitDepth) = 0;
-        //!cpp:function::
-        virtual BitDepth getFileOutputBitDepth() const = 0;
-        //!cpp:function::
-        virtual void setFileOutputBitDepth(BitDepth bitDepth) = 0;
-
-        //!rst:: **Range values**
-        //
-        // These values are normalized relative to what may be stored in file
-        // formats such as CLF. For example in a CLF file using a "10i" input
-        // depth, a MaxInValue of 1023 in the file is normalized to 1.0.
-        // Likewise, for an output depth of "12i", a MaxOutValue of 4095 in the
-        // file is normalized to 1.0. The values here are unclamped and may
-        // extend outside [0,1].
-
-        //!cpp:function:: Get the minimum value for the input.
-        virtual double getMinInValue() const = 0;
-        //!cpp:function:: Set the minimum value for the input.
-        virtual void setMinInValue(double val) = 0;
-        //!cpp:function:: Is the minimum value for the input set?
-        virtual bool hasMinInValue() const = 0;
-        //!cpp:function:: Unset the minimum value for the input
-        virtual void unsetMinInValue() = 0;
-
-        //!cpp:function:: Set the maximum value for the input.
-        virtual void setMaxInValue(double val) = 0;
-        //!cpp:function:: Get the maximum value for the input.
-        virtual double getMaxInValue() const = 0;
-        //!cpp:function:: Is the maximum value for the input set?
-        virtual bool hasMaxInValue() const = 0;
-        //!cpp:function:: Unset the maximum value for the input.
-        virtual void unsetMaxInValue() = 0;
-
-        //!cpp:function:: Set the minimum value for the output.
-        virtual void setMinOutValue(double val) = 0;
-        //!cpp:function:: Get the minimum value for the output.
-        virtual double getMinOutValue() const = 0;
-        //!cpp:function:: Is the minimum value for the output set?
-        virtual bool hasMinOutValue() const = 0;
-        //!cpp:function:: Unset the minimum value for the output.
-        virtual void unsetMinOutValue() = 0;
-
-        //!cpp:function:: Set the maximum value for the output.
-        virtual void setMaxOutValue(double val) = 0;
-        //!cpp:function:: Get the maximum value for the output.
-        virtual double getMaxOutValue() const = 0;
-        //!cpp:function:: Is the maximum value for the output set?
-        virtual bool hasMaxOutValue() const = 0;
-        //!cpp:function:: Unset the maximum value for the output.
-        virtual void unsetMaxOutValue() = 0;
-
-    protected:
-        RangeTransform() = default;
-        virtual ~RangeTransform() = default;
-
-    private:
-        RangeTransform(const RangeTransform &) = delete;
-        RangeTransform & operator= (const RangeTransform &) = delete;
-    };
+    // .. note::
+    //    These can throw an exception if for any component
+    //    ``oldmin == oldmax. (divide by 0)``
 
     //!cpp:function::
-    extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const RangeTransform &);
+    static void Fit(double * m44, double* offset4,
+                    const double * oldmin4, const double * oldmax4,
+                    const double * newmin4, const double * newmax4);
+
+    //!cpp:function::
+    static void Identity(double * m44, double * offset4);
+
+    //!cpp:function::
+    static void Sat(double * m44, double * offset4,
+                    double sat, const double * lumaCoef3);
+
+    //!cpp:function::
+    static void Scale(double * m44, double * offset4,
+                        const double * scale4);
+
+    //!cpp:function::
+    static void View(double * m44, double * offset4,
+                        int * channelHot4,
+                        const double * lumaCoef3);
+private:
+    MatrixTransform();
+    MatrixTransform(const MatrixTransform &);
+    virtual ~MatrixTransform();
+
+    MatrixTransform & operator=(const MatrixTransform &);
+
+    static void deleter(MatrixTransform * t);
+
+    class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+//!cpp:function::
+extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const MatrixTransform &);
+
+//!rst:: //////////////////////////////////////////////////////////////////
+
+//!cpp:class:: Represents a range transform
+//
+// The Range is used to apply an affine transform (scale & offset) and
+// clamps values to min/max bounds on all color components except the alpha.
+// The scale and offset values are computed from the input and output bounds.
+// 
+// Refer to section 7.2.4 in specification S-2014-006 "A Common File Format
+// for Look-Up Tables" from the Academy of Motion Picture Arts and Sciences
+// and the American Society of Cinematographers.
+//
+// The "noClamp" style described in the specification S-2014-006 becomes a
+// MatrixOp at the processor level.
+class OCIOEXPORT RangeTransform : public Transform
+{
+public:
+    //!cpp:function:: Creates an instance of RangeTransform.
+    static RangeTransformRcPtr Create();
+
+    //!cpp:function:: Creates a copy of this.
+    virtual TransformRcPtr createEditableCopy() const = 0;
+
+    //!cpp:function::
+    virtual TransformDirection getDirection() const = 0;
+    //!cpp:function:: Set the direction the Range should be evaluated in.
+    // Note that this only affects the evaluation and not the values stored
+    // in the object.
+    virtual void setDirection(TransformDirection dir) = 0;
+
+    //!cpp:function::
+    virtual RangeStyle getStyle() const = 0;
+    //!cpp:function:: Set the Range style to clamp or not input values.
+    virtual void setStyle(RangeStyle style) = 0;
+
+    //!cpp:function:: Will throw if data is not valid.
+    virtual void validate() const = 0;
+
+    //!cpp:function::
+    virtual const FormatMetadata & getFormatMetadata() const = 0;
+    //!cpp:function::
+    virtual FormatMetadata & getFormatMetadata() = 0;
+
+    //!cpp:function:: Checks if this equals other.
+    virtual bool equals(const RangeTransform & other) const = 0;
+
+    //!rst:: **File bit-depth**
+    //
+    // Get the bit-depths associated with the range values read from a file
+    // or set the bit-depths of values to be written to a file (for file
+    // formats such as CLF that support multiple bit-depths).
+    //
+    // In a format such as CLF, the range values are scaled to take
+    // pixels at the specified inBitDepth to pixels at the specified
+    // outBitDepth. This complicates the interpretation of the range
+    // values and so this object always holds normalized values and
+    // scaling is done on the way from or to file formats such as CLF.
+
+    //!cpp:function::
+    virtual BitDepth getFileInputBitDepth() const = 0;
+    //!cpp:function::
+    virtual void setFileInputBitDepth(BitDepth bitDepth) = 0;
+    //!cpp:function::
+    virtual BitDepth getFileOutputBitDepth() const = 0;
+    //!cpp:function::
+    virtual void setFileOutputBitDepth(BitDepth bitDepth) = 0;
+
+    //!rst:: **Range values**
+    //
+    // These values are normalized relative to what may be stored in file
+    // formats such as CLF. For example in a CLF file using a "10i" input
+    // depth, a MaxInValue of 1023 in the file is normalized to 1.0.
+    // Likewise, for an output depth of "12i", a MaxOutValue of 4095 in the
+    // file is normalized to 1.0. The values here are unclamped and may
+    // extend outside [0,1].
+
+    //!cpp:function:: Get the minimum value for the input.
+    virtual double getMinInValue() const = 0;
+    //!cpp:function:: Set the minimum value for the input.
+    virtual void setMinInValue(double val) = 0;
+    //!cpp:function:: Is the minimum value for the input set?
+    virtual bool hasMinInValue() const = 0;
+    //!cpp:function:: Unset the minimum value for the input
+    virtual void unsetMinInValue() = 0;
+
+    //!cpp:function:: Set the maximum value for the input.
+    virtual void setMaxInValue(double val) = 0;
+    //!cpp:function:: Get the maximum value for the input.
+    virtual double getMaxInValue() const = 0;
+    //!cpp:function:: Is the maximum value for the input set?
+    virtual bool hasMaxInValue() const = 0;
+    //!cpp:function:: Unset the maximum value for the input.
+    virtual void unsetMaxInValue() = 0;
+
+    //!cpp:function:: Set the minimum value for the output.
+    virtual void setMinOutValue(double val) = 0;
+    //!cpp:function:: Get the minimum value for the output.
+    virtual double getMinOutValue() const = 0;
+    //!cpp:function:: Is the minimum value for the output set?
+    virtual bool hasMinOutValue() const = 0;
+    //!cpp:function:: Unset the minimum value for the output.
+    virtual void unsetMinOutValue() = 0;
+
+    //!cpp:function:: Set the maximum value for the output.
+    virtual void setMaxOutValue(double val) = 0;
+    //!cpp:function:: Get the maximum value for the output.
+    virtual double getMaxOutValue() const = 0;
+    //!cpp:function:: Is the maximum value for the output set?
+    virtual bool hasMaxOutValue() const = 0;
+    //!cpp:function:: Unset the maximum value for the output.
+    virtual void unsetMaxOutValue() = 0;
+
+protected:
+    RangeTransform() = default;
+    virtual ~RangeTransform() = default;
+
+private:
+    RangeTransform(const RangeTransform &) = delete;
+    RangeTransform & operator= (const RangeTransform &) = delete;
+};
+
+//!cpp:function::
+extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const RangeTransform &);
 
 } // namespace OCIO_NAMESPACE
 

--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -23,669 +23,669 @@ C++ Types
 
 namespace OCIO_NAMESPACE
 {
-    // Predeclare all class ptr definitions
-
-    //!rst::
-    // Core
-    // ****
-
-    class OCIOEXPORT Config;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const Config> ConstConfigRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<Config> ConfigRcPtr;
-
-    class OCIOEXPORT ColorSpace;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const ColorSpace> ConstColorSpaceRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<ColorSpace> ColorSpaceRcPtr;
-
-    class OCIOEXPORT ColorSpaceSet;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const ColorSpaceSet> ConstColorSpaceSetRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<ColorSpaceSet> ColorSpaceSetRcPtr;
-
-    class OCIOEXPORT Look;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const Look> ConstLookRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<Look> LookRcPtr;
-
-    class OCIOEXPORT Context;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const Context> ConstContextRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<Context> ContextRcPtr;
-
-    class OCIOEXPORT Processor;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const Processor> ConstProcessorRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<Processor> ProcessorRcPtr;
-
-    class OCIOEXPORT CPUProcessor;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const CPUProcessor> ConstCPUProcessorRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<CPUProcessor> CPUProcessorRcPtr;
-
-    class OCIOEXPORT GPUProcessor;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const GPUProcessor> ConstGPUProcessorRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<GPUProcessor> GPUProcessorRcPtr;
-
-    class OCIOEXPORT ProcessorMetadata;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const ProcessorMetadata> ConstProcessorMetadataRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<ProcessorMetadata> ProcessorMetadataRcPtr;
-
-    class OCIOEXPORT Baker;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const Baker> ConstBakerRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<Baker> BakerRcPtr;
-
-    class OCIOEXPORT ImageDesc;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<ImageDesc> ImageDescRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const ImageDesc> ConstImageDescRcPtr;
-
-    class OCIOEXPORT Exception;
-
-    class OCIOEXPORT GpuShaderDesc;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<GpuShaderDesc> GpuShaderDescRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const GpuShaderDesc> ConstGpuShaderDescRcPtr;
-
-
-    //!rst::
-    // Transforms
-    // **********
-
-    class OCIOEXPORT Transform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const Transform> ConstTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<Transform> TransformRcPtr;
-
-    class OCIOEXPORT AllocationTransform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const AllocationTransform> ConstAllocationTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<AllocationTransform> AllocationTransformRcPtr;
-
-    class OCIOEXPORT CDLTransform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const CDLTransform> ConstCDLTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<CDLTransform> CDLTransformRcPtr;
-
-    class OCIOEXPORT ColorSpaceTransform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const ColorSpaceTransform> ConstColorSpaceTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<ColorSpaceTransform> ColorSpaceTransformRcPtr;
-
-    class OCIOEXPORT DisplayTransform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const DisplayTransform> ConstDisplayTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<DisplayTransform> DisplayTransformRcPtr;
-
-    class OCIOEXPORT DynamicProperty;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const DynamicProperty> ConstDynamicPropertyRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<DynamicProperty> DynamicPropertyRcPtr;
-
-    class OCIOEXPORT ExponentTransform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const ExponentTransform> ConstExponentTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<ExponentTransform> ExponentTransformRcPtr;
-
-    class OCIOEXPORT ExponentWithLinearTransform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const ExponentWithLinearTransform> ConstExponentWithLinearTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<ExponentWithLinearTransform> ExponentWithLinearTransformRcPtr;
-
-    class OCIOEXPORT ExposureContrastTransform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const ExposureContrastTransform> ConstExposureContrastTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<ExposureContrastTransform> ExposureContrastTransformRcPtr;
-
-    class OCIOEXPORT FileTransform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const FileTransform> ConstFileTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<FileTransform> FileTransformRcPtr;
-
-    class OCIOEXPORT FixedFunctionTransform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const FixedFunctionTransform> ConstFixedFunctionTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<FixedFunctionTransform> FixedFunctionTransformRcPtr;
-
-    class OCIOEXPORT GroupTransform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const GroupTransform> ConstGroupTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<GroupTransform> GroupTransformRcPtr;
-
-    class OCIOEXPORT LogTransform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const LogTransform> ConstLogTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<LogTransform> LogTransformRcPtr;
-
-    class OCIOEXPORT LogAffineTransform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const LogAffineTransform> ConstLogAffineTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<LogAffineTransform> LogAffineTransformRcPtr;
-
-    class OCIOEXPORT LookTransform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const LookTransform> ConstLookTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<LookTransform> LookTransformRcPtr;
-
-    class OCIOEXPORT LUT1DTransform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const LUT1DTransform> ConstLUT1DTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<LUT1DTransform> LUT1DTransformRcPtr;
-
-    class OCIOEXPORT LUT3DTransform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const LUT3DTransform> ConstLUT3DTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<LUT3DTransform> LUT3DTransformRcPtr;
-
-    class OCIOEXPORT MatrixTransform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const MatrixTransform> ConstMatrixTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<MatrixTransform> MatrixTransformRcPtr;
-
-    class OCIOEXPORT RangeTransform;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<const RangeTransform> ConstRangeTransformRcPtr;
-    //!cpp:type::
-    typedef OCIO_SHARED_PTR<RangeTransform> RangeTransformRcPtr;
-
-    template <class T, class U>
-    inline OCIO_SHARED_PTR<T> DynamicPtrCast(OCIO_SHARED_PTR<U> const & ptr)
-    {
-        return OCIO_DYNAMIC_POINTER_CAST<T,U>(ptr);
-    }
-
-    //! cpp:type:: Define the logging function signature.
-    using LoggingFunction = std::function<void(const char*)>;
-
-    //!rst::
-    // Enums
-    // *****
-
-    enum LoggingLevel
-    {
-        LOGGING_LEVEL_NONE = 0,
-        LOGGING_LEVEL_WARNING = 1,
-        LOGGING_LEVEL_INFO = 2,
-        LOGGING_LEVEL_DEBUG = 3,
-        LOGGING_LEVEL_UNKNOWN = 255,
-
-        LOGGING_LEVEL_DEFAULT = LOGGING_LEVEL_INFO
-    };
-
-    //!cpp:type::
-    enum ColorSpaceDirection
-    {
-        COLORSPACE_DIR_UNKNOWN = 0,
-        COLORSPACE_DIR_TO_REFERENCE,
-        COLORSPACE_DIR_FROM_REFERENCE
-    };
-
-    //!cpp:type::
-    enum ColorSpaceVisibility
-    {
-        COLORSPACE_ACTIVE = 0,
-        COLORSPACE_INACTIVE,
-        COLORSPACE_ALL
-    };
-    
-    //!cpp:type::
-    enum TransformDirection
-    {
-        TRANSFORM_DIR_UNKNOWN = 0,
-        TRANSFORM_DIR_FORWARD,
-        TRANSFORM_DIR_INVERSE
-    };
-
-    //!cpp:type::
-    //
-    // Specify the interpolation type to use
-    // If the specified interpolation type is not supported in the requested
-    // context (for example, using tetrahedral interpolationon 1D LUTs)
-    // an exception will be thrown.
-    //
-    // INTERP_DEFAULT will choose the default interpolation type for the requested
-    // context:
-    //
-    // 1D LUT INTERP_DEFAULT: LINEAR
-    // 3D LUT INTERP_DEFAULT: LINEAR
-    //
-    // INTERP_BEST will choose the best interpolation type for the requested
-    // context:
-    //
-    // 1D LUT INTERP_BEST: LINEAR
-    // 3D LUT INTERP_BEST: TETRAHEDRAL
-    //
-    // Note: INTERP_BEST and INTERP_DEFAULT are subject to change in minor
-    // releases, so if you care about locking off on a specific interpolation
-    // type, we'd recommend directly specifying it.
-    //
-    enum Interpolation
-    {
-        INTERP_UNKNOWN = 0,
-        INTERP_NEAREST = 1,     //! nearest neighbor in all dimensions
-        INTERP_LINEAR = 2,      //! linear interpolation in all dimensions
-        INTERP_TETRAHEDRAL = 3, //! tetrahedral interpolation in all directions
-        INTERP_CUBIC = 4,       //! cubic interpolation in all dimensions
-
-        INTERP_DEFAULT = 254,   //! the default interpolation type
-        INTERP_BEST = 255       //! the 'best' suitable interpolation type
-    };
-    
-    //!cpp:type:: Used in a configuration file to indicate the bit-depth of a color space,
-    // and by the :cpp:class`Processor` to specify the input and output bit-depths of 
-    // images to process.
-    // Note that :cpp:class`Processor` only supports: UINT8, UINT10, UINT12, UINT16, F16 and F32.
-    enum BitDepth
-    {
-        BIT_DEPTH_UNKNOWN = 0,
-        BIT_DEPTH_UINT8,
-        BIT_DEPTH_UINT10,
-        BIT_DEPTH_UINT12,
-        BIT_DEPTH_UINT14,
-        BIT_DEPTH_UINT16,
-        BIT_DEPTH_UINT32,
-        BIT_DEPTH_F16,
-        BIT_DEPTH_F32
-    };
-
-    //!cpp:type:: Used by :cpp:class`LUT1DTransform` to control optional hue restoration algorithm.
-    enum LUT1DHueAdjust
-    {
-        HUE_NONE = 0, // No adjustment.
-        HUE_DW3       // Algorithm used in ACES Output Transforms through v0.7.
-    };
-
-    //!cpp:type:: Used by :cpp:class`PackedImageDesc` to indicate the channel ordering 
-    //            of the image to process.
-    enum ChannelOrdering
-    {
-        CHANNEL_ORDERING_RGBA = 0,
-        CHANNEL_ORDERING_BGRA,
-        CHANNEL_ORDERING_ABGR,
-        CHANNEL_ORDERING_RGB,
-        CHANNEL_ORDERING_BGR
-    };
-
-    //!cpp:type::
-    enum Allocation {
-        ALLOCATION_UNKNOWN = 0,
-        ALLOCATION_UNIFORM,
-        ALLOCATION_LG2
-    };
-
-    //!cpp:type:: Used when there is a choice of hardware shader language.
-    enum GpuLanguage
-    {
-        GPU_LANGUAGE_UNKNOWN = 0,
-        GPU_LANGUAGE_CG,                ///< Nvidia Cg shader
-        GPU_LANGUAGE_GLSL_1_0,          ///< OpenGL Shading Language
-        GPU_LANGUAGE_GLSL_1_3,          ///< OpenGL Shading Language
-        GPU_LANGUAGE_GLSL_4_0,          ///< OpenGL Shading Language
-        GPU_LANGUAGE_HLSL_DX11          ///< DirectX Shading Language
-    };
-
-    //!cpp:type::
-    enum EnvironmentMode
-    {
-        ENV_ENVIRONMENT_UNKNOWN = 0,
-        ENV_ENVIRONMENT_LOAD_PREDEFINED,
-        ENV_ENVIRONMENT_LOAD_ALL
-    };
-
-    //!cpp:type:: A RangeTransform may be set to clamp the values, or not.
-    enum RangeStyle
-    {
-        RANGE_NO_CLAMP = 0,
-        RANGE_CLAMP
-    };
-
-    //!cpp:type:: Enumeration of the :cpp:class:`FixedFunctionTransform` transform algorithms.
-    enum FixedFunctionStyle
-    {
-        FIXED_FUNCTION_ACES_RED_MOD_03 = 0, //! Red modifier (ACES 0.3/0.7)
-        FIXED_FUNCTION_ACES_RED_MOD_10,     //! Red modifier (ACES 1.0)
-        FIXED_FUNCTION_ACES_GLOW_03,        //! Glow function (ACES 0.3/0.7)
-        FIXED_FUNCTION_ACES_GLOW_10,        //! Glow function (ACES 1.0)
-        FIXED_FUNCTION_ACES_DARK_TO_DIM_10, //! Dark to dim surround correction (ACES 1.0)
-        FIXED_FUNCTION_REC2100_SURROUND,    //! Rec.2100 surround correction (takes one double for the gamma param)
-        FIXED_FUNCTION_RGB_TO_HSV,          //! Classic RGB to HSV function
-        FIXED_FUNCTION_XYZ_TO_xyY,          //! CIE XYZ to 1931 xy chromaticity coordinates
-        FIXED_FUNCTION_XYZ_TO_uvY,          //! CIE XYZ to 1976 u'v' chromaticity coordinates
-        FIXED_FUNCTION_XYZ_TO_LUV           //! CIE XYZ to 1976 CIELUV colour space (D65 white)
-    };
-
-    //!cpp:type:: Enumeration of the :cpp:class:`ExposureContrastTransform` transform algorithms.
-    enum ExposureContrastStyle
-    {
-        EXPOSURE_CONTRAST_LINEAR = 0,      //! E/C to be applied to a linear space image
-        EXPOSURE_CONTRAST_VIDEO,           //! E/C to be applied to a video space image
-        EXPOSURE_CONTRAST_LOGARITHMIC      //! E/C to be applied to a log space image
-    };
-
-    enum DynamicPropertyType
-    {
-        DYNAMIC_PROPERTY_EXPOSURE = 0, //! Image exposure value (double floating point value)
-        DYNAMIC_PROPERTY_CONTRAST,     //! Image contrast value (double floating point value)
-        DYNAMIC_PROPERTY_GAMMA         //! Image gamma value (double floating point value)
-    };
-
-    enum DynamicPropertyValueType
-    {
-        DYNAMIC_PROPERTY_DOUBLE, //! Value is a double
-        DYNAMIC_PROPERTY_BOOL    //! Value is a bool
-    };
-
-    //!cpp:type:: Provides control over how the ops in a Processor are combined 
-    //            in order to improve performance.
-    enum OptimizationFlags : unsigned long
-    {
-        // Below are listed all the optimization types.
-
-        // Do not optimize.
-        OPTIMIZATION_NONE                            = 0x00000000,
-
-        // Replace identity ops (other than gamma).
-        OPTIMIZATION_IDENTITY                        = 0x00000001,
-        // Replace identity gamma ops.
-        OPTIMIZATION_IDENTITY_GAMMA                  = 0x00000002,
-        // Replace a pair of ops where one is the inverse of the other.
-        OPTIMIZATION_PAIR_IDENTITY_CDL               = 0x00000004,
-        OPTIMIZATION_PAIR_IDENTITY_EXPOSURE_CONTRAST = 0x00000008,
-        OPTIMIZATION_PAIR_IDENTITY_FIXED_FUNCTION    = 0x00000010,
-        OPTIMIZATION_PAIR_IDENTITY_GAMMA             = 0x00000020,
-        OPTIMIZATION_PAIR_IDENTITY_LUT1D             = 0x00000040,
-        OPTIMIZATION_PAIR_IDENTITY_LUT3D             = 0x00000080,
-        OPTIMIZATION_PAIR_IDENTITY_LOG               = 0x00000100,
-
-        // Compose a pair of ops into a single op.
-        OPTIMIZATION_COMP_EXPONENT                   = 0x00000200,
-        OPTIMIZATION_COMP_GAMMA                      = 0x00000400,
-        OPTIMIZATION_COMP_MATRIX                     = 0x00000800,
-        OPTIMIZATION_COMP_LUT1D                      = 0x00001000,
-        OPTIMIZATION_COMP_LUT3D                      = 0x00002000,
-        OPTIMIZATION_COMP_RANGE                      = 0x00004000,
-
-        // For integer and half bit-depths only, replace separable ops (i.e. no channel crosstalk
-        // ops) by a single 1D LUT of input bit-depth domain.
-        OPTIMIZATION_COMP_SEPARABLE_PREFIX           = 0x00008000,
-
-        // Implement inverse Lut1D and Lut3D evaluations using a a forward LUT (faster but less
-        // accurate).  Note that GPU evals always do FAST.
-        OPTIMIZATION_LUT_INV_FAST                    = 0x00010000,
-
-        // Turn off dynamic control of any ops that offer adjustment of parameter values after
-        // finalization (e.g. ExposureContrast).
-        OPTIMIZATION_NO_DYNAMIC_PROPERTIES           = 0x00020000,
-
-        // Apply all possible optimizations.
-        OPTIMIZATION_ALL                             = 0xFFFFFFFF,
-
-        // The following groupings of flags are provided as a convenient way to select an overall
-        // optimization level.
-
-        OPTIMIZATION_LOSSLESS   = (OPTIMIZATION_IDENTITY |
-                                   OPTIMIZATION_IDENTITY_GAMMA |
-                                   OPTIMIZATION_PAIR_IDENTITY_CDL |
-                                   OPTIMIZATION_PAIR_IDENTITY_EXPOSURE_CONTRAST |
-                                   OPTIMIZATION_PAIR_IDENTITY_FIXED_FUNCTION |
-                                   OPTIMIZATION_PAIR_IDENTITY_GAMMA |
-                                   OPTIMIZATION_PAIR_IDENTITY_LOG |
-                                   OPTIMIZATION_PAIR_IDENTITY_LUT1D |
-                                   OPTIMIZATION_PAIR_IDENTITY_LUT3D |
-                                   OPTIMIZATION_COMP_EXPONENT |
-                                   OPTIMIZATION_COMP_GAMMA |
-                                   OPTIMIZATION_COMP_MATRIX |
-                                   OPTIMIZATION_COMP_RANGE),
-
-        OPTIMIZATION_VERY_GOOD  = (OPTIMIZATION_LOSSLESS |
-                                   OPTIMIZATION_COMP_LUT1D |
-                                   OPTIMIZATION_LUT_INV_FAST |
-                                   OPTIMIZATION_COMP_SEPARABLE_PREFIX),
-
-        OPTIMIZATION_GOOD       = OPTIMIZATION_VERY_GOOD | OPTIMIZATION_COMP_LUT3D,
-
-        // For quite lossy optimizations.
-        OPTIMIZATION_DRAFT      = OPTIMIZATION_ALL,
-
-        OPTIMIZATION_DEFAULT    = OPTIMIZATION_VERY_GOOD
-    };
-
-
-    //!rst::
-    // Conversion
-    // **********
-
-    //!cpp:function::
-    extern OCIOEXPORT const char * BoolToString(bool val);
-    //!cpp:function::
-    extern OCIOEXPORT bool BoolFromString(const char * s);
-
-    //!cpp:function::
-    extern OCIOEXPORT const char * LoggingLevelToString(LoggingLevel level);
-    //!cpp:function::
-    extern OCIOEXPORT LoggingLevel LoggingLevelFromString(const char * s);
-
-    //!cpp:function::
-    extern OCIOEXPORT const char * TransformDirectionToString(TransformDirection dir);
-    //!cpp:function::
-    extern OCIOEXPORT TransformDirection TransformDirectionFromString(const char * s);
-
-    //!cpp:function::
-    extern OCIOEXPORT TransformDirection GetInverseTransformDirection(TransformDirection dir);
-    //!cpp:function::
-    extern OCIOEXPORT TransformDirection CombineTransformDirections(TransformDirection d1,
-                                                                    TransformDirection d2);
-
-    //!cpp:function::
-    extern OCIOEXPORT const char * ColorSpaceDirectionToString(ColorSpaceDirection dir);
-    //!cpp:function::
-    extern OCIOEXPORT ColorSpaceDirection ColorSpaceDirectionFromString(const char * s);
-
-    //!cpp:function::
-    extern OCIOEXPORT const char * BitDepthToString(BitDepth bitDepth);
-    //!cpp:function::
-    extern OCIOEXPORT BitDepth BitDepthFromString(const char * s);
-    //!cpp:function::
-    extern OCIOEXPORT bool BitDepthIsFloat(BitDepth bitDepth);
-    //!cpp:function::
-    extern OCIOEXPORT int BitDepthToInt(BitDepth bitDepth);
-
-    //!cpp:function::
-    extern OCIOEXPORT const char * AllocationToString(Allocation allocation);
-    //!cpp:function::
-    extern OCIOEXPORT Allocation AllocationFromString(const char * s);
-
-    //!cpp:function::
-    extern OCIOEXPORT const char * InterpolationToString(Interpolation interp);
-    //!cpp:function::
-    extern OCIOEXPORT Interpolation InterpolationFromString(const char * s);
-
-    //!cpp:function::
-    extern OCIOEXPORT const char * GpuLanguageToString(GpuLanguage language);
-    //!cpp:function::
-    extern OCIOEXPORT GpuLanguage GpuLanguageFromString(const char * s);
-
-    //!cpp:function::
-    extern OCIOEXPORT const char * EnvironmentModeToString(EnvironmentMode mode);
-    //!cpp:function::
-    extern OCIOEXPORT EnvironmentMode EnvironmentModeFromString(const char * s);
-
-    //!cpp:function::
-    extern OCIOEXPORT const char * RangeStyleToString(RangeStyle style);
-    //!cpp:function::
-    extern OCIOEXPORT RangeStyle RangeStyleFromString(const char * style);
-
-    //!cpp:function::
-    extern OCIOEXPORT const char * FixedFunctionStyleToString(FixedFunctionStyle style);
-    //!cpp:function::
-    extern OCIOEXPORT FixedFunctionStyle FixedFunctionStyleFromString(const char * style);
-
-    //!cpp:function::
-    extern OCIOEXPORT const char * ExposureContrastStyleToString(ExposureContrastStyle style);
-    //!cpp:function::
-    extern OCIOEXPORT ExposureContrastStyle ExposureContrastStyleFromString(const char * style);
-
-
-    /*!rst::
-    Roles
-    *****
-
-    ColorSpace Roles are used so that plugins, in addition to this API can have
-    abstract ways of asking for common colorspaces, without referring to them
-    by hardcoded names.
-
-    Internal::
-
-       GetGPUDisplayTransform - (ROLE_SCENE_LINEAR (fstop exposure))
-                                (ROLE_COLOR_TIMING (ASCColorCorrection))
-
-    External Plugins (currently known)::
-
-       Colorpicker UIs       - (ROLE_COLOR_PICKING)
-       Compositor LogConvert - (ROLE_SCENE_LINEAR, ROLE_COMPOSITING_LOG)
-
-    */
-
-    //!rst::
-    // .. c:var:: const char* ROLE_DEFAULT
-    //    
-    //    "default"
-    extern OCIOEXPORT const char * ROLE_DEFAULT;
-    //!rst::
-    // .. c:var:: const char* ROLE_REFERENCE
-    //    
-    //    "reference"
-    extern OCIOEXPORT const char * ROLE_REFERENCE;
-    //!rst::
-    // .. c:var:: const char* ROLE_DATA
-    //    
-    //    "data"
-    extern OCIOEXPORT const char * ROLE_DATA;
-    //!rst::
-    // .. c:var:: const char* ROLE_COLOR_PICKING
-    //    
-    //    "color_picking"
-    extern OCIOEXPORT const char * ROLE_COLOR_PICKING;
-    //!rst::
-    // .. c:var:: const char* ROLE_SCENE_LINEAR
-    //    
-    //    "scene_linear"
-    extern OCIOEXPORT const char * ROLE_SCENE_LINEAR;
-    //!rst::
-    // .. c:var:: const char* ROLE_COMPOSITING_LOG
-    //    
-    //    "compositing_log"
-    extern OCIOEXPORT const char * ROLE_COMPOSITING_LOG;
-    //!rst::
-    // .. c:var:: const char* ROLE_COLOR_TIMING
-    //    
-    //    "color_timing"
-    extern OCIOEXPORT const char * ROLE_COLOR_TIMING;
-    //!rst::
-    // .. c:var:: const char* ROLE_TEXTURE_PAINT
-    //    
-    //    This role defines the transform for painting textures. In some
-    //    workflows this is just a inverse display gamma with some limits
-    extern OCIOEXPORT const char * ROLE_TEXTURE_PAINT;
-    //!rst::
-    // .. c:var:: const char* ROLE_MATTE_PAINT
-    //    
-    //    This role defines the transform for matte painting. In some workflows
-    //    this is a 1D HDR to LDR allocation. It is normally combined with
-    //    another display transform in the host app for preview.
-    extern OCIOEXPORT const char * ROLE_MATTE_PAINT;
-
-    /*!rst::
-    FormatMetadata
-    **************
-
-    These constants describe various types of rich metadata. They are used with FormatMetadata
-    objects as the "name" part of a (name, value) pair. All of these types of metadata are
-    supported in the CLF/CTF file formats whereas other formats support some or none of them.
-
-    Although the string constants used here match those used in the CLF/CTF formats, the concepts
-    are generic, so the goal is for other file formats to reuse the same constants within a
-    FormatMetadata object (even if the syntax used in a given format is somewhat different).
-
-    */
-
-    //!rst::
-    // .. c:var:: const char * METADATA_DESCRIPTION
-    //    
-    //    A description string -- used as the "Description" element in CLF/CTF and CDL, and to
-    //    hold comments for other LUT formats when baking.
-    extern OCIOEXPORT const char * METADATA_DESCRIPTION;
-
-    //!rst::
-    // .. c:var:: const char * METADATA_INFO
-    //    
-    //    A block of informative metadata such as the "Info" element in CLF/CTF.
-    //    Usually contains child elements.
-    extern OCIOEXPORT const char * METADATA_INFO;
-
-    //!rst::
-    // .. c:var:: const char * METADATA_INPUT_DESCRIPTOR
-    //    
-    //    A string describing the expected input color space -- used as the "InputDescriptor"
-    //    element in CLF/CTF and the "InputDescription" in CDL.
-    extern OCIOEXPORT const char * METADATA_INPUT_DESCRIPTOR;
-
-    //!rst::
-    // .. c:var:: const char * METADATA_OUTPUT_DESCRIPTOR
-    //    
-    //    A string describing the output color space -- used as the "OutputDescriptor" element
-    //    in CLF/CTF and the "OutputDescription" in CDL.
-    extern OCIOEXPORT const char * METADATA_OUTPUT_DESCRIPTOR;
-
-    //!rst::
-    // .. c:var:: const char * METADATA_NAME
-    //    
-    //    A name string -- used as a "name" attribute in CLF/CTF elements.  Use on a GroupTransform
-    //    to get/set the name for the CLF/CTF ProcessList.  Use on an individual Transform
-    //    (i.e. MatrixTransform, etc.) to get/set the name of the corresponding process node.
-    extern OCIOEXPORT const char * METADATA_NAME;
-
-    //!rst::
-    // .. c:var:: const char * METADATA_ID
-    //    
-    //    An ID string -- used as an "id" attribute in CLF/CTF elements.  Use on a GroupTransform
-    //    to get/set the id for the CLF/CTF ProcessList.  Use on an individual Transform 
-    //    (i.e. MatrixTransform, etc.) to get/set the id of the corresponding process node.
-    extern OCIOEXPORT const char * METADATA_ID;
+// Predeclare all class ptr definitions
+
+//!rst::
+// Core
+// ****
+
+class OCIOEXPORT Config;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const Config> ConstConfigRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<Config> ConfigRcPtr;
+
+class OCIOEXPORT ColorSpace;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const ColorSpace> ConstColorSpaceRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<ColorSpace> ColorSpaceRcPtr;
+
+class OCIOEXPORT ColorSpaceSet;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const ColorSpaceSet> ConstColorSpaceSetRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<ColorSpaceSet> ColorSpaceSetRcPtr;
+
+class OCIOEXPORT Look;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const Look> ConstLookRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<Look> LookRcPtr;
+
+class OCIOEXPORT Context;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const Context> ConstContextRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<Context> ContextRcPtr;
+
+class OCIOEXPORT Processor;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const Processor> ConstProcessorRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<Processor> ProcessorRcPtr;
+
+class OCIOEXPORT CPUProcessor;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const CPUProcessor> ConstCPUProcessorRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<CPUProcessor> CPUProcessorRcPtr;
+
+class OCIOEXPORT GPUProcessor;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const GPUProcessor> ConstGPUProcessorRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<GPUProcessor> GPUProcessorRcPtr;
+
+class OCIOEXPORT ProcessorMetadata;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const ProcessorMetadata> ConstProcessorMetadataRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<ProcessorMetadata> ProcessorMetadataRcPtr;
+
+class OCIOEXPORT Baker;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const Baker> ConstBakerRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<Baker> BakerRcPtr;
+
+class OCIOEXPORT ImageDesc;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<ImageDesc> ImageDescRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const ImageDesc> ConstImageDescRcPtr;
+
+class OCIOEXPORT Exception;
+
+class OCIOEXPORT GpuShaderDesc;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<GpuShaderDesc> GpuShaderDescRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const GpuShaderDesc> ConstGpuShaderDescRcPtr;
+
+
+//!rst::
+// Transforms
+// **********
+
+class OCIOEXPORT Transform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const Transform> ConstTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<Transform> TransformRcPtr;
+
+class OCIOEXPORT AllocationTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const AllocationTransform> ConstAllocationTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<AllocationTransform> AllocationTransformRcPtr;
+
+class OCIOEXPORT CDLTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const CDLTransform> ConstCDLTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<CDLTransform> CDLTransformRcPtr;
+
+class OCIOEXPORT ColorSpaceTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const ColorSpaceTransform> ConstColorSpaceTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<ColorSpaceTransform> ColorSpaceTransformRcPtr;
+
+class OCIOEXPORT DisplayTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const DisplayTransform> ConstDisplayTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<DisplayTransform> DisplayTransformRcPtr;
+
+class OCIOEXPORT DynamicProperty;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const DynamicProperty> ConstDynamicPropertyRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<DynamicProperty> DynamicPropertyRcPtr;
+
+class OCIOEXPORT ExponentTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const ExponentTransform> ConstExponentTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<ExponentTransform> ExponentTransformRcPtr;
+
+class OCIOEXPORT ExponentWithLinearTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const ExponentWithLinearTransform> ConstExponentWithLinearTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<ExponentWithLinearTransform> ExponentWithLinearTransformRcPtr;
+
+class OCIOEXPORT ExposureContrastTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const ExposureContrastTransform> ConstExposureContrastTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<ExposureContrastTransform> ExposureContrastTransformRcPtr;
+
+class OCIOEXPORT FileTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const FileTransform> ConstFileTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<FileTransform> FileTransformRcPtr;
+
+class OCIOEXPORT FixedFunctionTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const FixedFunctionTransform> ConstFixedFunctionTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<FixedFunctionTransform> FixedFunctionTransformRcPtr;
+
+class OCIOEXPORT GroupTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const GroupTransform> ConstGroupTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<GroupTransform> GroupTransformRcPtr;
+
+class OCIOEXPORT LogTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const LogTransform> ConstLogTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<LogTransform> LogTransformRcPtr;
+
+class OCIOEXPORT LogAffineTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const LogAffineTransform> ConstLogAffineTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<LogAffineTransform> LogAffineTransformRcPtr;
+
+class OCIOEXPORT LookTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const LookTransform> ConstLookTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<LookTransform> LookTransformRcPtr;
+
+class OCIOEXPORT LUT1DTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const LUT1DTransform> ConstLUT1DTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<LUT1DTransform> LUT1DTransformRcPtr;
+
+class OCIOEXPORT LUT3DTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const LUT3DTransform> ConstLUT3DTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<LUT3DTransform> LUT3DTransformRcPtr;
+
+class OCIOEXPORT MatrixTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const MatrixTransform> ConstMatrixTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<MatrixTransform> MatrixTransformRcPtr;
+
+class OCIOEXPORT RangeTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const RangeTransform> ConstRangeTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<RangeTransform> RangeTransformRcPtr;
+
+template <class T, class U>
+inline OCIO_SHARED_PTR<T> DynamicPtrCast(OCIO_SHARED_PTR<U> const & ptr)
+{
+    return OCIO_DYNAMIC_POINTER_CAST<T,U>(ptr);
+}
+
+//! cpp:type:: Define the logging function signature.
+using LoggingFunction = std::function<void(const char*)>;
+
+//!rst::
+// Enums
+// *****
+
+enum LoggingLevel
+{
+    LOGGING_LEVEL_NONE = 0,
+    LOGGING_LEVEL_WARNING = 1,
+    LOGGING_LEVEL_INFO = 2,
+    LOGGING_LEVEL_DEBUG = 3,
+    LOGGING_LEVEL_UNKNOWN = 255,
+
+    LOGGING_LEVEL_DEFAULT = LOGGING_LEVEL_INFO
+};
+
+//!cpp:type::
+enum ColorSpaceDirection
+{
+    COLORSPACE_DIR_UNKNOWN = 0,
+    COLORSPACE_DIR_TO_REFERENCE,
+    COLORSPACE_DIR_FROM_REFERENCE
+};
+
+//!cpp:type::
+enum ColorSpaceVisibility
+{
+    COLORSPACE_ACTIVE = 0,
+    COLORSPACE_INACTIVE,
+    COLORSPACE_ALL
+};
+
+//!cpp:type::
+enum TransformDirection
+{
+    TRANSFORM_DIR_UNKNOWN = 0,
+    TRANSFORM_DIR_FORWARD,
+    TRANSFORM_DIR_INVERSE
+};
+
+//!cpp:type::
+//
+// Specify the interpolation type to use
+// If the specified interpolation type is not supported in the requested
+// context (for example, using tetrahedral interpolationon 1D LUTs)
+// an exception will be thrown.
+//
+// INTERP_DEFAULT will choose the default interpolation type for the requested
+// context:
+//
+// 1D LUT INTERP_DEFAULT: LINEAR
+// 3D LUT INTERP_DEFAULT: LINEAR
+//
+// INTERP_BEST will choose the best interpolation type for the requested
+// context:
+//
+// 1D LUT INTERP_BEST: LINEAR
+// 3D LUT INTERP_BEST: TETRAHEDRAL
+//
+// Note: INTERP_BEST and INTERP_DEFAULT are subject to change in minor
+// releases, so if you care about locking off on a specific interpolation
+// type, we'd recommend directly specifying it.
+//
+enum Interpolation
+{
+    INTERP_UNKNOWN = 0,
+    INTERP_NEAREST = 1,     //! nearest neighbor in all dimensions
+    INTERP_LINEAR = 2,      //! linear interpolation in all dimensions
+    INTERP_TETRAHEDRAL = 3, //! tetrahedral interpolation in all directions
+    INTERP_CUBIC = 4,       //! cubic interpolation in all dimensions
+
+    INTERP_DEFAULT = 254,   //! the default interpolation type
+    INTERP_BEST = 255       //! the 'best' suitable interpolation type
+};
+
+//!cpp:type:: Used in a configuration file to indicate the bit-depth of a color space,
+// and by the :cpp:class`Processor` to specify the input and output bit-depths of 
+// images to process.
+// Note that :cpp:class`Processor` only supports: UINT8, UINT10, UINT12, UINT16, F16 and F32.
+enum BitDepth
+{
+    BIT_DEPTH_UNKNOWN = 0,
+    BIT_DEPTH_UINT8,
+    BIT_DEPTH_UINT10,
+    BIT_DEPTH_UINT12,
+    BIT_DEPTH_UINT14,
+    BIT_DEPTH_UINT16,
+    BIT_DEPTH_UINT32,
+    BIT_DEPTH_F16,
+    BIT_DEPTH_F32
+};
+
+//!cpp:type:: Used by :cpp:class`LUT1DTransform` to control optional hue restoration algorithm.
+enum LUT1DHueAdjust
+{
+    HUE_NONE = 0, // No adjustment.
+    HUE_DW3       // Algorithm used in ACES Output Transforms through v0.7.
+};
+
+//!cpp:type:: Used by :cpp:class`PackedImageDesc` to indicate the channel ordering 
+//            of the image to process.
+enum ChannelOrdering
+{
+    CHANNEL_ORDERING_RGBA = 0,
+    CHANNEL_ORDERING_BGRA,
+    CHANNEL_ORDERING_ABGR,
+    CHANNEL_ORDERING_RGB,
+    CHANNEL_ORDERING_BGR
+};
+
+//!cpp:type::
+enum Allocation {
+    ALLOCATION_UNKNOWN = 0,
+    ALLOCATION_UNIFORM,
+    ALLOCATION_LG2
+};
+
+//!cpp:type:: Used when there is a choice of hardware shader language.
+enum GpuLanguage
+{
+    GPU_LANGUAGE_UNKNOWN = 0,
+    GPU_LANGUAGE_CG,                ///< Nvidia Cg shader
+    GPU_LANGUAGE_GLSL_1_0,          ///< OpenGL Shading Language
+    GPU_LANGUAGE_GLSL_1_3,          ///< OpenGL Shading Language
+    GPU_LANGUAGE_GLSL_4_0,          ///< OpenGL Shading Language
+    GPU_LANGUAGE_HLSL_DX11          ///< DirectX Shading Language
+};
+
+//!cpp:type::
+enum EnvironmentMode
+{
+    ENV_ENVIRONMENT_UNKNOWN = 0,
+    ENV_ENVIRONMENT_LOAD_PREDEFINED,
+    ENV_ENVIRONMENT_LOAD_ALL
+};
+
+//!cpp:type:: A RangeTransform may be set to clamp the values, or not.
+enum RangeStyle
+{
+    RANGE_NO_CLAMP = 0,
+    RANGE_CLAMP
+};
+
+//!cpp:type:: Enumeration of the :cpp:class:`FixedFunctionTransform` transform algorithms.
+enum FixedFunctionStyle
+{
+    FIXED_FUNCTION_ACES_RED_MOD_03 = 0, //! Red modifier (ACES 0.3/0.7)
+    FIXED_FUNCTION_ACES_RED_MOD_10,     //! Red modifier (ACES 1.0)
+    FIXED_FUNCTION_ACES_GLOW_03,        //! Glow function (ACES 0.3/0.7)
+    FIXED_FUNCTION_ACES_GLOW_10,        //! Glow function (ACES 1.0)
+    FIXED_FUNCTION_ACES_DARK_TO_DIM_10, //! Dark to dim surround correction (ACES 1.0)
+    FIXED_FUNCTION_REC2100_SURROUND,    //! Rec.2100 surround correction (takes one double for the gamma param)
+    FIXED_FUNCTION_RGB_TO_HSV,          //! Classic RGB to HSV function
+    FIXED_FUNCTION_XYZ_TO_xyY,          //! CIE XYZ to 1931 xy chromaticity coordinates
+    FIXED_FUNCTION_XYZ_TO_uvY,          //! CIE XYZ to 1976 u'v' chromaticity coordinates
+    FIXED_FUNCTION_XYZ_TO_LUV           //! CIE XYZ to 1976 CIELUV colour space (D65 white)
+};
+
+//!cpp:type:: Enumeration of the :cpp:class:`ExposureContrastTransform` transform algorithms.
+enum ExposureContrastStyle
+{
+    EXPOSURE_CONTRAST_LINEAR = 0,      //! E/C to be applied to a linear space image
+    EXPOSURE_CONTRAST_VIDEO,           //! E/C to be applied to a video space image
+    EXPOSURE_CONTRAST_LOGARITHMIC      //! E/C to be applied to a log space image
+};
+
+enum DynamicPropertyType
+{
+    DYNAMIC_PROPERTY_EXPOSURE = 0, //! Image exposure value (double floating point value)
+    DYNAMIC_PROPERTY_CONTRAST,     //! Image contrast value (double floating point value)
+    DYNAMIC_PROPERTY_GAMMA         //! Image gamma value (double floating point value)
+};
+
+enum DynamicPropertyValueType
+{
+    DYNAMIC_PROPERTY_DOUBLE, //! Value is a double
+    DYNAMIC_PROPERTY_BOOL    //! Value is a bool
+};
+
+//!cpp:type:: Provides control over how the ops in a Processor are combined 
+//            in order to improve performance.
+enum OptimizationFlags : unsigned long
+{
+    // Below are listed all the optimization types.
+
+    // Do not optimize.
+    OPTIMIZATION_NONE                            = 0x00000000,
+
+    // Replace identity ops (other than gamma).
+    OPTIMIZATION_IDENTITY                        = 0x00000001,
+    // Replace identity gamma ops.
+    OPTIMIZATION_IDENTITY_GAMMA                  = 0x00000002,
+    // Replace a pair of ops where one is the inverse of the other.
+    OPTIMIZATION_PAIR_IDENTITY_CDL               = 0x00000004,
+    OPTIMIZATION_PAIR_IDENTITY_EXPOSURE_CONTRAST = 0x00000008,
+    OPTIMIZATION_PAIR_IDENTITY_FIXED_FUNCTION    = 0x00000010,
+    OPTIMIZATION_PAIR_IDENTITY_GAMMA             = 0x00000020,
+    OPTIMIZATION_PAIR_IDENTITY_LUT1D             = 0x00000040,
+    OPTIMIZATION_PAIR_IDENTITY_LUT3D             = 0x00000080,
+    OPTIMIZATION_PAIR_IDENTITY_LOG               = 0x00000100,
+
+    // Compose a pair of ops into a single op.
+    OPTIMIZATION_COMP_EXPONENT                   = 0x00000200,
+    OPTIMIZATION_COMP_GAMMA                      = 0x00000400,
+    OPTIMIZATION_COMP_MATRIX                     = 0x00000800,
+    OPTIMIZATION_COMP_LUT1D                      = 0x00001000,
+    OPTIMIZATION_COMP_LUT3D                      = 0x00002000,
+    OPTIMIZATION_COMP_RANGE                      = 0x00004000,
+
+    // For integer and half bit-depths only, replace separable ops (i.e. no channel crosstalk
+    // ops) by a single 1D LUT of input bit-depth domain.
+    OPTIMIZATION_COMP_SEPARABLE_PREFIX           = 0x00008000,
+
+    // Implement inverse Lut1D and Lut3D evaluations using a a forward LUT (faster but less
+    // accurate).  Note that GPU evals always do FAST.
+    OPTIMIZATION_LUT_INV_FAST                    = 0x00010000,
+
+    // Turn off dynamic control of any ops that offer adjustment of parameter values after
+    // finalization (e.g. ExposureContrast).
+    OPTIMIZATION_NO_DYNAMIC_PROPERTIES           = 0x00020000,
+
+    // Apply all possible optimizations.
+    OPTIMIZATION_ALL                             = 0xFFFFFFFF,
+
+    // The following groupings of flags are provided as a convenient way to select an overall
+    // optimization level.
+
+    OPTIMIZATION_LOSSLESS   = (OPTIMIZATION_IDENTITY |
+                                OPTIMIZATION_IDENTITY_GAMMA |
+                                OPTIMIZATION_PAIR_IDENTITY_CDL |
+                                OPTIMIZATION_PAIR_IDENTITY_EXPOSURE_CONTRAST |
+                                OPTIMIZATION_PAIR_IDENTITY_FIXED_FUNCTION |
+                                OPTIMIZATION_PAIR_IDENTITY_GAMMA |
+                                OPTIMIZATION_PAIR_IDENTITY_LOG |
+                                OPTIMIZATION_PAIR_IDENTITY_LUT1D |
+                                OPTIMIZATION_PAIR_IDENTITY_LUT3D |
+                                OPTIMIZATION_COMP_EXPONENT |
+                                OPTIMIZATION_COMP_GAMMA |
+                                OPTIMIZATION_COMP_MATRIX |
+                                OPTIMIZATION_COMP_RANGE),
+
+    OPTIMIZATION_VERY_GOOD  = (OPTIMIZATION_LOSSLESS |
+                                OPTIMIZATION_COMP_LUT1D |
+                                OPTIMIZATION_LUT_INV_FAST |
+                                OPTIMIZATION_COMP_SEPARABLE_PREFIX),
+
+    OPTIMIZATION_GOOD       = OPTIMIZATION_VERY_GOOD | OPTIMIZATION_COMP_LUT3D,
+
+    // For quite lossy optimizations.
+    OPTIMIZATION_DRAFT      = OPTIMIZATION_ALL,
+
+    OPTIMIZATION_DEFAULT    = OPTIMIZATION_VERY_GOOD
+};
+
+
+//!rst::
+// Conversion
+// **********
+
+//!cpp:function::
+extern OCIOEXPORT const char * BoolToString(bool val);
+//!cpp:function::
+extern OCIOEXPORT bool BoolFromString(const char * s);
+
+//!cpp:function::
+extern OCIOEXPORT const char * LoggingLevelToString(LoggingLevel level);
+//!cpp:function::
+extern OCIOEXPORT LoggingLevel LoggingLevelFromString(const char * s);
+
+//!cpp:function::
+extern OCIOEXPORT const char * TransformDirectionToString(TransformDirection dir);
+//!cpp:function::
+extern OCIOEXPORT TransformDirection TransformDirectionFromString(const char * s);
+
+//!cpp:function::
+extern OCIOEXPORT TransformDirection GetInverseTransformDirection(TransformDirection dir);
+//!cpp:function::
+extern OCIOEXPORT TransformDirection CombineTransformDirections(TransformDirection d1,
+                                                                TransformDirection d2);
+
+//!cpp:function::
+extern OCIOEXPORT const char * ColorSpaceDirectionToString(ColorSpaceDirection dir);
+//!cpp:function::
+extern OCIOEXPORT ColorSpaceDirection ColorSpaceDirectionFromString(const char * s);
+
+//!cpp:function::
+extern OCIOEXPORT const char * BitDepthToString(BitDepth bitDepth);
+//!cpp:function::
+extern OCIOEXPORT BitDepth BitDepthFromString(const char * s);
+//!cpp:function::
+extern OCIOEXPORT bool BitDepthIsFloat(BitDepth bitDepth);
+//!cpp:function::
+extern OCIOEXPORT int BitDepthToInt(BitDepth bitDepth);
+
+//!cpp:function::
+extern OCIOEXPORT const char * AllocationToString(Allocation allocation);
+//!cpp:function::
+extern OCIOEXPORT Allocation AllocationFromString(const char * s);
+
+//!cpp:function::
+extern OCIOEXPORT const char * InterpolationToString(Interpolation interp);
+//!cpp:function::
+extern OCIOEXPORT Interpolation InterpolationFromString(const char * s);
+
+//!cpp:function::
+extern OCIOEXPORT const char * GpuLanguageToString(GpuLanguage language);
+//!cpp:function::
+extern OCIOEXPORT GpuLanguage GpuLanguageFromString(const char * s);
+
+//!cpp:function::
+extern OCIOEXPORT const char * EnvironmentModeToString(EnvironmentMode mode);
+//!cpp:function::
+extern OCIOEXPORT EnvironmentMode EnvironmentModeFromString(const char * s);
+
+//!cpp:function::
+extern OCIOEXPORT const char * RangeStyleToString(RangeStyle style);
+//!cpp:function::
+extern OCIOEXPORT RangeStyle RangeStyleFromString(const char * style);
+
+//!cpp:function::
+extern OCIOEXPORT const char * FixedFunctionStyleToString(FixedFunctionStyle style);
+//!cpp:function::
+extern OCIOEXPORT FixedFunctionStyle FixedFunctionStyleFromString(const char * style);
+
+//!cpp:function::
+extern OCIOEXPORT const char * ExposureContrastStyleToString(ExposureContrastStyle style);
+//!cpp:function::
+extern OCIOEXPORT ExposureContrastStyle ExposureContrastStyleFromString(const char * style);
+
+
+/*!rst::
+Roles
+*****
+
+ColorSpace Roles are used so that plugins, in addition to this API can have
+abstract ways of asking for common colorspaces, without referring to them
+by hardcoded names.
+
+Internal::
+
+    GetGPUDisplayTransform - (ROLE_SCENE_LINEAR (fstop exposure))
+                            (ROLE_COLOR_TIMING (ASCColorCorrection))
+
+External Plugins (currently known)::
+
+    Colorpicker UIs       - (ROLE_COLOR_PICKING)
+    Compositor LogConvert - (ROLE_SCENE_LINEAR, ROLE_COMPOSITING_LOG)
+
+*/
+
+//!rst::
+// .. c:var:: const char* ROLE_DEFAULT
+//
+//    "default"
+extern OCIOEXPORT const char * ROLE_DEFAULT;
+//!rst::
+// .. c:var:: const char* ROLE_REFERENCE
+//
+//    "reference"
+extern OCIOEXPORT const char * ROLE_REFERENCE;
+//!rst::
+// .. c:var:: const char* ROLE_DATA
+//
+//    "data"
+extern OCIOEXPORT const char * ROLE_DATA;
+//!rst::
+// .. c:var:: const char* ROLE_COLOR_PICKING
+//
+//    "color_picking"
+extern OCIOEXPORT const char * ROLE_COLOR_PICKING;
+//!rst::
+// .. c:var:: const char* ROLE_SCENE_LINEAR
+//
+//    "scene_linear"
+extern OCIOEXPORT const char * ROLE_SCENE_LINEAR;
+//!rst::
+// .. c:var:: const char* ROLE_COMPOSITING_LOG
+//
+//    "compositing_log"
+extern OCIOEXPORT const char * ROLE_COMPOSITING_LOG;
+//!rst::
+// .. c:var:: const char* ROLE_COLOR_TIMING
+//
+//    "color_timing"
+extern OCIOEXPORT const char * ROLE_COLOR_TIMING;
+//!rst::
+// .. c:var:: const char* ROLE_TEXTURE_PAINT
+//
+//    This role defines the transform for painting textures. In some
+//    workflows this is just a inverse display gamma with some limits
+extern OCIOEXPORT const char * ROLE_TEXTURE_PAINT;
+//!rst::
+// .. c:var:: const char* ROLE_MATTE_PAINT
+//
+//    This role defines the transform for matte painting. In some workflows
+//    this is a 1D HDR to LDR allocation. It is normally combined with
+//    another display transform in the host app for preview.
+extern OCIOEXPORT const char * ROLE_MATTE_PAINT;
+
+/*!rst::
+FormatMetadata
+**************
+
+These constants describe various types of rich metadata. They are used with FormatMetadata
+objects as the "name" part of a (name, value) pair. All of these types of metadata are
+supported in the CLF/CTF file formats whereas other formats support some or none of them.
+
+Although the string constants used here match those used in the CLF/CTF formats, the concepts
+are generic, so the goal is for other file formats to reuse the same constants within a
+FormatMetadata object (even if the syntax used in a given format is somewhat different).
+
+*/
+
+//!rst::
+// .. c:var:: const char * METADATA_DESCRIPTION
+//
+//    A description string -- used as the "Description" element in CLF/CTF and CDL, and to
+//    hold comments for other LUT formats when baking.
+extern OCIOEXPORT const char * METADATA_DESCRIPTION;
+
+//!rst::
+// .. c:var:: const char * METADATA_INFO
+//
+//    A block of informative metadata such as the "Info" element in CLF/CTF.
+//    Usually contains child elements.
+extern OCIOEXPORT const char * METADATA_INFO;
+
+//!rst::
+// .. c:var:: const char * METADATA_INPUT_DESCRIPTOR
+//
+//    A string describing the expected input color space -- used as the "InputDescriptor"
+//    element in CLF/CTF and the "InputDescription" in CDL.
+extern OCIOEXPORT const char * METADATA_INPUT_DESCRIPTOR;
+
+//!rst::
+// .. c:var:: const char * METADATA_OUTPUT_DESCRIPTOR
+//
+//    A string describing the output color space -- used as the "OutputDescriptor" element
+//    in CLF/CTF and the "OutputDescription" in CDL.
+extern OCIOEXPORT const char * METADATA_OUTPUT_DESCRIPTOR;
+
+//!rst::
+// .. c:var:: const char * METADATA_NAME
+//
+//    A name string -- used as a "name" attribute in CLF/CTF elements.  Use on a GroupTransform
+//    to get/set the name for the CLF/CTF ProcessList.  Use on an individual Transform
+//    (i.e. MatrixTransform, etc.) to get/set the name of the corresponding process node.
+extern OCIOEXPORT const char * METADATA_NAME;
+
+//!rst::
+// .. c:var:: const char * METADATA_ID
+//
+//    An ID string -- used as an "id" attribute in CLF/CTF elements.  Use on a GroupTransform
+//    to get/set the id for the CLF/CTF ProcessList.  Use on an individual Transform
+//    (i.e. MatrixTransform, etc.) to get/set the id of the corresponding process node.
+extern OCIOEXPORT const char * METADATA_ID;
 
 } // namespace OCIO_NAMESPACE
 


### PR DESCRIPTION
Format files in include folder to remove the tabulation inside namespaces and removing trailing spaces.

Signed-off-by: Bernard Lefebvre <bernard.lefebvre@autodesk.com>