### PR TITLE
Adsk Contrib - Adjust FileRules API

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -593,6 +593,20 @@ public:
     //    The argument is cloned.
     void setFileRules(ConstFileRulesRcPtr fileRules);
 
+    // !cpp:function:: Get the color space of the first rule that matched filePath.
+    const char * getColorSpaceFromFilepath(const char * filePath) const;
+
+    //!cpp:function:: Most applications will use the preceding method, but this method may be
+    // used for applications that want to know which was the highest priority rule to match
+    // filePath.  The getNumCustomKeys(ruleIndex) and custom keys methods may then be used
+    // to get additional information about the matching rule.
+    const char * getColorSpaceFromFilepath(const char * filePath, size_t & ruleIndex) const;
+
+    // !cpp:function:: Returns true if the only rule matched by filePath is the default rule.
+    // This is a convenience method for applications that want to require the user to manually
+    // choose a color space when strictParsing is true and no other rules match.
+    bool filepathOnlyMatchesDefaultRule(const char * filePath) const;
+
     ///////////////////////////////////////////////////////////////////////////
     //!rst:: .. _cfgprocessors_section:
     //
@@ -680,7 +694,6 @@ private:
     static void deleter(Config* c);
 
     class Impl;
-    friend class Impl;
     Impl * m_impl;
     Impl * getImpl() { return m_impl; }
     const Impl * getImpl() const { return m_impl; }
@@ -829,24 +842,6 @@ public:
     //!cpp:function:: Move a rule closer to the end of the list by one position.
     void decreaseRulePriority(size_t ruleIndex);
 
-    // !cpp:function:: Get the color space of the first rule that matched filePath.
-    const char * getColorSpaceFromFilepath(const Config & config, const char * filePath) const;
-
-    //!cpp:function:: Most applications will use the preceding method, but this method may be
-    // used for applications that want to know which was the highest priority rule to match
-    // filePath.  The getNumCustomKeys(ruleIndex) and custom keys methods may then be used
-    // to get additional information about the matching rule.
-    const char * getColorSpaceFromFilepath(const Config & config, const char * filePath,
-                                           size_t & ruleIndex) const;
-
-    // !cpp:function:: Returns true if the only rule matched by filePath is the default rule.
-    // This is a convenience method for applications that want to require the user to manually
-    // choose a color space when strictParsing is true and no other rules match.
-    bool filepathOnlyMatchesDefaultRule(const Config & config, const char * filePath) const;
-
-    //!cpp:function:: Called by :cpp:func:`Config::sanityCheck`.
-    void validate(const Config & config) const;
-
 private:
     FileRules();
     virtual ~FileRules();
@@ -856,8 +851,9 @@ private:
 
     static void deleter(FileRules* c);
 
+    friend class Config;
+
     class Impl;
-    friend class Impl;
     Impl * m_impl;
     Impl * getImpl() { return m_impl; }
     const Impl * getImpl() const { return m_impl; }
@@ -1032,7 +1028,6 @@ private:
     static void deleter(ColorSpace* c);
 
     class Impl;
-    friend class Impl;
     Impl * m_impl;
     Impl * getImpl() { return m_impl; }
     const Impl * getImpl() const { return m_impl; }
@@ -1121,7 +1116,6 @@ private:
     static void deleter(ColorSpaceSet * c);
 
     class Impl;
-    friend class Impl;
     Impl * m_impl;
     Impl * getImpl() { return m_impl; }
     const Impl * getImpl() const { return m_impl; }
@@ -1199,7 +1193,6 @@ private:
     static void deleter(Look* c);
 
     class Impl;
-    friend class Impl;
     Impl * m_impl;
     Impl * getImpl() { return m_impl; }
     const Impl * getImpl() const { return m_impl; }
@@ -1509,7 +1502,6 @@ private:
     static void deleter(ProcessorMetadata* c);
 
     class Impl;
-    friend class Impl;
     Impl * m_impl;
     Impl * getImpl() { return m_impl; }
     const Impl * getImpl() const { return m_impl; }
@@ -1636,7 +1628,6 @@ private:
     static void deleter(Baker* o);
 
     class Impl;
-    friend class Impl;
     Impl * m_impl;
     Impl * getImpl() { return m_impl; }
     const Impl * getImpl() const { return m_impl; }
@@ -2062,7 +2053,6 @@ protected:
     GpuShaderCreator & operator= (const GpuShaderCreator &) = delete;
 
     class Impl;
-    friend class Impl;
     Impl * m_impl;
     Impl * getImpl() { return m_impl; }
     const Impl * getImpl() const { return m_impl; }
@@ -2364,7 +2354,6 @@ private:
     static void deleter(Context* c);
 
     class Impl;
-    friend class Impl;
     Impl * m_impl;
     Impl * getImpl() { return m_impl; }
     const Impl * getImpl() const { return m_impl; }

--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -598,8 +598,8 @@ public:
 
     //!cpp:function:: Most applications will use the preceding method, but this method may be
     // used for applications that want to know which was the highest priority rule to match
-    // filePath.  The getNumCustomKeys(ruleIndex) and custom keys methods may then be used
-    // to get additional information about the matching rule.
+    // filePath.  The :cpp:func:`FileRules::getNumCustomKeys(ruleIndex)` and custom keys methods
+    // may then be used to get additional information about the matching rule.
     const char * getColorSpaceFromFilepath(const char * filePath, size_t & ruleIndex) const;
 
     // !cpp:function:: Returns true if the only rule matched by filePath is the default rule.

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -16,6 +16,7 @@
 #include "Logging.h"
 #include "LookParse.h"
 #include "Display.h"
+#include "FileRules.h"
 #include "MathUtils.h"
 #include "Mutex.h"
 #include "OpBuilders.h"
@@ -908,7 +909,8 @@ void Config::sanityCheck() const
 
     if (getMajorVersion() >= 2)
     {
-        getImpl()->m_fileRules->validate(*this);
+        auto colorSpaceAccessor = std::bind(&Config::getColorSpace, this, std::placeholders::_1);
+        getImpl()->m_fileRules->getImpl()->sanityCheck(colorSpaceAccessor);
     }
 
     // Everything is groovy.
@@ -1625,6 +1627,22 @@ void Config::setFileRules(ConstFileRulesRcPtr fileRules)
     AutoMutex lock(getImpl()->m_cacheidMutex);
     getImpl()->resetCacheIDs();
 }
+
+const char * Config::getColorSpaceFromFilepath(const char * filePath) const
+{
+    return getImpl()->m_fileRules->getImpl()->getColorSpaceFromFilepath(*this, filePath);
+}
+
+const char * Config::getColorSpaceFromFilepath(const char * filePath, size_t & ruleIndex) const
+{
+    return getImpl()->m_fileRules->getImpl()->getColorSpaceFromFilepath(*this, filePath, ruleIndex);
+}
+
+bool Config::filepathOnlyMatchesDefaultRule(const char * filePath) const
+{
+    return getImpl()->m_fileRules->getImpl()->filepathOnlyMatchesDefaultRule(*this, filePath);
+}
+
 
 ///////////////////////////////////////////////////////////////////////////
 

--- a/src/OpenColorIO/FileRules.h
+++ b/src/OpenColorIO/FileRules.h
@@ -5,6 +5,8 @@
 #ifndef INCLUDED_OCIO_FILERULES_H
 #define INCLUDED_OCIO_FILERULES_H
 
+#include <functional>
+
 #include <OpenColorIO/OpenColorIO.h>
 
 
@@ -26,6 +28,50 @@ constexpr char Regex[]      { "regex" };
 constexpr char CustomKey[]  { "custom" };
 
 }
+
+class FileRule;
+using FileRuleRcPtr = OCIO_SHARED_PTR<FileRule>;
+
+class FileRules::Impl
+{
+public:
+    enum DefaultAllowed
+    {
+        DEFAULT_ALLOWED,
+        DEFAULT_NOT_ALLOWED
+    };
+
+    Impl();
+    Impl(const Impl &) = delete;
+    Impl & operator=(const Impl & rhs);
+    ~Impl() = default;
+
+    const char * getRuleFromFilepath(const Config & config, const char * filePath,
+                                     size_t & ruleIndex) const;
+
+    void validatePosition(size_t ruleIndex, DefaultAllowed allowDefault) const;
+
+    // Throws if ruleIndex or name are invalid.
+    void validateNewRule(size_t ruleIndex, const char * name) const;
+
+    void moveRule(size_t ruleIndex, int offset);
+
+    const char * getColorSpaceFromFilepath(const Config & config, const char * filePath) const;
+
+    const char * getColorSpaceFromFilepath(const Config & config, const char * filePath,
+                                           size_t & ruleIndex) const;
+
+    bool filepathOnlyMatchesDefaultRule(const Config & config, const char * filePath) const;
+
+    void sanityCheck(std::function<ConstColorSpaceRcPtr(const char *)> colorSpaceAccessor) const;
+
+private:
+
+    friend class FileRules;
+
+    // All rules, default rule always at the end.
+    std::vector<FileRuleRcPtr> m_rules;
+};
 
 } // namespace OCIO_NAMESPACE
 

--- a/tests/cpu/FileRules_tests.cpp
+++ b/tests/cpu/FileRules_tests.cpp
@@ -421,266 +421,288 @@ OCIO_ADD_TEST(FileRules, rules_filepattern)
 
     // Add pattern + extension rule.
     OCIO_CHECK_NO_THROW(rules->insertRule(0, g_name, "cs1", "*", "[eE][xX][r]"));
+    config->setFileRules(rules);
 
     size_t rulePosition = 0;
-    rules->getColorSpaceFromFilepath(*config, "/An/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/Arbitrary/Path/MyFile.eXr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/Arbitrary/Path/MyFile.eXr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/Arbitrary/Path/MyFile.EXR", rulePosition);
+    config->getColorSpaceFromFilepath("/An/Arbitrary/Path/MyFile.EXR", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule. R must be lower case.
-    rules->getColorSpaceFromFilepath(*config, "/An/Arbitrary/Path/MyFileexr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/Arbitrary/Path/MyFileexr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/Arbitrary/Path/MyFile.jpeg", rulePosition);
+    config->getColorSpaceFromFilepath("/An/Arbitrary/Path/MyFile.jpeg", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/Arbitrary.exr/Path/MyFileexr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/Arbitrary.exr/Path/MyFileexr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "gamma"));
-    rules->getColorSpaceFromFilepath(*config, "/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*gamma"));
-    rules->getColorSpaceFromFilepath(*config, "/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "gamma*"));
-    rules->getColorSpaceFromFilepath(*config, "/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*gamma*"));
-    rules->getColorSpaceFromFilepath(*config, "/An/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/An/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/GaMma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/GaMma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gammaArbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gammaArbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*ga?ma*"));
-    rules->getColorSpaceFromFilepath(*config, "/An/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/An/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/GaMma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/GaMma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gammaArbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gammaArbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gatmaArbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gatmaArbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gatmaArbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gatmaArbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gatttttttmaArbitrary/Path/MyFile.exr",
-                                     rulePosition);
+    config->getColorSpaceFromFilepath("/An/gatttttttmaArbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gamaArbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gamaArbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*ga*ma*"));
-    rules->getColorSpaceFromFilepath(*config, "/An/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/An/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/GaMma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/GaMma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gammaArbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gammaArbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gatmaArbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gatmaArbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gatmaArbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gatmaArbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gatttttttmaArbitrary/Path/MyFile.exr",
-                                     rulePosition);
+    config->getColorSpaceFromFilepath("/An/gatttttttmaArbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gamaArbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gamaArbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*g?mm*"));
-    rules->getColorSpaceFromFilepath(*config, "/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gImma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gImma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gImmaaa/Arbitrary/Path/MyFile.exr",
-                                     rulePosition);
+    config->getColorSpaceFromFilepath("/An/gImmaaa/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*g*mm*"));
-    rules->getColorSpaceFromFilepath(*config, "/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gImma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gImma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gIIImmaaa/Arbitrary/Path/MyFile.exr",
-                                     rulePosition);
+    config->getColorSpaceFromFilepath("/An/gIIImmaaa/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gmm/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gmm/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*g?m?a*"));
-    rules->getColorSpaceFromFilepath(*config, "/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gImma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gImma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gImIa/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gImIa/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gIIImmaaa/Arbitrary/Path/MyFile.exr",
-                                     rulePosition);
+    config->getColorSpaceFromFilepath("/An/gIIImmaaa/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*g[a]mma*"));
-    rules->getColorSpaceFromFilepath(*config, "/An/gmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/An/gmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gbmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gbmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*g[!a]mma*"));
-    rules->getColorSpaceFromFilepath(*config, "/An/gmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/An/gmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gbmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gbmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*g[abcd]mma*"));
-    rules->getColorSpaceFromFilepath(*config, "/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gbmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gbmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gcmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gcmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gdmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gdmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gemma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gemma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gabmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gabmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*g[!abcd]mma*"));
-    rules->getColorSpaceFromFilepath(*config, "/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gbmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gbmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gcmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gcmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gdmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gdmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gemma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gemma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gabmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gabmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gefmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gefmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*g[a-d]mma*"));
-    rules->getColorSpaceFromFilepath(*config, "/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/An/gamma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gbmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gbmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gcmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gcmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gdmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gdmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "/An/gmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gemma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("/An/gemma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gabmma/Arbitrary/Path/MyFile.exr",
-                                     rulePosition);
+    config->getColorSpaceFromFilepath("/An/gabmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "/An/gefmma/Arbitrary/Path/MyFile.exr",
-                                     rulePosition);
+    config->getColorSpaceFromFilepath("/An/gefmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "g[!a-d]mma*"));
-    rules->getColorSpaceFromFilepath(*config, "gamma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("gamma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "gbmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("gbmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "gcmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("gcmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "gdmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("gdmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "gmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("gmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "gemma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("gemma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "gabmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("gabmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
-    rules->getColorSpaceFromFilepath(*config, "gefmma/Arbitrary/Path/MyFile.exr", rulePosition);
+    config->getColorSpaceFromFilepath("gefmma/Arbitrary/Path/MyFile.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "g[!a-d][\\*][e-g]mma"));
-    rules->getColorSpaceFromFilepath(*config, "ge*fmma.exr", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("ge*fmma.exr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
 
     // Add pattern + extension rule.
     OCIO_CHECK_NO_THROW(rules->insertRule(0, "rule0", "cs1", "*", "jpg"));
-    rules->getColorSpaceFromFilepath(*config, "test.jpg", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("test.jpg", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "test.Jpg", rulePosition);
+    config->getColorSpaceFromFilepath("test.Jpg", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "test.jpG", rulePosition);
+    config->getColorSpaceFromFilepath("test.jpG", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "test.Jpeg", rulePosition);
+    config->getColorSpaceFromFilepath("test.Jpeg", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 2); // Default rule.
 
     OCIO_CHECK_NO_THROW(rules->setExtension(0, "jp[gG]"));
-    rules->getColorSpaceFromFilepath(*config, "test.jpg", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("test.jpg", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "test.jpG", rulePosition);
+    config->getColorSpaceFromFilepath("test.jpG", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
-    rules->getColorSpaceFromFilepath(*config, "test.Jpg", rulePosition);
+    config->getColorSpaceFromFilepath("test.Jpg", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 2); // Default rule.
 
     OCIO_CHECK_NO_THROW(rules->setExtension(0, "[Jj]pg"));
-    rules->getColorSpaceFromFilepath(*config, "/mnt/media/image.Jpg", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/mnt/media/image.Jpg", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
 
     OCIO_CHECK_NO_THROW(rules->setExtension(0, "?pg"));
-    rules->getColorSpaceFromFilepath(*config, "/mnt/media/image.Jpg", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/mnt/media/image.Jpg", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
 
     OCIO_CHECK_NO_THROW(rules->setExtension(0, "jpg"));
-    rules->getColorSpaceFromFilepath(*config, "/mnt/media/image.Jpg", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/mnt/media/image.Jpg", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
 
     OCIO_CHECK_NO_THROW(rules->setExtension(0, "JPG"));
-    rules->getColorSpaceFromFilepath(*config, "/mnt/media/image.Jpg", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/mnt/media/image.Jpg", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
 
     OCIO_CHECK_NO_THROW(rules->setExtension(0, "jp[gG]"));
-    rules->getColorSpaceFromFilepath(*config, "/mnt/media/image.Jpg", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/mnt/media/image.Jpg", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 2);
 
     OCIO_CHECK_NO_THROW(rules->setExtension(0, "?PG"));
-    rules->getColorSpaceFromFilepath(*config, "/mnt/media/image.Jpg", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/mnt/media/image.Jpg", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 2);
 
     OCIO_CHECK_NO_THROW(rules->setExtension(0, "jP*"));
-    rules->getColorSpaceFromFilepath(*config, "/mnt/media/image.Jpg", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/mnt/media/image.Jpg", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 2);
 
     OCIO_CHECK_NO_THROW(rules->setExtension(0, "*g"));
-    rules->getColorSpaceFromFilepath(*config, "/mnt/media/image.Jpg", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/mnt/media/image.Jpg", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*[^]*"));
-    rules->getColorSpaceFromFilepath(*config, "/mnt/me^ia/image.Jpg", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/mnt/me^ia/image.Jpg", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
 
-    rules->getColorSpaceFromFilepath(*config, "/mnt/media/image.Jpg", rulePosition);
+    config->getColorSpaceFromFilepath("/mnt/media/image.Jpg", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 2);
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*(name)*"));
-    rules->getColorSpaceFromFilepath(*config, "/mnt/(name)/image.Jpg", rulePosition);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath("/mnt/(name)/image.Jpg", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
 }
 
@@ -694,21 +716,22 @@ OCIO_ADD_TEST(FileRules, rules_regex)
 
     // Add pattern + extension rule.
     OCIO_CHECK_NO_THROW(rules->insertRule(0, g_name, "cs1", R"((.*)(\bmine\b|\byours\b)(.*))"));
+    config->setFileRules(rules);
 
     size_t rulePosition = 0;
-    rules->getColorSpaceFromFilepath(*config, R"(mnt/mine/media/image.jpg)", rulePosition);
+    config->getColorSpaceFromFilepath(R"(mnt/mine/media/image.jpg)", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
 
-    rules->getColorSpaceFromFilepath(*config, R"(mnt/miner/media/image.jpg)", rulePosition);
+    config->getColorSpaceFromFilepath(R"(mnt/miner/media/image.jpg)", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1);
 
-    rules->getColorSpaceFromFilepath(*config, R"(yours/mnt/media/image.jpg)", rulePosition);
+    config->getColorSpaceFromFilepath(R"(yours/mnt/media/image.jpg)", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
 
-    rules->getColorSpaceFromFilepath(*config, R"(mnt\media\yours\image.jpg)", rulePosition);
+    config->getColorSpaceFromFilepath(R"(mnt\media\yours\image.jpg)", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
 
-    rules->getColorSpaceFromFilepath(*config, R"(mine/media/image.jpg)", rulePosition);
+    config->getColorSpaceFromFilepath(R"(mine/media/image.jpg)", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 0);
 
     // The error details may be different on each platform.
@@ -726,46 +749,55 @@ OCIO_ADD_TEST(FileRules, rules_long_filepattern)
 
     // Add pattern + extension rule.
     OCIO_CHECK_NO_THROW(rules->insertRule(0, g_name, "cs1", "*", "exr"));
+    config->setFileRules(rules);
 
     // The file path existence is not tested
     constexpr char arbitraryPath[] = "/Users/hodoulp/Documents/work/Color Management/ocio-images"
                                      ".1.0v4/spi-vfx/marci_512_srgb.exr";
 
     size_t rulePos = rules->getNumEntries();
-    rules->getColorSpaceFromFilepath(*config, arbitraryPath, rulePos);
+    config->getColorSpaceFromFilepath(arbitraryPath, rulePos);
     OCIO_CHECK_EQUAL(rulePos, 0);
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*Col?r*"));
-    rules->getColorSpaceFromFilepath(*config, arbitraryPath, rulePos);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath(arbitraryPath, rulePos);
     OCIO_CHECK_EQUAL(rulePos, 0);
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*****************************************************"
                                               "*******"));
-    rules->getColorSpaceFromFilepath(*config, arbitraryPath, rulePos);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath(arbitraryPath, rulePos);
     OCIO_CHECK_EQUAL(rulePos, 0);
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*?"));
-    rules->getColorSpaceFromFilepath(*config, arbitraryPath, rulePos);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath(arbitraryPath, rulePos);
     OCIO_CHECK_EQUAL(rulePos, 0);
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "?*"));
-    rules->getColorSpaceFromFilepath(*config, arbitraryPath, rulePos);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath(arbitraryPath, rulePos);
     OCIO_CHECK_EQUAL(rulePos, 0);
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "?*"));
-    rules->getColorSpaceFromFilepath(*config, arbitraryPath, rulePos);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath(arbitraryPath, rulePos);
     OCIO_CHECK_EQUAL(rulePos, 0);
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*?*"));
-    rules->getColorSpaceFromFilepath(*config, arbitraryPath, rulePos);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath(arbitraryPath, rulePos);
     OCIO_CHECK_EQUAL(rulePos, 0);
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*.1.0v4*"));
-    rules->getColorSpaceFromFilepath(*config, arbitraryPath, rulePos);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath(arbitraryPath, rulePos);
     OCIO_CHECK_EQUAL(rulePos, 0);
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "*.1.*"));
-    rules->getColorSpaceFromFilepath(*config, arbitraryPath, rulePos);
+    config->setFileRules(rules);
+    config->getColorSpaceFromFilepath(arbitraryPath, rulePos);
     OCIO_CHECK_EQUAL(rulePos, 0);
 }
 
@@ -778,32 +810,33 @@ OCIO_ADD_TEST(FileRules, rules_test)
     auto rules = config->getFileRules()->createEditableCopy();
     rules->insertRule(0, OCIO::FileRuleUtils::ParseName, nullptr, nullptr);
     rules->insertRule(1, "dpx file", "raw", "", "dpx");
+    config->setFileRules(rules);
 
     size_t rulePos = 0;
     const char * colorSpace;
-    colorSpace = rules->getColorSpaceFromFilepath(*config, "/mnt/user/show/img_cs1.dpx", rulePos);
+    colorSpace = config->getColorSpaceFromFilepath("/mnt/user/show/img_cs1.dpx", rulePos);
     OCIO_CHECK_EQUAL(rulePos, 0);
     OCIO_CHECK_ASSERT(colorSpace != nullptr && 0 == strcmp(colorSpace, "cs1"));
 
-    colorSpace = rules->getColorSpaceFromFilepath(*config, "show/cs2/img_cs1.exr", rulePos);
+    colorSpace = config->getColorSpaceFromFilepath("show/cs2/img_cs1.exr", rulePos);
     OCIO_CHECK_EQUAL(rulePos, 0);
     // The first color space name from the right.
     OCIO_CHECK_ASSERT(colorSpace != nullptr && 0 == strcmp(colorSpace, "cs1"));
 
-    colorSpace = rules->getColorSpaceFromFilepath(*config, "show/cs1/img_other_cs1.exr", rulePos);
+    colorSpace = config->getColorSpaceFromFilepath("show/cs1/img_other_cs1.exr", rulePos);
     OCIO_CHECK_EQUAL(rulePos, 0);
     // If there are 2 cs names ending the same position, the longest is used.
     OCIO_CHECK_ASSERT(colorSpace != nullptr && 0 == strcmp(colorSpace, "other_cs1"));
 
-    colorSpace = rules->getColorSpaceFromFilepath(*config, "show/other_cs1/img_cs1.exr", rulePos);
+    colorSpace = config->getColorSpaceFromFilepath("show/other_cs1/img_cs1.exr", rulePos);
     OCIO_CHECK_EQUAL(rulePos, 0);
     OCIO_CHECK_ASSERT(colorSpace != nullptr && 0 == strcmp(colorSpace, "cs1"));
 
-    colorSpace = rules->getColorSpaceFromFilepath(*config, "/mnt/user/unknown.dpx", rulePos);
+    colorSpace = config->getColorSpaceFromFilepath("/mnt/user/unknown.dpx", rulePos);
     OCIO_CHECK_EQUAL(rulePos, 1);
     OCIO_CHECK_ASSERT(colorSpace != nullptr && 0 == strcmp(colorSpace, "raw"));
 
-    colorSpace = rules->getColorSpaceFromFilepath(*config, "/mnt/user/unknown.jpg", rulePos);
+    colorSpace = config->getColorSpaceFromFilepath("/mnt/user/unknown.jpg", rulePos);
     OCIO_CHECK_EQUAL(rulePos, 2); // The default rule. 
     OCIO_CHECK_ASSERT(colorSpace != nullptr && 0 == strcmp(colorSpace, OCIO::ROLE_DEFAULT));
 }
@@ -818,22 +851,23 @@ OCIO_ADD_TEST(FileRules, rules_priority)
     rules->insertRule(0, "pattern dpx file", "raw", "*cs2*", "dpx");
     rules->insertRule(1, OCIO::FileRuleUtils::ParseName, nullptr, nullptr);
     rules->insertRule(2, "regex rule", "cs5", ".*cs5.dpx");
+    config->setFileRules(rules);
 
     size_t rulePos = 0;
     const char * colorSpace;
-    colorSpace = rules->getColorSpaceFromFilepath(*config, "/mnt/media/cs2.dpx", rulePos);
+    colorSpace = config->getColorSpaceFromFilepath("/mnt/media/cs2.dpx", rulePos);
     OCIO_CHECK_EQUAL(rulePos, 0);
     OCIO_CHECK_ASSERT(colorSpace != nullptr && 0 == strcmp(colorSpace, "raw"));
 
-    colorSpace = rules->getColorSpaceFromFilepath(*config, "/mnt/media/cs2.exr", rulePos);
+    colorSpace = config->getColorSpaceFromFilepath("/mnt/media/cs2.exr", rulePos);
     OCIO_CHECK_EQUAL(rulePos, 1);
     OCIO_CHECK_ASSERT(colorSpace != nullptr && 0 == strcmp(colorSpace, "cs2"));
 
-    colorSpace = rules->getColorSpaceFromFilepath(*config, "/mnt/media/cs5.dpx", rulePos);
+    colorSpace = config->getColorSpaceFromFilepath("/mnt/media/cs5.dpx", rulePos);
     OCIO_CHECK_EQUAL(rulePos, 2);
     OCIO_CHECK_ASSERT(colorSpace != nullptr && 0 == strcmp(colorSpace, "cs5"));
 
-    colorSpace = rules->getColorSpaceFromFilepath(*config, "/mnt/media/cs5.DPX", rulePos);
+    colorSpace = config->getColorSpaceFromFilepath("/mnt/media/cs5.DPX", rulePos);
     OCIO_CHECK_EQUAL(rulePos, 3);
     OCIO_CHECK_ASSERT(colorSpace != nullptr && 0 == strcmp(colorSpace, OCIO::ROLE_DEFAULT));
 }


### PR DESCRIPTION
FileRules was exposing some functions that were using a reference to a Config. This was not aligned with other API functions. These have been removed from the API.
Functions are now part of Config.

Signed-off-by: Bernard Lefebvre <bernard.lefebvre@autodesk.com>