### PR TITLE
Adsk Contrib - Improve the GPU public API

### DIFF
--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -103,6 +103,12 @@ typedef OCIO_SHARED_PTR<const ImageDesc> ConstImageDescRcPtr;
 
 class OCIOEXPORT Exception;
 
+class OCIOEXPORT GpuShaderCreator;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<GpuShaderCreator> GpuShaderCreatorRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const GpuShaderCreator> ConstGpuShaderCreatorRcPtr;
+
 class OCIOEXPORT GpuShaderDesc;
 //!cpp:type::
 typedef OCIO_SHARED_PTR<GpuShaderDesc> GpuShaderDescRcPtr;

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -61,6 +61,7 @@ set(SOURCES
 	ops/allocation/AllocationOp.cpp
 	ops/cdl/CDLOpCPU.cpp
 	ops/cdl/CDLOpData.cpp
+	ops/cdl/CDLOpGPU.cpp
 	ops/cdl/CDLOp.cpp
 	ops/exponent/ExponentOp.cpp
 	ops/exposurecontrast/ExposureContrastOpCPU.cpp
@@ -73,6 +74,7 @@ set(SOURCES
 	ops/fixedfunction/FixedFunctionOp.cpp
 	ops/gamma/GammaOpCPU.cpp
 	ops/gamma/GammaOpData.cpp
+	ops/gamma/GammaOpGPU.cpp
 	ops/gamma/GammaOpUtils.cpp
 	ops/gamma/GammaOp.cpp
 	ops/log/LogOpCPU.cpp
@@ -90,6 +92,7 @@ set(SOURCES
 	ops/lut3d/Lut3DOpGPU.cpp
 	ops/matrix/MatrixOpCPU.cpp
 	ops/matrix/MatrixOpData.cpp
+	ops/matrix/MatrixOpGPU.cpp
 	ops/matrix/MatrixOp.cpp
 	ops/noop/NoOps.cpp
 	ops/OpTools.cpp
@@ -126,7 +129,7 @@ set(SOURCES
 if(WIN32 AND BUILD_SHARED_LIBS)
 
     # To be appended to the binary file name.
-    set(LIBNAME_SUFFIX 
+    set(LIBNAME_SUFFIX
         ${OpenColorIO_VERSION_MAJOR}_${OpenColorIO_VERSION_MINOR}
     )
 
@@ -141,8 +144,8 @@ target_include_directories(OpenColorIO
 	PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_link_libraries(OpenColorIO 
-	PUBLIC 
+target_link_libraries(OpenColorIO
+	PUBLIC
 		public_api
 	PRIVATE
 		expat::expat
@@ -166,10 +169,10 @@ else()
 endif()
 
 if(BUILD_SHARED_LIBS OR (OCIO_BUILD_PYTHON AND UNIX))
-	# The Python bindings is a 'module' which is a dynamic library on Linux 
+	# The Python bindings is a 'module' which is a dynamic library on Linux
 	# (i.e. '-fPIC' needed), but a static library on Windows.
 
-	# If supported for the target machine, emit position-independent code 
+	# If supported for the target machine, emit position-independent code
 	# suitable for dynamic linking.
 	set_property(TARGET OpenColorIO PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
@@ -190,7 +193,7 @@ endif()
 if(WIN32)
     # A windows application linking to eXpat static libraries must
     # have the global macro XML_STATIC defined
-    target_compile_definitions(OpenColorIO 
+    target_compile_definitions(OpenColorIO
         PRIVATE
             XML_STATIC
     )

--- a/src/OpenColorIO/GPUProcessor.cpp
+++ b/src/OpenColorIO/GPUProcessor.cpp
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <algorithm>
+#include <cctype>
+#include <cstring>
 #include <sstream>
 
 #include <OpenColorIO/OpenColorIO.h>
@@ -8,6 +11,7 @@
 #include "GPUProcessor.h"
 #include "GpuShader.h"
 #include "GpuShaderUtils.h"
+#include "HashUtils.h"
 #include "Logging.h"
 #include "ops/allocation/AllocationOp.h"
 #include "ops/lut3d/Lut3DOp.h"
@@ -20,38 +24,38 @@ namespace OCIO_NAMESPACE
 namespace
 {
 
-void WriteShaderHeader(GpuShaderDescRcPtr & shaderDesc)
+void WriteShaderHeader(GpuShaderCreatorRcPtr & shaderCreator)
 {
-    const std::string fcnName(shaderDesc->getFunctionName());
+    const std::string fcnName(shaderCreator->getFunctionName());
 
-    GpuShaderText ss(shaderDesc->getLanguage());
+    GpuShaderText ss(shaderCreator->getLanguage());
 
     ss.newLine();
     ss.newLine() << "// Declaration of the OCIO shader function";
     ss.newLine();
 
-    ss.newLine() << ss.vec4fKeyword() << " " << fcnName 
+    ss.newLine() << ss.vec4fKeyword() << " " << fcnName
                  << "(in "  << ss.vec4fKeyword() << " inPixel)";
     ss.newLine() << "{";
     ss.indent();
-    ss.newLine() << ss.vec4fKeyword() << " " 
-                 << shaderDesc->getPixelName() << " = inPixel;";
+    ss.newLine() << ss.vec4fKeyword() << " "
+                 << shaderCreator->getPixelName() << " = inPixel;";
 
-    shaderDesc->addToFunctionHeaderShaderCode(ss.string().c_str());
+    shaderCreator->addToFunctionHeaderShaderCode(ss.string().c_str());
 }
 
 
-void WriteShaderFooter(GpuShaderDescRcPtr & shaderDesc)
+void WriteShaderFooter(GpuShaderCreatorRcPtr & shaderCreator)
 {
-    GpuShaderText ss(shaderDesc->getLanguage());
+    GpuShaderText ss(shaderCreator->getLanguage());
 
     ss.newLine();
     ss.indent();
-    ss.newLine() << "return " << shaderDesc->getPixelName() << ";";
+    ss.newLine() << "return " << shaderCreator->getPixelName() << ";";
     ss.dedent();
     ss.newLine() << "}";
 
-    shaderDesc->addToFunctionFooterShaderCode(ss.string().c_str());
+    shaderCreator->addToFunctionFooterShaderCode(ss.string().c_str());
 }
 
 
@@ -142,13 +146,13 @@ void GPUProcessor::Impl::finalize(const OpRcPtrVec & rawOps,
     m_cacheID = ss.str();
 }
 
-void GPUProcessor::Impl::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const
+void GPUProcessor::Impl::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
 {
     AutoMutex lock(m_mutex);
 
     OpRcPtrVec gpuOps;
 
-    LegacyGpuShaderDesc * legacy = dynamic_cast<LegacyGpuShaderDesc*>(shaderDesc.get());
+    LegacyGpuShaderDesc * legacy = dynamic_cast<LegacyGpuShaderDesc*>(shaderCreator.get());
     if(legacy)
     {
         gpuOps = m_ops;
@@ -192,22 +196,16 @@ void GPUProcessor::Impl::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) c
         gpuOps = m_ops;
     }
 
-    // Create the shader program information
+    // Create the shader program information.
     for(const auto & op : gpuOps)
     {
-        op->extractGpuShaderInfo(shaderDesc);
+        op->extractGpuShaderInfo(shaderCreator);
     }
 
-    WriteShaderHeader(shaderDesc);
-    WriteShaderFooter(shaderDesc);
+    WriteShaderHeader(shaderCreator);
+    WriteShaderFooter(shaderCreator);
 
-    shaderDesc->finalize();
-
-    if(IsDebugLoggingEnabled())
-    {
-        LogDebug("GPU Shader");
-        LogDebug(shaderDesc->getShaderText());
-    }
+    shaderCreator->finalize();
 }
 
 
@@ -252,7 +250,59 @@ DynamicPropertyRcPtr GPUProcessor::getDynamicProperty(DynamicPropertyType type) 
 
 void GPUProcessor::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const
 {
-    return getImpl()->extractGpuShaderInfo(shaderDesc);
+    GpuShaderCreatorRcPtr shaderCreator = DynamicPtrCast<GpuShaderCreator>(shaderDesc);
+    getImpl()->extractGpuShaderInfo(shaderCreator);
+}
+
+void GPUProcessor::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
+{
+    // Note that several generated fragment shader programs could be in the same
+    // global fragment shader program (i.e. being embedded in another one). To avoid
+    // any resource name conflict the processor instance provides a unique identifier
+    // to uniquely name the resources (when the color transformations are simlar
+    // i.e. same ops with different values) or as a key for a cache mechanism
+    // (color transforms are identical so a shader program could be reused).
+
+    // Build a unique key usable by the fragment shader program.
+
+    std::string tmpKey(shaderCreator->getCacheID());
+    tmpKey += getImpl()->getCacheID();
+
+    // Way too long uid for a resource name so shorten it.
+    std::string key(CacheIDHash(tmpKey.c_str(), (int)tmpKey.size()));
+
+    // Prepend a user defined uid if any.
+    if (std::strlen(shaderCreator->getUniqueID())!=0)
+    {
+        key = shaderCreator->getUniqueID() + key;
+    }
+
+    if (!std::isalpha(key[0]))
+    {
+        // A resource name must start with a letter.
+        key = "k_" + key;
+    }
+
+    // A resource name only accepts alphanumeric characters.
+    key.erase(std::remove_if(key.begin(), key.end(),
+                             [](char const & c) -> bool { return !std::isalnum(c) && c!='_'; } ),
+              key.end());
+
+    // Extract the information to fully build the fragment shader program.
+
+    shaderCreator->begin(key.c_str());
+
+    try
+    {
+        getImpl()->extractGpuShaderInfo(shaderCreator);
+    }
+    catch(const Exception &)
+    {
+        shaderCreator->end();
+        throw;
+    }
+
+    shaderCreator->end();
 }
 
 

--- a/src/OpenColorIO/GPUProcessor.h
+++ b/src/OpenColorIO/GPUProcessor.h
@@ -29,6 +29,7 @@ public:
     DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const;
 
     void extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const;
 
     ////////////////////////////////////////////
     //

--- a/src/OpenColorIO/GpuShader.cpp
+++ b/src/OpenColorIO/GpuShader.cpp
@@ -10,7 +10,6 @@
 
 #include "DynamicProperty.h"
 #include "GpuShader.h"
-#include "HashUtils.h"
 #include "ops/lut3d/Lut3DOpData.h"
 #include "Platform.h"
 
@@ -20,9 +19,9 @@ namespace OCIO_NAMESPACE
 namespace
 {
 
-static void  CreateArray(const float * buf, 
-                         unsigned w, unsigned h, unsigned d, 
-                         GpuShaderDesc::TextureType type, 
+static void  CreateArray(const float * buf,
+                         unsigned w, unsigned h, unsigned d,
+                         GpuShaderDesc::TextureType type,
                          std::vector<float> & res)
 {
     if(buf==nullptr)
@@ -30,7 +29,7 @@ static void  CreateArray(const float * buf,
         throw Exception("The buffer is invalid");
     }
 
-    const size_t size 
+    const size_t size
         = w * h * d * (type==GpuShaderDesc::TEXTURE_RGB_CHANNEL ? 3 : 1);
     res.resize(size);
     memcpy(&res[0], buf, size * sizeof(float));
@@ -45,25 +44,33 @@ class PrivateImpl
 public:
     struct Texture
     {
-        Texture(const char * name, const char * identifier, 
+        Texture(const char * textureName,
+                const char * samplerName,
+                const char * uid,
                 unsigned w, unsigned h, unsigned d,
-                GpuShaderDesc::TextureType channel, 
-                Interpolation interpolation, 
+                GpuShaderDesc::TextureType channel,
+                Interpolation interpolation,
                 const float * v)
-            :   m_name(name)
-            ,   m_id(identifier)
+            :   m_textureName(textureName)
+            ,   m_samplerName(samplerName)
+            ,   m_uid(uid)
             ,   m_width(w)
             ,   m_height(h)
             ,   m_depth(d)
             ,   m_type(channel)
             ,   m_interp(interpolation)
         {
-            if(!name || !*name)
+            if (!textureName || !*textureName)
             {
                 throw Exception("The texture name is invalid.");
             }
 
-            if(w==0 || h==0 || d==0)
+            if (!samplerName || !*samplerName)
+            {
+                throw Exception("The texture sampler name is invalid.");
+            }
+
+            if (w==0 || h==0 || d==0)
             {
                 std::stringstream ss;
                 ss << "The texture buffer size is invalid: ["
@@ -72,14 +79,15 @@ public:
                 throw Exception(ss.str().c_str());
             }
 
-            // An unfortunate copy is mandatory to allow the creation of a GPU shader cache. 
+            // An unfortunate copy is mandatory to allow the creation of a GPU shader cache.
             // The cache needs a decoupling of the processor and shader instances forbidding
             // shared naked pointer usage.
             CreateArray(v, m_width, m_height, m_depth, m_type, m_values);
         }
 
-        std::string m_name;
-        std::string m_id;
+        std::string m_textureName;
+        std::string m_samplerName;
+        std::string m_uid;
         unsigned m_width;
         unsigned m_height;
         unsigned m_depth;
@@ -98,20 +106,20 @@ public:
         Uniform(const char * name, const DynamicPropertyRcPtr & value)
             :   m_name(name)
         {
-            if(!name || !*name)
+            if (m_name.empty())
             {
                 throw Exception("The dynamic property name is invalid.");
             }
 
-            if(!value->isDynamic())
+            if (!value->isDynamic())
             {
                 // When a dynamic property is not dynamic, the GLSL fragment
-                // shader program should use a constant variable 
+                // shader program should use a constant variable
                 // (i.e. not a uniform variable).
                 throw Exception("The dynamic property is not dynamic.");
             }
 
-            m_value 
+            m_value
                 = std::make_shared<DynamicPropertyImpl>(
                     *dynamic_cast<DynamicPropertyImpl*>(value.get()) );
 
@@ -126,10 +134,9 @@ public:
     typedef std::vector<Uniform> Uniforms;
 
 public:
-    PrivateImpl()
-        :   m_max1DLUTWidth(4 * 1024)
-    {
-    }
+    PrivateImpl() : m_max1DLUTWidth(4 * 1024) {}
+    PrivateImpl(const PrivateImpl & rhs) = delete;
+    PrivateImpl& operator= (const PrivateImpl & rhs) = delete;
 
     virtual ~PrivateImpl() {}
 
@@ -138,9 +145,13 @@ public:
     inline unsigned get1dLutMaxWidth() const { return m_max1DLUTWidth; }
     inline void set1dLutMaxWidth(unsigned maxWidth) { m_max1DLUTWidth = maxWidth; }
 
-    void addTexture(const char * name, const char * id, unsigned width, unsigned height, 
+    void addTexture(const char * textureName,
+                    const char * samplerName,
+                    const char * uid,
+                    unsigned width, unsigned height,
                     GpuShaderDesc::TextureType channel,
-                    Interpolation interpolation, const float * values)
+                    Interpolation interpolation,
+                    const float * values)
     {
         if(width > get1dLutMaxWidth())
         {
@@ -150,13 +161,16 @@ public:
             throw Exception(ss.str().c_str());
         }
 
-        Texture t(name, id, width, height, 1, channel, interpolation, values);
+        Texture t(textureName, samplerName, uid, width, height, 1, channel, interpolation, values);
         m_textures.push_back(t);
     }
 
-    void getTexture(unsigned index, const char *& name, const char *& id, 
-                    unsigned & width, unsigned & height, 
-                    GpuShaderDesc::TextureType & channel, 
+    void getTexture(unsigned index,
+                    const char *& textureName,
+                    const char *& samplerName,
+                    const char *& uid,
+                    unsigned & width, unsigned & height,
+                    GpuShaderDesc::TextureType & channel,
                     Interpolation & interpolation) const
     {
         if(index >= m_textures.size())
@@ -168,8 +182,9 @@ public:
         }
 
         const Texture & t = m_textures[index];
-        name          = t.m_name.c_str();
-        id            = t.m_id.c_str();
+        textureName   = t.m_textureName.c_str();
+        samplerName   = t.m_samplerName.c_str();
+        uid           = t.m_uid.c_str();
         width         = t.m_width;
         height        = t.m_height;
         channel       = t.m_type;
@@ -190,8 +205,12 @@ public:
         values   = &t.m_values[0];
     }
 
-    void add3DTexture(const char * name, const char * id, unsigned dimension, 
-                      Interpolation interpolation, const float * values)
+    void add3DTexture(const char * textureName,
+                      const char * samplerName,
+                      const char * uid,
+                      unsigned dimension,
+                      Interpolation interpolation,
+                      const float * values)
     {
         if(dimension > get3dLutMaxDimension())
         {
@@ -201,15 +220,17 @@ public:
             throw Exception(ss.str().c_str());
         }
 
-        Texture t(
-            name, id, dimension, dimension, dimension, 
-            GpuShaderDesc::TEXTURE_RGB_CHANNEL, 
-            interpolation, values);
+        Texture t(textureName, samplerName, uid, dimension, dimension, dimension,
+                  GpuShaderDesc::TEXTURE_RGB_CHANNEL,
+                  interpolation, values);
         m_textures3D.push_back(t);
     }
 
-    void get3DTexture(unsigned index, const char *& name, const char *& id, 
-                      unsigned & edgelen, 
+    void get3DTexture(unsigned index,
+                      const char *& textureName,
+                      const char *& samplerName,
+                      const char *& uid,
+                      unsigned & edgelen,
                       Interpolation & interpolation) const
     {
         if(index >= m_textures3D.size())
@@ -221,8 +242,9 @@ public:
         }
 
         const Texture & t = m_textures3D[index];
-        name          = t.m_name.c_str();
-        id            = t.m_id.c_str();
+        textureName   = t.m_textureName.c_str();
+        samplerName   = t.m_samplerName.c_str();
+        uid           = t.m_uid.c_str();
         edgelen       = t.m_width;
         interpolation = t.m_interp;
     }
@@ -281,82 +303,23 @@ public:
         return true;
     }
 
-    void createShaderText(const char * shaderDeclarations,
-                          const char * shaderHelperMethods,
-                          const char * shaderFunctionHeader,
-                          const char * shaderFunctionBody,
-                          const char * shaderFunctionFooter)
-    {
-        m_shaderCode.resize(0);
-        m_shaderCode += (shaderDeclarations   && *shaderDeclarations)   ? shaderDeclarations   : "";
-        m_shaderCode += (shaderHelperMethods  && *shaderHelperMethods)  ? shaderHelperMethods  : "";
-        m_shaderCode += (shaderFunctionHeader && *shaderFunctionHeader) ? shaderFunctionHeader : "";
-        m_shaderCode += (shaderFunctionBody   && *shaderFunctionBody)   ? shaderFunctionBody   : "";
-        m_shaderCode += (shaderFunctionFooter && *shaderFunctionFooter) ? shaderFunctionFooter : "";
-
-        m_shaderCodeID.resize(0);
-    }
-
-    void finalize(const std::string & cacheID)
-    {
-        // Finalize the shader program
-        createShaderText(m_declarations.c_str(),
-                         m_helperMethods.c_str(), 
-                         m_functionHeader.c_str(), 
-                         m_functionBody.c_str(), 
-                         m_functionFooter.c_str());
-
-        // Compute the identifier
-        std::ostringstream os;
-        os << m_shaderCode;
-        os << "T3D: " << m_textures3D.size();
-        for(auto & t : m_textures3D)
-        {
-            os << t.m_id << " ";
-        }
-        os << "T1D: " << m_textures.size();
-        for(auto & t : m_textures)
-        {
-            os << t.m_id << " ";
-        }
-        os << "U: " << m_uniforms.size();
-        for (auto & u : m_uniforms)
-        {
-            os << u.m_name << " ";
-        }
-
-        const std::string id = os.str();
-        m_shaderCodeID = cacheID 
-            + CacheIDHash(id.c_str(), unsigned(id.length()));
-    }
-
-    std::string m_declarations;
-    std::string m_helperMethods;
-    std::string m_functionHeader;
-    std::string m_functionBody;
-    std::string m_functionFooter;
-
-    std::string m_shaderCode;
-    std::string m_shaderCodeID;
-
     Textures m_textures;
     Textures m_textures3D;
-
     Uniforms m_uniforms;
 
 protected:
     unsigned m_max1DLUTWidth;
-
-private:
-    PrivateImpl(const PrivateImpl & rhs) = delete;
-    PrivateImpl& operator= (const PrivateImpl & rhs) = delete;
 };
 
 } // namespace GPUShaderImpl
 
 class LegacyGpuShaderDesc::Impl : public GPUShaderImpl::PrivateImpl
 {
-public:       
+public:
+    Impl() = delete;
+    Impl(const Impl &) = delete;
+    Impl & operator=(const Impl &) = delete;
+
     explicit Impl(unsigned edgelen)
         :   GPUShaderImpl::PrivateImpl()
         ,   m_edgelen(edgelen)
@@ -393,7 +356,7 @@ unsigned LegacyGpuShaderDesc::getEdgelen() const
     return getImpl()->getEdgelen();
 }
 
-unsigned LegacyGpuShaderDesc::getNumUniforms() const
+unsigned LegacyGpuShaderDesc::getNumUniforms() const noexcept
 {
     return 0;
 }
@@ -408,9 +371,9 @@ bool LegacyGpuShaderDesc::addUniform(const char *, const DynamicPropertyRcPtr &)
     throw Exception("Uniforms are not supported");
 }
 
-unsigned LegacyGpuShaderDesc::getTextureMaxWidth() const 
+unsigned LegacyGpuShaderDesc::getTextureMaxWidth() const noexcept
 {
-    throw Exception("1D LUTs are not supported");
+    return 0;
 }
 
 void LegacyGpuShaderDesc::setTextureMaxWidth(unsigned)
@@ -418,20 +381,20 @@ void LegacyGpuShaderDesc::setTextureMaxWidth(unsigned)
     throw Exception("1D LUTs are not supported");
 }
 
-unsigned LegacyGpuShaderDesc::getNumTextures() const
+unsigned LegacyGpuShaderDesc::getNumTextures() const noexcept
 {
     return 0;
 }
 
 void LegacyGpuShaderDesc::addTexture(
-    const char *, const char *, unsigned, unsigned,
+    const char *, const char *, const char *, unsigned, unsigned,
     TextureType, Interpolation, const float *)
 {
     throw Exception("1D LUTs are not supported");
 }
 
 void LegacyGpuShaderDesc::getTexture(
-    unsigned, const char *&, const char *&, 
+    unsigned, const char *&, const char *&, const char *&,
     unsigned &, unsigned &, TextureType &, Interpolation &) const
 {
     throw Exception("1D LUTs are not supported");
@@ -442,13 +405,16 @@ void LegacyGpuShaderDesc::getTextureValues(unsigned, const float *&) const
     throw Exception("1D LUTs are not supported");
 }
 
-unsigned LegacyGpuShaderDesc::getNum3DTextures() const
+unsigned LegacyGpuShaderDesc::getNum3DTextures() const noexcept
 {
     return unsigned(getImpl()->m_textures3D.size());
 }
 
-void LegacyGpuShaderDesc::add3DTexture(const char * name, const char * id, unsigned dimension, 
-                                       Interpolation interpolation, const float * values)
+void LegacyGpuShaderDesc::add3DTexture(const char * textureName,
+                                       const char * samplerName,
+                                       const char * uid, unsigned dimension,
+                                       Interpolation interpolation,
+                                       const float * values)
 {
     if(dimension!=getImpl()->getEdgelen())
     {
@@ -464,76 +430,22 @@ void LegacyGpuShaderDesc::add3DTexture(const char * name, const char * id, unsig
         throw Exception(ss.c_str());
     }
 
-    getImpl()->add3DTexture(name, id, dimension, interpolation, values);
+    getImpl()->add3DTexture(textureName, samplerName, uid, dimension, interpolation, values);
 }
 
-void LegacyGpuShaderDesc::get3DTexture(unsigned index, const char *& name, 
-                                       const char *& id, unsigned & edgelen, 
+void LegacyGpuShaderDesc::get3DTexture(unsigned index,
+                                       const char *& textureName,
+                                       const char *& samplerName,
+                                       const char *& uid,
+                                       unsigned & edgelen,
                                        Interpolation & interpolation) const
 {
-    getImpl()->get3DTexture(index, name, id, edgelen, interpolation);
+    getImpl()->get3DTexture(index, textureName, samplerName, uid, edgelen, interpolation);
 }
 
 void LegacyGpuShaderDesc::get3DTextureValues(unsigned index, const float *& values) const
 {
     getImpl()->get3DTextureValues(index, values);
-}
-
-const char * LegacyGpuShaderDesc::getShaderText() const
-{
-    return getImpl()->m_shaderCode.c_str();
-}
-
-const char * LegacyGpuShaderDesc::getCacheID() const
-{
-    return getImpl()->m_shaderCodeID.c_str();
-}
-
-void LegacyGpuShaderDesc::addToDeclareShaderCode(const char * shaderCode)
-{
-    if(getImpl()->m_declarations.empty())
-    {
-        getImpl()->m_declarations += "\n// Declaration of all variables\n\n";
-    }
-    getImpl()->m_declarations += (shaderCode && *shaderCode) ? shaderCode : "";
-}
-
-void LegacyGpuShaderDesc::addToHelperShaderCode(const char * shaderCode)
-{
-    getImpl()->m_helperMethods += (shaderCode && *shaderCode) ? shaderCode : "";
-}
-
-void LegacyGpuShaderDesc::addToFunctionShaderCode(const char * shaderCode)
-{
-    getImpl()->m_functionBody += (shaderCode && *shaderCode) ? shaderCode : "";
-}
-
-void LegacyGpuShaderDesc::addToFunctionHeaderShaderCode(const char * shaderCode)
-{
-    getImpl()->m_functionHeader += (shaderCode && *shaderCode) ? shaderCode : "";
-}
-
-void LegacyGpuShaderDesc::addToFunctionFooterShaderCode(const char * shaderCode)
-{
-    getImpl()->m_functionFooter += (shaderCode && *shaderCode) ? shaderCode : "";
-}
-
-void LegacyGpuShaderDesc::createShaderText(const char * shaderDeclarations, 
-                                           const char * shaderHelperMethods,
-                                           const char * shaderFunctionHeader,
-                                           const char * shaderFunctionBody,
-                                           const char * shaderFunctionFooter)
-{
-    getImpl()->createShaderText(shaderDeclarations,
-                                shaderHelperMethods,
-                                shaderFunctionHeader, 
-                                shaderFunctionBody,
-                                shaderFunctionFooter);
-}
-
-void LegacyGpuShaderDesc::finalize()
-{
-    getImpl()->finalize(GpuShaderDesc::getCacheID());
 }
 
 void LegacyGpuShaderDesc::Deleter(LegacyGpuShaderDesc* c)
@@ -544,7 +456,7 @@ void LegacyGpuShaderDesc::Deleter(LegacyGpuShaderDesc* c)
 
 class GenericGpuShaderDesc::Impl : public GPUShaderImpl::PrivateImpl
 {
-public:       
+public:
     Impl() : GPUShaderImpl::PrivateImpl() {}
     ~Impl() {}
 };
@@ -566,7 +478,7 @@ GenericGpuShaderDesc::~GenericGpuShaderDesc()
     m_impl = 0x0;
 }
 
-unsigned GenericGpuShaderDesc::getNumUniforms() const
+unsigned GenericGpuShaderDesc::getNumUniforms() const noexcept
 {
     return getImpl()->getNumUniforms();
 }
@@ -582,7 +494,7 @@ bool GenericGpuShaderDesc::addUniform(const char * name, const DynamicPropertyRc
     return getImpl()->addUniform(name, value);
 }
 
-unsigned GenericGpuShaderDesc::getTextureMaxWidth() const 
+unsigned GenericGpuShaderDesc::getTextureMaxWidth() const noexcept
 {
     return getImpl()->get1dLutMaxWidth();
 }
@@ -592,26 +504,31 @@ void GenericGpuShaderDesc::setTextureMaxWidth(unsigned maxWidth)
     getImpl()->set1dLutMaxWidth(maxWidth);
 }
 
-unsigned GenericGpuShaderDesc::getNumTextures() const
+unsigned GenericGpuShaderDesc::getNumTextures() const noexcept
 {
     return unsigned(getImpl()->m_textures.size());
 }
 
-void GenericGpuShaderDesc::addTexture(const char * name, const char * id, 
+void GenericGpuShaderDesc::addTexture(const char * textureName,
+                                      const char * samplerName,
+                                      const char * uid,
                                       unsigned width, unsigned height,
-                                      TextureType channel, 
+                                      TextureType channel,
                                       Interpolation interpolation,
                                       const float * values)
 {
-    getImpl()->addTexture(name, id, width, height, channel, interpolation, values);
+    getImpl()->addTexture(textureName, samplerName, uid, width, height, channel, interpolation, values);
 }
 
-void GenericGpuShaderDesc::getTexture(unsigned index, const char *& name, 
-                                      const char *& id, unsigned & width, unsigned & height,
-                                      TextureType & channel, 
+void GenericGpuShaderDesc::getTexture(unsigned index,
+                                      const char *& textureName,
+                                      const char *& samplerName,
+                                      const char *& uid,
+                                      unsigned & width, unsigned & height,
+                                      TextureType & channel,
                                       Interpolation & interpolation) const
 {
-    getImpl()->getTexture(index, name, id, width, height, channel, interpolation);
+    getImpl()->getTexture(index, textureName, samplerName, uid, width, height, channel, interpolation);
 }
 
 void GenericGpuShaderDesc::getTextureValues(unsigned index, const float *& values) const
@@ -619,88 +536,34 @@ void GenericGpuShaderDesc::getTextureValues(unsigned index, const float *& value
     getImpl()->getTextureValues(index, values);
 }
 
-unsigned GenericGpuShaderDesc::getNum3DTextures() const
+unsigned GenericGpuShaderDesc::getNum3DTextures() const noexcept
 {
     return unsigned(getImpl()->m_textures3D.size());
 }
 
-void GenericGpuShaderDesc::add3DTexture(
-    const char * name, const char * id, unsigned edgelen, 
-    Interpolation interpolation, const float * values)
+void GenericGpuShaderDesc::add3DTexture(const char * textureName,
+                                        const char * samplerName,
+                                        const char * uid,
+                                        unsigned edgelen,
+                                        Interpolation interpolation,
+                                        const float * values)
 {
-    getImpl()->add3DTexture(name, id, edgelen, interpolation, values);
+    getImpl()->add3DTexture(textureName, samplerName, uid, edgelen, interpolation, values);
 }
 
-void GenericGpuShaderDesc::get3DTexture(unsigned index, const char *& name, 
-                                        const char *& id, unsigned & edgelen, 
+void GenericGpuShaderDesc::get3DTexture(unsigned index,
+                                        const char *& textureName,
+                                        const char *& samplerName,
+                                        const char *& uid,
+                                        unsigned & edgelen,
                                         Interpolation & interpolation) const
 {
-    getImpl()->get3DTexture(index, name, id, edgelen, interpolation);
+    getImpl()->get3DTexture(index, textureName, samplerName, uid, edgelen, interpolation);
 }
 
 void GenericGpuShaderDesc::get3DTextureValues(unsigned index, const float *& values) const
 {
     getImpl()->get3DTextureValues(index, values);
-}
-
-const char * GenericGpuShaderDesc::getShaderText() const
-{
-    return getImpl()->m_shaderCode.c_str();
-}
-
-const char * GenericGpuShaderDesc::getCacheID() const
-{
-    return getImpl()->m_shaderCodeID.c_str();
-}
-
-void GenericGpuShaderDesc::addToDeclareShaderCode(const char * shaderCode)
-{
-    if(getImpl()->m_declarations.empty())
-    {
-        getImpl()->m_declarations += "\n// Declaration of all variables\n\n";
-    }
-    getImpl()->m_declarations += (shaderCode && *shaderCode) ? shaderCode : "";
-}
-
-void GenericGpuShaderDesc::addToHelperShaderCode(const char * shaderCode)
-{
-    if(getImpl()->m_helperMethods.empty())
-    {
-        getImpl()->m_helperMethods += "\n// Declaration of all helper methods\n\n";
-    }
-    getImpl()->m_helperMethods += (shaderCode && *shaderCode) ? shaderCode : "";
-}
-
-void GenericGpuShaderDesc::addToFunctionShaderCode(const char * shaderCode)
-{
-    getImpl()->m_functionBody += (shaderCode && *shaderCode) ? shaderCode : "";
-}
-
-void GenericGpuShaderDesc::addToFunctionHeaderShaderCode(const char * shaderCode)
-{
-    getImpl()->m_functionHeader += (shaderCode && *shaderCode) ? shaderCode : "";
-}
-
-void GenericGpuShaderDesc::addToFunctionFooterShaderCode(const char * shaderCode)
-{
-    getImpl()->m_functionFooter += (shaderCode && *shaderCode) ? shaderCode : "";
-}
-
-void GenericGpuShaderDesc::createShaderText(
-    const char * shaderDeclarations, const char * shaderHelperMethods,
-    const char * shaderFunctionHeader, const char * shaderFunctionBody,
-    const char * shaderFunctionFooter)
-{
-    getImpl()->createShaderText(shaderDeclarations,
-                                shaderHelperMethods,
-                                shaderFunctionHeader, 
-                                shaderFunctionBody,
-                                shaderFunctionFooter);
-}
-
-void GenericGpuShaderDesc::finalize()
-{
-    getImpl()->finalize(GpuShaderDesc::getCacheID());
 }
 
 void GenericGpuShaderDesc::Deleter(GenericGpuShaderDesc* c)

--- a/src/OpenColorIO/GpuShader.h
+++ b/src/OpenColorIO/GpuShader.h
@@ -29,45 +29,29 @@ public:
 
     // Accessors to the 3D textures built from 3D LUT
     //
-    unsigned getNum3DTextures() const override;
-    void add3DTexture(const char * name, const char * id, unsigned edgelen, 
-                      Interpolation interpolation, const float * values) override;
-    void get3DTexture(unsigned index, const char *& name, 
-                      const char *& id, unsigned & edgelen, 
+    unsigned getNum3DTextures() const noexcept override;
+    void add3DTexture(const char * textureName,
+                      const char * samplerName,
+                      const char * uid,
+                      unsigned edgelen,
+                      Interpolation interpolation,
+                      const float * values) override;
+    void get3DTexture(unsigned index,
+                      const char *& textureName,
+                      const char *& samplerName,
+                      const char *& uid,
+                      unsigned & edgelen,
                       Interpolation & interpolation) const override;
     void get3DTextureValues(unsigned index, const float *& value) const override;
 
-    // Get the complete shader text
-    const char * getShaderText() const override;
-
-    // Get the corresponding cache identifier
-    virtual const char * getCacheID() const override;
-
-    virtual void finalize() override;
-
-    // Methods to specialize each part of a complete shader program
-    //
-    void addToDeclareShaderCode(const char * shaderCode) override;
-    void addToHelperShaderCode(const char * shaderCode) override;
-    void addToFunctionHeaderShaderCode(const char * shaderCode) override;
-    void addToFunctionShaderCode(const char * shaderCode) override;
-    void addToFunctionFooterShaderCode(const char * shaderCode) override;
-
-    // Method called to build the complete shader program
-    void createShaderText(const char * shaderDeclarations,
-                          const char * shaderHelperMethods,
-                          const char * shaderFunctionHeader,
-                          const char * shaderFunctionBody,
-                          const char * shaderFunctionFooter) override;
-
 protected:
 
-    unsigned getTextureMaxWidth() const override;
+    unsigned getTextureMaxWidth() const noexcept override;
     void setTextureMaxWidth(unsigned maxWidth) override;
 
     // Uniforms are not used by the legacy shader builder
     //
-    unsigned getNumUniforms() const override;
+    unsigned getNumUniforms() const noexcept override;
     void getUniform(unsigned index, const char *& name,
                     DynamicPropertyRcPtr & value) const override;
     bool addUniform(const char * name,
@@ -75,13 +59,18 @@ protected:
 
     // 1D & 2D textures are not used by the legacy shader builder
     //
-    unsigned getNumTextures() const override;
-    void addTexture(const char * name, const char * id,
+    unsigned getNumTextures() const noexcept override;
+    void addTexture(const char * textureName,
+                    const char * samplerName,
+                    const char * uid,
                     unsigned width, unsigned height,
                     TextureType channel, Interpolation interpolation,
                     const float * values) override;
     // Get the texture 1D or 2D information
-    void getTexture(unsigned index, const char *& name, const char *& id, 
+    void getTexture(unsigned index,
+                    const char *& textureName,
+                    const char *& samplerName,
+                    const char *& uid,
                     unsigned & width, unsigned & height,
                     TextureType & channel,
                     Interpolation & interpolation) const override;
@@ -110,23 +99,23 @@ private:
 
 // GenericGpuShaderDesc
 // *************
-// 
+//
 // The class holds all the information to build a shader program without baking
-// the color transform. It mainly means that the processor could contain 
+// the color transform. It mainly means that the processor could contain
 // several 1D or 3D LUTs.
-// 
+//
 
 class GenericGpuShaderDesc : public GpuShaderDesc
 {
 public:
     static GpuShaderDescRcPtr Create();
 
-    unsigned getTextureMaxWidth() const override;
+    unsigned getTextureMaxWidth() const noexcept override;
     void setTextureMaxWidth(unsigned maxWidth) override;
 
     // Accessors to the uniforms
     //
-    unsigned getNumUniforms() const override;
+    unsigned getNumUniforms() const noexcept override;
     void getUniform(unsigned index, const char *& name,
                     DynamicPropertyRcPtr & value) const override;
     bool addUniform(const char * name,
@@ -134,11 +123,18 @@ public:
 
     // Accessors to the 1D & 2D textures built from 1D LUT
     //
-    unsigned getNumTextures() const override;
-    void addTexture(const char * name, const char * id,
-                    unsigned width, unsigned height, TextureType channel,
-                    Interpolation interpolation, const float * values) override;
-    void getTexture(unsigned index, const char *& name, const char *& id, 
+    unsigned getNumTextures() const noexcept override;
+    void addTexture(const char * textureName,
+                    const char * samplerNName,
+                    const char * uid,
+                    unsigned width, unsigned height,
+                    TextureType channel,
+                    Interpolation interpolation,
+                    const float * values) override;
+    void getTexture(unsigned index,
+                    const char *& textureName,
+                    const char *& samplerName,
+                    const char *& uid,
                     unsigned & width, unsigned & height,
                     TextureType & channel,
                     Interpolation & interpolation) const override;
@@ -146,36 +142,20 @@ public:
 
     // Accessors to the 3D textures built from 3D LUT
     //
-    unsigned getNum3DTextures() const  override;
-    void add3DTexture(const char * name, const char * id, unsigned edgelen, 
-                      Interpolation interpolation, const float * values) override;
-    void get3DTexture(unsigned index, const char *& name, 
-                      const char *& id, unsigned & edgelen, 
+    unsigned getNum3DTextures() const noexcept override;
+    void add3DTexture(const char * textureName,
+                      const char * samplerName,
+                      const char * uid,
+                      unsigned edgelen,
+                      Interpolation interpolation,
+                      const float * values) override;
+    void get3DTexture(unsigned index,
+                      const char *& textureName,
+                      const char *& samplerName,
+                      const char *& uid,
+                      unsigned & edgelen,
                       Interpolation & interpolation) const override;
     void get3DTextureValues(unsigned index, const float *& value) const override;
-
-    // Get the complete shader text
-    const char * getShaderText() const override;
-
-    // Get the corresponding cache identifier
-    virtual const char * getCacheID() const override;
-
-    virtual void finalize() override;
-
-    // Methods to specialize each part of a complete shader program
-    //
-    void addToDeclareShaderCode(const char * shaderCode) override;
-    void addToHelperShaderCode(const char * shaderCode) override;
-    void addToFunctionHeaderShaderCode(const char * shaderCode) override;
-    void addToFunctionShaderCode(const char * shaderCode) override;
-    void addToFunctionFooterShaderCode(const char * shaderCode) override;
-
-    // Method called to build the complete shader program
-    void createShaderText(const char * shaderDeclarations, 
-                          const char * shaderHelperMethods,
-                          const char * shaderMainHeader,
-                          const char * shaderMainBody,
-                          const char * shaderMainFooter) override;
 
 private:
 

--- a/src/OpenColorIO/GpuShaderDesc.cpp
+++ b/src/OpenColorIO/GpuShaderDesc.cpp
@@ -61,11 +61,11 @@ public:
             m_numResources   = rhs.m_numResources;
             m_cacheID        = rhs.m_cacheID;
 
-            m_declarations   = m_declarations;
-            m_helperMethods  = m_helperMethods;
-            m_functionHeader = m_functionHeader;
-            m_functionBody   = m_functionBody;
-            m_functionFooter = m_functionFooter;
+            m_declarations   = rhs.m_declarations;
+            m_helperMethods  = rhs.m_helperMethods;
+            m_functionHeader = rhs.m_functionHeader;
+            m_functionBody   = rhs.m_functionBody;
+            m_functionFooter = rhs.m_functionFooter;
 
             m_shaderCode.clear();
             m_shaderCodeID.clear();

--- a/src/OpenColorIO/GpuShaderDesc.cpp
+++ b/src/OpenColorIO/GpuShaderDesc.cpp
@@ -6,26 +6,39 @@
 #include <OpenColorIO/OpenColorIO.h>
 
 #include "GpuShader.h"
+#include "HashUtils.h"
+#include "Logging.h"
 #include "Mutex.h"
 #include "pystring/pystring.h"
 
 
 namespace OCIO_NAMESPACE
 {
-class GpuShaderDesc::Impl
+
+class GpuShaderCreator::Impl
 {
 public:
-    GpuLanguage m_language;
+    std::string m_uid; // Custom uid if needed.
+    GpuLanguage m_language = GPU_LANGUAGE_UNKNOWN;
     std::string m_functionName;
     std::string m_resourcePrefix;
     std::string m_pixelName;
+    unsigned m_numResources = 0;
 
     mutable std::string m_cacheID;
     mutable Mutex m_cacheIDMutex;
 
+    std::string m_declarations;
+    std::string m_helperMethods;
+    std::string m_functionHeader;
+    std::string m_functionBody;
+    std::string m_functionFooter;
+
+    std::string m_shaderCode;
+    std::string m_shaderCodeID;
+
     Impl()
-        :   m_language(GPU_LANGUAGE_UNKNOWN)
-        ,   m_functionName("OCIOMain")
+        :   m_functionName("OCIOMain")
         ,   m_resourcePrefix("ocio")
         ,   m_pixelName("outColor")
     {
@@ -34,19 +47,210 @@ public:
     ~Impl()
     { }
 
+    Impl(const Impl & rhs) = delete;
+
     Impl& operator= (const Impl & rhs)
     {
         if (this != &rhs)
         {
-            m_language = rhs.m_language;
-            m_functionName = rhs.m_functionName;
+            m_uid            = rhs.m_uid;
+            m_language       = rhs.m_language;
+            m_functionName   = rhs.m_functionName;
             m_resourcePrefix = rhs.m_resourcePrefix;
-            m_pixelName = rhs.m_pixelName;
-            m_cacheID = rhs.m_cacheID;
+            m_pixelName      = rhs.m_pixelName;
+            m_numResources   = rhs.m_numResources;
+            m_cacheID        = rhs.m_cacheID;
+
+            m_declarations   = m_declarations;
+            m_helperMethods  = m_helperMethods;
+            m_functionHeader = m_functionHeader;
+            m_functionBody   = m_functionBody;
+            m_functionFooter = m_functionFooter;
+
+            m_shaderCode.clear();
+            m_shaderCodeID.clear();
         }
         return *this;
     }
 };
+
+GpuShaderCreator::GpuShaderCreator()
+    :   m_impl(new GpuShaderDesc::Impl)
+{
+}
+
+GpuShaderCreator::~GpuShaderCreator()
+{
+    delete m_impl;
+    m_impl = nullptr;
+}
+
+void GpuShaderCreator::setUniqueID(const char * uid) noexcept
+{
+    AutoMutex lock(getImpl()->m_cacheIDMutex);
+    getImpl()->m_uid = uid;
+    getImpl()->m_cacheID.clear();
+}
+
+const char * GpuShaderCreator::getUniqueID() const noexcept
+{
+    return getImpl()->m_uid.c_str();
+}
+
+void GpuShaderCreator::setLanguage(GpuLanguage lang) noexcept
+{
+    AutoMutex lock(getImpl()->m_cacheIDMutex);
+    getImpl()->m_language = lang;
+    getImpl()->m_cacheID.clear();
+}
+
+GpuLanguage GpuShaderCreator::getLanguage() const noexcept
+{
+    return getImpl()->m_language;
+}
+
+void GpuShaderCreator::setFunctionName(const char * name) noexcept
+{
+    AutoMutex lock(getImpl()->m_cacheIDMutex);
+    // Note: Remove potentially problematic double underscores from GLSL resource names.
+    getImpl()->m_functionName = pystring::replace(name, "__", "_");
+    getImpl()->m_cacheID.clear();
+}
+
+const char * GpuShaderCreator::getFunctionName() const noexcept
+{
+    return getImpl()->m_functionName.c_str();
+}
+
+void GpuShaderCreator::setResourcePrefix(const char * prefix) noexcept
+{
+    AutoMutex lock(getImpl()->m_cacheIDMutex);
+    // Note: Remove potentially problematic double underscores from GLSL resource names.
+    getImpl()->m_resourcePrefix = pystring::replace(prefix, "__", "_");
+    getImpl()->m_cacheID.clear();
+}
+
+const char * GpuShaderCreator::getResourcePrefix() const noexcept
+{
+    return getImpl()->m_resourcePrefix.c_str();
+}
+
+void GpuShaderCreator::setPixelName(const char * name) noexcept
+{
+    AutoMutex lock(getImpl()->m_cacheIDMutex);
+    // Note: Remove potentially problematic double underscores from GLSL resource names.
+    getImpl()->m_pixelName = pystring::replace(name, "__", "_");
+    getImpl()->m_cacheID.clear();
+}
+
+const char * GpuShaderCreator::getPixelName() const noexcept
+{
+    return getImpl()->m_pixelName.c_str();
+}
+
+unsigned GpuShaderCreator::getNextResourceIndex() noexcept
+{
+    return getImpl()->m_numResources++;
+}
+
+void GpuShaderCreator::begin(const char *)
+{
+}
+
+void GpuShaderCreator::end()
+{
+}
+
+const char * GpuShaderCreator::getCacheID() const noexcept
+{
+    AutoMutex lock(getImpl()->m_cacheIDMutex);
+
+    if(getImpl()->m_cacheID.empty())
+    {
+        std::ostringstream os;
+        os << GpuLanguageToString(getImpl()->m_language) << " ";
+        os << getImpl()->m_functionName << " ";
+        os << getImpl()->m_resourcePrefix << " ";
+        os << getImpl()->m_pixelName << " ";
+        os << getImpl()->m_numResources << " ";
+        os << getImpl()->m_shaderCodeID;
+        getImpl()->m_cacheID = os.str();
+    }
+
+    return getImpl()->m_cacheID.c_str();
+}
+
+void GpuShaderCreator::addToDeclareShaderCode(const char * shaderCode)
+{
+    if(getImpl()->m_declarations.empty())
+    {
+        getImpl()->m_declarations += "\n// Declaration of all variables\n\n";
+    }
+    getImpl()->m_declarations += (shaderCode && *shaderCode) ? shaderCode : "";
+}
+
+void GpuShaderCreator::addToHelperShaderCode(const char * shaderCode)
+{
+    if(getImpl()->m_helperMethods.empty())
+    {
+        getImpl()->m_helperMethods += "\n// Declaration of all helper methods\n\n";
+    }
+    getImpl()->m_helperMethods += (shaderCode && *shaderCode) ? shaderCode : "";
+}
+
+void GpuShaderCreator::addToFunctionShaderCode(const char * shaderCode)
+{
+    getImpl()->m_functionBody += (shaderCode && *shaderCode) ? shaderCode : "";
+}
+
+void GpuShaderCreator::addToFunctionHeaderShaderCode(const char * shaderCode)
+{
+    getImpl()->m_functionHeader += (shaderCode && *shaderCode) ? shaderCode : "";
+}
+
+void GpuShaderCreator::addToFunctionFooterShaderCode(const char * shaderCode)
+{
+    getImpl()->m_functionFooter += (shaderCode && *shaderCode) ? shaderCode : "";
+}
+
+void GpuShaderCreator::createShaderText(const char * shaderDeclarations,
+                                        const char * shaderHelperMethods,
+                                        const char * shaderFunctionHeader,
+                                        const char * shaderFunctionBody,
+                                        const char * shaderFunctionFooter)
+{
+    AutoMutex lock(getImpl()->m_cacheIDMutex);
+
+    getImpl()->m_shaderCode.clear();
+    getImpl()->m_shaderCode += (shaderDeclarations   && *shaderDeclarations)   ? shaderDeclarations   : "";
+    getImpl()->m_shaderCode += (shaderHelperMethods  && *shaderHelperMethods)  ? shaderHelperMethods  : "";
+    getImpl()->m_shaderCode += (shaderFunctionHeader && *shaderFunctionHeader) ? shaderFunctionHeader : "";
+    getImpl()->m_shaderCode += (shaderFunctionBody   && *shaderFunctionBody)   ? shaderFunctionBody   : "";
+    getImpl()->m_shaderCode += (shaderFunctionFooter && *shaderFunctionFooter) ? shaderFunctionFooter : "";
+
+    getImpl()->m_shaderCodeID = CacheIDHash(getImpl()->m_shaderCode.c_str(),
+                                            unsigned(getImpl()->m_shaderCode.length()));
+
+    getImpl()->m_cacheID.clear();
+}
+
+void GpuShaderCreator::finalize()
+{
+    createShaderText(getImpl()->m_declarations.c_str(),
+                     getImpl()->m_helperMethods.c_str(),
+                     getImpl()->m_functionHeader.c_str(),
+                     getImpl()->m_functionBody.c_str(),
+                     getImpl()->m_functionFooter.c_str());
+
+
+    if(IsDebugLoggingEnabled())
+    {
+        LogDebug("GPU Shader");
+        LogDebug(getImpl()->m_shaderCode);
+    }
+}
+
+
 
 GpuShaderDescRcPtr GpuShaderDesc::CreateLegacyShaderDesc(unsigned edgelen)
 {
@@ -59,82 +263,25 @@ GpuShaderDescRcPtr GpuShaderDesc::CreateShaderDesc()
 }
 
 GpuShaderDesc::GpuShaderDesc()
-    :   m_impl(new GpuShaderDesc::Impl)
+    :   GpuShaderCreator()
 {
 }
 
 GpuShaderDesc::~GpuShaderDesc()
 {
-    delete m_impl;
-    m_impl = NULL;
 }
 
-void GpuShaderDesc::setLanguage(GpuLanguage lang)
+GpuShaderCreatorRcPtr GpuShaderDesc::clone() const
 {
-    AutoMutex lock(getImpl()->m_cacheIDMutex);
-    getImpl()->m_language = lang;
-    getImpl()->m_cacheID = "";
+    GpuShaderDescRcPtr gpuDesc = CreateShaderDesc();
+    *(gpuDesc->getImpl()) = *getImpl();
+
+    return DynamicPtrCast<GpuShaderCreator>(gpuDesc);
 }
 
-GpuLanguage GpuShaderDesc::getLanguage() const
+const char * GpuShaderDesc::getShaderText() const noexcept
 {
-    return getImpl()->m_language;
-}
-
-void GpuShaderDesc::setFunctionName(const char * name)
-{
-    AutoMutex lock(getImpl()->m_cacheIDMutex);
-	// Note: Remove potentially problematic double underscores from GLSL resource names.
-    getImpl()->m_functionName = pystring::replace(name, "__", "_");
-    getImpl()->m_cacheID      = "";
-}
-
-const char * GpuShaderDesc::getFunctionName() const
-{
-    return getImpl()->m_functionName.c_str();
-}
-
-void GpuShaderDesc::setResourcePrefix(const char * prefix)
-{
-    AutoMutex lock(getImpl()->m_cacheIDMutex);
-    // Note: Remove potentially problematic double underscores from GLSL resource names.
-    getImpl()->m_resourcePrefix = pystring::replace(prefix, "__", "_");
-    getImpl()->m_cacheID        = "";
-}
-
-const char * GpuShaderDesc::getResourcePrefix() const
-{
-    return getImpl()->m_resourcePrefix.c_str();
-}
-
-void GpuShaderDesc::setPixelName(const char * name)
-{
-    AutoMutex lock(getImpl()->m_cacheIDMutex);
-    // Note: Remove potentially problematic double underscores from GLSL resource names.
-    getImpl()->m_pixelName = pystring::replace(name, "__", "_");
-    getImpl()->m_cacheID   = "";
-}
-
-const char * GpuShaderDesc::getPixelName() const
-{
-    return getImpl()->m_pixelName.c_str();
-}
-
-const char * GpuShaderDesc::getCacheID() const
-{
-    AutoMutex lock(getImpl()->m_cacheIDMutex);
-
-    if(getImpl()->m_cacheID.empty())
-    {
-        std::ostringstream os;
-        os << GpuLanguageToString(getImpl()->m_language) << " ";
-        os << getImpl()->m_functionName << " ";
-        os << getImpl()->m_resourcePrefix << " ";
-        os << getImpl()->m_pixelName << " ";
-        getImpl()->m_cacheID = os.str();
-    }
-
-    return getImpl()->m_cacheID.c_str();
+    return getImpl()->m_shaderCode.c_str();
 }
 
 } // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/Op.h
+++ b/src/OpenColorIO/Op.h
@@ -201,100 +201,100 @@ void CreateOpVecFromOpDataVec(OpRcPtrVec & ops,
 
 class Op
 {
-    public:
-        virtual ~Op();
+public:
+    virtual ~Op();
 
-        virtual OpRcPtr clone() const = 0;
+    virtual OpRcPtr clone() const = 0;
 
-        // Something short, and printable.
-        // The type of stuff you'd want to see in debugging.
-        virtual std::string getInfo() const = 0;
+    // Something short, and printable.
+    // The type of stuff you'd want to see in debugging.
+    virtual std::string getInfo() const = 0;
 
-        // This should yield a string of not unreasonable length.
-        // It can only be called after finalize()
-        virtual std::string getCacheID() const { return m_cacheID; }
+    // This should yield a string of not unreasonable length.
+    // It can only be called after finalize()
+    virtual std::string getCacheID() const { return m_cacheID; }
 
-        virtual bool isNoOpType() const { return m_data->getType() == OpData::NoOpType; }
+    virtual bool isNoOpType() const { return m_data->getType() == OpData::NoOpType; }
 
-        // Is the processing a noop? I.e, does apply do nothing.
-        // (Even no-ops may define Allocation though.)
-        // This must be implemented in a manner where its valid to
-        // call *prior* to finalize. (Optimizers may make use of it)
-        virtual bool isNoOp() const { return m_data->isNoOp(); }
+    // Is the processing a noop? I.e, does apply do nothing.
+    // (Even no-ops may define Allocation though.)
+    // This must be implemented in a manner where its valid to
+    // call *prior* to finalize. (Optimizers may make use of it)
+    virtual bool isNoOp() const { return m_data->isNoOp(); }
 
-        virtual bool isIdentity() const { return m_data->isIdentity(); }
+    virtual bool isIdentity() const { return m_data->isIdentity(); }
 
-        OpRcPtr getIdentityReplacement() const;
+    OpRcPtr getIdentityReplacement() const;
 
-        virtual bool isSameType(ConstOpRcPtr & op) const = 0;
+    virtual bool isSameType(ConstOpRcPtr & op) const = 0;
 
-        virtual bool isInverse(ConstOpRcPtr & op) const = 0;
+    virtual bool isInverse(ConstOpRcPtr & op) const = 0;
 
-        virtual bool canCombineWith(ConstOpRcPtr & op) const;
+    virtual bool canCombineWith(ConstOpRcPtr & op) const;
 
-        // Return a vector of result ops, which correspond to
-        // THIS combinedWith secondOp.
-        //
-        // If the result is a noOp, it is valid for the resulting opsVec
-        // to be empty.
+    // Return a vector of result ops, which correspond to
+    // THIS combinedWith secondOp.
+    //
+    // If the result is a noOp, it is valid for the resulting opsVec
+    // to be empty.
 
-        virtual void combineWith(OpRcPtrVec & ops, ConstOpRcPtr & secondOp) const;
+    virtual void combineWith(OpRcPtrVec & ops, ConstOpRcPtr & secondOp) const;
 
-        virtual bool hasChannelCrosstalk() const { return m_data->hasChannelCrosstalk(); }
+    virtual bool hasChannelCrosstalk() const { return m_data->hasChannelCrosstalk(); }
 
-        virtual void dumpMetadata(ProcessorMetadataRcPtr & /*metadata*/) const
-        { }
+    virtual void dumpMetadata(ProcessorMetadataRcPtr & /*metadata*/) const
+    { }
 
-        // This is called a single time after construction.
-        // Final pre-processing and safety checks should happen here,
-        // rather than in the constructor.
+    // This is called a single time after construction.
+    // Final pre-processing and safety checks should happen here,
+    // rather than in the constructor.
 
-        virtual void finalize(OptimizationFlags oFlags) = 0;
+    virtual void finalize(OptimizationFlags oFlags) = 0;
 
-        // Render the specified pixels.
-        //
-        // This must be safe to call in a multi-threaded context.
-        // Ops that have mutable data internally, or rely on external
-        // caching, must thus be appropriately mutexed.
+    // Render the specified pixels.
+    //
+    // This must be safe to call in a multi-threaded context.
+    // Ops that have mutable data internally, or rely on external
+    // caching, must thus be appropriately mutexed.
 
-        virtual void apply(void * img, long numPixels) const
-        { getCPUOp()->apply(img, img, numPixels); }
+    virtual void apply(void * img, long numPixels) const
+    { getCPUOp()->apply(img, img, numPixels); }
 
-        virtual void apply(const void * inImg, void * outImg, long numPixels) const
-        { getCPUOp()->apply(inImg, outImg, numPixels); }
+    virtual void apply(const void * inImg, void * outImg, long numPixels) const
+    { getCPUOp()->apply(inImg, outImg, numPixels); }
 
 
-        // Is this op supported by the legacy shader text generator?
-        virtual bool supportedByLegacyShader() const { return true; }
+    // Is this op supported by the legacy shader text generator?
+    virtual bool supportedByLegacyShader() const { return true; }
 
-        // Create & add the gpu shader information needed by the op
-        virtual void extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const = 0;
+    // Create & add the gpu shader information needed by the op.
+    virtual void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const = 0;
 
-        virtual bool isDynamic() const;
-        virtual bool hasDynamicProperty(DynamicPropertyType type) const;
-        virtual DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const;
-        virtual void replaceDynamicProperty(DynamicPropertyType type,
-                                            DynamicPropertyImplRcPtr prop);
-        // Make dynamic properties non-dynamic.
-        virtual void removeDynamicProperties() {}
+    virtual bool isDynamic() const;
+    virtual bool hasDynamicProperty(DynamicPropertyType type) const;
+    virtual DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const;
+    virtual void replaceDynamicProperty(DynamicPropertyType type,
+                                        DynamicPropertyImplRcPtr prop);
+    // Make dynamic properties non-dynamic.
+    virtual void removeDynamicProperties() {}
 
-        // On-demand creation of the OpCPU instance.
-        virtual ConstOpCPURcPtr getCPUOp() const = 0;
+    // On-demand creation of the OpCPU instance.
+    virtual ConstOpCPURcPtr getCPUOp() const = 0;
 
-        ConstOpDataRcPtr data() const { return std::const_pointer_cast<const OpData>(m_data); }
+    ConstOpDataRcPtr data() const { return std::const_pointer_cast<const OpData>(m_data); }
 
-    protected:
-        Op();
-        OpDataRcPtr & data() { return m_data; }
+protected:
+    Op();
+    OpDataRcPtr & data() { return m_data; }
 
-        std::string m_cacheID;
+    std::string m_cacheID;
 
-    private:
-        Op(const Op &) = delete;
-        Op& operator= (const Op &) = delete;
+private:
+    Op(const Op &) = delete;
+    Op& operator= (const Op &) = delete;
 
-        // The OpData instance holds the parameters (LUT values, matrix coefs, etc.) being used.
-        OpDataRcPtr m_data;
+    // The OpData instance holds the parameters (LUT values, matrix coefs, etc.) being used.
+    OpDataRcPtr m_data;
 };
 
 std::ostream& operator<< (std::ostream&, const Op&);

--- a/src/OpenColorIO/Processor.cpp
+++ b/src/OpenColorIO/Processor.cpp
@@ -174,7 +174,7 @@ const char * Processor::getFormatExtensionByIndex(int index)
 {
     return FormatRegistry::GetInstance().getFormatExtensionByIndex(FORMAT_CAPABILITY_WRITE, index);
 }
-	
+
 bool Processor::hasDynamicProperty(DynamicPropertyType type) const
 {
     return getImpl()->hasDynamicProperty(type);
@@ -210,7 +210,7 @@ ConstCPUProcessorRcPtr Processor::getOptimizedCPUProcessor(OptimizationFlags oFl
     return getImpl()->getOptimizedCPUProcessor(oFlags);
 }
 
-ConstCPUProcessorRcPtr Processor::getOptimizedCPUProcessor(BitDepth inBitDepth, 
+ConstCPUProcessorRcPtr Processor::getOptimizedCPUProcessor(BitDepth inBitDepth,
                                                             BitDepth outBitDepth,
                                                             OptimizationFlags oFlags) const
 {
@@ -381,9 +381,7 @@ ConstCPUProcessorRcPtr Processor::Impl::getDefaultCPUProcessor() const
 {
     CPUProcessorRcPtr cpu = CPUProcessorRcPtr(new CPUProcessor(), &CPUProcessor::deleter);
 
-    cpu->getImpl()->finalize(m_ops, 
-                                BIT_DEPTH_F32, BIT_DEPTH_F32, 
-                                OPTIMIZATION_DEFAULT);
+    cpu->getImpl()->finalize(m_ops, BIT_DEPTH_F32, BIT_DEPTH_F32, OPTIMIZATION_DEFAULT);
 
     return cpu;
 }
@@ -392,16 +390,14 @@ ConstCPUProcessorRcPtr Processor::Impl::getOptimizedCPUProcessor(OptimizationFla
 {
     CPUProcessorRcPtr cpu = CPUProcessorRcPtr(new CPUProcessor(), &CPUProcessor::deleter);
 
-    cpu->getImpl()->finalize(m_ops,
-                                BIT_DEPTH_F32, BIT_DEPTH_F32,
-                                oFlags);
+    cpu->getImpl()->finalize(m_ops, BIT_DEPTH_F32, BIT_DEPTH_F32, oFlags);
 
     return cpu;
 }
 
-ConstCPUProcessorRcPtr Processor::Impl::getOptimizedCPUProcessor(BitDepth inBitDepth, 
-                                                                    BitDepth outBitDepth,
-                                                                    OptimizationFlags oFlags) const
+ConstCPUProcessorRcPtr Processor::Impl::getOptimizedCPUProcessor(BitDepth inBitDepth,
+                                                                 BitDepth outBitDepth,
+                                                                 OptimizationFlags oFlags) const
 {
     CPUProcessorRcPtr cpu = CPUProcessorRcPtr(new CPUProcessor(), &CPUProcessor::deleter);
 
@@ -415,9 +411,9 @@ ConstCPUProcessorRcPtr Processor::Impl::getOptimizedCPUProcessor(BitDepth inBitD
 
 
 void Processor::Impl::setColorSpaceConversion(const Config & config,
-                                                const ConstContextRcPtr & context,
-                                                const ConstColorSpaceRcPtr & srcColorSpace,
-                                                const ConstColorSpaceRcPtr & dstColorSpace)
+                                              const ConstContextRcPtr & context,
+                                              const ConstColorSpaceRcPtr & srcColorSpace,
+                                              const ConstColorSpaceRcPtr & dstColorSpace)
 {
     if (!m_ops.empty())
     {
@@ -429,9 +425,9 @@ void Processor::Impl::setColorSpaceConversion(const Config & config,
 }
 
 void Processor::Impl::setTransform(const Config & config,
-                                    const ConstContextRcPtr & context,
-                                    const ConstTransformRcPtr& transform,
-                                    TransformDirection direction)
+                                   const ConstContextRcPtr & context,
+                                   const ConstTransformRcPtr& transform,
+                                   TransformDirection direction)
 {
     if (!m_ops.empty())
     {

--- a/src/OpenColorIO/Processor.h
+++ b/src/OpenColorIO/Processor.h
@@ -72,14 +72,14 @@ public:
     // Builder functions, Not exposed
 
     void setColorSpaceConversion(const Config & config,
-                                    const ConstContextRcPtr & context,
-                                    const ConstColorSpaceRcPtr & srcColorSpace,
-                                    const ConstColorSpaceRcPtr & dstColorSpace);
+                                 const ConstContextRcPtr & context,
+                                 const ConstColorSpaceRcPtr & srcColorSpace,
+                                 const ConstColorSpaceRcPtr & dstColorSpace);
 
     void setTransform(const Config & config,
-                        const ConstContextRcPtr & context,
-                        const ConstTransformRcPtr& transform,
-                        TransformDirection direction);
+                      const ConstContextRcPtr & context,
+                      const ConstTransformRcPtr& transform,
+                      TransformDirection direction);
 
     void computeMetadata();
 };

--- a/src/OpenColorIO/ops/cdl/CDLOpData.cpp
+++ b/src/OpenColorIO/ops/cdl/CDLOpData.cpp
@@ -164,7 +164,7 @@ bool CDLOpData::operator==(const OpData& other) const
 
     const CDLOpData* cdl = static_cast<const CDLOpData*>(&other);
 
-    return m_style        == cdl->m_style 
+    return m_style        == cdl->m_style
         && m_slopeParams  == cdl->m_slopeParams
         && m_offsetParams == cdl->m_offsetParams
         && m_powerParams  == cdl->m_powerParams
@@ -224,8 +224,8 @@ void CDLOpData::setSaturation(const double saturation)
 }
 
 // Validate if a parameter is greater than or equal to threshold value.
-void validateGreaterEqual(const char * name, 
-                          const double value, 
+void validateGreaterEqual(const char * name,
+                          const double value,
                           const double threshold)
 {
     if (!(value >= threshold))
@@ -241,10 +241,10 @@ void validateGreaterEqual(const char * name,
 }
 
 // Validate if a parameter is greater than a threshold value.
-void validateGreaterThan(const char * name, 
-                        const double value, 
+void validateGreaterThan(const char * name,
+                        const double value,
                          const double threshold)
-{ 
+{
     if (!(value > threshold))
     {
         std::ostringstream oss;
@@ -257,12 +257,12 @@ void validateGreaterThan(const char * name,
     }
 }
 
-typedef void(*parameter_validation_function)(const char *, 
-                                             const double, 
+typedef void(*parameter_validation_function)(const char *,
+                                             const double,
                                              const double);
 
 template<parameter_validation_function fnVal>
-void validateChannelParams(const char * name, 
+void validateChannelParams(const char * name,
                            const CDLOpData::ChannelParams& params,
                            double threshold)
 {
@@ -435,7 +435,10 @@ void CDLOpData::finalize()
     validate();
 
     std::ostringstream cacheIDStream;
-    cacheIDStream << getID() << " ";
+    if (!getID().empty())
+    {
+        cacheIDStream << getID() << " ";
+    }
 
     cacheIDStream.precision(DefaultValues::FLOAT_DECIMALS);
 

--- a/src/OpenColorIO/ops/cdl/CDLOpGPU.cpp
+++ b/src/OpenColorIO/ops/cdl/CDLOpGPU.cpp
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "ops/cdl/CDLOpCPU.h"
+#include "ops/cdl/CDLOpGPU.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+void GetCDLGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator, ConstCDLOpDataRcPtr & cdl)
+{
+    RenderParams params;
+    params.update(cdl);
+
+    const float * slope    = params.getSlope();
+    const float * offset   = params.getOffset();
+    const float * power    = params.getPower();
+    const float saturation = params.getSaturation();
+
+    GpuShaderText ss(shaderCreator->getLanguage());
+    ss.indent();
+
+    ss.newLine() << "";
+    ss.newLine() << "// Add CDL '" << CDLOpData::GetStyleName(cdl->getStyle()) << "' processing";
+    ss.newLine() << "";
+
+    ss.newLine() << "{";
+    ss.indent();
+
+    // Since alpha is not affected, only need to use the RGB components
+    ss.declareVec3f("lumaWeights", 0.2126f,   0.7152f,   0.0722f  );
+    ss.declareVec3f("slope",       slope [0], slope [1], slope [2]);
+    ss.declareVec3f("offset",      offset[0], offset[1], offset[2]);
+    ss.declareVec3f("power",       power [0], power [1], power [2]);
+
+    ss.declareVar("saturation" , saturation);
+
+    ss.newLine() << ss.vec3fDecl("pix") << " = "
+                 << shaderCreator->getPixelName() << ".xyz;";
+
+    if ( !params.isReverse() )
+    {
+        // Forward style
+
+        // Slope
+        ss.newLine() << "pix = pix * slope;";
+
+        // Offset
+        ss.newLine() << "pix = pix + offset;";
+
+        // Power
+        if ( !params.isNoClamp() )
+        {
+            ss.newLine() << "pix = clamp(pix, 0.0, 1.0);";
+            ss.newLine() << "pix = pow(pix, power);";
+        }
+        else
+        {
+            ss.newLine() << ss.vec3fDecl("posPix") << " = step(0.0, pix);";
+            ss.newLine() << ss.vec3fDecl("pixPower") << " = pow(abs(pix), power);";
+            ss.newLine() << "pix = " << ss.lerp("pix", "pixPower", "posPix") << ";";
+        }
+
+        // Saturation
+        ss.newLine() << "float luma = dot(pix, lumaWeights);";
+        ss.newLine() << "pix = luma + saturation * (pix - luma);";
+
+        // Post-saturation clamp
+        if ( !params.isNoClamp() )
+        {
+            ss.newLine() << "pix = clamp(pix, 0.0, 1.0);";
+        }
+    }
+    else
+    {
+        // Reverse style
+
+        // Pre-saturation clamp
+        if ( !params.isNoClamp() )
+        {
+            ss.newLine() << "pix = clamp(pix, 0.0, 1.0);";
+        }
+
+        // Saturation
+        ss.newLine() << "float luma = dot(pix, lumaWeights);";
+        ss.newLine() << "pix = luma + saturation * (pix - luma);";
+
+        // Power
+        if ( !params.isNoClamp() )
+        {
+            ss.newLine() << "pix = clamp(pix, 0.0, 1.0);";
+            ss.newLine() << "pix = pow(pix, power);";
+        }
+        else
+        {
+            ss.newLine() << ss.vec3fDecl("posPix") << " = step(0.0, pix);";
+            ss.newLine() << ss.vec3fDecl("pixPower") << " = pow(abs(pix), power);";
+            ss.newLine() << "pix = " << ss.lerp("pix", "pixPower", "posPix") << ";";
+        }
+
+        // Offset
+        ss.newLine() << "pix = pix + offset;";
+
+        // Slope
+        ss.newLine() << "pix = pix * slope;";
+
+        // Post-slope clamp
+        if ( !params.isNoClamp() )
+        {
+            ss.newLine() << "pix = clamp(pix, 0.0, 1.0);";
+        }
+    }
+
+    ss.newLine() << shaderCreator->getPixelName() << ".xyz = pix;";
+
+    ss.dedent();
+    ss.newLine() << "}";
+
+    shaderCreator->addToFunctionShaderCode(ss.string().c_str());
+}
+
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/cdl/CDLOpGPU.h
+++ b/src/OpenColorIO/ops/cdl/CDLOpGPU.h
@@ -1,25 +1,20 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
-
-#ifndef INCLUDED_OCIO_RANGEOP_GPU_H
-#define INCLUDED_OCIO_RANGEOP_GPU_H
-
+#ifndef INCLUDED_OCIO_CDL_GPU_H
+#define INCLUDED_OCIO_CDL_GPU_H
 
 #include <OpenColorIO/OpenColorIO.h>
 
 #include "GpuShaderUtils.h"
-#include "ops/range/RangeOpData.h"
+#include "ops/cdl/CDLOpData.h"
 
 
 namespace OCIO_NAMESPACE
 {
 
-void GetRangeGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator, ConstRangeOpDataRcPtr & range);
+void GetCDLGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator, ConstCDLOpDataRcPtr & cdl);
 
 } // namespace OCIO_NAMESPACE
 
-
-#endif
-
-
+#endif // INCLUDED_OCIO_CDL_GPU_H

--- a/src/OpenColorIO/ops/exponent/ExponentOp.h
+++ b/src/OpenColorIO/ops/exponent/ExponentOp.h
@@ -20,7 +20,7 @@ class ExponentOpData : public OpData
 public:
     ExponentOpData();
     ExponentOpData(const ExponentOpData & rhs);
-    ExponentOpData(const double * exp4);
+    explicit ExponentOpData(const double * exp4);
     virtual ~ExponentOpData() {}
 
     ExponentOpData & operator = (const ExponentOpData & rhs);

--- a/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOp.cpp
+++ b/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOp.cpp
@@ -50,15 +50,15 @@ public:
 
     ConstOpCPURcPtr getCPUOp() const override;
 
-    void extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
 
 protected:
     ConstExposureContrastOpDataRcPtr ecData() const
-    { 
+    {
         return DynamicPtrCast<const ExposureContrastOpData>(data());
     }
     ExposureContrastOpDataRcPtr ecData()
-    { 
+    {
         return DynamicPtrCast<ExposureContrastOpData>(data());
     }
 };
@@ -123,10 +123,10 @@ void ExposureContrastOp::finalize(OptimizationFlags /*oFlags*/)
 {
     ecData()->finalize();
 
-    // Create the cacheID
+    // Create the cacheID.
     std::ostringstream cacheIDStream;
     cacheIDStream << "<ExposureContrastOp ";
-    cacheIDStream << ecData()->getCacheID() << " ";
+    cacheIDStream << ecData()->getCacheID();
     cacheIDStream << ">";
 
     m_cacheID = cacheIDStream.str();
@@ -138,10 +138,10 @@ ConstOpCPURcPtr ExposureContrastOp::getCPUOp() const
     return GetExposureContrastCPURenderer(ecOpData);
 }
 
-void ExposureContrastOp::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const
+void ExposureContrastOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
 {
     ConstExposureContrastOpDataRcPtr ecOpData = ecData();
-    GetExposureContrastGPUShaderProgram(shaderDesc, ecOpData);
+    GetExposureContrastGPUShaderProgram(shaderCreator, ecOpData);
 }
 
 bool ExposureContrastOp::isDynamic() const

--- a/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpData.cpp
+++ b/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpData.cpp
@@ -255,7 +255,10 @@ void ExposureContrastOpData::finalize()
     AutoMutex lock(m_mutex);
 
     std::ostringstream cacheIDStream;
-    cacheIDStream << getID();
+    if (!getID().empty())
+    {
+        cacheIDStream << getID() << " ";
+    }
 
     cacheIDStream.precision(DefaultValues::FLOAT_DECIMALS);
 

--- a/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpGPU.cpp
+++ b/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpGPU.cpp
@@ -7,6 +7,7 @@
 #include <OpenColorIO/OpenColorIO.h>
 
 #include "ops/exposurecontrast/ExposureContrastOpGPU.h"
+#include "pystring/pystring.h"
 
 
 namespace OCIO_NAMESPACE
@@ -18,22 +19,22 @@ static constexpr const char * EC_EXPOSURE = "exposureVal";
 static constexpr const char * EC_CONTRAST = "contrastVal";
 static constexpr const char * EC_GAMMA = "gammaVal";
 
-void AddUniform(GpuShaderDescRcPtr & shaderDesc,
+void AddUniform(GpuShaderCreatorRcPtr & shaderCreator,
                 GpuShaderText & st,
                 DynamicPropertyImplRcPtr prop,
                 const std::string & name)
 {
     // Add the uniform if it does not already exist.
-    if (shaderDesc->addUniform(name.c_str(), prop))
+    if (shaderCreator->addUniform(name.c_str(), prop))
     {
         // Declare uniform.
-        GpuShaderText stDecl(shaderDesc->getLanguage());
+        GpuShaderText stDecl(shaderCreator->getLanguage());
         stDecl.declareUniformFloat(name);
-        shaderDesc->addToDeclareShaderCode(stDecl.string().c_str());
+        shaderCreator->addToDeclareShaderCode(stDecl.string().c_str());
     }
 }
 
-std::string AddDynamicProperty(GpuShaderDescRcPtr & shaderDesc,
+std::string AddDynamicProperty(GpuShaderCreatorRcPtr & shaderCreator,
                                GpuShaderText & st,
                                DynamicPropertyImplRcPtr prop,
                                const std::string & name)
@@ -42,13 +43,17 @@ std::string AddDynamicProperty(GpuShaderDescRcPtr & shaderDesc,
 
     if(prop->isDynamic())
     {
-        finalName = shaderDesc->getResourcePrefix();
+        finalName = shaderCreator->getResourcePrefix();
+        finalName += "_";
         finalName += name;
+
+        // Note: Remove potentially problematic double underscores from GLSL resource names.
+        finalName = pystring::replace(finalName, "__", "_");
 
         // NB: No need to add an index to the name to avoid collisions
         //     as the dynamic properties are shared i.e. only one instance.
 
-        AddUniform(shaderDesc, st, prop, finalName);
+        AddUniform(shaderCreator, st, prop, finalName);
     }
     else
     {
@@ -60,16 +65,16 @@ std::string AddDynamicProperty(GpuShaderDescRcPtr & shaderDesc,
     return finalName;
 }
 
-void AddProperties(GpuShaderDescRcPtr & shaderDesc,
+void AddProperties(GpuShaderCreatorRcPtr & shaderCreator,
                    GpuShaderText & st,
                    ConstExposureContrastOpDataRcPtr & ec,
                    std::string & exposureName,
                    std::string & contrastName,
                    std::string & gammaName)
 {
-    exposureName = AddDynamicProperty(shaderDesc, st, ec->getExposureProperty(), EC_EXPOSURE);
-    contrastName = AddDynamicProperty(shaderDesc, st, ec->getContrastProperty(), EC_CONTRAST);
-    gammaName    = AddDynamicProperty(shaderDesc, st, ec->getGammaProperty(),    EC_GAMMA);
+    exposureName = AddDynamicProperty(shaderCreator, st, ec->getExposureProperty(), EC_EXPOSURE);
+    contrastName = AddDynamicProperty(shaderCreator, st, ec->getContrastProperty(), EC_CONTRAST);
+    gammaName    = AddDynamicProperty(shaderCreator, st, ec->getGammaProperty(),    EC_GAMMA);
 }
 
 void AddECLinearShader(GpuShaderText & st,
@@ -211,7 +216,7 @@ void AddECLogarithmicShader(GpuShaderText & st,
 {
     double pivot = std::max(EC::MIN_PIVOT, ec->getPivot());
     float logPivot = (float)std::max(0., std::log2(pivot / 0.18) *
-                                         ec->getLogExposureStep() + 
+                                         ec->getLogExposureStep() +
                                          ec->getLogMidGray());
 
     st.newLine() << "float exposure = " << exposureName << " * "
@@ -230,7 +235,7 @@ void AddECLogarithmicRevShader(GpuShaderText & st,
 {
     double pivot = std::max(EC::MIN_PIVOT, ec->getPivot());
     float logPivot = (float)std::max(0., std::log2(pivot / 0.18) *
-                                         ec->getLogExposureStep() + 
+                                         ec->getLogExposureStep() +
                                          ec->getLogMidGray());
 
     st.newLine() << "float exposure = " << exposureName << " * "
@@ -244,25 +249,25 @@ void AddECLogarithmicRevShader(GpuShaderText & st,
 
 }
 
-void GetExposureContrastGPUShaderProgram(GpuShaderDescRcPtr & shaderDesc,
+void GetExposureContrastGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
                                          ConstExposureContrastOpDataRcPtr & ec)
 {
     std::string exposureName;
     std::string contrastName;
     std::string gammaName;
 
-    GpuShaderText st(shaderDesc->getLanguage());
+    GpuShaderText st(shaderCreator->getLanguage());
     st.indent();
 
     st.newLine() << "";
-    st.newLine() << "// Add ExposureContrast "
+    st.newLine() << "// Add ExposureContrast '"
                  << ExposureContrastOpData::ConvertStyleToString(ec->getStyle())
-                 << " processing";
+                 << "' processing";
     st.newLine() << "";
     st.newLine() << "{";
     st.indent();
 
-    AddProperties(shaderDesc, st, ec,
+    AddProperties(shaderCreator, st, ec,
                   exposureName,
                   contrastName,
                   gammaName);
@@ -293,7 +298,7 @@ void GetExposureContrastGPUShaderProgram(GpuShaderDescRcPtr & shaderDesc,
     st.newLine() << "}";
 
     st.dedent();
-    shaderDesc->addToFunctionShaderCode(st.string().c_str());
+    shaderCreator->addToFunctionShaderCode(st.string().c_str());
 }
 
 } // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpGPU.h
+++ b/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpGPU.h
@@ -13,7 +13,7 @@
 namespace OCIO_NAMESPACE
 {
 
-void GetExposureContrastGPUShaderProgram(GpuShaderDescRcPtr & shaderDesc,
+void GetExposureContrastGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
                                          ConstExposureContrastOpDataRcPtr & ec);
 
 } // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/fixedfunction/FixedFunctionOp.cpp
+++ b/src/OpenColorIO/ops/fixedfunction/FixedFunctionOp.cpp
@@ -45,7 +45,7 @@ public:
 
     ConstOpCPURcPtr getCPUOp() const override;
 
-    void extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
 
 protected:
     ConstFixedFunctionOpDataRcPtr fnData() const { return DynamicPtrCast<const FixedFunctionOpData>(data()); }
@@ -112,10 +112,10 @@ void FixedFunctionOp::finalize(OptimizationFlags /*oFlags*/)
 {
     fnData()->finalize();
 
-    // Create the cacheID
+    // Create the cacheID.
     std::ostringstream cacheIDStream;
     cacheIDStream << "<FixedFunctionOp ";
-    cacheIDStream << fnData()->getCacheID() << " ";
+    cacheIDStream << fnData()->getCacheID();
     cacheIDStream << ">";
 
     m_cacheID = cacheIDStream.str();
@@ -127,17 +127,10 @@ ConstOpCPURcPtr FixedFunctionOp::getCPUOp() const
     return GetFixedFunctionCPURenderer(data);
 }
 
-void FixedFunctionOp::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const
+void FixedFunctionOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
 {
-    GpuShaderText ss(shaderDesc->getLanguage());
-    ss.indent();
-
     ConstFixedFunctionOpDataRcPtr fnOpData = fnData();
-    GetFixedFunctionGPUShaderProgram(ss, fnOpData);
-
-    ss.dedent();
-
-    shaderDesc->addToFunctionShaderCode(ss.string().c_str());
+    GetFixedFunctionGPUShaderProgram(shaderCreator, fnOpData);
 }
 
 
@@ -149,7 +142,7 @@ void FixedFunctionOp::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) cons
 ///////////////////////////////////////////////////////////////////////////
 
 
-void CreateFixedFunctionOp(OpRcPtrVec & ops, 
+void CreateFixedFunctionOp(OpRcPtrVec & ops,
                            const FixedFunctionOpData::Params & params,
                            FixedFunctionOpData::Style style)
 {
@@ -157,7 +150,7 @@ void CreateFixedFunctionOp(OpRcPtrVec & ops,
     CreateFixedFunctionOp(ops, funcData, TRANSFORM_DIR_FORWARD);
 }
 
-void CreateFixedFunctionOp(OpRcPtrVec & ops, 
+void CreateFixedFunctionOp(OpRcPtrVec & ops,
                            FixedFunctionOpDataRcPtr & funcData,
                            TransformDirection direction)
 {

--- a/src/OpenColorIO/ops/fixedfunction/FixedFunctionOpData.cpp
+++ b/src/OpenColorIO/ops/fixedfunction/FixedFunctionOpData.cpp
@@ -40,7 +40,7 @@ constexpr const char * LUV_TO_XYZ_STR          = "LUV_TO_XYZ";
 
 // NOTE: Converts the enumeration value to its string representation (i.e. CLF reader).
 //       It could add details for error reporting.
-//          
+//
 // Convert internal OpData style enum to CTF attribute string.  Set 'detailed' to true to get
 // a more verbose human readable string
 const char * FixedFunctionOpData::ConvertStyleToString(Style style, bool detailed)
@@ -65,14 +65,14 @@ const char * FixedFunctionOpData::ConvertStyleToString(Style style, bool detaile
             return detailed ? "ACES_Glow10 (Inverse)"      : ACES_GLOW_10_REV_STR;
         case ACES_DARK_TO_DIM_10_FWD:
             return detailed ? "ACES_DarkToDim10 (Forward)" : ACES_DARK_TO_DIM_10_STR;
-        case ACES_DARK_TO_DIM_10_INV: 
+        case ACES_DARK_TO_DIM_10_INV:
             return detailed ? "ACES_DarkToDim10 (Inverse)" : ACES_DIM_TO_DARK_10_STR;
         case REC2100_SURROUND_FWD:
         case REC2100_SURROUND_INV:
             return detailed ? "REC2100_Surround"           : REC_2100_SURROUND_STR;
         case RGB_TO_HSV:
             return RGB_TO_HSV_STR;
-        case HSV_TO_RGB: 
+        case HSV_TO_RGB:
             return HSV_TO_RGB_STR;
         case XYZ_TO_xyY:
             return XYZ_TO_xyY_STR;
@@ -337,8 +337,8 @@ void FixedFunctionOpData::validate() const
         if (m_params.size() != 1)
         {
             std::stringstream ss;
-            ss  << "The style '" << ConvertStyleToString(m_style, true) 
-                << "' must have one parameter but " 
+            ss  << "The style '" << ConvertStyleToString(m_style, true)
+                << "' must have one parameter but "
                 << m_params.size() << " found.";
             throw Exception(ss.str().c_str());
         }
@@ -365,8 +365,8 @@ void FixedFunctionOpData::validate() const
         if(m_params.size()!=0)
         {
             std::stringstream ss;
-            ss  << "The style '" << ConvertStyleToString(m_style, true) 
-                << "' must have zero parameters but " 
+            ss  << "The style '" << ConvertStyleToString(m_style, true)
+                << "' must have zero parameters but "
                 << m_params.size() << " found.";
             throw Exception(ss.str().c_str());
         }
@@ -571,13 +571,19 @@ void FixedFunctionOpData::finalize()
     validate();
 
     std::ostringstream cacheIDStream;
-    cacheIDStream << getID();
+    if (!getID().empty())
+    {
+        cacheIDStream << getID() << " ";
+    }
 
     cacheIDStream.precision(DefaultValues::FLOAT_DECIMALS);
 
-    cacheIDStream << ConvertStyleToString(m_style, true) << " ";
+    cacheIDStream << ConvertStyleToString(m_style, true);
 
-    for( auto param: m_params ) cacheIDStream << param << " ";
+    for (const auto & param : m_params)
+    {
+        cacheIDStream << " " << param;
+    }
 
     m_cacheID = cacheIDStream.str();
 }

--- a/src/OpenColorIO/ops/fixedfunction/FixedFunctionOpGPU.cpp
+++ b/src/OpenColorIO/ops/fixedfunction/FixedFunctionOpGPU.cpp
@@ -62,7 +62,7 @@ void Add_RedMod_03_Fwd_Shader(GpuShaderText & ss)
 
     ss.newLine() << "float f_S = ( max(1e-10, maxval.r) - max(1e-10, minval.r) ) / max(1e-2, maxval.r);";
 
-    ss.newLine() << "outColor.r = outColor.r + f_H * f_S * (" << _pivot 
+    ss.newLine() << "outColor.r = outColor.r + f_H * f_S * (" << _pivot
                  << " - outColor.r) * " << _1minusScale << ";";
 
     ss.newLine() << ss.vec3fDecl("maxval2") << " = max( outColor.rgb, max( outColor.gbr, outColor.brg));";
@@ -89,7 +89,7 @@ void Add_RedMod_03_Inv_Shader(GpuShaderText & ss)
     // Note: If f_H == 0, the following generally doesn't change the red value,
     //       but it does for R < 0, hence the need for the if-statement above.
     ss.newLine() << "float ka = f_H * " << _1minusScale << " - 1.;";
-    ss.newLine() << "float kb = outColor.r - f_H * (" << _pivot << " + minval.r) * " 
+    ss.newLine() << "float kb = outColor.r - f_H * (" << _pivot << " + minval.r) * "
                  << _1minusScale << ";";
     ss.newLine() << "float kc = f_H * " << _pivot << " * minval.r * " << _1minusScale << ";";
     ss.newLine() << "outColor.r = ( -kb - sqrt( kb * kb - 4. * ka * kc)) / ( 2. * ka);";
@@ -133,7 +133,7 @@ void Add_RedMod_10_Inv_Shader(GpuShaderText & ss)
     // Note: If f_H == 0, the following generally doesn't change the red value
     //       but it does for R < 0, hence the if.
     ss.newLine() << "float ka = f_H * " << _1minusScale << " - 1.;";
-    ss.newLine() << "float kb = outColor.r - f_H * (" << _pivot << " + minval.r) * " 
+    ss.newLine() << "float kb = outColor.r - f_H * (" << _pivot << " + minval.r) * "
                  << _1minusScale << ";";
     ss.newLine() << "float kc = f_H * " << _pivot << " * minval.r * " << _1minusScale << ";";
     ss.newLine() << "outColor.r = ( -kb - sqrt( kb * kb - 4. * ka * kc)) / ( 2. * ka);";
@@ -183,7 +183,7 @@ void Add_Glow_03_Inv_Shader(GpuShaderText & ss, float glowGain, float glowMid)
 
     ss.newLine() << "float GlowGain = " << glowGain << " * s;";
     ss.newLine() << "float GlowMid = " << glowMid << ";";
-    ss.newLine() << "float glowGainOut = " 
+    ss.newLine() << "float glowGainOut = "
                  << ss.lerp( "-GlowGain / (1. + GlowGain)",
                              "GlowGain * (GlowMid / YC - 0.5) / (GlowGain * 0.5 - 1.)",
                              "float( YC > (1. + GlowGain) * GlowMid * 2. / 3. )" ) << ";";
@@ -322,7 +322,7 @@ void Add_XYZ_TO_LUV(GpuShaderText & ss)
     ss.newLine() << "float v = outColor.g * 9. * d;";
     ss.newLine() << "float Y = outColor.g;";
 
-    ss.newLine() << "float Lstar = " << ss.lerp( "1.16 * pow( max(0., Y), 1./3. ) - 0.16", "9.0329629629629608 * Y", 
+    ss.newLine() << "float Lstar = " << ss.lerp( "1.16 * pow( max(0., Y), 1./3. ) - 0.16", "9.0329629629629608 * Y",
                                                  "float(Y <= 0.008856451679)" ) << ";";
     ss.newLine() << "float ustar = 13. * Lstar * (u - 0.19783001);";
     ss.newLine() << "float vstar = 13. * Lstar * (v - 0.46831999);";
@@ -346,13 +346,16 @@ void Add_LUV_TO_XYZ(GpuShaderText & ss)
     ss.newLine() << "outColor.g = Y;";
 }
 
-void GetFixedFunctionGPUShaderProgram(GpuShaderText & ss, 
+void GetFixedFunctionGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
                                       ConstFixedFunctionOpDataRcPtr & func)
 {
+    GpuShaderText ss(shaderCreator->getLanguage());
+    ss.indent();
+
     ss.newLine() << "";
-    ss.newLine() << "// Add FixedFunction "
+    ss.newLine() << "// Add FixedFunction '"
                  << FixedFunctionOpData::ConvertStyleToString(func->getStyle(), true)
-                 << " processing";
+                 << "' processing";
     ss.newLine() << "";
     ss.newLine() << "{";
     ss.indent();
@@ -465,6 +468,9 @@ void GetFixedFunctionGPUShaderProgram(GpuShaderText & ss,
 
     ss.dedent();
     ss.newLine() << "}";
+
+    ss.dedent();
+    shaderCreator->addToFunctionShaderCode(ss.string().c_str());
 }
 
 } // OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/fixedfunction/FixedFunctionOpGPU.h
+++ b/src/OpenColorIO/ops/fixedfunction/FixedFunctionOpGPU.h
@@ -12,7 +12,7 @@
 namespace OCIO_NAMESPACE
 {
 
-void GetFixedFunctionGPUShaderProgram(GpuShaderText & ss, 
+void GetFixedFunctionGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
                                       ConstFixedFunctionOpDataRcPtr & func);
 
 } // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/gamma/GammaOp.cpp
+++ b/src/OpenColorIO/ops/gamma/GammaOp.cpp
@@ -5,8 +5,9 @@
 
 #include "GpuShaderUtils.h"
 #include "ops/exponent/ExponentOp.h"
-#include "ops/gamma/GammaOpCPU.h"
 #include "ops/gamma/GammaOp.h"
+#include "ops/gamma/GammaOpCPU.h"
+#include "ops/gamma/GammaOpGPU.h"
 #include "ops/gamma/GammaOpUtils.h"
 #include "transforms/ExponentTransform.h"
 #include "transforms/ExponentWithLinearTransform.h"
@@ -16,105 +17,6 @@ namespace OCIO_NAMESPACE
 
 namespace
 {
-
-// Create shader for basic gamma style
-void AddBasicFwdShader(ConstGammaOpDataRcPtr gamma, GpuShaderText & ss)
-{
-    const double redGamma   = gamma->getRedParams()[0];
-    const double grnGamma   = gamma->getGreenParams()[0];
-    const double bluGamma   = gamma->getBlueParams()[0];
-    const double alphaGamma = gamma->getAlphaParams()[0];
-
-    ss.declareVec4f( "gamma", redGamma, grnGamma, bluGamma, alphaGamma);
-
-    ss.newLine() << "outColor = pow( max( " 
-                 << ss.vec4fConst(0.0f) 
-                 << ", outColor ), gamma );";
-}
-
-void AddBasicRevShader(ConstGammaOpDataRcPtr gamma, GpuShaderText & ss)
-{
-    const double redGamma   = 1. / gamma->getRedParams()[0];
-    const double grnGamma   = 1. / gamma->getGreenParams()[0];
-    const double bluGamma   = 1. / gamma->getBlueParams()[0];
-    const double alphaGamma = 1. / gamma->getAlphaParams()[0];
-
-    ss.declareVec4f( "gamma", redGamma, grnGamma, bluGamma, alphaGamma);
-
-    ss.newLine() << "outColor = pow( max( " 
-                 << ss.vec4fConst(0.0f) 
-                 << ", outColor ), gamma );";
-}
-
-// Create shader for moncurveFwd style
-void AddMoncurveFwdShader(ConstGammaOpDataRcPtr gamma, GpuShaderText & ss)
-{
-    RendererParams red, green, blue, alpha;
-
-    ComputeParamsFwd(gamma->getRedParams(),   red);
-    ComputeParamsFwd(gamma->getGreenParams(), green);
-    ComputeParamsFwd(gamma->getBlueParams(),  blue);
-    ComputeParamsFwd(gamma->getAlphaParams(), alpha);
-
-    // Even if all components are the same, on OS X, a vec4 needs to be
-    // declared.  This code will work in both cases.
-    ss.declareVec4f( "breakPnt", 
-                     red.breakPnt, green.breakPnt, blue.breakPnt, alpha.breakPnt);
-    ss.declareVec4f( "slope" , 
-                     red.slope, green.slope, blue.slope, alpha.slope);
-    ss.declareVec4f( "scale" , 
-                     red.scale, green.scale, blue.scale, alpha.scale);
-    ss.declareVec4f( "offset", 
-                     red.offset, green.offset, blue.offset, alpha.offset);
-    ss.declareVec4f( "gamma" , 
-                     red.gamma, green.gamma, blue.gamma, alpha.gamma);
-
-    ss.newLine() << ss.vec4fDecl("isAboveBreak") << " = " 
-                 << ss.vec4fGreaterThan("outColor", "breakPnt") << ";";
-
-    ss.newLine() << ss.vec4fDecl("linSeg") << " = outColor * slope;";
-
-    ss.newLine() << ss.vec4fDecl("powSeg") << " = pow( max( " 
-                 << ss.vec4fConst(0.0f) << ", scale * outColor + offset), gamma);";
-
-    ss.newLine() << "outColor = isAboveBreak * powSeg + ( " 
-                 << ss.vec4fConst(1.0f) << " - isAboveBreak ) * linSeg;";
-}
-
-// Create shader for moncurveRev style
-void AddMoncurveRevShader(ConstGammaOpDataRcPtr gamma, GpuShaderText & ss)
-{
-    RendererParams red, green, blue, alpha;
-
-    ComputeParamsRev(gamma->getRedParams(),   red);
-    ComputeParamsRev(gamma->getGreenParams(), green);
-    ComputeParamsRev(gamma->getBlueParams(),  blue);
-    ComputeParamsRev(gamma->getAlphaParams(), alpha);
-
-    // Even if all components are the same, on OS X, a vec4 needs to be
-    // declared.  This code will work in both cases.
-    ss.declareVec4f( "breakPnt", 
-                     red.breakPnt, green.breakPnt, blue.breakPnt, alpha.breakPnt);
-    ss.declareVec4f( "slope" , 
-                     red.slope, green.slope, blue.slope, alpha.slope);
-    ss.declareVec4f( "scale" , 
-                     red.scale, green.scale, blue.scale, alpha.scale);
-    ss.declareVec4f( "offset", 
-                     red.offset, green.offset, blue.offset, alpha.offset);
-    ss.declareVec4f( "gamma" , 
-                     red.gamma, green.gamma, blue.gamma, alpha.gamma);
-
-    ss.newLine() << ss.vec4fDecl("isAboveBreak") << " = " 
-                 << ss.vec4fGreaterThan("outColor", "breakPnt") << ";";
-
-    ss.newLine() << ss.vec4fDecl("linSeg") << " = outColor * slope;";
-    ss.newLine() << ss.vec4fDecl("powSeg") << " = pow( max( " 
-                 << ss.vec4fConst(0.0f) << ", outColor ), gamma ) * scale - offset;";
-
-    ss.newLine() << "outColor = isAboveBreak * powSeg + ( " 
-                 << ss.vec4fConst(1.0f) << " - isAboveBreak ) * linSeg;";
-}
-
 
 class GammaOp;
 typedef OCIO_SHARED_PTR<GammaOp> GammaOpRcPtr;
@@ -148,7 +50,7 @@ public:
 
     ConstOpCPURcPtr getCPUOp() const override;
 
-    void extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
 
 protected:
     ConstGammaOpDataRcPtr gammaData() const { return DynamicPtrCast<const GammaOpData>(data()); }
@@ -241,54 +143,15 @@ ConstOpCPURcPtr GammaOp::getCPUOp() const
     return GetGammaRenderer(data);
 }
 
-void GammaOp::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const
+void GammaOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
 {
-    GpuShaderText ss(shaderDesc->getLanguage());
-    ss.indent();
-
-    ss.newLine() << "";
-    ss.newLine() << "// Add Gamma "
-                 << GammaOpData::ConvertStyleToString(gammaData()->getStyle())
-                 << " processing";
-    ss.newLine() << "";
-
-    ss.newLine() << "{";
-    ss.indent();
-
-    switch(gammaData()->getStyle())
-    {
-        case GammaOpData::MONCURVE_FWD:
-        {
-            AddMoncurveFwdShader(gammaData(), ss);
-            break;
-        }
-        case GammaOpData::MONCURVE_REV:
-        {
-            AddMoncurveRevShader(gammaData(), ss);
-            break;
-        }
-        case GammaOpData::BASIC_FWD:
-        {
-            AddBasicFwdShader(gammaData(), ss);
-            break;
-        }
-        case GammaOpData::BASIC_REV:
-        {
-            AddBasicRevShader(gammaData(), ss);
-            break;
-        }
-    }
-
-    ss.dedent();
-    ss.newLine() << "}";
-    ss.dedent();
-
-    shaderDesc->addToFunctionShaderCode(ss.string().c_str());
+    ConstGammaOpDataRcPtr data = gammaData();
+    GetGammaGPUShaderProgram(shaderCreator, data);
 }
 
 }  // Anon namespace
 
-void CreateGammaOp(OpRcPtrVec & ops, 
+void CreateGammaOp(OpRcPtrVec & ops,
                    GammaOpDataRcPtr & gammaData,
                    TransformDirection direction)
 {

--- a/src/OpenColorIO/ops/gamma/GammaOpGPU.cpp
+++ b/src/OpenColorIO/ops/gamma/GammaOpGPU.cpp
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "ops/gamma/GammaOpGPU.h"
+#include "ops/gamma/GammaOpUtils.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+namespace
+{
+
+// Create shader for basic gamma style
+void AddBasicFwdShader(ConstGammaOpDataRcPtr gamma, GpuShaderText & ss)
+{
+    const double redGamma   = gamma->getRedParams()[0];
+    const double grnGamma   = gamma->getGreenParams()[0];
+    const double bluGamma   = gamma->getBlueParams()[0];
+    const double alphaGamma = gamma->getAlphaParams()[0];
+
+    ss.declareVec4f( "gamma", redGamma, grnGamma, bluGamma, alphaGamma);
+
+    ss.newLine() << "outColor = pow( max( "
+                 << ss.vec4fConst(0.0f)
+                 << ", outColor ), gamma );";
+}
+
+void AddBasicRevShader(ConstGammaOpDataRcPtr gamma, GpuShaderText & ss)
+{
+    const double redGamma   = 1. / gamma->getRedParams()[0];
+    const double grnGamma   = 1. / gamma->getGreenParams()[0];
+    const double bluGamma   = 1. / gamma->getBlueParams()[0];
+    const double alphaGamma = 1. / gamma->getAlphaParams()[0];
+
+    ss.declareVec4f( "gamma", redGamma, grnGamma, bluGamma, alphaGamma);
+
+    ss.newLine() << "outColor = pow( max( "
+                 << ss.vec4fConst(0.0f)
+                 << ", outColor ), gamma );";
+}
+
+// Create shader for moncurveFwd style
+void AddMoncurveFwdShader(ConstGammaOpDataRcPtr gamma, GpuShaderText & ss)
+{
+    RendererParams red, green, blue, alpha;
+
+    ComputeParamsFwd(gamma->getRedParams(),   red);
+    ComputeParamsFwd(gamma->getGreenParams(), green);
+    ComputeParamsFwd(gamma->getBlueParams(),  blue);
+    ComputeParamsFwd(gamma->getAlphaParams(), alpha);
+
+    // Even if all components are the same, on OS X, a vec4 needs to be
+    // declared.  This code will work in both cases.
+    ss.declareVec4f( "breakPnt",
+                     red.breakPnt, green.breakPnt, blue.breakPnt, alpha.breakPnt);
+    ss.declareVec4f( "slope" ,
+                     red.slope, green.slope, blue.slope, alpha.slope);
+    ss.declareVec4f( "scale" ,
+                     red.scale, green.scale, blue.scale, alpha.scale);
+    ss.declareVec4f( "offset",
+                     red.offset, green.offset, blue.offset, alpha.offset);
+    ss.declareVec4f( "gamma" ,
+                     red.gamma, green.gamma, blue.gamma, alpha.gamma);
+
+    ss.newLine() << ss.vec4fDecl("isAboveBreak") << " = "
+                 << ss.vec4fGreaterThan("outColor", "breakPnt") << ";";
+
+    ss.newLine() << ss.vec4fDecl("linSeg") << " = outColor * slope;";
+
+    ss.newLine() << ss.vec4fDecl("powSeg") << " = pow( max( "
+                 << ss.vec4fConst(0.0f) << ", scale * outColor + offset), gamma);";
+
+    ss.newLine() << "outColor = isAboveBreak * powSeg + ( "
+                 << ss.vec4fConst(1.0f) << " - isAboveBreak ) * linSeg;";
+}
+
+// Create shader for moncurveRev style
+void AddMoncurveRevShader(ConstGammaOpDataRcPtr gamma, GpuShaderText & ss)
+{
+    RendererParams red, green, blue, alpha;
+
+    ComputeParamsRev(gamma->getRedParams(),   red);
+    ComputeParamsRev(gamma->getGreenParams(), green);
+    ComputeParamsRev(gamma->getBlueParams(),  blue);
+    ComputeParamsRev(gamma->getAlphaParams(), alpha);
+
+    // Even if all components are the same, on OS X, a vec4 needs to be
+    // declared.  This code will work in both cases.
+    ss.declareVec4f( "breakPnt",
+                     red.breakPnt, green.breakPnt, blue.breakPnt, alpha.breakPnt);
+    ss.declareVec4f( "slope" ,
+                     red.slope, green.slope, blue.slope, alpha.slope);
+    ss.declareVec4f( "scale" ,
+                     red.scale, green.scale, blue.scale, alpha.scale);
+    ss.declareVec4f( "offset",
+                     red.offset, green.offset, blue.offset, alpha.offset);
+    ss.declareVec4f( "gamma" ,
+                     red.gamma, green.gamma, blue.gamma, alpha.gamma);
+
+    ss.newLine() << ss.vec4fDecl("isAboveBreak") << " = "
+                 << ss.vec4fGreaterThan("outColor", "breakPnt") << ";";
+
+    ss.newLine() << ss.vec4fDecl("linSeg") << " = outColor * slope;";
+    ss.newLine() << ss.vec4fDecl("powSeg") << " = pow( max( "
+                 << ss.vec4fConst(0.0f) << ", outColor ), gamma ) * scale - offset;";
+
+    ss.newLine() << "outColor = isAboveBreak * powSeg + ( "
+                 << ss.vec4fConst(1.0f) << " - isAboveBreak ) * linSeg;";
+}
+
+}
+
+void GetGammaGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator, ConstGammaOpDataRcPtr & gamma)
+{
+    GpuShaderText ss(shaderCreator->getLanguage());
+    ss.indent();
+
+    ss.newLine() << "";
+    ss.newLine() << "// Add Gamma '"
+                 << GammaOpData::ConvertStyleToString(gamma->getStyle())
+                 << "' processing";
+    ss.newLine() << "";
+
+    ss.newLine() << "{";
+    ss.indent();
+
+    switch(gamma->getStyle())
+    {
+        case GammaOpData::MONCURVE_FWD:
+        {
+            AddMoncurveFwdShader(gamma, ss);
+            break;
+        }
+        case GammaOpData::MONCURVE_REV:
+        {
+            AddMoncurveRevShader(gamma, ss);
+            break;
+        }
+        case GammaOpData::BASIC_FWD:
+        {
+            AddBasicFwdShader(gamma, ss);
+            break;
+        }
+        case GammaOpData::BASIC_REV:
+        {
+            AddBasicRevShader(gamma, ss);
+            break;
+        }
+    }
+
+    ss.dedent();
+    ss.newLine() << "}";
+    ss.dedent();
+
+    shaderCreator->addToFunctionShaderCode(ss.string().c_str());
+}
+
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/gamma/GammaOpGPU.h
+++ b/src/OpenColorIO/ops/gamma/GammaOpGPU.h
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#ifndef INCLUDED_OCIO_GAMMA_GPU_H
+#define INCLUDED_OCIO_GAMMA_GPU_H
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "GpuShaderUtils.h"
+#include "ops/gamma/GammaOpData.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+void GetGammaGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
+                              ConstGammaOpDataRcPtr & gamma);
+
+} // namespace OCIO_NAMESPACE
+
+#endif // INCLUDED_OCIO_GAMMA_GPU_H
+
+

--- a/src/OpenColorIO/ops/gamma/GammaOps.cpp
+++ b/src/OpenColorIO/ops/gamma/GammaOps.cpp
@@ -146,7 +146,7 @@ public:
 
     ConstOpCPURcPtr getCPUOp() const override;
 
-    void extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const override;
+    void extractGpuShaderInfo(GpuShaderDescRcPtr & shaderCreator) const override;
 
 protected:
     ConstGammaOpDataRcPtr gammaData() const { return DynamicPtrCast<const GammaOpData>(data()); }
@@ -239,9 +239,9 @@ ConstOpCPURcPtr GammaOp::getCPUOp() const
     return GetGammaRenderer(data);
 }
 
-void GammaOp::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const
+void GammaOp::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderCreator) const
 {
-    GpuShaderText ss(shaderDesc->getLanguage());
+    GpuShaderText ss(shaderCreator->getLanguage());
     ss.indent();
 
     ss.newLine() << "";
@@ -281,12 +281,12 @@ void GammaOp::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const
     ss.newLine() << "}";
     ss.dedent();
 
-    shaderDesc->addToFunctionShaderCode(ss.string().c_str());
+    shaderCreator->addToFunctionShaderCode(ss.string().c_str());
 }
 
 }  // Anon namespace
 
-void CreateGammaOp(OpRcPtrVec & ops, 
+void CreateGammaOp(OpRcPtrVec & ops,
                    GammaOpDataRcPtr & gammaData,
                    TransformDirection direction)
 {
@@ -368,7 +368,7 @@ void BuildExponentWithLinearOp(OpRcPtrVec & ops,
                                const ExponentWithLinearTransform & transform,
                                TransformDirection dir)
 {
-    TransformDirection combinedDir 
+    TransformDirection combinedDir
         = CombineTransformDirections(dir, transform.getDirection());
 
     double gammaVals[4] = { 1., 1., 1., 1. };

--- a/src/OpenColorIO/ops/log/LogOp.cpp
+++ b/src/OpenColorIO/ops/log/LogOp.cpp
@@ -43,7 +43,7 @@ public:
 
     ConstOpCPURcPtr getCPUOp() const override;
 
-    void extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
 
 protected:
     ConstLogOpDataRcPtr logData() const { return DynamicPtrCast<const LogOpData>(data()); }
@@ -96,10 +96,10 @@ void LogOp::finalize(OptimizationFlags /*oFlags*/)
 {
     logData()->finalize();
 
-    // Create the cacheID
+    // Create the cacheID.
     std::ostringstream cacheIDStream;
     cacheIDStream << "<LogOp ";
-    cacheIDStream << logData()->getCacheID() << " ";
+    cacheIDStream << logData()->getCacheID();
     cacheIDStream << ">";
 
     m_cacheID = cacheIDStream.str();
@@ -111,10 +111,10 @@ ConstOpCPURcPtr LogOp::getCPUOp() const
     return GetLogRenderer(data);
 }
 
-void LogOp::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const
+void LogOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
 {
     ConstLogOpDataRcPtr data = logData();
-    GetLogGPUShaderProgram(shaderDesc, data);
+    GetLogGPUShaderProgram(shaderCreator, data);
 }
 
 }  // Anon namespace

--- a/src/OpenColorIO/ops/log/LogOpData.cpp
+++ b/src/OpenColorIO/ops/log/LogOpData.cpp
@@ -259,14 +259,17 @@ void LogOpData::finalize()
     validate();
 
     std::ostringstream cacheIDStream;
-    cacheIDStream << getID() << " ";
+    if (!getID().empty())
+    {
+        cacheIDStream << getID() << " ";
+    }
 
     cacheIDStream << TransformDirectionToString(m_direction) << " ";
 
-    cacheIDStream << "Base "         << getBaseString(DefaultValues::FLOAT_DECIMALS) << " ";
-    cacheIDStream << "LogSlope "     << getLogSlopeString(DefaultValues::FLOAT_DECIMALS) << " ";
+    cacheIDStream << "Base "         << getBaseString(DefaultValues::FLOAT_DECIMALS)      << " ";
+    cacheIDStream << "LogSlope "     << getLogSlopeString(DefaultValues::FLOAT_DECIMALS)  << " ";
     cacheIDStream << "LogOffset "    << getLogOffsetString(DefaultValues::FLOAT_DECIMALS) << " ";
-    cacheIDStream << "LinearSlope "  << getLinSlopeString(DefaultValues::FLOAT_DECIMALS) << " ";
+    cacheIDStream << "LinearSlope "  << getLinSlopeString(DefaultValues::FLOAT_DECIMALS)  << " ";
     cacheIDStream << "LinearOffset " << getLinOffsetString(DefaultValues::FLOAT_DECIMALS);
 
     m_cacheID = cacheIDStream.str();
@@ -318,7 +321,7 @@ bool LogOpData::isInverse(ConstLogOpDataRcPtr & r) const
     {
         return true;
     }
- 
+
     // Note:  Actually the R/G/B channels would not need to be equal for an
     // inverse, however, the identity replacement would get more complicated if
     // we allowed that case.  Since it is not a typical use-case, we don't

--- a/src/OpenColorIO/ops/log/LogOpGPU.h
+++ b/src/OpenColorIO/ops/log/LogOpGPU.h
@@ -12,8 +12,7 @@
 namespace OCIO_NAMESPACE
 {
 
-void GetLogGPUShaderProgram(GpuShaderDescRcPtr & shaderDesc,
-                            ConstLogOpDataRcPtr & logData);
+void GetLogGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator, ConstLogOpDataRcPtr & logData);
 
 } // namespace OCIO_NAMESPACE
 

--- a/src/OpenColorIO/ops/lut1d/Lut1DOp.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOp.cpp
@@ -51,7 +51,7 @@ public:
     ConstOpCPURcPtr getCPUOp() const override;
 
     bool supportedByLegacyShader() const override { return false; }
-    void extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
 
     ConstLut1DOpDataRcPtr lut1DData() const { return DynamicPtrCast<const Lut1DOpData>(data()); }
     Lut1DOpDataRcPtr lut1DData() { return DynamicPtrCast<Lut1DOpData>(data()); }
@@ -135,17 +135,15 @@ void Lut1DOp::finalize(OptimizationFlags oFlags)
 {
     Lut1DOpDataRcPtr lutData = lut1DData();
 
-    const bool invLutFast = (oFlags & OPTIMIZATION_LUT_INV_FAST) ==
-                            OPTIMIZATION_LUT_INV_FAST;
-    lutData->setInversionQuality(
-        invLutFast ? LUT_INVERSION_FAST: LUT_INVERSION_EXACT);
+    const bool invLutFast = (oFlags & OPTIMIZATION_LUT_INV_FAST) == OPTIMIZATION_LUT_INV_FAST;
+    lutData->setInversionQuality(invLutFast ? LUT_INVERSION_FAST: LUT_INVERSION_EXACT);
 
     lutData->finalize();
 
-    // Rebuild the cache identifier
+    // Rebuild the cache identifier.
     std::ostringstream cacheIDStream;
     cacheIDStream << "<Lut1D ";
-    cacheIDStream << lutData->getCacheID() << " ";
+    cacheIDStream << lutData->getCacheID();
     cacheIDStream << ">";
 
     m_cacheID = cacheIDStream.str();
@@ -157,7 +155,7 @@ ConstOpCPURcPtr Lut1DOp::getCPUOp() const
     return GetLut1DRenderer(data, BIT_DEPTH_F32, BIT_DEPTH_F32);
 }
 
-void Lut1DOp::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const
+void Lut1DOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
 {
     ConstLut1DOpDataRcPtr lutData = lut1DData();
     if (lutData->getDirection() == TRANSFORM_DIR_INVERSE)
@@ -175,7 +173,7 @@ void Lut1DOp::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const
         lutData = tmp;
     }
 
-    GetLut1DGPUShaderProgram(shaderDesc, lutData);
+    GetLut1DGPUShaderProgram(shaderCreator, lutData);
 }
 }
 

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpData.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpData.cpp
@@ -140,7 +140,7 @@ bool Lut1DOpData::Lut3by1DArray::isIdentity(HalfFlags halfFlags) const
         //
         // Note: LUTs that are approximately identity transforms and
         // contain a wide range of float values should use the
-        // half-domain representation.  The contents of most LUTs using 
+        // half-domain representation.  The contents of most LUTs using
         // this branch will hence either not be close to an identity anyway
         // or will be in units that are roughly perceptually uniform and hence
         // it is more appropriate to use an absolute error based on the
@@ -351,7 +351,7 @@ void Lut1DOpData::validate() const
 
 unsigned long Lut1DOpData::GetLutIdealSize(BitDepth incomingBitDepth)
 {
-    // Return the number of entries needed in order to do a lookup 
+    // Return the number of entries needed in order to do a lookup
     // for the specified bit-depth.
 
     // For 32f, a look-up is impractical so in that case return 64k.
@@ -557,11 +557,16 @@ void Lut1DOpData::finalize()
     md5_finish(&state, digest);
 
     std::ostringstream cacheIDStream;
-    cacheIDStream << GetPrintableHash(digest) << " ";
-    cacheIDStream << TransformDirectionToString(m_direction) << " ";
-    cacheIDStream << InterpolationToString(m_interpolation) << " ";
-    cacheIDStream << (isInputHalfDomain()?"half domain ":"standard domain ");
+    if (!getID().empty())
+    {
+        cacheIDStream << getID() << " ";
+    }
+    cacheIDStream << GetPrintableHash(digest)                                  << " ";
+    cacheIDStream << TransformDirectionToString(m_direction)                   << " ";
+    cacheIDStream << InterpolationToString(m_interpolation)                    << " ";
+    cacheIDStream << (isInputHalfDomain() ? "half domain" : "standard domain") << " ";
     cacheIDStream << GetHueAdjustName(m_hueAdjust);
+
     // NB: The m_invQuality is not currently included.
 
     m_cacheID = cacheIDStream.str();
@@ -593,7 +598,7 @@ void Lut1DOpData::finalize()
 //
 // Note3:  We do not attempt to propagate hueAdjust or bypass states.
 //         These must be taken care of by the caller.
-// 
+//
 // A is used as in/out parameter. As input is it the first LUT in the composition,
 // as output it is the result of the composition.
 void Lut1DOpData::ComposeVec(Lut1DOpDataRcPtr & A, OpRcPtrVec & B)
@@ -702,7 +707,7 @@ void Lut1DOpData::Compose(Lut1DOpDataRcPtr & A,
     // TODO:  May want to revisit metadata propagation.
     A->getFormatMetadata().combine(B->getFormatMetadata());
 
-    // See note above: Taking these from B since the common use case is for B to be 
+    // See note above: Taking these from B since the common use case is for B to be
     // the original LUT and A to be a new domain (e.g. used in LUT1D renderers).
     // TODO: Adjust domain in Lut1D renderer to be one channel.
     A->setHueAdjust(B->getHueAdjust());
@@ -819,7 +824,7 @@ bool Lut1DOpData::hasExtendedRange() const
     return false;
 }
 
-// NB: The half domain includes pos/neg infinity and NaNs.  
+// NB: The half domain includes pos/neg infinity and NaNs.
 // The prepareArray makes the LUT monotonic to ensure a unique inverse and
 // determines an effective domain to handle flat spots at the ends nicely.
 // It's not clear how the NaN part of the domain should be included in the

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpGPU.h
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpGPU.h
@@ -12,8 +12,7 @@
 namespace OCIO_NAMESPACE
 {
 
-void GetLut1DGPUShaderProgram(GpuShaderDescRcPtr & shaderDesc,
-                              ConstLut1DOpDataRcPtr & lutData);
+void GetLut1DGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator, ConstLut1DOpDataRcPtr & lutData);
 
 } // namespace OCIO_NAMESPACE
 

--- a/src/OpenColorIO/ops/lut3d/Lut3DOp.cpp
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOp.cpp
@@ -179,7 +179,7 @@ public:
     ConstOpCPURcPtr getCPUOp() const override;
 
     bool supportedByLegacyShader() const override { return false; }
-    void extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
 
 #ifdef OCIO_UNIT_TEST
     Array & getArray()
@@ -195,7 +195,7 @@ protected:
     }
 
     Lut3DOpDataRcPtr lut3DData()
-    { 
+    {
         return DynamicPtrCast<Lut3DOpData>(data());
     }
 };
@@ -290,7 +290,7 @@ void Lut3DOp::finalize(OptimizationFlags oFlags)
 
     std::ostringstream cacheIDStream;
     cacheIDStream << "<Lut3D ";
-    cacheIDStream << lutData->getCacheID() << " ";
+    cacheIDStream << lutData->getCacheID();
     cacheIDStream << ">";
 
     m_cacheID = cacheIDStream.str();
@@ -302,7 +302,7 @@ ConstOpCPURcPtr Lut3DOp::getCPUOp() const
     return GetLut3DRenderer(data);
 }
 
-void Lut3DOp::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const
+void Lut3DOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
 {
     ConstLut3DOpDataRcPtr lutData = lut3DData();
     if (lutData->getDirection() == TRANSFORM_DIR_INVERSE)
@@ -320,7 +320,7 @@ void Lut3DOp::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const
         lutData = tmp;
     }
 
-    GetLut3DGPUShaderProgram(shaderDesc, lutData);
+    GetLut3DGPUShaderProgram(shaderCreator, lutData);
 }
 }
 

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpData.cpp
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpData.cpp
@@ -34,8 +34,8 @@ Lut3DOpDataRcPtr MakeFastLut3DFromInverse(ConstLut3DOpDataRcPtr & lut)
     LutStyleGuard<Lut3DOpData> guard(*lut);
 
     // Make a domain for the composed Lut3D.
-    // TODO: Using a large number like 48 here is better for accuracy, 
-    // but it causes a delay when creating the renderer. 
+    // TODO: Using a large number like 48 here is better for accuracy,
+    // but it causes a delay when creating the renderer.
     const long GridSize = 48u;
     Lut3DOpDataRcPtr newDomain = std::make_shared<Lut3DOpData>(GridSize);
 
@@ -470,9 +470,15 @@ void Lut3DOpData::finalize()
     md5_finish(&state, digest);
 
     std::ostringstream cacheIDStream;
-    cacheIDStream << GetPrintableHash(digest) << " ";
-    cacheIDStream << InterpolationToString(m_interpolation) << " ";
+    if (!getID().empty())
+    {
+        cacheIDStream << getID() << " ";
+    }
+
+    cacheIDStream << GetPrintableHash(digest)                << " ";
+    cacheIDStream << InterpolationToString(m_interpolation)  << " ";
     cacheIDStream << TransformDirectionToString(m_direction) << " ";
+
     // NB: The m_invQuality is not currently included.
 
     m_cacheID = cacheIDStream.str();

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpGPU.h
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpGPU.h
@@ -12,8 +12,7 @@
 namespace OCIO_NAMESPACE
 {
 
-void GetLut3DGPUShaderProgram(GpuShaderDescRcPtr & shaderDesc,
-                              ConstLut3DOpDataRcPtr & lutData);
+void GetLut3DGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator, ConstLut3DOpDataRcPtr & lutData);
 
 } // namespace OCIO_NAMESPACE
 

--- a/src/OpenColorIO/ops/matrix/MatrixOpData.cpp
+++ b/src/OpenColorIO/ops/matrix/MatrixOpData.cpp
@@ -807,7 +807,10 @@ void MatrixOpData::finalize()
     validate();
 
     std::ostringstream cacheIDStream;
-    cacheIDStream << getID();
+    if (!getID().empty())
+    {
+        cacheIDStream << getID() << " ";
+    }
 
     md5_state_t state;
     md5_byte_t digest[16];
@@ -823,6 +826,7 @@ void MatrixOpData::finalize()
     md5_finish(&state, digest);
 
     cacheIDStream << GetPrintableHash(digest);
+
     m_cacheID = cacheIDStream.str();
 }
 

--- a/src/OpenColorIO/ops/matrix/MatrixOpGPU.cpp
+++ b/src/OpenColorIO/ops/matrix/MatrixOpGPU.cpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "ops/matrix/MatrixOpGPU.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+void GetMatrixGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator, ConstMatrixOpDataRcPtr & matrix)
+{
+    GpuShaderText ss(shaderCreator->getLanguage());
+    ss.indent();
+
+    ss.newLine() << "";
+    ss.newLine() << "// Add a Matrix processing";
+    ss.newLine() << "";
+
+    ArrayDouble::Values values = matrix->getArray().getValues();
+    MatrixOpData::Offsets offs(matrix->getOffsets());
+
+    if (!matrix->isUnityDiagonal())
+    {
+        if (matrix->isDiagonal())
+        {
+            ss.newLine() << shaderCreator->getPixelName() << " = "
+                            << ss.vec4fConst((float)values[0],
+                                            (float)values[5],
+                                            (float)values[10],
+                                            (float)values[15])
+                            << " * " << shaderCreator->getPixelName() << ";";
+        }
+        else
+        {
+            ss.newLine() << shaderCreator->getPixelName() << " = "
+                            << ss.mat4fMul(&values[0], shaderCreator->getPixelName())
+                            << ";";
+        }
+    }
+
+    if (matrix->hasOffsets())
+    {
+        ss.newLine() << shaderCreator->getPixelName() << " = "
+                        << ss.vec4fConst((float)offs[0], (float)offs[1], (float)offs[2], (float)offs[3])
+                        << " + " << shaderCreator->getPixelName() << ";";
+    }
+
+    shaderCreator->addToFunctionShaderCode(ss.string().c_str());
+}
+
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/matrix/MatrixOpGPU.h
+++ b/src/OpenColorIO/ops/matrix/MatrixOpGPU.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#ifndef INCLUDED_OCIO_GPU_MATRIXOP_H
+#define INCLUDED_OCIO_GPU_MATRIXOP_H
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "GpuShaderUtils.h"
+#include "ops/matrix/MatrixOpData.h"
+
+namespace OCIO_NAMESPACE
+{
+
+void GetMatrixGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
+                               ConstMatrixOpDataRcPtr & matrix);
+
+} // namespace OCIO_NAMESPACE
+
+#endif // INCLUDED_OCIO_GPU_MATRIXOP_H
+
+

--- a/src/OpenColorIO/ops/noop/NoOps.cpp
+++ b/src/OpenColorIO/ops/noop/NoOps.cpp
@@ -49,7 +49,7 @@ public:
     void apply(const void * inImg, void * outImg, long numPixels) const override
     { memcpy(outImg, inImg, numPixels * 4 * sizeof(float)); }
 
-    void extractGpuShaderInfo(GpuShaderDescRcPtr & /*shaderDesc*/) const override {}
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & /*shaderCreator*/) const override {}
 
     void getGpuAllocation(AllocationData & allocation) const;
 
@@ -330,7 +330,7 @@ public:
     void apply(const void * inImg, void * outImg, long numPixels) const override
     { memcpy(outImg, inImg, numPixels * 4 * sizeof(float)); }
 
-    void extractGpuShaderInfo(GpuShaderDescRcPtr & /*shaderDesc*/) const override {}
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & /*shaderCreator*/) const override {}
 
 private:
     std::string m_fileReference;
@@ -412,7 +412,7 @@ public:
     void apply(const void * inImg, void * outImg, long numPixels) const override
     { memcpy(outImg, inImg, numPixels * 4 * sizeof(float)); }
 
-    void extractGpuShaderInfo(GpuShaderDescRcPtr & /*shaderDesc*/) const override {}
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & /*shaderCreator*/) const override {}
 
 private:
     std::string m_look;

--- a/src/OpenColorIO/ops/range/RangeOp.cpp
+++ b/src/OpenColorIO/ops/range/RangeOp.cpp
@@ -51,7 +51,7 @@ public:
 
     ConstOpCPURcPtr getCPUOp() const override;
 
-    void extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
 
 protected:
     ConstRangeOpDataRcPtr rangeData() const { return DynamicPtrCast<const RangeOpData>(data()); }
@@ -202,7 +202,7 @@ void RangeOp::finalize(OptimizationFlags /*oFlags*/)
     std::ostringstream cacheIDStream;
     cacheIDStream << "<RangeOp ";
     cacheIDStream << constThis.rangeData()->getCacheID() << " ";
-    cacheIDStream << TransformDirectionToString(m_direction) << " ";
+    cacheIDStream << TransformDirectionToString(m_direction);
     cacheIDStream << ">";
 
     m_cacheID = cacheIDStream.str();
@@ -214,7 +214,7 @@ ConstOpCPURcPtr RangeOp::getCPUOp() const
     return GetRangeRenderer(data);
 }
 
-void RangeOp::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const
+void RangeOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
 {
     if (m_direction != TRANSFORM_DIR_FORWARD)
     {
@@ -222,7 +222,7 @@ void RangeOp::extractGpuShaderInfo(GpuShaderDescRcPtr & shaderDesc) const
     }
 
     ConstRangeOpDataRcPtr data = rangeData();
-    GetRangeGPUShaderProgram(shaderDesc, data);
+    GetRangeGPUShaderProgram(shaderCreator, data);
 }
 
 }  // Anon namespace

--- a/src/OpenColorIO/ops/range/RangeOpCPU.cpp
+++ b/src/OpenColorIO/ops/range/RangeOpCPU.cpp
@@ -181,7 +181,7 @@ void RangeScaleMaxRenderer::apply(const void * inImg, void * outImg, long numPix
 }
 
 // NOTE: Currently there is no way to create the Scale renderer.  If a Range Op
-// has a min or max defined (which is necessary to have an offset), then it clamps.  
+// has a min or max defined (which is necessary to have an offset), then it clamps.
 // If it doesn't, then it is just a bit depth conversion and is therefore an identity.
 // The optimizer currently replaces identities with a scale matrix.
 //

--- a/src/OpenColorIO/ops/range/RangeOpData.cpp
+++ b/src/OpenColorIO/ops/range/RangeOpData.cpp
@@ -545,14 +545,18 @@ void RangeOpData::finalize()
     validate();
 
     std::ostringstream cacheIDStream;
-    cacheIDStream << getID();
+    if (!getID().empty())
+    {
+        cacheIDStream << getID() << " ";
+    }
 
     cacheIDStream.precision(DefaultValues::FLOAT_DECIMALS);
 
-    cacheIDStream << m_minInValue;
-    cacheIDStream << m_maxInValue;
-    cacheIDStream << m_minOutValue;
-    cacheIDStream << m_maxOutValue;
+    cacheIDStream << "[" << m_minInValue
+                  << ", " << m_maxInValue
+                  << ", " << m_minOutValue
+                  << ", " << m_maxOutValue
+                  << "]";
 
     m_cacheID = cacheIDStream.str();
 }

--- a/src/OpenColorIO/ops/range/RangeOpGPU.cpp
+++ b/src/OpenColorIO/ops/range/RangeOpGPU.cpp
@@ -12,10 +12,9 @@
 namespace OCIO_NAMESPACE
 {
 
-void GetRangeGPUShaderProgram(GpuShaderDescRcPtr & shaderDesc,
-                              ConstRangeOpDataRcPtr & range)
+void GetRangeGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator, ConstRangeOpDataRcPtr & range)
 {
-    GpuShaderText ss(shaderDesc->getLanguage());
+    GpuShaderText ss(shaderCreator->getLanguage());
     ss.indent();
 
     ss.newLine() << "";
@@ -29,13 +28,13 @@ void GetRangeGPUShaderProgram(GpuShaderDescRcPtr & shaderDesc,
                 range->getScale(),
                 range->getScale() };
 
-        const double offset[3] 
-            = { range->getOffset(), 
-                range->getOffset(), 
+        const double offset[3]
+            = { range->getOffset(),
+                range->getOffset(),
                 range->getOffset() };
 
-        ss.newLine() << shaderDesc->getPixelName() << ".rgb = "
-                     << shaderDesc->getPixelName() << ".rgb * "
+        ss.newLine() << shaderCreator->getPixelName() << ".rgb = "
+                     << shaderCreator->getPixelName() << ".rgb * "
                      << ss.vec3fConst(scale[0], scale[1], scale[2])
                      << " + "
                      << ss.vec3fConst(offset[0], offset[1], offset[2])
@@ -44,16 +43,16 @@ void GetRangeGPUShaderProgram(GpuShaderDescRcPtr & shaderDesc,
 
     if(!range->minIsEmpty())
     {
-        const double lowerBound[3] 
-            = { range->getMinOutValue(), 
-                range->getMinOutValue(), 
+        const double lowerBound[3]
+            = { range->getMinOutValue(),
+                range->getMinOutValue(),
                 range->getMinOutValue() };
 
-        ss.newLine() << shaderDesc->getPixelName() << ".rgb = "
+        ss.newLine() << shaderCreator->getPixelName() << ".rgb = "
                      << "max(" << ss.vec3fConst(lowerBound[0],
                                                 lowerBound[1],
                                                 lowerBound[2]) << ", "
-                     << shaderDesc->getPixelName()
+                     << shaderCreator->getPixelName()
                      << ".rgb);";
     }
 
@@ -64,15 +63,15 @@ void GetRangeGPUShaderProgram(GpuShaderDescRcPtr & shaderDesc,
                 range->getMaxOutValue(),
                 range->getMaxOutValue() };
 
-        ss.newLine() << shaderDesc->getPixelName() << ".rgb = "
+        ss.newLine() << shaderCreator->getPixelName() << ".rgb = "
             << "min(" << ss.vec3fConst(upperBound[0],
                                        upperBound[1],
                                        upperBound[2]) << ", "
-            << shaderDesc->getPixelName()
+            << shaderCreator->getPixelName()
             << ".rgb);";
     }
 
-    shaderDesc->addToFunctionShaderCode(ss.string().c_str());
+    shaderCreator->addToFunctionShaderCode(ss.string().c_str());
 }
 
 

--- a/src/OpenColorIO/ops/reference/ReferenceOpData.cpp
+++ b/src/OpenColorIO/ops/reference/ReferenceOpData.cpp
@@ -64,7 +64,10 @@ void ReferenceOpData::finalize()
     AutoMutex lock(m_mutex);
 
     std::ostringstream cacheIDStream;
-    cacheIDStream << getID() << " ";
+    if (!getID().empty())
+    {
+        cacheIDStream << getID() << " ";
+    }
 
     cacheIDStream << m_referenceStyle << " ";
     cacheIDStream << TransformDirectionToString(m_direction) << " ";

--- a/src/libutils/oglbuilder/glsl.cpp
+++ b/src/libutils/oglbuilder/glsl.cpp
@@ -272,18 +272,22 @@ void OpenGLBuilder::allocateAllTextures(unsigned startIndex)
     {
         // 1. Get the information of the 3D LUT.
 
-        const char* name = 0x0;
-        const char* uid  = 0x0;
+        const char * textureName = nullptr;
+        const char * samplerName = nullptr;
+        const char * uid         = nullptr;
         unsigned edgelen = 0;
         Interpolation interpolation = INTERP_LINEAR;
-        m_shaderDesc->get3DTexture(idx, name, uid, edgelen, interpolation);
+        m_shaderDesc->get3DTexture(idx, textureName, samplerName, uid, edgelen, interpolation);
 
-        if(!name || !*name || !uid || !*uid || edgelen==0)
+        if(!textureName || !*textureName
+            || !samplerName || !*samplerName
+            || !uid || !*uid
+            || edgelen==0)
         {
             throw Exception("The texture data is corrupted");
         }
 
-        const float* values = 0x0;
+        const float * values = nullptr;
         m_shaderDesc->get3DTextureValues(idx, values);
         if(!values)
         {
@@ -297,7 +301,7 @@ void OpenGLBuilder::allocateAllTextures(unsigned startIndex)
 
         // 3. Keep the texture id & name for the later enabling.
 
-        m_textureIds.push_back(TextureId(texId, name, GL_TEXTURE_3D));
+        m_textureIds.push_back(TextureId(texId, textureName, samplerName, GL_TEXTURE_3D));
 
         currIndex++;
     }
@@ -309,15 +313,19 @@ void OpenGLBuilder::allocateAllTextures(unsigned startIndex)
     {
         // 1. Get the information of the 1D LUT.
 
-        const char* name = 0x0;
-        const char* uid  = 0x0;
+        const char * textureName = nullptr;
+        const char * samplerName = nullptr;
+        const char * uid         = nullptr;
         unsigned width = 0;
         unsigned height = 0;
         GpuShaderDesc::TextureType channel = GpuShaderDesc::TEXTURE_RGB_CHANNEL;
         Interpolation interpolation = INTERP_LINEAR;
-        m_shaderDesc->getTexture(idx, name, uid, width, height, channel, interpolation);
+        m_shaderDesc->getTexture(idx, textureName, samplerName, uid, width, height, channel, interpolation);
 
-        if(!name || !*name || !uid || !*uid || width==0)
+        if (!textureName || !*textureName
+            || !samplerName || !*samplerName
+            || !uid || !*uid
+            || width==0)
         {
             throw Exception("The texture data is corrupted");
         }
@@ -337,7 +345,7 @@ void OpenGLBuilder::allocateAllTextures(unsigned startIndex)
         // 3. Keep the texture id & name for the later enabling.
 
         unsigned type = (height > 1) ? GL_TEXTURE_2D : GL_TEXTURE_1D;
-        m_textureIds.push_back(TextureId(texId, name, type));
+        m_textureIds.push_back(TextureId(texId, textureName, samplerName, type));
         currIndex++;
     }
 }
@@ -345,10 +353,10 @@ void OpenGLBuilder::allocateAllTextures(unsigned startIndex)
 void OpenGLBuilder::deleteAllTextures()
 {
     const size_t max = m_textureIds.size();
-    for(size_t idx=0; idx<max; ++idx)
+    for (size_t idx=0; idx<max; ++idx)
     {
-        const TextureId& data = m_textureIds[idx];
-        glDeleteTextures(1, &data.m_id);
+        const TextureId & data = m_textureIds[idx];
+        glDeleteTextures(1, &data.m_uid);
     }
 
     m_textureIds.clear();
@@ -357,14 +365,14 @@ void OpenGLBuilder::deleteAllTextures()
 void OpenGLBuilder::useAllTextures()
 {
     const size_t max = m_textureIds.size();
-    for(size_t idx=0; idx<max; ++idx)
+    for (size_t idx=0; idx<max; ++idx)
     {
         const TextureId& data = m_textureIds[idx];
         glActiveTexture((GLenum)(GL_TEXTURE0 + m_startIndex + idx));
-        glBindTexture(data.m_type, data.m_id);
+        glBindTexture(data.m_type, data.m_uid);
         glUniform1i(
-            glGetUniformLocation(m_program, 
-                                 data.m_name.c_str()), 
+            glGetUniformLocation(m_program,
+                                 data.m_samplerName.c_str()),
                                  GLint(m_startIndex + idx) );
     }
 }

--- a/src/libutils/oglbuilder/glsl.h
+++ b/src/libutils/oglbuilder/glsl.h
@@ -16,21 +16,26 @@ class OpenGLBuilder;
 typedef OCIO_SHARED_PTR<OpenGLBuilder> OpenGLBuilderRcPtr;
 
 
-// This is a reference implementation showing how to do the texture upload & allocation, 
+// This is a reference implementation showing how to do the texture upload & allocation,
 // and the program compilation for the GLSL shader language.
 
 class OpenGLBuilder
 {
     struct TextureId
     {
-        unsigned m_id = -1;
-        std::string m_name;
-        unsigned m_type = -1;
+        unsigned    m_uid = -1;
+        std::string m_textureName;
+        std::string m_samplerName;
+        unsigned    m_type = -1;
 
-        TextureId(unsigned id, const std::string& name, unsigned type)
-            : m_id(id)
-            , m_name(name)
-            , m_type(type)
+        TextureId(unsigned uid,
+                  const std::string & textureName,
+                  const std::string & samplerName,
+                  unsigned type)
+            :   m_uid(uid)
+            ,   m_textureName(textureName)
+            ,   m_samplerName(samplerName)
+            ,   m_type(type)
         {}
     };
 

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -48,7 +48,7 @@ function(add_ocio_test NAME SOURCES PRIVATE_INCLUDES)
 				XML_STATIC
 		)
 	endif(WIN32)
-	set_target_properties(${TEST_BINARY} PROPERTIES 
+	set_target_properties(${TEST_BINARY} PROPERTIES
 		COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
 
 	add_test(${TEST_NAME} ${TEST_BINARY})
@@ -75,11 +75,14 @@ set(SOURCES
 	md5/md5.cpp
 	OCIOYaml.cpp
 	ops/cdl/CDLOpCPU.cpp
+	ops/cdl/CDLOpGPU.cpp
 	ops/exposurecontrast/ExposureContrastOpGPU.cpp
 	ops/fixedfunction/FixedFunctionOpGPU.cpp
 	ops/gamma/GammaOpCPU.cpp
+	ops/gamma/GammaOpGPU.cpp
 	ops/log/LogOpGPU.cpp
 	ops/lut3d/Lut3DOpGPU.cpp
+	ops/matrix/MatrixOpGPU.cpp
 	ops/OpTools.cpp
 	ops/range/RangeOpGPU.cpp
 	ScanlineHelper.cpp

--- a/tests/cpu/CPUProcessor_tests.cpp
+++ b/tests/cpu/CPUProcessor_tests.cpp
@@ -627,7 +627,7 @@ OCIO_ADD_TEST(CPUProcessor, with_one_1d_lut)
     }
 
     {
-        const std::vector<uint16_t> ui10_inImg 
+        const std::vector<uint16_t> ui10_inImg
             = {     0,     8,    32,
                    64,   128,   256,
                    96,   256,   512,
@@ -675,7 +675,7 @@ OCIO_ADD_TEST(CPUProcessor, with_one_1d_lut)
     }
 
     {
-        const std::vector<uint16_t> ui12_inImg 
+        const std::vector<uint16_t> ui12_inImg
             = {     0,     8,    32,
                    64,   128,   256,
                    96,   256,   512,
@@ -809,15 +809,15 @@ OCIO_ADD_TEST(CPUProcessor, with_several_ops)
 
             auto cpuProcessor = ComputeValues<OCIO::BIT_DEPTH_UINT16,
                                               OCIO::BIT_DEPTH_F32,
-                                              __LINE__>(processor, 
-                                                        &i_inImg[0], OCIO::CHANNEL_ORDERING_RGBA, 
-                                                        &resImg[0],  OCIO::CHANNEL_ORDERING_RGBA, 
+                                              __LINE__>(processor,
+                                                        &i_inImg[0], OCIO::CHANNEL_ORDERING_RGBA,
+                                                        &resImg[0],  OCIO::CHANNEL_ORDERING_RGBA,
                                                         NB_PIXELS, 1e-7f);
 
             const std::string cacheID{ cpuProcessor->getCacheID() };
 
             const std::string expectedID("CPU Processor: from 16ui to 32f oFlags 122879 ops"
-                ": <Lut1D $a57d7444e629d796d2234c18a0539c74 forward default standard domain none >");
+                ": <Lut1D $a57d7444e629d796d2234c18a0539c74 forward default standard domain none>");
 
             // Test integer optimization. The ops should be optimized into a single LUT
             // when finalizing with an integer input bit-depth.
@@ -2078,9 +2078,9 @@ void ComputeImage(unsigned width, unsigned height, unsigned nChannels,
         const float pxl[4]{ (float(inValues[idx+0]) * inScale + (float)offset4[0]) * outScale,
                             (float(inValues[idx+1]) * inScale + (float)offset4[1]) * outScale,
                             (float(inValues[idx+2]) * inScale + (float)offset4[2]) * outScale,
-                            nChannels==4 
-                                ? ((float(inValues[idx+3]) * inScale + (float)offset4[3]) * outScale) 
-                                : 0.0f 
+                            nChannels==4
+                                ? ((float(inValues[idx+3]) * inScale + (float)offset4[3]) * outScale)
+                                : 0.0f
                           };
 
         // Validate all the results.

--- a/tests/cpu/GpuShader_tests.cpp
+++ b/tests/cpu/GpuShader_tests.cpp
@@ -32,8 +32,8 @@ OCIO_ADD_TEST(GpuShader, generic_shader)
 
         OCIO_CHECK_NO_THROW(shaderDesc->finalize());
         const std::string id(shaderDesc->getCacheID());
-        OCIO_CHECK_EQUAL(id, std::string("glsl_1.3 1sd234_ res_1sd234_ pxl_1sd234_ "
-                                         "$159b6ac2bdbbe3b57824faea46bd829b"));
+        OCIO_CHECK_EQUAL(id, std::string("glsl_1.3 1sd234_ res_1sd234_ pxl_1sd234_ 0 "
+                                         "$4dd1c89df8002b409e089089ce8f24e7"));
         OCIO_CHECK_NO_THROW(shaderDesc->setResourcePrefix("res_1"));
         OCIO_CHECK_NO_THROW(shaderDesc->finalize());
         OCIO_CHECK_NE(std::string(shaderDesc->getCacheID()), id);
@@ -49,30 +49,35 @@ OCIO_ADD_TEST(GpuShader, generic_shader)
                 0.1f, 0.2f, 0.3f,  0.4f, 0.5f, 0.6f,  0.7f, 0.8f, 0.9f };
 
         OCIO_CHECK_EQUAL(shaderDesc->getNumTextures(), 0U);
-        OCIO_CHECK_NO_THROW(shaderDesc->addTexture("lut1", "1234", width, height, 
-                                                   OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL, 
+        OCIO_CHECK_NO_THROW(shaderDesc->addTexture("lut1",
+                                                   "lut1Sampler",
+                                                   "1234",
+                                                   width, height,
+                                                   OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL,
                                                    OCIO::INTERP_TETRAHEDRAL,
                                                    &values[0]));
 
         OCIO_CHECK_EQUAL(shaderDesc->getNumTextures(), 1U);
 
-        const char * name = 0x0;
-        const char * id = 0x0;
+        const char * textureName = nullptr;
+        const char * samplerName = nullptr;
+        const char * uid         = nullptr;
         unsigned w = 0;
         unsigned h = 0;
         OCIO::GpuShaderDesc::TextureType t = OCIO::GpuShaderDesc::TEXTURE_RED_CHANNEL;
         OCIO::Interpolation i = OCIO::INTERP_UNKNOWN;
 
-        OCIO_CHECK_NO_THROW(shaderDesc->getTexture(0, name, id, w, h, t, i));
+        OCIO_CHECK_NO_THROW(shaderDesc->getTexture(0, textureName, samplerName, uid, w, h, t, i));
 
-        OCIO_CHECK_EQUAL(std::string(name), "lut1");
-        OCIO_CHECK_EQUAL(std::string(id), "1234");
+        OCIO_CHECK_EQUAL(std::string(textureName), "lut1");
+        OCIO_CHECK_EQUAL(std::string(samplerName), "lut1Sampler");
+        OCIO_CHECK_EQUAL(std::string(uid), "1234");
         OCIO_CHECK_EQUAL(width, w);
         OCIO_CHECK_EQUAL(height, h);
         OCIO_CHECK_EQUAL(OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL, t);
         OCIO_CHECK_EQUAL(OCIO::INTERP_TETRAHEDRAL, i);
 
-        OCIO_CHECK_THROW_WHAT(shaderDesc->getTexture(1, name, id, w, h, t, i),
+        OCIO_CHECK_THROW_WHAT(shaderDesc->getTexture(1, textureName, samplerName, uid, w, h, t, i),
                               OCIO::Exception,
                               "1D LUT access error");
 
@@ -90,8 +95,8 @@ OCIO_ADD_TEST(GpuShader, generic_shader)
 
         // Support several 1D LUTs
 
-        OCIO_CHECK_NO_THROW(shaderDesc->addTexture("lut2", "1234", width, height, 
-                                                   OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL, 
+        OCIO_CHECK_NO_THROW(shaderDesc->addTexture("lut2", "lut2Sampler", "1234", width, height,
+                                                   OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL,
                                                    OCIO::INTERP_TETRAHEDRAL,
                                                    &values[0]));
 
@@ -112,31 +117,33 @@ OCIO_ADD_TEST(GpuShader, generic_shader)
                 0.1f, 0.2f, 0.3f,  0.4f, 0.5f, 0.6f,  0.7f, 0.8f, 0.9f,  0.7f, 0.8f, 0.9f, };
 
         OCIO_CHECK_EQUAL(shaderDesc->getNum3DTextures(), 0U);
-        OCIO_CHECK_NO_THROW(shaderDesc->add3DTexture("lut1", "1234", edgelen, 
+        OCIO_CHECK_NO_THROW(shaderDesc->add3DTexture("lut1", "lut1Sampler", "1234", edgelen,
                                                      OCIO::INTERP_TETRAHEDRAL,
                                                      &values[0]));
 
         OCIO_CHECK_EQUAL(shaderDesc->getNum3DTextures(), 1U);
 
-        const char * name = 0x0;
-        const char * id = 0x0;
+        const char * textureName = nullptr;
+        const char * samplerName = nullptr;
+        const char * uid         = nullptr;
         unsigned e = 0;
         OCIO::Interpolation i = OCIO::INTERP_UNKNOWN;
 
-        OCIO_CHECK_NO_THROW(shaderDesc->get3DTexture(0, name, id, e, i));
+        OCIO_CHECK_NO_THROW(shaderDesc->get3DTexture(0, textureName, samplerName, uid, e, i));
 
-        OCIO_CHECK_EQUAL(std::string(name), "lut1");
-        OCIO_CHECK_EQUAL(std::string(id), "1234");
+        OCIO_CHECK_EQUAL(std::string(textureName), "lut1");
+        OCIO_CHECK_EQUAL(std::string(samplerName), "lut1Sampler");
+        OCIO_CHECK_EQUAL(std::string(uid), "1234");
         OCIO_CHECK_EQUAL(edgelen, e);
         OCIO_CHECK_EQUAL(OCIO::INTERP_TETRAHEDRAL, i);
 
-        OCIO_CHECK_THROW_WHAT(shaderDesc->get3DTexture(1, name, id, e, i),
+        OCIO_CHECK_THROW_WHAT(shaderDesc->get3DTexture(1, textureName, samplerName, uid, e, i),
                               OCIO::Exception,
                               "3D LUT access error");
 
-        const float * vals = 0x0;
+        const float * vals = nullptr;
         OCIO_CHECK_NO_THROW(shaderDesc->get3DTextureValues(0, vals));
-        OCIO_CHECK_NE(vals, 0x0);
+        OCIO_CHECK_ASSERT(vals!=nullptr);
         for(unsigned idx=0; idx<size; ++idx)
         {
             OCIO_CHECK_EQUAL(values[idx], vals[idx]);
@@ -148,7 +155,7 @@ OCIO_ADD_TEST(GpuShader, generic_shader)
 
         // Supports several 3D LUTs
 
-        OCIO_CHECK_NO_THROW(shaderDesc->add3DTexture("lut1", "1234", edgelen, 
+        OCIO_CHECK_NO_THROW(shaderDesc->add3DTexture("lut1", "lut1Sampler", "1234", edgelen,
                                                      OCIO::INTERP_TETRAHEDRAL,
                                                      &values[0]));
 
@@ -156,7 +163,7 @@ OCIO_ADD_TEST(GpuShader, generic_shader)
 
         // Check the 3D LUT limit
 
-        OCIO_CHECK_THROW(shaderDesc->add3DTexture("lut1", "1234", 130,
+        OCIO_CHECK_THROW(shaderDesc->add3DTexture("lut1", "lut1Sampler", "1234", 130,
                                                   OCIO::INTERP_TETRAHEDRAL,
                                                   &values[0]),
                          OCIO::Exception);
@@ -201,21 +208,22 @@ OCIO_ADD_TEST(GpuShader, legacy_shader)
         float values[size];
 
         OCIO_CHECK_EQUAL(shaderDesc->getNumTextures(), 0U);
-        OCIO_CHECK_THROW_WHAT(shaderDesc->addTexture("lut1", "1234", width, height, 
-                                                     OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL, 
+        OCIO_CHECK_THROW_WHAT(shaderDesc->addTexture("lut1", "lut1Sampler", "1234", width, height,
+                                                     OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL,
                                                      OCIO::INTERP_TETRAHEDRAL,
-                                                     &values[0]), 
+                                                     &values[0]),
                               OCIO::Exception,
                               "1D LUTs are not supported");
 
-        const char * name = 0x0;
-        const char * id = 0x0;
+        const char * textureName = nullptr;
+        const char * samplerName = nullptr;
+        const char * uid         = nullptr;
         unsigned w = 0;
         unsigned h = 0;
         OCIO::GpuShaderDesc::TextureType t = OCIO::GpuShaderDesc::TEXTURE_RED_CHANNEL;
         OCIO::Interpolation i = OCIO::INTERP_UNKNOWN;
 
-        OCIO_CHECK_THROW_WHAT(shaderDesc->getTexture(0, name, id, w, h, t, i),
+        OCIO_CHECK_THROW_WHAT(shaderDesc->getTexture(0, textureName, samplerName, uid, w, h, t, i),
                               OCIO::Exception,
                               "1D LUTs are not supported");
     }
@@ -227,25 +235,27 @@ OCIO_ADD_TEST(GpuShader, legacy_shader)
                 0.1f, 0.2f, 0.3f,  0.4f, 0.5f, 0.6f,  0.7f, 0.8f, 0.9f,  0.7f, 0.8f, 0.9f, };
 
         OCIO_CHECK_EQUAL(shaderDesc->getNum3DTextures(), 0U);
-        OCIO_CHECK_NO_THROW(shaderDesc->add3DTexture("lut1", "1234", edgelen, 
+        OCIO_CHECK_NO_THROW(shaderDesc->add3DTexture("lut1", "lut1Sampler", "1234", edgelen,
                                                      OCIO::INTERP_TETRAHEDRAL,
                                                      &values[0]));
 
         OCIO_CHECK_EQUAL(shaderDesc->getNum3DTextures(), 1U);
 
-        const char * name = 0x0;
-        const char * id = 0x0;
+        const char * textureName = nullptr;
+        const char * samplerName = nullptr;
+        const char * uid         = nullptr;
         unsigned e = 0;
         OCIO::Interpolation i = OCIO::INTERP_UNKNOWN;
 
-        OCIO_CHECK_NO_THROW(shaderDesc->get3DTexture(0, name, id, e, i));
+        OCIO_CHECK_NO_THROW(shaderDesc->get3DTexture(0, textureName, samplerName, uid, e, i));
 
-        OCIO_CHECK_EQUAL(std::string(name), "lut1");
-        OCIO_CHECK_EQUAL(std::string(id), "1234");
+        OCIO_CHECK_EQUAL(std::string(textureName), "lut1");
+        OCIO_CHECK_EQUAL(std::string(samplerName), "lut1Sampler");
+        OCIO_CHECK_EQUAL(std::string(uid),         "1234");
         OCIO_CHECK_EQUAL(edgelen, e);
         OCIO_CHECK_EQUAL(OCIO::INTERP_TETRAHEDRAL, i);
 
-        OCIO_CHECK_THROW_WHAT(shaderDesc->get3DTexture(1, name, id, e, i),
+        OCIO_CHECK_THROW_WHAT(shaderDesc->get3DTexture(1, textureName, samplerName, uid, e, i),
                               OCIO::Exception,
                               "3D LUT access error");
 
@@ -263,7 +273,7 @@ OCIO_ADD_TEST(GpuShader, legacy_shader)
 
         // Only one 3D LUT
 
-        OCIO_CHECK_THROW_WHAT(shaderDesc->add3DTexture("lut1", "1234", edgelen, 
+        OCIO_CHECK_THROW_WHAT(shaderDesc->add3DTexture("lut1", "lut1Sampler", "1234", edgelen,
                                                        OCIO::INTERP_TETRAHEDRAL,
                                                        &values[0]),
                               OCIO::Exception,

--- a/tests/cpu/Processor_tests.cpp
+++ b/tests/cpu/Processor_tests.cpp
@@ -25,7 +25,7 @@ OCIO_ADD_TEST(Processor, basic)
     auto processorMat = config->getProcessor(mat);
     OCIO_CHECK_EQUAL(processorMat->getNumTransforms(), 1);
 
-    OCIO_CHECK_EQUAL(std::string(processorMat->getCacheID()), "$c15dfc9b251ee075f33c4ccb3eb1e4b8");
+    OCIO_CHECK_EQUAL(std::string(processorMat->getCacheID()), "$dff619808a13760b73a99db2e19a4dd2");
 }
 
 OCIO_ADD_TEST(Processor, shared_dynamic_properties)

--- a/tests/gpu/GPUUnitTest.cpp
+++ b/tests/gpu/GPUUnitTest.cpp
@@ -400,8 +400,7 @@ namespace
         shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_GLSL_1_3);
 
         // Step 2: Collect the shader program information for a specific processor.
-        OCIO::ConstGPUProcessorRcPtr gpuProcessor
-            = processor->getDefaultGPUProcessor();
+        OCIO::ConstGPUProcessorRcPtr gpuProcessor = processor->getDefaultGPUProcessor();
         gpuProcessor->extractGpuShaderInfo(shaderDesc);
 
         // Step 3: Create the OpenGL builder to prepare the GPU shader program.
@@ -601,7 +600,7 @@ int main(int, char **)
     int argc = 2;
     const char* argv[] = { "main", "-glDebug" };
     glutInit(&argc, const_cast<char**>(&argv[0]));
-    
+
     glutInitDisplayMode(GLUT_RGBA | GLUT_DOUBLE | GLUT_DEPTH);
     glutInitWindowSize(g_winWidth, g_winHeight);
     glutInitWindowPosition(0, 0);

--- a/tests/python/GpuShaderDescTest.py
+++ b/tests/python/GpuShaderDescTest.py
@@ -5,7 +5,7 @@ import unittest, os, sys
 import PyOpenColorIO as OCIO
 
 class GpuShaderDescTest(unittest.TestCase):
-    
+
     def test_interface(self):
         desc = OCIO.GpuShaderDesc()
         desc.setLanguage(OCIO.Constants.GPU_LANGUAGE_GLSL_1_3)
@@ -13,6 +13,6 @@ class GpuShaderDescTest(unittest.TestCase):
         desc.setFunctionName("foo123")
         self.assertEqual("foo123", desc.getFunctionName())
         desc.finalize()
-        self.assertEqual("glsl_1.3 foo123 ocio outColor $159b6ac2bdbbe3b57824faea46bd829b", 
+        self.assertEqual("glsl_1.3 foo123 ocio outColor 0 $4dd1c89df8002b409e089089ce8f24e7",
                          desc.getCacheID())
 


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

The pull request improves the support of the two main use cases when integrating the GPU color transformation in a DCC.
The first one (i.e. currently implemented in `master` and used by `ociodisplay`) is to collect all the information and to call directly OpenGL. The app `ociodisplay` uses the `GpuShaderDesc` helper class to collect the information and the `oglbuilder` library to build the GPU shader program.
The second use case is when a DCC already manages the GPU (through a library abstracting the hardware for example). The latter case only needs to receive requests as a library already implements `GpuShaderDesc` & `oglbuilder`. So, the DCC would implement a custom class inheriting from the new OCIO class `GpuShaderCreator` to use its own library (i.e. no need of `GpuShaderDesc` & `oglbuilder`).

While modifying code around the GPU generation some cleanups were done:
- Improve the 'cacheId' generation,
- Improve the comments in the shader program,
- Refactor some GPU Op code to be consistent with other Ops.
