### PR TITLE
Adsk Contrib - Create optimized processor

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -1214,6 +1214,13 @@ public:
     //!cpp:function:: 
     const char * getCacheID() const;
 
+    //!cpp:function:: Create a :cpp:class:`Processor` that is an optimized version of this.
+    // Note that one typically does not need to explicitly create an optimized Processor instance
+    // since optimization happens implicitly during the creation of a CPUProcessor or GPUProcessor.
+    // This method is provided primarily for diagnostic purposes.
+    ConstProcessorRcPtr getOptimizedProcessor(BitDepth inBD, BitDepth outBD,
+                                              OptimizationFlags oFlags) const;
+
     ///////////////////////////////////////////////////////////////////////////
     //!rst::
     // GPU Renderer

--- a/src/OpenColorIO/Processor.cpp
+++ b/src/OpenColorIO/Processor.cpp
@@ -190,6 +190,15 @@ const char * Processor::getCacheID() const
     return getImpl()->getCacheID();
 }
 
+ConstProcessorRcPtr Processor::getOptimizedProcessor(BitDepth inBD, BitDepth outBD,
+                                                     OptimizationFlags oFlags) const
+{
+    auto proc = Create();
+    *proc->getImpl() = *m_impl;
+    proc->getImpl()->optimize(inBD, outBD, oFlags);
+    return proc;
+}
+
 ConstGPUProcessorRcPtr Processor::getDefaultGPUProcessor() const
 {
     return getImpl()->getDefaultGPUProcessor();
@@ -224,7 +233,18 @@ Processor::Impl::Impl():
 }
 
 Processor::Impl::~Impl()
-{ }
+{
+}
+
+Processor::Impl & Processor::Impl::operator=(const Impl & rhs)
+{
+    if (this != &rhs)
+    {
+        m_metadata = rhs.m_metadata;
+        m_ops = rhs.m_ops;
+    }
+    return *this;
+}
 
 bool Processor::Impl::isNoOp() const
 {
@@ -353,6 +373,15 @@ const char * Processor::Impl::getCacheID() const
     }
 
     return m_cpuCacheID.c_str();
+}
+
+void Processor::Impl::optimize(BitDepth inBD, BitDepth outBD, OptimizationFlags oFlags)
+{
+    auto numOps = m_ops.size();
+    if (numOps)
+    {
+        OptimizeOpVec(m_ops, inBD, outBD, oFlags);
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/OpenColorIO/Processor.h
+++ b/src/OpenColorIO/Processor.h
@@ -29,6 +29,8 @@ public:
     Impl();
     ~Impl();
 
+    Impl & operator=(const Impl & rhs);
+
     bool isNoOp() const;
     bool hasChannelCrosstalk() const;
 
@@ -43,6 +45,8 @@ public:
     DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const;
 
     const char * getCacheID() const;
+
+    void optimize(BitDepth inBD, BitDepth outBD, OptimizationFlags oFlags);
 
     GroupTransformRcPtr createGroupTransform() const;
 

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpData.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpData.cpp
@@ -768,19 +768,6 @@ void Lut1DOpData::scale(float scale)
     getArray().scale(scale);
 }
 
-void Lut1DOpData::initializeFromForward()
-{
-    // This routine is to be called (e.g. in XML reader) once the base forward
-    // Lut1D has been created and then sets up what is needed for the invLut1D.
-
-    // Note that if the original LUT had a half domain, the invLut needs to as
-    // well so that the appropriate evaluation algorithm is called.
-
-    // NB: The file reader must call setFileOutputBitDepth since some methods
-    // need to know the original scaling of the LUT.
-    prepareArray();
-}
-
 bool Lut1DOpData::hasExtendedRange() const
 {
     // The forward LUT is allowed to have entries outside the outDepth (e.g. a
@@ -819,16 +806,25 @@ bool Lut1DOpData::hasExtendedRange() const
     return false;
 }
 
-// NB: The half domain includes pos/neg infinity and NaNs.  
-// The prepareArray makes the LUT monotonic to ensure a unique inverse and
-// determines an effective domain to handle flat spots at the ends nicely.
-// It's not clear how the NaN part of the domain should be included in the
-// monotonicity constraints, furthermore there are 2048 NaNs that could each
-// potentially have different values.  For now, the inversion algorithm and
-// the pre-processing ignore the NaN part of the domain.
-
-void Lut1DOpData::prepareArray()
+void Lut1DOpData::initializeFromForward()
 {
+    // This routine is to be called (e.g. in XML reader) once the base forward
+    // Lut1D has been created and then sets up what is needed for the invLut1D.
+
+    // Note that if the original LUT had a half domain, the invLut needs to as
+    // well so that the appropriate evaluation algorithm is called.
+
+    // NB: The file reader must call setFileOutputBitDepth since some methods
+    // need to know the original scaling of the LUT.
+
+    // NB: The half domain includes pos/neg infinity and NaNs.  
+    // InitializeFromForward makes the LUT monotonic to ensure a unique inverse and
+    // determines an effective domain to handle flat spots at the ends nicely.
+    // It's not clear how the NaN part of the domain should be included in the
+    // monotonicity constraints, furthermore there are 2048 NaNs that could each
+    // potentially have different values.  For now, the inversion algorithm and
+    // the pre-processing ignore the NaN part of the domain.
+
     // Note: Data allocated for the array is length*getMaxColorComponents().
     const unsigned long length = getArray().getLength();
     const unsigned long maxChannels = getArray().getMaxColorComponents();
@@ -853,8 +849,7 @@ void Lut1DOpData::prepareArray()
         }
 
         {
-            m_componentProperties[c].isIncreasing
-                = (values[lowInd] < values[highInd]);
+            m_componentProperties[c].isIncreasing = (values[lowInd] < values[highInd]);
         }
 
         // Flatten reversals.

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpData.h
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpData.h
@@ -249,9 +249,8 @@ private:
 
     // For inverse LUT.
 
-    void initializeFromForward();
     // Make the array monotonic and prepare params for the renderer.
-    void prepareArray();
+    void initializeFromForward();
 
     // Get the LUT length that would allow a look-up for inputBitDepth.
     // - halfFlags except if the LUT has a half domain, always return 65536


### PR DESCRIPTION
Add a function to create an optimized version of a Processor.
This can be used for debug purposes to inspect how a Processor is optimized (for CPU or GPU). Processor could be optimized and written (or converted to transform).

Signed-off-by: Bernard Lefebvre <bernard.lefebvre@autodesk.com>