### PR TITLE
Adsk Contrib - Add the Display reference space

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -353,11 +353,15 @@ public:
     //
     ColorSpaceSetRcPtr getColorSpaces(const char * category) const;
 
-    //!cpp:function:: Work on the color spaces selected by the visibility.
-    int getNumColorSpaces(ColorSpaceVisibility visibility) const;
-    //!cpp:function:: Work on the color spaces selected by the visibility (active or inactive)
-    // and return null for invalid index.
-    const char * getColorSpaceNameByIndex(ColorSpaceVisibility visibility, int index) const;
+    //!cpp:function:: Work on the color spaces selected by the reference color space type
+    // and visibility.
+    int getNumColorSpaces(SearchReferenceSpaceType searchReferenceType,
+                          ColorSpaceVisibility visibility) const;
+
+    //!cpp:function:: Work on the color spaces selected by the reference color space type
+    // and visibility (active or inactive). Return empty for invalid index.
+    const char * getColorSpaceNameByIndex(SearchReferenceSpaceType searchReferenceType,
+                                          ColorSpaceVisibility visibility, int index) const;
 
     //!cpp:function:: Get the color space from all the color spaces
     // (i.e. active and inactive) and return null if the name is not found.
@@ -440,7 +444,6 @@ public:
     //!cpp:function::
     const char * getInactiveColorSpaces() const;
 
-
     ///////////////////////////////////////////////////////////////////////////
     //!rst:: .. _cfgroles_section:
     //
@@ -488,17 +491,23 @@ public:
     //!cpp:function::
     const char * getView(const char * display, int index) const;
 
-    //!cpp:function::
+    //!cpp:function:: Returns the view_transform attribute of the (display, view) pair.
+    const char * getDisplayViewTransformName(const char * display, const char * view) const;
+    //!cpp:function:: Returns the colorspace attribute of the (display, view) pair.
+    // (Note that this may be either a color space or a display color space.)
     const char * getDisplayColorSpaceName(const char * display, const char * view) const;
-    //!cpp:function::
+    //!cpp:function:: Returns the looks attribute of a (display, view) pair.
     const char * getDisplayLooks(const char * display, const char * view) const;
 
-    //!cpp:function:: For the (display,view) combination,
-    // specify which colorSpace and look to use.
+    //!cpp:function:: For the (display, view) pair, specify which color space and look to use.
     // If a look is not desired, then just pass an empty string
-
     void addDisplay(const char * display, const char * view,
                     const char * colorSpaceName, const char * looks);
+
+    //!cpp:function:: For the (display, view) pair, specify a viewTransform + displayColorSpace
+    // to use.  (Looks work the same as above.)
+    void addDisplay(const char * display, const char * view, const char * viewTransform,
+                    const char * displayColorSpaceName, const char * looks);
 
     //!cpp:function::
     void clearDisplays();
@@ -526,7 +535,6 @@ public:
     void setActiveViews(const char * views);
     //!cpp:function::
     const char * getActiveViews() const;
-
 
     ///////////////////////////////////////////////////////////////////////////
     //!rst:: .. _cfgluma_section:
@@ -578,6 +586,35 @@ public:
 
 
     ///////////////////////////////////////////////////////////////////////////
+    //!rst:: .. _cfgview_transforms_section:
+    //
+    // View Transforms
+    // ^^^^^^^^^^^^^^^
+    //
+    // :cpp:class:`ViewTransform` objects are used with the display reference space.
+
+    //!cpp:function::
+    int getNumViewTransforms() const noexcept;
+
+    //!cpp:function::
+    ConstViewTransformRcPtr getViewTransform(const char * name) const noexcept;
+
+    //!cpp:function::
+    const char * getViewTransformNameByIndex(int i) const noexcept;
+
+    //!cpp:function::
+    void addViewTransform(const ConstViewTransformRcPtr & viewTransform);
+
+    //!cpp:function:: The default transform to use for scene-referred to display-referred
+    // reference space conversions is the first scene-referred view transform listed in
+    // that section of the config (the one with the lowest index).  Returns a null
+    // ConstTransformRcPtr if there isn't one.
+    ConstViewTransformRcPtr getDefaultSceneToDisplayViewTransform() const;
+
+    //!cpp:function::
+    void clearViewTransforms();
+
+    ///////////////////////////////////////////////////////////////////////////
     //!rst:: .. _cfgfilerules_section:
     // 
     // File Rules
@@ -603,6 +640,9 @@ public:
     // color spaces.  It may then be used to create a :cpp:class:`CPUProcessor`
     // or :cpp:class:`GPUProcessor` to process/convert pixels.
 
+    //!rst:: Get the processor to apply a ColorSpaceTransform from a source to a destination
+    // color space.
+
     //!cpp:function::
     ConstProcessorRcPtr getProcessor(const ConstContextRcPtr & context,
                                         const ConstColorSpaceRcPtr & srcColorSpace,
@@ -620,6 +660,17 @@ public:
     ConstProcessorRcPtr getProcessor(const ConstContextRcPtr & context,
                                         const char * srcName,
                                         const char * dstName) const;
+
+    //!rst:: Get the processor to apply a DisplayTransform for a display and view.  Refer to the
+    // Display/View Registration section above for more info on the display and view arguments.
+
+    //!cpp:function::
+    ConstProcessorRcPtr getProcessor(const char * inputColorSpaceName,
+                                     const char * display, const char * view) const;
+    //!cpp:function::
+    ConstProcessorRcPtr getProcessor(const ConstContextRcPtr & context,
+                                     const char * inputColorSpaceName,
+                                     const char * display, const char * view) const;
 
     //!rst:: Get the processor for the specified transform.
     //
@@ -753,7 +804,7 @@ class FileRules
 {
 public:
     //!cpp:function:: Creates FileRules for a Config. File rules will contain the default rule
-    // using the default role. The default rule can not be removed.
+    // using the default role. The default rule cannot be removed.
     static FileRulesRcPtr Create();
 
     //!cpp:function:: The method clones the content decoupling the two instances.
@@ -890,6 +941,9 @@ public:
     static ColorSpaceRcPtr Create();
 
     //!cpp:function::
+    static ColorSpaceRcPtr Create(ReferenceSpaceType referenceSpace);
+
+    //!cpp:function::
     ColorSpaceRcPtr createEditableCopy() const;
 
     //!cpp:function::
@@ -953,7 +1007,7 @@ public:
     //!cpp:function:: Return the category name using its index
     // .. note:: Will be null if the index is invalid.
     const char * getCategory(int index) const;
-    // Clear all the categories.
+    //!cpp:function:: Clear all the categories.
     void clearCategories();
 
     ///////////////////////////////////////////////////////////////////////////
@@ -973,6 +1027,9 @@ public:
     bool isData() const;
     //!cpp:function::
     void setIsData(bool isData);
+
+    //!cpp:function:: A display color space will use the display-referred reference space.
+    ReferenceSpaceType getReferenceSpaceType() const;
 
     ///////////////////////////////////////////////////////////////////////////
     //!rst::
@@ -1023,6 +1080,7 @@ public:
                         ColorSpaceDirection dir);
 
 private:
+    ColorSpace(ReferenceSpaceType referenceSpace);
     ColorSpace();
     ~ColorSpace();
 
@@ -1207,6 +1265,91 @@ private:
 
 extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const Look&);
 
+///////////////////////////////////////////////////////////////////////////
+//!rst:: .. _view_transform_section:
+//
+// ViewTransform
+// *************
+// A *ViewTransform* provides a conversion from the main (usually scene-referred) reference space
+// to the display-referred reference space.  This allows splitting the conversion from the main
+// reference space to a display into two parts: the ViewTransform plus a display color space.
+//
+// It is also possible to provide a ViewTransform that converts from the display-referred
+// reference space back to that space.  This is useful in cases when a ViewTransform is needed
+// when converting between displays (such as HDR to SDR).
+//
+// The ReferenceSpaceType indicates whether the ViewTransform converts from scene-to-display
+// reference or display-to-display reference.
+//
+// The from_reference transform direction is the one that is used when going out towards a display.
+
+//!cpp:class::
+class OCIOEXPORT ViewTransform
+{
+public:
+    //!cpp:function::
+    static ViewTransformRcPtr Create(ReferenceSpaceType referenceSpace);
+
+    //!cpp:function::
+    ViewTransformRcPtr createEditableCopy() const;
+
+    //!cpp:function::
+    const char * getName() const noexcept;
+    //!cpp:function::
+    void setName(const char * name) noexcept;
+
+    //!cpp:function:: See :cpp:func:`ColorSpace::getFamily`.
+    const char * getFamily() const noexcept;
+    //!cpp:function:: See :cpp:func:`ColorSpace::setFamily`.
+    void setFamily(const char * family);
+
+    //!cpp:function::
+    const char * getDescription() const noexcept;
+    //!cpp:function::
+    void setDescription(const char * description);
+
+    //!cpp:function:: See :cpp:func:`ColorSpace::hasCategory`.
+    bool hasCategory(const char * category) const;
+    //!cpp:function:: See :cpp:func:`ColorSpace::addCategory`.
+    void addCategory(const char * category);
+    //!cpp:function:: See :cpp:func:`ColorSpace::removeCategory`.
+    void removeCategory(const char * category);
+    //!cpp:function:: See :cpp:func:`ColorSpace::getNumCategories`.
+    int getNumCategories() const;
+    //!cpp:function:: See :cpp:func:`ColorSpace::getCategory`.
+    const char * getCategory(int index) const;
+    //!cpp:function:: See :cpp:func:`ColorSpace::clearCategories`.
+    void clearCategories();
+
+    //!cpp:function::
+    ReferenceSpaceType getReferenceSpaceType() const noexcept;
+
+    //!cpp:function:: If a transform in the specified direction has been specified, return it.
+    // Otherwise return a null ConstTransformRcPtr
+    ConstTransformRcPtr getTransform(ViewTransformDirection dir) const;
+
+    //!cpp:function:: Specify the transform for the appropriate direction. Setting the transform
+    // to null will clear it.
+    void setTransform(const ConstTransformRcPtr & transform, ViewTransformDirection dir);
+
+private:
+    ViewTransform();
+    ViewTransform(ReferenceSpaceType referenceSpace);
+    ~ViewTransform();
+
+    ViewTransform(const ViewTransform &) = delete;
+    ViewTransform & operator= (const ViewTransform &) = delete;
+
+    static void deleter(ViewTransform * c);
+
+    class Impl;
+    friend class Impl;
+    Impl * m_impl;
+    Impl * getImpl() { return m_impl; }
+    const Impl * getImpl() const { return m_impl; }
+};
+
+extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const ViewTransform&);
 
 ///////////////////////////////////////////////////////////////////////////
 //!rst::

--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -59,6 +59,12 @@ typedef OCIO_SHARED_PTR<const Look> ConstLookRcPtr;
 //!cpp:type::
 typedef OCIO_SHARED_PTR<Look> LookRcPtr;
 
+class OCIOEXPORT ViewTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const ViewTransform> ConstViewTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<ViewTransform> ViewTransformRcPtr;
+
 class OCIOEXPORT Context;
 //!cpp:type::
 typedef OCIO_SHARED_PTR<const Context> ConstContextRcPtr;
@@ -264,6 +270,34 @@ enum LoggingLevel
     LOGGING_LEVEL_DEFAULT = LOGGING_LEVEL_INFO
 };
 
+//!cpp:type:: OCIO does not mandate the image state of the main reference space and it is not
+// required to be scene-referred.  This enum is used in connection with the display color space
+// and view transform features which do assume that the main reference space is scene-referred
+// and the display reference space is display-referred.  If a config used a non-scene-referred
+// reference space, presumably it would not use either display color spaces or view transforms,
+// so this enum becomes irrelevant.
+enum ReferenceSpaceType
+{
+    REFERENCE_SPACE_SCENE = 0,  // the main scene reference space
+    REFERENCE_SPACE_DISPLAY     // the reference space for display color spaces
+};
+
+//!cpp:type::
+enum SearchReferenceSpaceType
+{
+    SEARCH_REFERENCE_SPACE_SCENE = 0,
+    SEARCH_REFERENCE_SPACE_DISPLAY,
+    SEARCH_REFERENCE_SPACE_ALL
+};
+
+//!cpp:type::
+enum ColorSpaceVisibility
+{
+    COLORSPACE_ACTIVE = 0,
+    COLORSPACE_INACTIVE,
+    COLORSPACE_ALL
+};
+
 //!cpp:type::
 enum ColorSpaceDirection
 {
@@ -273,11 +307,11 @@ enum ColorSpaceDirection
 };
 
 //!cpp:type::
-enum ColorSpaceVisibility
+enum ViewTransformDirection
 {
-    COLORSPACE_ACTIVE = 0,
-    COLORSPACE_INACTIVE,
-    COLORSPACE_ALL
+    VIEWTRANSFORM_DIR_UNKNOWN = 0,
+    VIEWTRANSFORM_DIR_TO_REFERENCE,
+    VIEWTRANSFORM_DIR_FROM_REFERENCE
 };
 
 //!cpp:type::

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -125,6 +125,7 @@ set(SOURCES
 	transforms/Lut3DTransform.cpp
 	transforms/MatrixTransform.cpp
 	transforms/RangeTransform.cpp
+	ViewTransform.cpp
 )
 
 if(WIN32 AND BUILD_SHARED_LIBS)

--- a/src/OpenColorIO/Categories.h
+++ b/src/OpenColorIO/Categories.h
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#ifndef INCLUDED_OCIO_CATEGORIES_H
+#define INCLUDED_OCIO_CATEGORIES_H
+
+#include <cstring>
+#include <vector>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "PrivateTypes.h"
+#include "pystring/pystring.h"
+
+namespace OCIO_NAMESPACE
+{
+
+class CategoriesManager
+{
+public:
+    CategoriesManager() = default;
+    CategoriesManager(const CategoriesManager &) = delete;
+    virtual ~CategoriesManager() = default;
+    CategoriesManager & operator=(const CategoriesManager &) = default;
+
+    typedef StringVec Categories;
+
+    Categories::const_iterator findCategory(const char * category) const
+    {
+        if (!category || !*category) return m_categories.end();
+
+        // NB: Categories are not case-sensitive and whitespace is stripped.
+        const std::string ref(pystring::strip(pystring::lower(category)));
+
+        for (auto itr = m_categories.begin(); itr != m_categories.end(); ++itr)
+        {
+            if (pystring::strip(pystring::lower(*itr)) == ref)
+            {
+                return itr;
+            }
+        }
+
+        return m_categories.end();
+    }
+
+    bool hasCategory(const char * category) const
+    {
+        return findCategory(category) != m_categories.end();
+    }
+
+    void addCategory(const char * category)
+    {
+        if (findCategory(category) == m_categories.end())
+        {
+            m_categories.push_back(pystring::strip(category));
+        }
+    }
+
+    void removeCategory(const char * category)
+    {
+        if (!category || !*category) return;
+
+        // NB: Categories are not case-sensitive and whitespace is stripped.
+        const std::string ref(pystring::strip(pystring::lower(category)));
+
+        for (auto itr = m_categories.begin(); itr != m_categories.end(); ++itr)
+        {
+            if (pystring::strip(pystring::lower(*itr)) == ref)
+            {
+                m_categories.erase(itr);
+                return;
+            }
+        }
+
+        return;
+    }
+
+    int getNumCategories() const
+    {
+        return static_cast<int>(m_categories.size());
+    }
+
+    const char * getCategory(int index) const
+    {
+        if (index<0 || index >= (int)m_categories.size()) return nullptr;
+
+        return m_categories[index].c_str();
+    }
+
+    void clearCategories()
+    {
+        m_categories.clear();
+    }
+
+protected:
+    Categories m_categories;
+};
+
+} // namespace OCIO_NAMESPACE
+
+#endif

--- a/src/OpenColorIO/ColorSpace.cpp
+++ b/src/OpenColorIO/ColorSpace.cpp
@@ -281,15 +281,16 @@ std::ostream & operator<< (std::ostream & os, const ColorSpace & cs)
     std::vector<float> vars(numVars);
     cs.getAllocationVars(&vars[0]);
 
-    const auto refType = cs.getReferenceSpaceType();
+    os << "<ColorSpace referenceSpaceType=";
 
+    const auto refType = cs.getReferenceSpaceType();
     switch (refType)
     {
     case REFERENCE_SPACE_SCENE:
-        os << "<ColorSpace ";
+        os << "scene, ";
         break;
     case REFERENCE_SPACE_DISPLAY:
-        os << "<DisplayColorSpace ";
+        os << "display, ";
         break;
     }
     os << "name=" << cs.getName() << ", ";

--- a/src/OpenColorIO/ColorSpace.cpp
+++ b/src/OpenColorIO/ColorSpace.cpp
@@ -7,23 +7,15 @@
 
 #include <OpenColorIO/OpenColorIO.h>
 
+#include "Categories.h"
 #include "PrivateTypes.h"
 #include "pystring/pystring.h"
 
 
 namespace OCIO_NAMESPACE
 {
-ColorSpaceRcPtr ColorSpace::Create()
-{
-    return ColorSpaceRcPtr(new ColorSpace(), &deleter);
-}
 
-void ColorSpace::deleter(ColorSpace* c)
-{
-    delete c;
-}
-
-class ColorSpace::Impl
+class ColorSpace::Impl : public CategoriesManager
 {
 public:
     std::string m_name;
@@ -31,33 +23,32 @@ public:
     std::string m_equalityGroup;
     std::string m_description;
 
-    BitDepth m_bitDepth;
-    bool m_isData;
+    BitDepth m_bitDepth{ BIT_DEPTH_UNKNOWN };
+    bool m_isData{ false };
 
-    Allocation m_allocation;
+    ReferenceSpaceType m_referenceSpaceType{ REFERENCE_SPACE_SCENE };
+
+    Allocation m_allocation{ ALLOCATION_UNIFORM };
     std::vector<float> m_allocationVars;
 
     TransformRcPtr m_toRefTransform;
     TransformRcPtr m_fromRefTransform;
 
-    bool m_toRefSpecified;
-    bool m_fromRefSpecified;
+    bool m_toRefSpecified{ false };
+    bool m_fromRefSpecified{ false };
 
-    typedef StringVec Categories;
-    Categories m_categories;
-
-    Impl() :
-        m_bitDepth(BIT_DEPTH_UNKNOWN),
-        m_isData(false),
-        m_allocation(ALLOCATION_UNIFORM),
-        m_toRefSpecified(false),
-        m_fromRefSpecified(false)
-    { }
+    Impl() = delete;
+    Impl(ReferenceSpaceType referenceSpace)
+        : CategoriesManager()
+        , m_referenceSpaceType(referenceSpace)
+    {
+    }
 
     Impl(const Impl &) = delete;
 
     ~Impl()
-    { }
+    {
+    }
 
     Impl& operator= (const Impl & rhs)
     {
@@ -69,6 +60,7 @@ public:
             m_description = rhs.m_description;
             m_bitDepth = rhs.m_bitDepth;
             m_isData = rhs.m_isData;
+            m_referenceSpaceType = rhs.m_referenceSpaceType;
             m_allocation = rhs.m_allocation;
             m_allocationVars = rhs.m_allocationVars;
 
@@ -88,58 +80,36 @@ public:
         return *this;
     }
 
-    Categories::const_iterator findCategory(const char * category) const
-    {
-        if(!category || !*category) return m_categories.end();
-
-        // NB: Categories are not case-sensitive and whitespace is stripped.
-        const std::string ref(pystring::strip(pystring::lower(category)));
-
-        for(auto itr = m_categories.begin(); itr!=m_categories.end(); ++itr)
-        {
-            if(pystring::strip(pystring::lower(*itr))==ref)
-            {
-                return itr;
-            }
-        }
-
-        return m_categories.end();
-    }
-
-    void removeCategory(const char * category)
-    {
-        if(!category || !*category) return;
-
-        // NB: Categories are not case-sensitive and whitespace is stripped.
-        const std::string ref(pystring::strip(pystring::lower(category)));
-
-        for(auto itr = m_categories.begin(); itr!=m_categories.end(); ++itr)
-        {
-            if(pystring::strip(pystring::lower(*itr))==ref)
-            {
-                m_categories.erase(itr);
-                return;
-            }
-        }
-
-        return;
-    }
 };
 
 
 ///////////////////////////////////////////////////////////////////////////
 
+ColorSpaceRcPtr ColorSpace::Create()
+{
+    return ColorSpaceRcPtr(new ColorSpace(REFERENCE_SPACE_SCENE), &deleter);
+}
 
+void ColorSpace::deleter(ColorSpace* c)
+{
+    delete c;
+}
 
-ColorSpace::ColorSpace()
-: m_impl(new ColorSpace::Impl)
+ColorSpaceRcPtr ColorSpace::Create(ReferenceSpaceType referenceSpace)
+{
+    auto cs = ColorSpaceRcPtr(new ColorSpace(referenceSpace), &deleter);
+    return cs;
+}
+
+ColorSpace::ColorSpace(ReferenceSpaceType referenceSpace)
+: m_impl(new ColorSpace::Impl(referenceSpace))
 {
 }
 
 ColorSpace::~ColorSpace()
 {
     delete m_impl;
-    m_impl = NULL;
+    m_impl = nullptr;
 }
 
 ColorSpaceRcPtr ColorSpace::createEditableCopy() const
@@ -158,6 +128,7 @@ void ColorSpace::setName(const char * name)
 {
     getImpl()->m_name = name;
 }
+
 const char * ColorSpace::getFamily() const noexcept
 {
     return getImpl()->m_family.c_str();
@@ -200,17 +171,12 @@ void ColorSpace::setBitDepth(BitDepth bitDepth)
 
 bool ColorSpace::hasCategory(const char * category) const
 {
-    return getImpl()->findCategory(category)
-        != getImpl()->m_categories.end();
+    return getImpl()->hasCategory(category);
 }
 
 void ColorSpace::addCategory(const char * category)
 {
-    if(getImpl()->findCategory(category) 
-        == getImpl()->m_categories.end())
-    {
-        getImpl()->m_categories.push_back(pystring::strip(category));
-    }
+    getImpl()->addCategory(category);
 }
 
 void ColorSpace::removeCategory(const char * category)
@@ -220,19 +186,17 @@ void ColorSpace::removeCategory(const char * category)
 
 int ColorSpace::getNumCategories() const
 {
-    return static_cast<int>(getImpl()->m_categories.size());
+    return getImpl()->getNumCategories();
 }
 
 const char * ColorSpace::getCategory(int index) const
 {
-    if(index<0 || index>=(int)getImpl()->m_categories.size()) return nullptr;
-
-    return getImpl()->m_categories[index].c_str();
+    return getImpl()->getCategory(index);
 }
 
 void ColorSpace::clearCategories()
 {
-    getImpl()->m_categories.clear();
+    getImpl()->clearCategories();
 }
 
 bool ColorSpace::isData() const
@@ -243,6 +207,11 @@ bool ColorSpace::isData() const
 void ColorSpace::setIsData(bool val)
 {
     getImpl()->m_isData = val;
+}
+
+ReferenceSpaceType ColorSpace::getReferenceSpaceType() const
+{
+    return getImpl()->m_referenceSpaceType;
 }
 
 Allocation ColorSpace::getAllocation() const
@@ -306,13 +275,23 @@ void ColorSpace::setTransform(const ConstTransformRcPtr & transform,
         throw Exception("Unspecified ColorSpaceDirection");
 }
 
-std::ostream& operator<< (std::ostream& os, const ColorSpace& cs)
+std::ostream & operator<< (std::ostream & os, const ColorSpace & cs)
 {
     int numVars(cs.getAllocationNumVars());
     std::vector<float> vars(numVars);
     cs.getAllocationVars(&vars[0]);
 
-    os << "<ColorSpace ";
+    const auto refType = cs.getReferenceSpaceType();
+
+    switch (refType)
+    {
+    case REFERENCE_SPACE_SCENE:
+        os << "<ColorSpace ";
+        break;
+    case REFERENCE_SPACE_DISPLAY:
+        os << "<DisplayColorSpace ";
+        break;
+    }
     os << "name=" << cs.getName() << ", ";
     os << "family=" << cs.getFamily() << ", ";
     os << "equalityGroup=" << cs.getEqualityGroup() << ", ";

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -249,6 +249,8 @@ public:
     StringVec m_activeViews;
     StringVec m_activeViewsEnvOverride;
 
+    std::vector<ViewTransformRcPtr> m_viewTransforms;
+
     mutable std::string m_activeDisplaysStr;
     mutable std::string m_activeViewsStr;
     mutable StringVec m_displayCache;
@@ -319,16 +321,15 @@ public:
             m_inactiveColorSpaceNamesEnv  = rhs.m_inactiveColorSpaceNamesEnv;
             m_inactiveColorSpaceNamesAPI  = rhs.m_inactiveColorSpaceNamesAPI;
 
-            // Deep copy the looks
+            // Deep copy the looks.
             m_looksList.clear();
             m_looksList.reserve(rhs.m_looksList.size());
             for(unsigned int i=0; i<rhs.m_looksList.size(); ++i)
             {
-                m_looksList.push_back(
-                    rhs.m_looksList[i]->createEditableCopy());
+                m_looksList.push_back(rhs.m_looksList[i]->createEditableCopy());
             }
 
-            // Assignment operator will suffice for these
+            // Assignment operator will suffice for these.
             m_roles = rhs.m_roles;
 
             m_displays = rhs.m_displays;
@@ -338,6 +339,14 @@ public:
             m_activeDisplaysEnvOverride = rhs.m_activeDisplaysEnvOverride;
             m_activeDisplaysStr = rhs.m_activeDisplaysStr;
             m_displayCache = rhs.m_displayCache;
+
+            // Deep copy view transforms.
+            m_viewTransforms.clear();
+            m_viewTransforms.reserve(rhs.m_viewTransforms.size());
+            for (const auto & vt : rhs.m_viewTransforms)
+            {
+                m_viewTransforms.push_back(vt->createEditableCopy());
+            }
 
             m_defaultLumaCoefs = rhs.m_defaultLumaCoefs;
             m_strictParsing = rhs.m_strictParsing;
@@ -359,7 +368,7 @@ public:
         return *index!=-1;
     }
 
-    std::vector<std::string> buildInactiveColorSpaceList() const;
+    StringVec buildInactiveColorSpaceList() const;
     void refreshActiveColorSpaces();
 
     // Any time you modify the state of the config, you must call this
@@ -388,7 +397,7 @@ public:
         const char * rname = LookupRole(m_roles, ROLE_DEFAULT);
         if (!FindColorSpaceIndex(&csindex, m_allColorSpaces, rname))
         {
-            std::string defaultCS{ "" };
+            std::string defaultCS;
             bool addNewDefault = true;
             // The default role doesn't exist so look for a color space named "raw"
             // (not case-sensitive) with isdata true.
@@ -575,12 +584,16 @@ void Config::sanityCheck() const
     getImpl()->m_sanitytext = "";
 
     ///// COLORSPACES
+
     StringSet existingColorSpaces;
 
-    // Confirm all ColorSpaces are valid
+    bool hasDisplayReferredColorspace = false;
+
+    // Confirm all ColorSpaces are valid.
     for(int i=0; i<getImpl()->m_allColorSpaces->getNumColorSpaces(); ++i)
     {
-        if(!getImpl()->m_allColorSpaces->getColorSpaceByIndex(i))
+        const auto cs = getImpl()->m_allColorSpaces->getColorSpaceByIndex(i);
+        if (!cs)
         {
             std::ostringstream os;
             os << "Config failed sanitycheck. ";
@@ -589,8 +602,8 @@ void Config::sanityCheck() const
             throw Exception(getImpl()->m_sanitytext.c_str());
         }
 
-        const char * name = getImpl()->m_allColorSpaces->getColorSpaceByIndex(i)->getName();
-        if(!name || strlen(name) == 0)
+        const char * name = cs->getName();
+        if (!name || !*name)
         {
             std::ostringstream os;
             os << "Config failed sanitycheck. ";
@@ -599,9 +612,9 @@ void Config::sanityCheck() const
             throw Exception(getImpl()->m_sanitytext.c_str());
         }
 
-        std::string namelower = pystring::lower(name);
+        const std::string namelower = pystring::lower(name);
         StringSet::const_iterator it = existingColorSpaces.find(namelower);
-        if(it != existingColorSpaces.end())
+        if (it != existingColorSpaces.end())
         {
             std::ostringstream os;
             os << "Config failed sanitycheck. ";
@@ -611,7 +624,6 @@ void Config::sanityCheck() const
             throw Exception(getImpl()->m_sanitytext.c_str());
         }
 
-        const auto cs = getImpl()->m_allColorSpaces->getColorSpaceByIndex(i);
         ConstTransformRcPtr toTrans = cs->getTransform(COLORSPACE_DIR_TO_REFERENCE);
         if (toTrans)
         {
@@ -625,9 +637,13 @@ void Config::sanityCheck() const
         }
 
         existingColorSpaces.insert(namelower);
+        if (cs->getReferenceSpaceType() == REFERENCE_SPACE_DISPLAY)
+        {
+            hasDisplayReferredColorspace = true;
+        }
     }
 
-    // Confirm all roles are valid
+    // Confirm all roles are valid.
     {
         for(StringMap::const_iterator iter = getImpl()->m_roles.begin(),
             end = getImpl()->m_roles.end(); iter!=end; ++iter)
@@ -658,17 +674,16 @@ void Config::sanityCheck() const
     }
 
     // Confirm all inactive color spaces exist.
-    const std::vector<std::string> inactiveColorSpaceNames
-        = getImpl()->buildInactiveColorSpaceList();
+    const StringVec inactiveColorSpaceNames = getImpl()->buildInactiveColorSpaceList();
 
     for (const auto & name : inactiveColorSpaceNames)
     {
         ConstColorSpaceRcPtr cs = getImpl()->m_allColorSpaces->getColorSpace(name.c_str());
         if (!cs)
         {
-            std::stringstream ss;
-            ss << "Inactive color space '" << name << "' does not exist.";
-            LogWarning(ss.str());
+            std::ostringstream os;
+            os << "Inactive color space '" << name << "' does not exist.";
+            LogWarning(os.str());
         }
     }
 
@@ -682,7 +697,7 @@ void Config::sanityCheck() const
         iter != getImpl()->m_displays.end();
         ++iter)
     {
-        std::string display = iter->first;
+        const std::string display = iter->first;
         const ViewVec & views = iter->second;
         if(views.empty())
         {
@@ -697,7 +712,7 @@ void Config::sanityCheck() const
         // Confirm view references exist.
         for(unsigned int i=0; i<views.size(); ++i)
         {
-            if(views[i].name.empty() || views[i].colorspace.empty())
+            if(views[i].m_name.empty() || views[i].m_colorspace.empty())
             {
                 std::ostringstream os;
                 os << "Config failed sanitycheck. ";
@@ -708,27 +723,57 @@ void Config::sanityCheck() const
             }
 
             int csindex = -1;
-            if(!getImpl()->findColorSpaceIndex(&csindex, views[i].colorspace))
+            if(!getImpl()->findColorSpaceIndex(&csindex, views[i].m_colorspace))
             {
                 std::ostringstream os;
                 os << "Config failed sanitycheck. ";
                 os << "The display '" << display << "' ";
-                os << "refers to a color space, '" << views[i].colorspace << "', ";
+                os << " view '" << views[i].m_name << "' ";
+                os << "refers to a color space, '" << views[i].m_colorspace << "', ";
                 os << "which is not defined.";
                 getImpl()->m_sanitytext = os.str();
                 throw Exception(getImpl()->m_sanitytext.c_str());
             }
 
+            // If there is a view transform, it must exist and its color space must be a
+            // display-referred color space.
+            if (!views[i].m_viewTransform.empty())
+            {
+                if (!getViewTransform(views[i].m_viewTransform.c_str()))
+                {
+                    std::ostringstream os;
+                    os << "Config failed sanitycheck. ";
+                    os << "The display '" << display << "' ";
+                    os << " view '" << views[i].m_name << "' ";
+                    os << "refers to a view transform, '" << views[i].m_viewTransform << "', ";
+                    os << "which is not defined.";
+                    getImpl()->m_sanitytext = os.str();
+                    throw Exception(getImpl()->m_sanitytext.c_str());
+                }
+                auto cs = getImpl()->m_allColorSpaces->getColorSpaceByIndex(csindex);
+                if (cs->getReferenceSpaceType() != REFERENCE_SPACE_DISPLAY)
+                {
+                    std::ostringstream os;
+                    os << "Config failed sanitycheck. ";
+                    os << "The display '" << display << "' ";
+                    os << " view '" << views[i].m_name << "' ";
+                    os << "refers to a color space, '" << views[i].m_colorspace << "', ";
+                    os << "that is not a display-referred color space.";
+                    getImpl()->m_sanitytext = os.str();
+                    throw Exception(getImpl()->m_sanitytext.c_str());
+                }
+            }
+
             // Confirm looks references exist.
             LookParseResult looks;
-            const LookParseResult::Options & options = looks.parse(views[i].looks);
+            const LookParseResult::Options & options = looks.parse(views[i].m_looks);
 
             for(unsigned int optionindex=0;
-                optionindex<options.size();
+                optionindex < options.size();
                 ++optionindex)
             {
                 for(unsigned int tokenindex=0;
-                    tokenindex<options[optionindex].size();
+                    tokenindex < options[optionindex].size();
                     ++tokenindex)
                 {
                     std::string look = options[optionindex][tokenindex].name;
@@ -751,7 +796,7 @@ void Config::sanityCheck() const
     }
 
     // Confirm at least one display entry exists.
-    if(numviews == 0)
+    if (numviews == 0)
     {
         std::ostringstream os;
         os << "Config failed sanitycheck. ";
@@ -784,27 +829,28 @@ void Config::sanityCheck() const
                 = IntersectStringVecsCaseIgnore(getImpl()->m_activeDisplaysEnvOverride, displays);
             if (orderedDisplays.empty())
             {
-                std::stringstream ss;
-                ss << "The content of the env. variable for the list of active displays ["
+                std::ostringstream os;
+                os << "The content of the env. variable for the list of active displays ["
                    << JoinStringEnvStyle(getImpl()->m_activeDisplaysEnvOverride)
                    << "] is invalid.";
-                throw Exception(ss.str().c_str());
+                getImpl()->m_sanitytext = os.str();
+                throw Exception(getImpl()->m_sanitytext.c_str());
             }
             if (orderedDisplays.size()!=getImpl()->m_activeDisplaysEnvOverride.size())
             {
-                std::stringstream ss;
-                ss << "The content of the env. variable for the list of active displays ["
+                std::ostringstream os;
+                os << "The content of the env. variable for the list of active displays ["
                    << JoinStringEnvStyle(getImpl()->m_activeDisplaysEnvOverride)
                    << "] contains invalid display name(s).";
-                throw Exception(ss.str().c_str());
+                getImpl()->m_sanitytext = os.str();
+                throw Exception(getImpl()->m_sanitytext.c_str());
             }
         }
     }
-    else if(!getImpl()->m_activeDisplays.empty())
+    else if (!getImpl()->m_activeDisplays.empty())
     {
-        const bool useAllDisplays
-            = getImpl()->m_activeDisplays.size()==1
-                && getImpl()->m_activeDisplays[0] == "";
+        const bool useAllDisplays = getImpl()->m_activeDisplays.size() == 1 &&
+                                    getImpl()->m_activeDisplays[0] == "";
 
         if (!useAllDisplays)
         {
@@ -812,19 +858,21 @@ void Config::sanityCheck() const
                 = IntersectStringVecsCaseIgnore(getImpl()->m_activeDisplays, displays);
             if (orderedDisplays.empty())
             {
-                std::stringstream ss;
-                ss << "The list of active displays ["
+                std::ostringstream os;
+                os << "The list of active displays ["
                    << JoinStringEnvStyle(getImpl()->m_activeDisplays)
                    << "] from the config file is invalid.";
-                throw Exception(ss.str().c_str());
+                getImpl()->m_sanitytext = os.str();
+                throw Exception(getImpl()->m_sanitytext.c_str());
             }
             if (orderedDisplays.size()!=getImpl()->m_activeDisplays.size())
             {
-                std::stringstream ss;
-                ss << "The list of active displays ["
+                std::ostringstream os;
+                os << "The list of active displays ["
                    << JoinStringEnvStyle(getImpl()->m_activeDisplays)
                    << "] from the config file contains invalid display name(s).";
-                throw Exception(ss.str().c_str());
+                getImpl()->m_sanitytext = os.str();
+                throw Exception(getImpl()->m_sanitytext.c_str());
             }
         }
     }
@@ -871,24 +919,17 @@ void Config::sanityCheck() const
     // For all looks, confirm the process space exists and the look is named
     for(unsigned int i=0; i<getImpl()->m_looksList.size(); ++i)
     {
-        std::string name = getImpl()->m_looksList[i]->getName();
-        if(name.empty())
-        {
-            std::ostringstream os;
-            os << "Config failed sanitycheck. ";
-            os << "The look at index '" << i << "' ";
-            os << "does not specify a name.";
-            getImpl()->m_sanitytext = os.str();
-            throw Exception(getImpl()->m_sanitytext.c_str());
-        }
+        // Note: Config::addLook validates that looks have a unique, non-empty name.
 
-        std::string processSpace = getImpl()->m_looksList[i]->getProcessSpace();
+        const std::string name = getImpl()->m_looksList[i]->getName();
+
+        const std::string processSpace = getImpl()->m_looksList[i]->getProcessSpace();
         if(processSpace.empty())
         {
             std::ostringstream os;
             os << "Config failed sanitycheck. ";
             os << "The look '" << name << "' ";
-            os << "does not specify a process space.";
+            os << "does not specify a process color space.";
             getImpl()->m_sanitytext = os.str();
             throw Exception(getImpl()->m_sanitytext.c_str());
         }
@@ -905,6 +946,31 @@ void Config::sanityCheck() const
             throw Exception(getImpl()->m_sanitytext.c_str());
         }
     }
+
+    ///// ViewTransforms
+
+    if (!getImpl()->m_viewTransforms.empty())
+    {
+        // Note: Config::addViewTransform validates that view_transforms have a unique, non-empty
+        // name and define a transform.
+
+        auto fromScene = getDefaultSceneToDisplayViewTransform();
+        // If there are view transforms, there must be one from the scene reference space.
+        if (!fromScene)
+        {
+            getImpl()->m_sanitytext = "Config failed sanitycheck. If there are view_transforms, "
+                                      "at least one must use the scene reference space.";
+            throw Exception(getImpl()->m_sanitytext.c_str());
+        }
+    }
+    else if (hasDisplayReferredColorspace)
+    {
+        getImpl()->m_sanitytext = "Config failed sanitycheck. If there are display-referred "
+                                  "color spaces, there must be view_transforms.";
+        throw Exception(getImpl()->m_sanitytext.c_str());
+    }
+
+    ///// FileRules
 
     if (getMajorVersion() >= 2)
     {
@@ -1076,44 +1142,185 @@ ColorSpaceSetRcPtr Config::getColorSpaces(const char * category) const
     return res;
 }
 
-int Config::getNumColorSpaces(ColorSpaceVisibility visibility) const
+namespace
 {
-    switch(visibility)
+bool MatchReferenceType(SearchReferenceSpaceType st, ReferenceSpaceType t)
+{
+    switch (st)
     {
-        case COLORSPACE_ALL:
-            return getImpl()->m_allColorSpaces->getNumColorSpaces();
-        case COLORSPACE_ACTIVE:
-            return (int)getImpl()->m_activeColorSpaceNames.size();
-        case COLORSPACE_INACTIVE:
-        {
-            const std::vector<std::string> inactiveColorSpaceNames
-                = getImpl()->buildInactiveColorSpaceList();
-            return (int)inactiveColorSpaceNames.size();
-        }
+    case SEARCH_REFERENCE_SPACE_SCENE:
+        return t == REFERENCE_SPACE_SCENE;
+    case SEARCH_REFERENCE_SPACE_DISPLAY:
+        return t == REFERENCE_SPACE_DISPLAY;
+    case SEARCH_REFERENCE_SPACE_ALL:
+        return true;
     }
-
-    return 0;
+    return false;
+}
 }
 
-const char * Config::getColorSpaceNameByIndex(ColorSpaceVisibility visibility, int index) const
+int Config::getNumColorSpaces(SearchReferenceSpaceType searchReferenceType,
+                              ColorSpaceVisibility visibility) const
 {
-    if (index < 0 || index >= getNumColorSpaces(visibility))
+    int res = 0;
+    switch (visibility)
+    {
+    case COLORSPACE_ALL:
+    {
+        const int nbCS = getImpl()->m_allColorSpaces->getNumColorSpaces();
+        if (searchReferenceType == SEARCH_REFERENCE_SPACE_ALL)
+        {
+            return nbCS;
+        }
+        for (int i = 0; i < nbCS; ++i)
+        {
+            auto cs = getImpl()->m_allColorSpaces->getColorSpaceByIndex(i);
+            if (MatchReferenceType(searchReferenceType, cs->getReferenceSpaceType()))
+            {
+                ++res;
+            }
+        }
+        break;
+    }
+    case COLORSPACE_ACTIVE:
+    {
+        const size_t nbCS = getImpl()->m_activeColorSpaceNames.size();
+        if (searchReferenceType == SEARCH_REFERENCE_SPACE_ALL)
+        {
+            return (int)nbCS;
+        }
+        for (auto csname : getImpl()->m_activeColorSpaceNames)
+        {
+            auto cs = getColorSpace(csname.c_str());
+            if (MatchReferenceType(searchReferenceType, cs->getReferenceSpaceType()))
+            {
+                ++res;
+            }
+        }
+        break;
+    }
+    case COLORSPACE_INACTIVE:
+    {
+        const StringVec inactiveColorSpaceNames = getImpl()->buildInactiveColorSpaceList();
+        const size_t nbCS = inactiveColorSpaceNames.size();
+        if (searchReferenceType == SEARCH_REFERENCE_SPACE_ALL)
+        {
+            return (int)nbCS;
+        }
+        for (auto csname : inactiveColorSpaceNames)
+        {
+            auto cs = getColorSpace(csname.c_str());
+            if (MatchReferenceType(searchReferenceType, cs->getReferenceSpaceType()))
+            {
+                ++res;
+            }
+        }
+        break;
+    }
+    }
+
+    return res;
+}
+
+const char * Config::getColorSpaceNameByIndex(SearchReferenceSpaceType searchReferenceType,
+                                              ColorSpaceVisibility visibility, int index) const
+{
+    if (index < 0)
     {
         return "";
     }
 
-    switch(visibility)
+    int current = 0;
+    switch (visibility)
     {
-        case COLORSPACE_ALL:
-            return getImpl()->m_allColorSpaces->getColorSpaceNameByIndex(index);
-        case COLORSPACE_ACTIVE:
-            return getImpl()->m_activeColorSpaceNames[index].c_str();
-        case COLORSPACE_INACTIVE:
+    case COLORSPACE_ALL:
+    {
+        if (searchReferenceType == SEARCH_REFERENCE_SPACE_ALL)
         {
-            const std::vector<std::string> inactiveColorSpaceNames
-                = getImpl()->buildInactiveColorSpaceList();
-            return inactiveColorSpaceNames[index].c_str();
+            if (index < getImpl()->m_allColorSpaces->getNumColorSpaces())
+            {
+                return getImpl()->m_allColorSpaces->getColorSpaceNameByIndex(index);
+            }
+            else
+            {
+                return "";
+            }
         }
+        const int nbCS = getImpl()->m_allColorSpaces->getNumColorSpaces();
+        for (int i = 0; i < nbCS; ++i)
+        {
+            auto cs = getImpl()->m_allColorSpaces->getColorSpaceByIndex(i);
+            if (MatchReferenceType(searchReferenceType, cs->getReferenceSpaceType()))
+            {
+                if (current == index)
+                {
+                    return cs->getName();
+                }
+                ++current;
+            }
+        }
+        break;
+    }
+    case COLORSPACE_ACTIVE:
+    {
+        if (searchReferenceType == SEARCH_REFERENCE_SPACE_ALL)
+        {
+            if (index < (int)getImpl()->m_activeColorSpaceNames.size())
+            {
+                return getImpl()->m_activeColorSpaceNames[index].c_str();
+            }
+            else
+            {
+                return "";
+            }
+        }
+        const int nbCS = (int)getImpl()->m_activeColorSpaceNames.size();
+        for (int i = 0; i < nbCS; ++i)
+        {
+            auto csname = getImpl()->m_activeColorSpaceNames[i];
+            auto cs = getColorSpace(csname.c_str());
+            if (MatchReferenceType(searchReferenceType, cs->getReferenceSpaceType()))
+            {
+                if (current == index)
+                {
+                    return cs->getName();
+                }
+                ++current;
+            }
+        }
+        break;
+    }
+    case COLORSPACE_INACTIVE:
+    {
+        // TODO: Building the list at each call could be an issue when called in loops.
+        const StringVec inactiveColorSpaceNames = getImpl()->buildInactiveColorSpaceList();
+        if (searchReferenceType == SEARCH_REFERENCE_SPACE_ALL)
+        {
+            if (index < (int)inactiveColorSpaceNames.size())
+            {
+                return inactiveColorSpaceNames[index].c_str();
+            }
+            else
+            {
+                return "";
+            }
+        }
+        const int nbCS = (int)inactiveColorSpaceNames.size();
+        for (int i = 0; i < nbCS; ++i)
+        {
+            auto csname = inactiveColorSpaceNames[i];
+            auto cs = getColorSpace(csname.c_str());
+            if (MatchReferenceType(searchReferenceType, cs->getReferenceSpaceType()))
+            {
+                if (current == index)
+                {
+                    return cs->getName();
+                }
+                ++current;
+            }
+        }
+        break;
+    }
     }
 
     return "";
@@ -1136,12 +1343,12 @@ ConstColorSpaceRcPtr Config::getColorSpace(const char * name) const
 
 int Config::getNumColorSpaces() const
 {
-    return getNumColorSpaces(COLORSPACE_ACTIVE);
+    return getNumColorSpaces(SEARCH_REFERENCE_SPACE_ALL, COLORSPACE_ACTIVE);
 }
 
 const char * Config::getColorSpaceNameByIndex(int index) const
 {
-    return getColorSpaceNameByIndex(COLORSPACE_ACTIVE, index);
+    return getColorSpaceNameByIndex(SEARCH_REFERENCE_SPACE_ALL, COLORSPACE_ACTIVE, index);
 }
 
 int Config::getIndexForColorSpace(const char * name) const
@@ -1153,9 +1360,11 @@ int Config::getIndexForColorSpace(const char * name) const
     }
 
     // Check to see if the name is an active color space.
-    for (int idx = 0; idx < getNumColorSpaces(COLORSPACE_ACTIVE); ++idx)
+    for (int idx = 0; idx < getNumColorSpaces(SEARCH_REFERENCE_SPACE_ALL,
+                                              COLORSPACE_ACTIVE); ++idx)
     {
-        if (std::string(getColorSpaceNameByIndex(COLORSPACE_ACTIVE, idx))
+        if (std::string(getColorSpaceNameByIndex(SEARCH_REFERENCE_SPACE_ALL,
+                                                 COLORSPACE_ACTIVE, idx))
                 == std::string(cs->getName()))
         {
             return idx;
@@ -1355,7 +1564,7 @@ int Config::getNumViews(const char * display) const
     StringVec masterViews;
     for(unsigned int i=0; i<views.size(); ++i)
     {
-        masterViews.push_back(views[i].name);
+        masterViews.push_back(views[i].m_name);
     }
 
     if(!getImpl()->m_activeViewsEnvOverride.empty())
@@ -1370,8 +1579,8 @@ int Config::getNumViews(const char * display) const
     }
     else if(!getImpl()->m_activeViews.empty())
     {
-        const StringVec orderedViews
-            = IntersectStringVecsCaseIgnore(getImpl()->m_activeViews, masterViews);
+        const StringVec orderedViews = IntersectStringVecsCaseIgnore(getImpl()->m_activeViews,
+                                                                     masterViews);
 
         if(!orderedViews.empty())
         {
@@ -1402,7 +1611,7 @@ const char * Config::getView(const char * display, int index) const
     StringVec masterViews;
     for(unsigned int i = 0; i < views.size(); ++i)
     {
-        masterViews.push_back(views[i].name);
+        masterViews.push_back(views[i].m_name);
     }
 
     int idx = index;
@@ -1430,15 +1639,29 @@ const char * Config::getView(const char * display, int index) const
 
     if(idx >= 0)
     {
-        return views[idx].name.c_str();
+        return views[idx].m_name.c_str();
     }
 
     if(!views.empty())
     {
-        return views[0].name.c_str();
+        return views[0].m_name.c_str();
     }
 
     return "";
+}
+
+const char * Config::getDisplayViewTransformName(const char * display, const char * view) const
+{
+    if (!display || !view) return "";
+
+    DisplayMap::const_iterator iter = find_display_const(getImpl()->m_displays, display);
+    if (iter == getImpl()->m_displays.end()) return "";
+
+    const ViewVec & views = iter->second;
+    const int index = find_view(views, view);
+    if (index<0) return "";
+
+    return views[index].m_viewTransform.c_str();
 }
 
 const char * Config::getDisplayColorSpaceName(const char * display, const char * view) const
@@ -1449,10 +1672,10 @@ const char * Config::getDisplayColorSpaceName(const char * display, const char *
     if(iter == getImpl()->m_displays.end()) return "";
 
     const ViewVec & views = iter->second;
-    int index = find_view(views, view);
+    const int index = find_view(views, view);
     if(index<0) return "";
 
-    return views[index].colorspace.c_str();
+    return views[index].m_colorspace.c_str();
 }
 
 const char * Config::getDisplayLooks(const char * display, const char * view) const
@@ -1463,20 +1686,24 @@ const char * Config::getDisplayLooks(const char * display, const char * view) co
     if(iter == getImpl()->m_displays.end()) return "";
 
     const ViewVec & views = iter->second;
-    int index = find_view(views, view);
+    const int index = find_view(views, view);
     if(index<0) return "";
 
-    return views[index].looks.c_str();
+    return views[index].m_looks.c_str();
 }
 
 void Config::addDisplay(const char * display, const char * view,
-                        const char * colorSpaceName, const char * lookName)
+                        const char * colorSpaceName, const char * looks)
 {
+    addDisplay(display, view, "", colorSpaceName, looks);
+}
 
-    if(!display || !view || !colorSpaceName || !lookName) return;
+void Config::addDisplay(const char * display, const char * view, const char * viewTransform,
+                        const char * displayColorSpaceName, const char * looks)
+{
+    if (!display || !view || !viewTransform || !displayColorSpaceName || !looks) return;
 
-    AddDisplay(getImpl()->m_displays,
-                display, view, colorSpaceName, lookName);
+    AddDisplay(getImpl()->m_displays, display, view, viewTransform, displayColorSpaceName, looks);
     getImpl()->m_displayCache.clear();
 
     AutoMutex lock(getImpl()->m_cacheidMutex);
@@ -1545,7 +1772,7 @@ void Config::setDefaultLumaCoefs(const double * c3)
 
 ConstLookRcPtr Config::getLook(const char * name) const
 {
-    std::string namelower = pystring::lower(name);
+    const std::string namelower = pystring::lower(name);
 
     for(unsigned int i=0; i<getImpl()->m_looksList.size(); ++i)
     {
@@ -1575,11 +1802,11 @@ const char * Config::getLookNameByIndex(int index) const
 
 void Config::addLook(const ConstLookRcPtr & look)
 {
-    std::string name = look->getName();
+    const std::string name = look->getName();
     if(name.empty())
         throw Exception("Cannot addLook with an empty name.");
 
-    std::string namelower = pystring::lower(name);
+    const std::string namelower = pystring::lower(name);
 
     // If the look exists, replace it
     for(unsigned int i=0; i<getImpl()->m_looksList.size(); ++i)
@@ -1601,6 +1828,100 @@ void Config::addLook(const ConstLookRcPtr & look)
 void Config::clearLooks()
 {
     getImpl()->m_looksList.clear();
+
+    AutoMutex lock(getImpl()->m_cacheidMutex);
+    getImpl()->resetCacheIDs();
+}
+
+///////////////////////////////////////////////////////////////////////////
+
+int Config::getNumViewTransforms() const noexcept
+{
+    return static_cast<int>(getImpl()->m_viewTransforms.size());
+}
+
+ConstViewTransformRcPtr Config::getViewTransform(const char * name) const noexcept
+{
+    const std::string namelower = pystring::lower(name);
+
+    for (auto vt : getImpl()->m_viewTransforms)
+    {
+        if (pystring::lower(vt->getName()) == namelower)
+        {
+            return vt;
+        }
+    }
+
+    return ConstViewTransformRcPtr();
+}
+
+const char * Config::getViewTransformNameByIndex(int index) const noexcept
+{
+    if (index<0 || index >= static_cast<int>(getImpl()->m_viewTransforms.size()))
+    {
+        return "";
+    }
+
+    return getImpl()->m_viewTransforms[index]->getName();
+}
+
+ConstViewTransformRcPtr Config::getDefaultSceneToDisplayViewTransform() const
+{
+    // The default view transform between the main reference space (scene-referred) and the
+    // display-referred space is the first one in the list that uses a scene-referred
+    // reference space.
+    for (const auto & viewTransform : getImpl()->m_viewTransforms)
+    {
+        if (viewTransform->getReferenceSpaceType() == REFERENCE_SPACE_SCENE)
+        {
+            return viewTransform;
+        }
+    }
+    return ConstViewTransformRcPtr();
+}
+
+void Config::addViewTransform(const ConstViewTransformRcPtr & viewTransform)
+{
+    const std::string name = viewTransform->getName();
+    if (name.empty())
+    {
+        throw Exception("Cannot add view transform with an empty name.");
+    }
+
+    if (!viewTransform->getTransform(VIEWTRANSFORM_DIR_TO_REFERENCE) &&
+        !viewTransform->getTransform(VIEWTRANSFORM_DIR_FROM_REFERENCE))
+    {
+        throw Exception("Cannot add view transform with no transform.");
+    }
+
+    const std::string namelower = pystring::lower(name);
+
+    bool addIt = true;
+
+    // If the view transform exists, replace it.
+    for (auto && vt : getImpl()->m_viewTransforms)
+    {
+        if (pystring::lower(vt->getName()) == namelower)
+        {
+            vt = viewTransform->createEditableCopy();
+            addIt = false;
+            break;
+        }
+    }
+
+    // Otherwise, add it.
+    if (addIt)
+    {
+        getImpl()->m_viewTransforms.push_back(viewTransform->createEditableCopy());
+    }
+
+    AutoMutex lock(getImpl()->m_cacheidMutex);
+    getImpl()->resetCacheIDs();
+}
+
+void Config::clearViewTransforms()
+{
+    getImpl()->m_viewTransforms.clear();
 
     AutoMutex lock(getImpl()->m_cacheidMutex);
     getImpl()->resetCacheIDs();
@@ -1683,6 +2004,26 @@ ConstProcessorRcPtr Config::getProcessor(const ConstContextRcPtr & context,
     }
 
     return getProcessor(context, src, dst);
+}
+
+
+ConstProcessorRcPtr Config::getProcessor(const char * inputColorSpaceName,
+                                         const char * display, const char * view) const
+{
+    ConstContextRcPtr context = getCurrentContext();
+    return getProcessor(context, inputColorSpaceName, display, view);
+}
+
+ConstProcessorRcPtr Config::getProcessor(const ConstContextRcPtr & context,
+                                         const char * inputColorSpaceName,
+                                         const char * display, const char * view) const
+{
+    auto dt = DisplayTransform::Create();
+    dt->setInputColorSpaceName(inputColorSpaceName);
+    dt->setDisplay(display);
+    dt->setView(view);
+    dt->validate();
+    return getProcessor(context, dt, TRANSFORM_DIR_FORWARD);
 }
 
 ConstProcessorRcPtr Config::getProcessor(const ConstTransformRcPtr& transform) const
@@ -1846,7 +2187,7 @@ const char * Config::getCacheID(const ConstContextRcPtr & context) const
     AutoMutex lock(getImpl()->m_cacheidMutex);
 
     // A null context will use the empty cacheid
-    std::string contextcacheid = "";
+    std::string contextcacheid;
     if(context) contextcacheid = context->getCacheID();
 
     StringMap::const_iterator cacheiditer = getImpl()->m_cacheids.find(contextcacheid);
@@ -1858,14 +2199,14 @@ const char * Config::getCacheID(const ConstContextRcPtr & context) const
     // Include the hash of the yaml config serialization
     if(getImpl()->m_cacheidnocontext.empty())
     {
-        std::stringstream cacheid;
+        std::ostringstream cacheid;
         serialize(cacheid);
-        std::string fullstr = cacheid.str();
+        const std::string fullstr = cacheid.str();
         getImpl()->m_cacheidnocontext = CacheIDHash(fullstr.c_str(), (int)fullstr.size());
     }
 
     // Also include all file references, using the context (if specified)
-    std::string fileReferencesFashHash = "";
+    std::string fileReferencesFashHash;
     if(context)
     {
         std::ostringstream filehash;
@@ -1887,7 +2228,7 @@ const char * Config::getCacheID(const ConstContextRcPtr & context) const
 
             try
             {
-                std::string resolvedLocation = context->resolveFileLocation(iter->c_str());
+                const std::string resolvedLocation = context->resolveFileLocation(iter->c_str());
                 filehash << GetFastFileHash(resolvedLocation) << " ";
             }
             catch(...)
@@ -1897,7 +2238,7 @@ const char * Config::getCacheID(const ConstContextRcPtr & context) const
             }
         }
 
-        std::string fullstr = filehash.str();
+        const std::string fullstr = filehash.str();
         fileReferencesFashHash = CacheIDHash(fullstr.c_str(), (int)fullstr.size());
     }
 
@@ -1926,9 +2267,9 @@ void Config::serialize(std::ostream& os) const
 ///////////////////////////////////////////////////////////////////////////
 //  Config::Impl
 
-std::vector<std::string> Config::Impl::buildInactiveColorSpaceList() const
+StringVec Config::Impl::buildInactiveColorSpaceList() const
 {
-    std::vector<std::string> inactiveColorSpaces;
+    StringVec inactiveColorSpaces;
 
     // An API request always supersedes the other lists.
     if (!m_inactiveColorSpaceNamesAPI.empty())
@@ -1957,7 +2298,7 @@ void Config::Impl::refreshActiveColorSpaces()
 {
     m_activeColorSpaceNames.clear();
 
-    const std::vector<std::string> inactiveColorSpaces = buildInactiveColorSpaceList();
+    const StringVec inactiveColorSpaces = buildInactiveColorSpaceList();
 
     for (int i = 0; i < m_allColorSpaces->getNumColorSpaces(); ++i)
     {

--- a/src/OpenColorIO/Display.cpp
+++ b/src/OpenColorIO/Display.cpp
@@ -37,7 +37,7 @@ int find_view(const ViewVec & vec, const std::string & name)
 {
     for(unsigned int i=0; i<vec.size(); ++i)
     {
-        if(StrEqualsCaseIgnore(name, vec[i].name)) return i;
+        if(StrEqualsCaseIgnore(name, vec[i].m_name)) return i;
     }
     return -1;
 }
@@ -45,14 +45,27 @@ int find_view(const ViewVec & vec, const std::string & name)
 void AddDisplay(DisplayMap & displays,
                 const std::string & display,
                 const std::string & view,
-                const std::string & colorspace,
+                const std::string & viewTransform,
+                const std::string & displayColorspace,
                 const std::string & looks)
 {
+    if (display.empty())
+    {
+        throw Exception("Can't add a display with empty name.");
+    }
+    if (view.empty())
+    {
+        throw Exception("Can't add a display with empty view name.");
+    }
+    if (displayColorspace.empty())
+    {
+        throw Exception("Can't add a display with empty color space name.");
+    }
     DisplayMap::iterator iter = find_display(displays, display);
     if(iter == displays.end())
     {
         ViewVec views;
-        views.push_back( View(view, colorspace, looks) );
+        views.push_back( View(view, viewTransform, displayColorspace, looks) );
         displays.push_back(std::make_pair(display, views));
     }
     else
@@ -61,20 +74,21 @@ void AddDisplay(DisplayMap & displays,
         int index = find_view(views, view);
         if (index < 0)
         {
-            views.push_back( View(view, colorspace, looks) );
+            views.push_back( View(view, viewTransform, displayColorspace, looks) );
         }
         else
         {
-            views[index].colorspace = colorspace;
-            views[index].looks = looks;
+            views[index].m_viewTransform = viewTransform;
+            views[index].m_colorspace = displayColorspace;
+            views[index].m_looks = looks;
         }
     }
 }
 
 void ComputeDisplays(StringVec & displayCache,
-                        const DisplayMap & displays,
-                        const StringVec & activeDisplays,
-                        const StringVec & activeDisplaysEnvOverride)
+                     const DisplayMap & displays,
+                     const StringVec & activeDisplays,
+                     const StringVec & activeDisplaysEnvOverride)
 {
     displayCache.clear();
 

--- a/src/OpenColorIO/Display.h
+++ b/src/OpenColorIO/Display.h
@@ -18,18 +18,21 @@ namespace OCIO_NAMESPACE
 // Displays
 struct View
 {
-    std::string name;
-    std::string colorspace;
-    std::string looks;
+    std::string m_name;
+    std::string m_viewTransform; // Added for v2, might be empty.
+    std::string m_colorspace;
+    std::string m_looks;
 
-    View() { }
+    View() = default;
 
-    View(const std::string & name_,
-         const std::string & colorspace_,
-         const std::string & looksList_) :
-         name(name_),
-         colorspace(colorspace_),
-         looks(looksList_)
+    View(const std::string & name,
+         const std::string & viewTransform,
+         const std::string & colorspace,
+         const std::string & looksList)
+        : m_name(name)
+        , m_viewTransform(viewTransform)
+        , m_colorspace(colorspace)
+        , m_looks(looksList)
     { }
 };
 
@@ -40,16 +43,16 @@ typedef std::vector<View> ViewVec;
 // can remain in config order but we left the "Map" in the name since it refers to a Yaml::Map.
 typedef std::vector<std::pair<std::string, ViewVec>> DisplayMap;  // Pair is (display name : ViewVec)
 
-DisplayMap::iterator find_display(DisplayMap & displays, const std::string & display);
-
 DisplayMap::const_iterator find_display_const(const DisplayMap & displays, const std::string & display);
 
 int find_view(const ViewVec & vec, const std::string & name);
 
+// Note: displayColorSpace has to be a display-referred color space if viewTransform is not empty.
 void AddDisplay(DisplayMap & displays,
                 const std::string & display,
                 const std::string & view,
-                const std::string & colorspace,
+                const std::string & viewTransform,
+                const std::string & displayColorspace,
                 const std::string & looks);
 
 void ComputeDisplays(StringVec & displayCache,

--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -277,7 +277,8 @@ inline void load(const YAML::Node& node, View& v)
         return;
 
     std::string key, stringval;
-
+    bool expectingSceneCS = false;
+    bool expectingDisplayCS = false;
     for (Iterator iter = node.begin();
             iter != node.end();
             ++iter)
@@ -292,44 +293,74 @@ inline void load(const YAML::Node& node, View& v)
         if(key == "name")
         {
             load(second, stringval);
-            v.name = stringval;
+            v.m_name = stringval;
+        }
+        else if (key == "view_transform")
+        {
+            expectingDisplayCS = true;
+            load(second, stringval);
+            v.m_viewTransform = stringval;
         }
         else if(key == "colorspace")
         {
+            expectingSceneCS = true;
             load(second, stringval);
-            v.colorspace = stringval;
+            v.m_colorspace = stringval;
+        }
+        else if (key == "display_colorspace")
+        {
+            expectingDisplayCS = true;
+            load(second, stringval);
+            v.m_colorspace = stringval;
         }
         else if(key == "looks" || key == "look")
         {
             load(second, stringval);
-            v.looks = stringval;
+            v.m_looks = stringval;
         }
         else
         {
             LogUnknownKeyWarning(node, first);
         }
     }
-    if(v.name.empty())
+    if(v.m_name.empty())
     {
         throwError(node, "View does not specify 'name'.");
     }
-    if(v.colorspace.empty())
+    if (expectingDisplayCS == expectingSceneCS)
     {
         std::ostringstream os;
-        os << "View '" << v.name << "' "
-            << "does not specify colorspace.";
+        os << "View '" << v.m_name <<
+              "' must specify colorspace or view_transform and display_colorspace.";
+        throwError(node, os.str().c_str());
+    }
+    if(v.m_colorspace.empty())
+    {
+        std::ostringstream os;
+        os << "View '" << v.m_name << "' does not specify colorspace.";
         throwError(node, os.str().c_str());
     }
 }
 
-inline void save(YAML::Emitter& out, View view)
+inline void save(YAML::Emitter& out, const View & view)
 {
     out << YAML::VerbatimTag("View");
     out << YAML::Flow;
     out << YAML::BeginMap;
-    out << YAML::Key << "name" << YAML::Value << view.name;
-    out << YAML::Key << "colorspace" << YAML::Value << view.colorspace;
-    if(!view.looks.empty()) out << YAML::Key << "looks" << YAML::Value << view.looks;
+    out << YAML::Key << "name" << YAML::Value << view.m_name;
+    if (view.m_viewTransform.empty())
+    {
+        out << YAML::Key << "colorspace" << YAML::Value << view.m_colorspace;
+    }
+    else
+    {
+        out << YAML::Key << "view_transform" << YAML::Value << view.m_viewTransform;
+        out << YAML::Key << "display_colorspace" << YAML::Value << view.m_colorspace;
+    }
+    if (!view.m_looks.empty())
+    {
+        out << YAML::Key << "looks" << YAML::Value << view.m_looks;
+    }
     out << YAML::EndMap;
 }
 
@@ -2044,12 +2075,42 @@ inline void load(const YAML::Node& node, ColorSpaceRcPtr& cs)
         }
         else if(key == "to_reference")
         {
+            if (cs->getReferenceSpaceType() == REFERENCE_SPACE_DISPLAY)
+            {
+                throwError(node, "'to_reference' cannot be used for a display color space.");
+            }
+            TransformRcPtr val;
+            load(second, val);
+            cs->setTransform(val, COLORSPACE_DIR_TO_REFERENCE);
+        }
+        else if (key == "to_display_reference")
+        {
+            if (cs->getReferenceSpaceType() == REFERENCE_SPACE_SCENE)
+            {
+                throwError(node, "'to_display_reference' cannot be used for a "
+                                 "non-display color space.");
+            }
             TransformRcPtr val;
             load(second, val);
             cs->setTransform(val, COLORSPACE_DIR_TO_REFERENCE);
         }
         else if(key == "from_reference")
         {
+            if (cs->getReferenceSpaceType() == REFERENCE_SPACE_DISPLAY)
+            {
+                throwError(node, "'from_reference' cannot be used for a display color space.");
+            }
+            TransformRcPtr val;
+            load(second, val);
+            cs->setTransform(val, COLORSPACE_DIR_FROM_REFERENCE);
+        }
+        else if (key == "from_display_reference")
+        {
+            if (cs->getReferenceSpaceType() == REFERENCE_SPACE_SCENE)
+            {
+                throwError(node, "'from_display_reference' cannot be used for a "
+                                 "non-display color space.");
+            }
             TransformRcPtr val;
             load(second, val);
             cs->setTransform(val, COLORSPACE_DIR_FROM_REFERENCE);
@@ -2099,19 +2160,18 @@ inline void save(YAML::Emitter& out, ConstColorSpaceRcPtr cs)
         out << YAML::Flow << YAML::Value << allocationvars;
     }
 
-    ConstTransformRcPtr toref = \
-        cs->getTransform(COLORSPACE_DIR_TO_REFERENCE);
+    const auto isDisplay = (cs->getReferenceSpaceType() == REFERENCE_SPACE_DISPLAY);
+    ConstTransformRcPtr toref = cs->getTransform(COLORSPACE_DIR_TO_REFERENCE);
     if(toref)
     {
-        out << YAML::Key << "to_reference" << YAML::Value;
+        out << YAML::Key << (isDisplay ? "to_display_reference" : "to_reference") << YAML::Value;
         save(out, toref);
     }
 
-    ConstTransformRcPtr fromref = \
-        cs->getTransform(COLORSPACE_DIR_FROM_REFERENCE);
+    ConstTransformRcPtr fromref = cs->getTransform(COLORSPACE_DIR_FROM_REFERENCE);
     if(fromref)
     {
-        out << YAML::Key << "from_reference" << YAML::Value;
+        out << YAML::Key << (isDisplay ? "from_display_reference" : "from_reference") << YAML::Value;
         save(out, fromref);
     }
 
@@ -2197,6 +2257,185 @@ inline void save(YAML::Emitter& out, ConstLookRcPtr look)
         out << YAML::Key << "inverse_transform";
         out << YAML::Value;
         save(out, look->getInverseTransform());
+    }
+
+    out << YAML::EndMap;
+    out << YAML::Newline;
+}
+
+// View transform
+
+inline ReferenceSpaceType peekViewTransformReferenceSpace(const YAML::Node & node)
+{
+    if (node.Type() != YAML::NodeType::Map)
+    {
+        throwError(node, "The '!<ViewTransform>' content needs to be a map.");
+    }
+
+    std::string key;
+    bool isScene = false;
+    bool isDisplay = false;
+
+    for (const auto & iter : node)
+    {
+        const YAML::Node& first = iter.first;
+        const YAML::Node& second = iter.second;
+
+        load(first, key);
+
+        if (second.IsNull() || !second.IsDefined()) continue;
+
+        if (key == "to_reference")
+        {
+            isScene = true;
+        }
+        else if (key == "to_display_reference")
+        {
+            isDisplay = true;
+        }
+        else if (key == "from_reference")
+        {
+            isScene = true;
+        }
+        else if (key == "from_display_reference")
+        {
+            isDisplay = true;
+        }
+    }
+
+    if (!isScene && !isDisplay)
+    {
+        throwError(node, "The '!<ViewTransform>' needs to refer to a transform.");
+    }
+    else if (isScene && isDisplay)
+    {
+        throwError(node, "The '!<ViewTransform>' cannot have both to/from_reference and "
+                         "to/from_display_reference transforms.");
+    }
+
+    return isDisplay ? REFERENCE_SPACE_DISPLAY : REFERENCE_SPACE_SCENE;
+}
+
+inline void load(const YAML::Node & node, ViewTransformRcPtr & vt)
+{
+    if (node.Tag() != "ViewTransform")
+    {
+        return; // not a !<ViewTransform> tag
+    }
+
+    if (node.Type() != YAML::NodeType::Map)
+    {
+        std::ostringstream os;
+        os << "The '!<ViewTransform>' content needs to be a map.";
+        throwError(node, os.str());
+    }
+
+    std::string key, stringval;
+
+    for (const auto & iter : node)
+    {
+        const YAML::Node& first = iter.first;
+        const YAML::Node& second = iter.second;
+
+        load(first, key);
+
+        if (second.IsNull() || !second.IsDefined()) continue;
+
+        if (key == "name")
+        {
+            load(second, stringval);
+            vt->setName(stringval.c_str());
+        }
+        else if (key == "description")
+        {
+            load(second, stringval);
+            vt->setDescription(stringval.c_str());
+        }
+        else if (key == "family")
+        {
+            load(second, stringval);
+            vt->setFamily(stringval.c_str());
+        }
+        else if (key == "categories")
+        {
+            StringVec categories;
+            load(second, categories);
+            for (auto name : categories)
+            {
+                vt->addCategory(name.c_str());
+            }
+        }
+        else if (key == "to_reference")
+        {
+            TransformRcPtr val;
+            load(second, val);
+            vt->setTransform(val, VIEWTRANSFORM_DIR_TO_REFERENCE);
+        }
+        else if (key == "to_display_reference")
+        {
+            TransformRcPtr val;
+            load(second, val);
+            vt->setTransform(val, VIEWTRANSFORM_DIR_TO_REFERENCE);
+        }
+        else if (key == "from_reference")
+        {
+            TransformRcPtr val;
+            load(second, val);
+            vt->setTransform(val, VIEWTRANSFORM_DIR_FROM_REFERENCE);
+        }
+        else if (key == "from_display_reference")
+        {
+            TransformRcPtr val;
+            load(second, val);
+            vt->setTransform(val, VIEWTRANSFORM_DIR_FROM_REFERENCE);
+        }
+        else
+        {
+            LogUnknownKeyWarning(node, first);
+        }
+    }
+}
+
+inline void save(YAML::Emitter & out, ConstViewTransformRcPtr & vt)
+{
+    out << YAML::VerbatimTag("ViewTransform");
+    out << YAML::BeginMap;
+
+    out << YAML::Key << "name" << YAML::Value << vt->getName();
+    if (vt->getFamily() != NULL && strlen(vt->getFamily()) > 0)
+    {
+        out << YAML::Key << "family" << YAML::Value << vt->getFamily();
+    }
+    if (vt->getDescription() != NULL && strlen(vt->getDescription()) > 0)
+    {
+        out << YAML::Key << "description";
+        out << YAML::Value << YAML::Literal << vt->getDescription();
+    }
+
+    if (vt->getNumCategories() > 0)
+    {
+        StringVec categories;
+        for (int idx = 0; idx < vt->getNumCategories(); ++idx)
+        {
+            categories.push_back(vt->getCategory(idx));
+        }
+        out << YAML::Key << "categories";
+        out << YAML::Flow << YAML::Value << categories;
+    }
+
+    const auto isDisplay = (vt->getReferenceSpaceType() == REFERENCE_SPACE_DISPLAY);
+    ConstTransformRcPtr toref = vt->getTransform(VIEWTRANSFORM_DIR_TO_REFERENCE);
+    if (toref)
+    {
+        out << YAML::Key << (isDisplay ? "to_display_reference" : "to_reference") << YAML::Value;
+        save(out, toref);
+    }
+
+    ConstTransformRcPtr fromref = vt->getTransform(VIEWTRANSFORM_DIR_FROM_REFERENCE);
+    if (fromref)
+    {
+        out << YAML::Key << (isDisplay ? "from_display_reference" : "from_reference") << YAML::Value;
+        save(out, fromref);
     }
 
     out << YAML::EndMap;
@@ -2600,8 +2839,8 @@ inline void load(const YAML::Node& node, ConfigRcPtr& c, const char* filename)
                 {
                     View view;
                     load(val, view);
-                    c->addDisplay(display.c_str(), view.name.c_str(),
-                                  view.colorspace.c_str(), view.looks.c_str());
+                    c->addDisplay(display.c_str(), view.m_name.c_str(), view.m_viewTransform.c_str(),
+                                  view.m_colorspace.c_str(), view.m_looks.c_str());
                 }
             }
         }
@@ -2636,11 +2875,44 @@ inline void load(const YAML::Node& node, ConfigRcPtr& c, const char* filename)
             {
                 if(val.Tag() == "ColorSpace")
                 {
-                    ColorSpaceRcPtr cs = ColorSpace::Create();
+                    ColorSpaceRcPtr cs = ColorSpace::Create(REFERENCE_SPACE_SCENE);
                     load(val, cs);
                     for(int ii = 0; ii < c->getNumColorSpaces(); ++ii)
                     {
                         if(strcmp(c->getColorSpaceNameByIndex(ii), cs->getName()) == 0)
+                        {
+                            std::ostringstream os;
+                            os << "Colorspace with name '" << cs->getName() << "' already defined.";
+                            throwError(second, os.str());
+                        }
+                    }
+                    c->addColorSpace(cs);
+                }
+                else
+                {
+                    std::ostringstream os;
+                    os << "Unknown element found in colorspaces:";
+                    os << val.Tag() << ". Only ColorSpace(s)";
+                    os << " currently handled.";
+                    LogWarning(os.str());
+                }
+            }
+        }
+        else if (key == "display_colorspaces")
+        {
+            if (second.Type() != YAML::NodeType::Sequence)
+            {
+                throwError(second, "'display_colorspaces' field needs to be a (- !<ColorSpace>) list.");
+            }
+            for (const auto & val : second)
+            {
+                if (val.Tag() == "ColorSpace")
+                {
+                    ColorSpaceRcPtr cs = ColorSpace::Create(REFERENCE_SPACE_DISPLAY);
+                    load(val, cs);
+                    for (int ii = 0; ii < c->getNumColorSpaces(); ++ii)
+                    {
+                        if (strcmp(c->getColorSpaceNameByIndex(ii), cs->getName()) == 0)
                         {
                             std::ostringstream os;
                             os << "Colorspace with name '" << cs->getName() << "' already defined.";
@@ -2684,13 +2956,40 @@ inline void load(const YAML::Node& node, ConfigRcPtr& c, const char* filename)
                 }
             }
         }
+        else if (key == "view_transforms")
+        {
+            if (second.Type() != YAML::NodeType::Sequence)
+            {
+                throwError(second, "'view_transforms' field needs to be a (- !<ViewTransform>) list.");
+            }
+
+            for (const auto & val : second)
+            {
+                if (val.Tag() == "ViewTransform")
+                {
+                    ReferenceSpaceType rst = peekViewTransformReferenceSpace(val);
+                    ViewTransformRcPtr vt = ViewTransform::Create(rst);
+                    load(val, vt);
+                    c->addViewTransform(vt);
+                }
+                else
+                {
+                    std::ostringstream os;
+                    os << "Unknown element found in view_transforms:";
+                    os << val.Tag() << ". Only ViewTransform(s)";
+                    os << " currently handled.";
+                    LogWarning(os.str());
+                }
+            }
+
+        }
         else
         {
             LogUnknownKeyWarning("profile", first);
         }
     }
 
-    if(filename)
+    if (filename)
     {
         std::string realfilename = AbsPath(filename);
         std::string configrootdir = pystring::os::path::dirname(realfilename);
@@ -2873,10 +3172,11 @@ inline void save(YAML::Emitter& out, const Config* c)
         for(int v = 0; v < c->getNumViews(display); ++v)
         {
             View dview;
-            dview.name = c->getView(display, v);
-            dview.colorspace = c->getDisplayColorSpaceName(display, dview.name.c_str());
-            if(c->getDisplayLooks(display, dview.name.c_str()) != NULL)
-                dview.looks = c->getDisplayLooks(display, dview.name.c_str());
+            dview.m_name = c->getView(display, v);
+            dview.m_colorspace = c->getDisplayViewTransformName(display, dview.m_name.c_str());
+            dview.m_colorspace = c->getDisplayColorSpaceName(display, dview.m_name.c_str());
+            if(c->getDisplayLooks(display, dview.m_name.c_str()) != NULL)
+                dview.m_looks = c->getDisplayLooks(display, dview.m_name.c_str());
             save(out, dview);
 
         }
@@ -2923,15 +3223,60 @@ inline void save(YAML::Emitter& out, const Config* c)
         out << YAML::Newline;
     }
 
+    // View transform
+    const int numVT = c->getNumViewTransforms();
+    if (numVT > 0)
+    {
+        out << YAML::Newline;
+        out << YAML::Key << "view_transforms";
+        out << YAML::Value << YAML::BeginSeq;
+        for (int i = 0; i < numVT; ++i)
+        {
+            auto name = c->getViewTransformNameByIndex(i);
+            auto vt = c->getViewTransform(name);
+            save(out, vt);
+        }
+        out << YAML::EndSeq;
+    }
+
+    std::vector<ConstColorSpaceRcPtr> sceneCS;
+    std::vector<ConstColorSpaceRcPtr> displayCS;
+    for (int i = 0; i < c->getNumColorSpaces(SEARCH_REFERENCE_SPACE_ALL, COLORSPACE_ALL); ++i)
+    {
+        const char* name = c->getColorSpaceNameByIndex(SEARCH_REFERENCE_SPACE_ALL,
+                                                       COLORSPACE_ALL, i);
+        auto cs = c->getColorSpace(name);
+        if (cs->getReferenceSpaceType() == REFERENCE_SPACE_DISPLAY)
+        {
+            displayCS.push_back(cs);
+        }
+        else
+        {
+            sceneCS.push_back(cs);
+        }
+    }
+
+    // Display ColorSpaces
+    if (!displayCS.empty())
+    {
+        out << YAML::Newline;
+        out << YAML::Key << "display_colorspaces";
+        out << YAML::Value << YAML::BeginSeq;
+        for (auto cs : displayCS)
+        {
+            save(out, cs);
+        }
+        out << YAML::EndSeq;
+    }
+
     // ColorSpaces
     {
         out << YAML::Newline;
         out << YAML::Key << "colorspaces";
         out << YAML::Value << YAML::BeginSeq;
-        for(int i = 0; i < c->getNumColorSpaces(COLORSPACE_ALL); ++i)
+        for (auto cs : sceneCS)
         {
-            const char* name = c->getColorSpaceNameByIndex(COLORSPACE_ALL, i);
-            save(out, c->getColorSpace(name));
+            save(out, cs);
         }
         out << YAML::EndSeq;
     }

--- a/src/OpenColorIO/OpBuilders.h
+++ b/src/OpenColorIO/OpBuilders.h
@@ -43,6 +43,22 @@ void BuildColorSpaceOps(OpRcPtrVec & ops,
                         const ConstColorSpaceRcPtr & srcColorSpace,
                         const ConstColorSpaceRcPtr & dstColorSpace);
 
+void BuildColorSpaceToReferenceOps(OpRcPtrVec & ops,
+                                   const Config & config,
+                                   const ConstContextRcPtr & context,
+                                   const ConstColorSpaceRcPtr & srcColorSpace);
+
+void BuildColorSpaceFromReferenceOps(OpRcPtrVec & ops,
+                                     const Config & config,
+                                     const ConstContextRcPtr & context,
+                                     const ConstColorSpaceRcPtr & dstColorSpace);
+
+void BuildReferenceConversionOps(OpRcPtrVec & ops,
+                                 const Config & config,
+                                 const ConstContextRcPtr & context,
+                                 ReferenceSpaceType srcReferenceSpace,
+                                 ReferenceSpaceType dstReferenceSpace);
+
 void BuildDisplayOps(OpRcPtrVec & ops,
                      const Config & config,
                      const ConstContextRcPtr & context,

--- a/src/OpenColorIO/ParseUtils.cpp
+++ b/src/OpenColorIO/ParseUtils.cpp
@@ -362,9 +362,9 @@ FixedFunctionStyle FixedFunctionStyleFromString(const char * style)
 
 namespace
 {
-static constexpr char EC_STYLE_VIDEO[] = "video";
+static constexpr char EC_STYLE_VIDEO[]       = "video";
 static constexpr char EC_STYLE_LOGARITHMIC[] = "log";
-static constexpr char EC_STYLE_LINEAR[] = "linear";
+static constexpr char EC_STYLE_LINEAR[]      = "linear";
 }
 
 const char * ExposureContrastStyleToString(ExposureContrastStyle style)

--- a/src/OpenColorIO/PathUtils.cpp
+++ b/src/OpenColorIO/PathUtils.cpp
@@ -237,7 +237,7 @@ int ParseColorSpaceFromString(const Config & config, const char * str)
     int rightMostColorSpaceIndex = -1;
 
     // Find the right-most occcurance within the string for each colorspace.
-    for (int i = 0; i < config.getNumColorSpaces(COLORSPACE_ALL); ++i)
+    for (int i = 0; i < config.getNumColorSpaces(SEARCH_REFERENCE_SPACE_ALL, COLORSPACE_ALL); ++i)
     {
         std::string csname = pystring::lower(config.getColorSpaceNameByIndex(i));
 

--- a/src/OpenColorIO/Transform.cpp
+++ b/src/OpenColorIO/Transform.cpp
@@ -29,7 +29,7 @@ void Transform::validate() const
         && getDirection() != TRANSFORM_DIR_INVERSE)
     {
         std::string err(typeid(*this).name());
-        err += ": invalid direction";
+        err += ": invalid direction.";
 
         throw Exception(err.c_str());
     }

--- a/src/OpenColorIO/ViewTransform.cpp
+++ b/src/OpenColorIO/ViewTransform.cpp
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#include <ostream>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "Categories.h"
+
+namespace OCIO_NAMESPACE
+{
+
+class ViewTransform::Impl : public CategoriesManager
+{
+public:
+    std::string m_name;
+    std::string m_family;
+    std::string m_description;
+    ReferenceSpaceType m_referenceSpaceType{ REFERENCE_SPACE_SCENE };
+
+    TransformRcPtr m_toRefTransform;
+    TransformRcPtr m_fromRefTransform;
+
+    Impl() = delete;
+    Impl(ReferenceSpaceType referenceSpace)
+        : CategoriesManager()
+        , m_referenceSpaceType(referenceSpace)
+    {
+    }
+
+    Impl(const Impl &) = delete;
+    ~Impl() = default;
+
+    Impl & operator= (const Impl & rhs)
+    {
+        if (this != &rhs)
+        {
+            m_name        = rhs.m_name;
+            m_family      = rhs.m_family;
+            m_description = rhs.m_description;
+
+            m_referenceSpaceType = rhs.m_referenceSpaceType;
+
+            m_toRefTransform = rhs.m_toRefTransform ? rhs.m_toRefTransform->createEditableCopy() :
+                                                      rhs.m_toRefTransform;
+
+            m_fromRefTransform = rhs.m_fromRefTransform ?
+                                 rhs.m_fromRefTransform->createEditableCopy() :
+                                 rhs.m_fromRefTransform;
+
+            m_categories = rhs.m_categories;
+        }
+        return *this;
+    }
+};
+
+
+ViewTransformRcPtr ViewTransform::Create(ReferenceSpaceType referenceSpace)
+{
+    return ViewTransformRcPtr(new ViewTransform(referenceSpace), &deleter);
+}
+
+void ViewTransform::deleter(ViewTransform * v)
+{
+    delete v;
+}
+
+ViewTransformRcPtr ViewTransform::createEditableCopy() const
+{
+    ViewTransformRcPtr cs = ViewTransform::Create(getImpl()->m_referenceSpaceType);
+    *cs->m_impl = *m_impl;
+    return cs;
+}
+
+ViewTransform::ViewTransform(ReferenceSpaceType referenceSpace)
+    : m_impl(new ViewTransform::Impl(referenceSpace))
+{
+}
+
+ViewTransform::~ViewTransform()
+{
+    delete m_impl;
+    m_impl = NULL;
+}
+
+const char * ViewTransform::getName() const noexcept
+{
+    return getImpl()->m_name.c_str();
+}
+
+void ViewTransform::setName(const char * name) noexcept
+{
+    getImpl()->m_name = name;
+}
+
+const char * ViewTransform::getFamily() const noexcept
+{
+    return getImpl()->m_family.c_str();
+}
+
+void ViewTransform::setFamily(const char * family)
+{
+    getImpl()->m_family = family;
+}
+
+const char * ViewTransform::getDescription() const noexcept
+{
+    return getImpl()->m_description.c_str();
+}
+
+void ViewTransform::setDescription(const char * description)
+{
+    getImpl()->m_description = description;
+}
+
+bool ViewTransform::hasCategory(const char * category) const
+{
+    return getImpl()->hasCategory(category);
+}
+
+void ViewTransform::addCategory(const char * category)
+{
+    getImpl()->addCategory(category);
+}
+void ViewTransform::removeCategory(const char * category)
+{
+    getImpl()->removeCategory(category);
+}
+
+int ViewTransform::getNumCategories() const
+{
+    return getImpl()->getNumCategories();
+}
+
+const char * ViewTransform::getCategory(int index) const
+{
+    return getImpl()->getCategory(index);
+}
+
+void ViewTransform::clearCategories()
+{
+    getImpl()->clearCategories();
+}
+
+
+ReferenceSpaceType ViewTransform::getReferenceSpaceType() const noexcept
+{
+    return getImpl()->m_referenceSpaceType;
+}
+
+ConstTransformRcPtr ViewTransform::getTransform(ViewTransformDirection dir) const
+{
+    if (dir == VIEWTRANSFORM_DIR_TO_REFERENCE)
+    {
+        return getImpl()->m_toRefTransform;
+    }
+    else if (dir == VIEWTRANSFORM_DIR_FROM_REFERENCE)
+    {
+        return getImpl()->m_fromRefTransform;
+    }
+
+    throw Exception("View transform: Unspecified ViewTransformDirection.");
+}
+
+void ViewTransform::setTransform(const ConstTransformRcPtr & transform, ViewTransformDirection dir)
+{
+    TransformRcPtr transformCopy;
+    if (transform)
+    {
+        transformCopy = transform->createEditableCopy();
+    }
+
+    if (dir == VIEWTRANSFORM_DIR_TO_REFERENCE)
+    {
+        getImpl()->m_toRefTransform = transformCopy;
+    }
+    else if (dir == VIEWTRANSFORM_DIR_FROM_REFERENCE)
+    {
+        getImpl()->m_fromRefTransform = transformCopy;
+    }
+    else
+    {
+        throw Exception("View transform: Unspecified ViewTransformDirection.");
+    }
+}
+
+
+namespace
+{
+static constexpr char REFERENCE_SPACE_SCENE_STR[]{ "scene" };
+static constexpr char REFERENCE_SPACE_DISPLAY_STR[]{ "display" };
+
+const char * ReferenceSpaceTypeToString(ReferenceSpaceType reference)
+{
+    switch (reference)
+    {
+    case REFERENCE_SPACE_SCENE:   return REFERENCE_SPACE_SCENE_STR;
+    case REFERENCE_SPACE_DISPLAY: return REFERENCE_SPACE_DISPLAY_STR;
+    }
+
+    // Default type is meaningless.
+    throw Exception("Unknown reference type");
+}
+}
+
+std::ostream & operator<< (std::ostream & os, const ViewTransform & vt)
+{
+    os << "<ViewTransform ";
+    os << "name=" << vt.getName() << ", ";
+    os << "family=" << vt.getFamily() << ", ";
+    os << "referenceSpaceType=" << ReferenceSpaceTypeToString(vt.getReferenceSpaceType());
+    os << ">";
+
+    if (vt.getTransform(VIEWTRANSFORM_DIR_TO_REFERENCE))
+    {
+        os << "\n    " << vt.getName() << " --> Reference";
+        os << "\n\t" << *vt.getTransform(VIEWTRANSFORM_DIR_TO_REFERENCE);
+    }
+
+    if (vt.getTransform(VIEWTRANSFORM_DIR_FROM_REFERENCE))
+    {
+        os << "\n    Reference --> " << vt.getName();
+        os << "\n\t" << *vt.getTransform(VIEWTRANSFORM_DIR_FROM_REFERENCE);
+    }
+    return os;
+}
+
+} // namespace OCIO_NAMESPACE
+

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -87,8 +87,6 @@ set(SOURCES
 	ops/range/RangeOpGPU.cpp
 	ScanlineHelper.cpp
 	Transform.cpp
-	transforms/ColorSpaceTransform.cpp
-	transforms/DisplayTransform.cpp
 	transforms/LookTransform.cpp
 )
 
@@ -176,6 +174,8 @@ set(TESTS
 	transforms/RangeTransform_tests.cpp
 	transforms/AllocationTransform_tests.cpp
 	transforms/CDLTransform_tests.cpp
+	transforms/ColorSpaceTransform_tests.cpp
+	transforms/DisplayTransform_tests.cpp
 	transforms/ExponentTransform_tests.cpp
 	transforms/ExponentWithLinearTransform_tests.cpp
 	transforms/ExposureContrastTransform_tests.cpp
@@ -190,6 +190,7 @@ set(TESTS
 	UnitTest.cpp
 	UnitTestLogUtils.cpp
 	UnitTestUtils.cpp
+	ViewTransform_tests.cpp
 )
 
 function(prepend var prefix)

--- a/tests/cpu/ColorSpace_tests.cpp
+++ b/tests/cpu/ColorSpace_tests.cpp
@@ -6,6 +6,52 @@
 #include "UnitTest.h"
 namespace OCIO = OCIO_NAMESPACE;
 
+OCIO_ADD_TEST(ColorSpace, basic)
+{
+    OCIO::ColorSpaceRcPtr cs = OCIO::ColorSpace::Create();
+    OCIO_REQUIRE_ASSERT(cs);
+    OCIO_REQUIRE_EQUAL(cs->getReferenceSpaceType(), OCIO::REFERENCE_SPACE_SCENE);
+
+    cs = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_DISPLAY);
+    OCIO_REQUIRE_ASSERT(cs);
+    OCIO_REQUIRE_EQUAL(cs->getReferenceSpaceType(), OCIO::REFERENCE_SPACE_DISPLAY);
+
+    cs = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_SCENE);
+    OCIO_REQUIRE_ASSERT(cs);
+    OCIO_REQUIRE_EQUAL(cs->getReferenceSpaceType(), OCIO::REFERENCE_SPACE_SCENE);
+
+    OCIO_CHECK_EQUAL(std::string(""), cs->getName());
+    OCIO_CHECK_EQUAL(std::string(""), cs->getFamily());
+    OCIO_CHECK_EQUAL(std::string(""), cs->getDescription());
+    OCIO_CHECK_EQUAL(std::string(""), cs->getEqualityGroup());
+    OCIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UNKNOWN, cs->getBitDepth());
+    OCIO_CHECK_ASSERT(!cs->isData());
+    OCIO_CHECK_EQUAL(OCIO::ALLOCATION_UNIFORM, cs->getAllocation());
+    OCIO_CHECK_EQUAL(0, cs->getAllocationNumVars());
+
+    cs->setName("name");
+    OCIO_CHECK_EQUAL(std::string("name"), cs->getName());
+    cs->setFamily("family");
+    OCIO_CHECK_EQUAL(std::string("family"), cs->getFamily());
+    cs->setDescription("description");
+    OCIO_CHECK_EQUAL(std::string("description"), cs->getDescription());
+    cs->setEqualityGroup("equalitygroup");
+    OCIO_CHECK_EQUAL(std::string("equalitygroup"), cs->getEqualityGroup());
+    cs->setBitDepth(OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(OCIO::BIT_DEPTH_F16, cs->getBitDepth());
+    cs->setIsData(true);
+    OCIO_CHECK_ASSERT(cs->isData());
+    cs->setAllocation(OCIO::ALLOCATION_UNKNOWN);
+    OCIO_CHECK_EQUAL(OCIO::ALLOCATION_UNKNOWN, cs->getAllocation());
+    const float vars[2]{ 1.f, 2.f };
+    cs->setAllocationVars(2, vars);
+    OCIO_CHECK_EQUAL(2, cs->getAllocationNumVars());
+    float readVars[2]{};
+    cs->getAllocationVars(readVars);
+    OCIO_CHECK_EQUAL(1.f, readVars[0]);
+    OCIO_CHECK_EQUAL(2.f, readVars[1]);
+}
+
 OCIO_ADD_TEST(ColorSpace, category)
 {
     OCIO::ColorSpaceRcPtr cs = OCIO::ColorSpace::Create();

--- a/tests/cpu/ColorSpace_tests.cpp
+++ b/tests/cpu/ColorSpace_tests.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <sstream>
+
 #include "ColorSpace.cpp"
 
 #include "UnitTest.h"
@@ -50,6 +52,10 @@ OCIO_ADD_TEST(ColorSpace, basic)
     cs->getAllocationVars(readVars);
     OCIO_CHECK_EQUAL(1.f, readVars[0]);
     OCIO_CHECK_EQUAL(2.f, readVars[1]);
+
+    std::ostringstream oss;
+    oss << *cs;
+    OCIO_CHECK_EQUAL(oss.str().size(), 149);
 }
 
 OCIO_ADD_TEST(ColorSpace, category)

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -231,7 +231,7 @@ OCIO_ADD_TEST(Config, serialize_group_transform)
             OCIO::FileTransform::Create();
         OCIO::GroupTransformRcPtr groupTransform = OCIO::GroupTransform::Create();
         groupTransform->appendTransform(transform1);
-        cs->setTransform(groupTransform, OCIO::COLORSPACE_DIR_FROM_REFERENCE);
+        OCIO_CHECK_NO_THROW(cs->setTransform(groupTransform, OCIO::COLORSPACE_DIR_FROM_REFERENCE));
         config->addColorSpace(cs);
         config->setRole( OCIO::ROLE_COMPOSITING_LOG, cs->getName() );
     }
@@ -243,7 +243,7 @@ OCIO_ADD_TEST(Config, serialize_group_transform)
             OCIO::ExponentTransform::Create();
         OCIO::GroupTransformRcPtr groupTransform = OCIO::GroupTransform::Create();
         groupTransform->appendTransform(transform1);
-        cs->setTransform(groupTransform, OCIO::COLORSPACE_DIR_TO_REFERENCE);
+        OCIO_CHECK_NO_THROW(cs->setTransform(groupTransform, OCIO::COLORSPACE_DIR_TO_REFERENCE));
         config->addColorSpace(cs);
         config->setRole( OCIO::ROLE_COMPOSITING_LOG, cs->getName() );
     }
@@ -626,7 +626,8 @@ OCIO_ADD_TEST(Config, env_colorspace_name)
                               "This config references a color space, '$MISSING_ENV', "
                               "which is not defined");
         OCIO_CHECK_THROW_WHAT(config->getProcessor("raw", "lgh"), OCIO::Exception,
-                              "BuildColorSpaceOps failed, null dstColorSpace");
+                              "BuildColorSpaceOps failed: destination color space '$MISSING_ENV' "
+                              "could not be found");
     }
 
     {
@@ -645,7 +646,8 @@ OCIO_ADD_TEST(Config, env_colorspace_name)
         OCIO_CHECK_THROW_WHAT(config->sanityCheck(), OCIO::Exception,
                               "color space, 'FaultyColorSpaceName', which is not defined");
         OCIO_CHECK_THROW_WHAT(config->getProcessor("raw", "lgh"), OCIO::Exception,
-                              "BuildColorSpaceOps failed, null dstColorSpace");
+                              "BuildColorSpaceOps failed: destination color space '$OCIO_TEST' "
+                              "could not be found");
     }
 
     {
@@ -781,7 +783,7 @@ const std::string SIMPLE_PROFILE_A =
     "  scene_linear: lnh\n"
     "\n";
 
-const std::string SIMPLE_PROFILE_B =
+const std::string SIMPLE_PROFILE_DISPLAYS_LOOKS =
     "displays:\n"
     "  sRGB:\n"
     "    - !<View> {name: Raw, colorspace: raw}\n"
@@ -795,7 +797,9 @@ const std::string SIMPLE_PROFILE_B =
     "    name: beauty\n"
     "    process_space: lnh\n"
     "    transform: !<CDLTransform> {slope: [1, 2, 1]}\n"
-    "\n"
+    "\n";
+
+const std::string SIMPLE_PROFILE_CS =
     "\n"
     "colorspaces:\n"
     "  - !<ColorSpace>\n"
@@ -813,6 +817,8 @@ const std::string SIMPLE_PROFILE_B =
     "    bitdepth: unknown\n"
     "    isdata: false\n"
     "    allocation: uniform\n";
+
+const std::string SIMPLE_PROFILE_B = SIMPLE_PROFILE_DISPLAYS_LOOKS + SIMPLE_PROFILE_CS;
 
 const std::string DEFAULT_RULES =
     "file_rules:\n"
@@ -3055,32 +3061,41 @@ OCIO_ADD_TEST(Config, inactive_color_space)
 
     // Step 1 - No inactive color spaces.
 
-    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_INACTIVE), 0);
-    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ACTIVE), 5);
-    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ALL), 5);
+    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                 OCIO::COLORSPACE_INACTIVE), 0);
+    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                 OCIO::COLORSPACE_ACTIVE), 5);
+    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                 OCIO::COLORSPACE_ALL), 5);
 
-    OCIO_CHECK_EQUAL(
-        config->getColorSpaceNameByIndex(OCIO::COLORSPACE_ALL, 0), std::string("raw"));
-    OCIO_CHECK_EQUAL(
-        config->getColorSpaceNameByIndex(OCIO::COLORSPACE_ALL, 1), std::string("lnh"));
-    OCIO_CHECK_EQUAL(
-        config->getColorSpaceNameByIndex(OCIO::COLORSPACE_ALL, 2), std::string("cs1"));
-    OCIO_CHECK_EQUAL(
-        config->getColorSpaceNameByIndex(OCIO::COLORSPACE_ALL, 3), std::string("cs2"));
-    OCIO_CHECK_EQUAL(
-        config->getColorSpaceNameByIndex(OCIO::COLORSPACE_ALL, 4), std::string("cs3"));
+    OCIO_CHECK_EQUAL(std::string("raw"),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                      OCIO::COLORSPACE_ALL, 0));
+    OCIO_CHECK_EQUAL(std::string("lnh"),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                      OCIO::COLORSPACE_ALL, 1));
+    OCIO_CHECK_EQUAL(std::string("cs1"),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                      OCIO::COLORSPACE_ALL, 2));
+    OCIO_CHECK_EQUAL(std::string("cs2"),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                      OCIO::COLORSPACE_ALL, 3));
+    OCIO_CHECK_EQUAL(std::string("cs3"),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                      OCIO::COLORSPACE_ALL, 4));
     // Check a faulty call.
-    OCIO_CHECK_EQUAL(
-        config->getColorSpaceNameByIndex(OCIO::COLORSPACE_ALL, 5), std::string(""));
+    OCIO_CHECK_EQUAL(std::string(""),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                      OCIO::COLORSPACE_ALL, 5));
 
     OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(), 5);
-    OCIO_CHECK_EQUAL(config->getColorSpaceNameByIndex(0), std::string("raw"));
-    OCIO_CHECK_EQUAL(config->getColorSpaceNameByIndex(1), std::string("lnh"));
-    OCIO_CHECK_EQUAL(config->getColorSpaceNameByIndex(2), std::string("cs1"));
-    OCIO_CHECK_EQUAL(config->getColorSpaceNameByIndex(3), std::string("cs2"));
-    OCIO_CHECK_EQUAL(config->getColorSpaceNameByIndex(4), std::string("cs3"));
+    OCIO_CHECK_EQUAL(std::string("raw"), config->getColorSpaceNameByIndex(0));
+    OCIO_CHECK_EQUAL(std::string("lnh"), config->getColorSpaceNameByIndex(1));
+    OCIO_CHECK_EQUAL(std::string("cs1"), config->getColorSpaceNameByIndex(2));
+    OCIO_CHECK_EQUAL(std::string("cs2"), config->getColorSpaceNameByIndex(3));
+    OCIO_CHECK_EQUAL(std::string("cs3"), config->getColorSpaceNameByIndex(4));
     // Check a faulty call.
-    OCIO_CHECK_EQUAL(config->getColorSpaceNameByIndex(5), std::string(""));
+    OCIO_CHECK_EQUAL(std::string(""), config->getColorSpaceNameByIndex(5));
 
     OCIO::ColorSpaceSetRcPtr css;
     OCIO_CHECK_NO_THROW(css = config->getColorSpaces(nullptr));
@@ -3089,7 +3104,7 @@ OCIO_ADD_TEST(Config, inactive_color_space)
     OCIO::ConstColorSpaceRcPtr cs;
     OCIO_CHECK_NO_THROW(cs = config->getColorSpace("scene_linear"));
     OCIO_REQUIRE_ASSERT(cs);
-    OCIO_CHECK_EQUAL(cs->getName(), std::string("lnh"));
+    OCIO_CHECK_EQUAL(std::string("lnh"), cs->getName());
 
     OCIO_CHECK_EQUAL(config->getIndexForColorSpace("scene_linear"), 1);
     OCIO_CHECK_EQUAL(config->getIndexForColorSpace("lnh"), 1);
@@ -3100,28 +3115,51 @@ OCIO_ADD_TEST(Config, inactive_color_space)
     OCIO_CHECK_NO_THROW(config->setInactiveColorSpaces("lnh, cs1"));
     OCIO_CHECK_EQUAL(config->getInactiveColorSpaces(), std::string("lnh, cs1"));
 
-    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_INACTIVE), 2);
-    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ACTIVE), 3);
-    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ALL), 5);
+    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                 OCIO::COLORSPACE_INACTIVE), 2);
+    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                 OCIO::COLORSPACE_ACTIVE), 3);
+    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                 OCIO::COLORSPACE_ALL), 5);
+
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_SCENE,
+                                               OCIO::COLORSPACE_INACTIVE), 2);
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_SCENE,
+                                               OCIO::COLORSPACE_ACTIVE), 3);
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_SCENE,
+                                               OCIO::COLORSPACE_ALL), 5);
+
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_DISPLAY,
+                                               OCIO::COLORSPACE_INACTIVE), 0);
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_DISPLAY,
+                                               OCIO::COLORSPACE_ACTIVE), 0);
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_DISPLAY,
+                                               OCIO::COLORSPACE_ALL), 0);
 
     // Check methods working on all color spaces.
-    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ALL), 5);
-    OCIO_CHECK_EQUAL(
-        config->getColorSpaceNameByIndex(OCIO::COLORSPACE_ALL, 0), std::string("raw"));
-    OCIO_CHECK_EQUAL(
-        config->getColorSpaceNameByIndex(OCIO::COLORSPACE_ALL, 1), std::string("lnh"));
-    OCIO_CHECK_EQUAL(
-        config->getColorSpaceNameByIndex(OCIO::COLORSPACE_ALL, 2), std::string("cs1"));
-    OCIO_CHECK_EQUAL(
-        config->getColorSpaceNameByIndex(OCIO::COLORSPACE_ALL, 3), std::string("cs2"));
-    OCIO_CHECK_EQUAL(
-        config->getColorSpaceNameByIndex(OCIO::COLORSPACE_ALL, 4), std::string("cs3"));
+    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL, 
+                                                 OCIO::COLORSPACE_ALL), 5);
+    OCIO_CHECK_EQUAL(std::string("raw"),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                      OCIO::COLORSPACE_ALL, 0));
+    OCIO_CHECK_EQUAL(std::string("lnh"),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                      OCIO::COLORSPACE_ALL, 1));
+    OCIO_CHECK_EQUAL(std::string("cs1"),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                      OCIO::COLORSPACE_ALL, 2));
+    OCIO_CHECK_EQUAL(std::string("cs2"),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                      OCIO::COLORSPACE_ALL, 3));
+    OCIO_CHECK_EQUAL(std::string("cs3"),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                      OCIO::COLORSPACE_ALL, 4));
 
     // Check methods working on only active color spaces.
     OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(), 3);
-    OCIO_CHECK_EQUAL(config->getColorSpaceNameByIndex(0), std::string("raw"));
-    OCIO_CHECK_EQUAL(config->getColorSpaceNameByIndex(1), std::string("cs2"));
-    OCIO_CHECK_EQUAL(config->getColorSpaceNameByIndex(2), std::string("cs3"));
+    OCIO_CHECK_EQUAL(std::string("raw"), config->getColorSpaceNameByIndex(0));
+    OCIO_CHECK_EQUAL(std::string("cs2"), config->getColorSpaceNameByIndex(1));
+    OCIO_CHECK_EQUAL(std::string("cs3"), config->getColorSpaceNameByIndex(2));
 
     // Asking for a color space set with no categories returns active color spaces only.
     OCIO_CHECK_NO_THROW(css = config->getColorSpaces(nullptr));
@@ -3138,22 +3176,22 @@ OCIO_ADD_TEST(Config, inactive_color_space)
     // Request an active color space.
     OCIO_CHECK_NO_THROW(cs = config->getColorSpace("cs2"));
     OCIO_CHECK_ASSERT(cs);
-    OCIO_CHECK_EQUAL(cs->getName(), std::string("cs2"));
+    OCIO_CHECK_EQUAL(std::string("cs2"), cs->getName());
 
     // Request an inactive color space.
     OCIO_CHECK_NO_THROW(cs = config->getColorSpace("cs1"));
     OCIO_CHECK_ASSERT(cs);
-    OCIO_CHECK_EQUAL(cs->getName(), std::string("cs1"));
+    OCIO_CHECK_EQUAL(std::string("cs1"), cs->getName());
 
     // Request a role with an active color space.
     OCIO_CHECK_NO_THROW(cs = config->getColorSpace("default"));
     OCIO_REQUIRE_ASSERT(cs);
-    OCIO_CHECK_EQUAL(cs->getName(), std::string("raw"));
+    OCIO_CHECK_EQUAL(std::string("raw"), cs->getName());
 
     // Request a role with an inactive color space.
     OCIO_CHECK_NO_THROW(cs = config->getColorSpace("scene_linear"));
     OCIO_CHECK_ASSERT(cs);
-    OCIO_CHECK_EQUAL(cs->getName(), std::string("lnh"));
+    OCIO_CHECK_EQUAL(std::string("lnh"), cs->getName());
     // ... the color is not an active color space.
     OCIO_CHECK_EQUAL(config->getIndexForColorSpace("scene_linear"), -1);
     OCIO_CHECK_EQUAL(config->getIndexForColorSpace("lnh"), -1);
@@ -3188,7 +3226,8 @@ OCIO_ADD_TEST(Config, inactive_color_space)
     OCIO_CHECK_NO_THROW(config->setInactiveColorSpaces(""));
     OCIO_CHECK_EQUAL(config->getInactiveColorSpaces(), std::string(""));
 
-    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ALL), 5);
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                               OCIO::COLORSPACE_ALL), 5);
     OCIO_CHECK_EQUAL(config->getNumColorSpaces(), 5);
 
     // Step 4 - No inactive color spaces.
@@ -3196,8 +3235,88 @@ OCIO_ADD_TEST(Config, inactive_color_space)
     OCIO_CHECK_NO_THROW(config->setInactiveColorSpaces(nullptr));
     OCIO_CHECK_EQUAL(config->getInactiveColorSpaces(), std::string(""));
 
-    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ALL), 5);
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                               OCIO::COLORSPACE_ALL), 5);
     OCIO_CHECK_EQUAL(config->getNumColorSpaces(), 5);
+
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_SCENE,
+                                               OCIO::COLORSPACE_ALL), 5);
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_DISPLAY,
+                                               OCIO::COLORSPACE_ALL), 0);
+
+    // Step 5 - Add display color spaces.
+    auto dcs0 = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_DISPLAY);
+    dcs0->setName("display0");
+    config->addColorSpace(dcs0);
+    auto dcs1 = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_DISPLAY);
+    dcs1->setName("display1");
+    config->addColorSpace(dcs1);
+    auto dcs2 = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_DISPLAY);
+    dcs2->setName("display2");
+    config->addColorSpace(dcs2);
+
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                               OCIO::COLORSPACE_ALL), 8);
+
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_SCENE,
+                                               OCIO::COLORSPACE_ALL), 5);
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_DISPLAY,
+                                               OCIO::COLORSPACE_ALL), 3);
+
+    // Step 6 - Some inactive color spaces.
+    OCIO_CHECK_NO_THROW(config->setInactiveColorSpaces("cs1, display1"));
+    OCIO_CHECK_EQUAL(config->getInactiveColorSpaces(), std::string("cs1, display1"));
+
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_SCENE,
+                                               OCIO::COLORSPACE_INACTIVE), 1);
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_DISPLAY,
+                                               OCIO::COLORSPACE_INACTIVE), 1);
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                               OCIO::COLORSPACE_INACTIVE), 2);
+    OCIO_CHECK_EQUAL(std::string("cs1"),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_SCENE,
+                                                      OCIO::COLORSPACE_INACTIVE, 0));
+    OCIO_CHECK_EQUAL(std::string("display1"),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_DISPLAY,
+                                                      OCIO::COLORSPACE_INACTIVE, 0));
+    OCIO_CHECK_EQUAL(std::string(""),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_SCENE,
+                                                      OCIO::COLORSPACE_INACTIVE, 1));
+    OCIO_CHECK_EQUAL(std::string(""),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_DISPLAY,
+                                                      OCIO::COLORSPACE_INACTIVE, 1));
+
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_SCENE,
+                                               OCIO::COLORSPACE_ACTIVE), 4);
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_DISPLAY,
+                                               OCIO::COLORSPACE_ACTIVE), 2);
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                               OCIO::COLORSPACE_ACTIVE), 6);
+    OCIO_CHECK_EQUAL(std::string("cs2"),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_SCENE,
+                                                      OCIO::COLORSPACE_ACTIVE, 2));
+    OCIO_CHECK_EQUAL(std::string("display2"),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_DISPLAY,
+                                                      OCIO::COLORSPACE_ACTIVE, 1));
+
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_SCENE,
+                                               OCIO::COLORSPACE_ALL), 5);
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_DISPLAY,
+                                               OCIO::COLORSPACE_ALL), 3);
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                               OCIO::COLORSPACE_ALL), 8);
+    OCIO_CHECK_EQUAL(std::string("raw"),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_SCENE,
+                                                      OCIO::COLORSPACE_ALL, 0));
+    OCIO_CHECK_EQUAL(std::string("cs2"),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_SCENE,
+                                                      OCIO::COLORSPACE_ALL, 3));
+    OCIO_CHECK_EQUAL(std::string(""),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_SCENE,
+                                                      OCIO::COLORSPACE_ALL, 10));
+    OCIO_CHECK_EQUAL(std::string("display1"),
+                     config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_DISPLAY,
+                                                      OCIO::COLORSPACE_ALL, 1));
 }
 
 OCIO_ADD_TEST(Config, inactive_color_space_precedence)
@@ -3217,9 +3336,12 @@ OCIO_ADD_TEST(Config, inactive_color_space_precedence)
     OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is)->createEditableCopy());
     OCIO_CHECK_NO_THROW(config->sanityCheck());
 
-    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_INACTIVE), 1);
-    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ACTIVE), 4);
-    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ALL), 5);
+    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                 OCIO::COLORSPACE_INACTIVE), 1);
+    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                 OCIO::COLORSPACE_ACTIVE), 4);
+    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                 OCIO::COLORSPACE_ALL), 5);
 
     OCIO_CHECK_EQUAL(config->getColorSpaceNameByIndex(0), std::string("raw"));
     OCIO_CHECK_EQUAL(config->getColorSpaceNameByIndex(1), std::string("lnh"));
@@ -3234,9 +3356,12 @@ OCIO_ADD_TEST(Config, inactive_color_space_precedence)
     OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is)->createEditableCopy());
     OCIO_CHECK_NO_THROW(config->sanityCheck());
 
-    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_INACTIVE), 3);
-    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ACTIVE), 2);
-    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ALL), 5);
+    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                 OCIO::COLORSPACE_INACTIVE), 3);
+    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                 OCIO::COLORSPACE_ACTIVE), 2);
+    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                 OCIO::COLORSPACE_ALL), 5);
 
     OCIO_CHECK_EQUAL(config->getColorSpaceNameByIndex(0), std::string("raw"));
     OCIO_CHECK_EQUAL(config->getColorSpaceNameByIndex(1), std::string("cs2"));
@@ -3245,9 +3370,12 @@ OCIO_ADD_TEST(Config, inactive_color_space_precedence)
 
     OCIO_CHECK_NO_THROW(config->setInactiveColorSpaces("cs1, lnh"));
 
-    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_INACTIVE), 2);
-    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ACTIVE), 3);
-    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ALL), 5);
+    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                 OCIO::COLORSPACE_INACTIVE), 2);
+    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                 OCIO::COLORSPACE_ACTIVE), 3);
+    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                 OCIO::COLORSPACE_ALL), 5);
 
     OCIO_CHECK_EQUAL(config->getColorSpaceNameByIndex(0), std::string("raw"));
     OCIO_CHECK_EQUAL(config->getColorSpaceNameByIndex(1), std::string("cs2"));
@@ -3271,7 +3399,8 @@ OCIO_ADD_TEST(Config, inactive_color_space_read_write)
         OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
         OCIO_CHECK_NO_THROW(config->sanityCheck());
 
-        OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ALL), 5);
+        OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                     OCIO::COLORSPACE_ALL), 5);
         OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(), 4);
 
         std::stringstream ss;
@@ -3297,7 +3426,8 @@ OCIO_ADD_TEST(Config, inactive_color_space_read_write)
             OCIO_CHECK_NO_THROW(config->sanityCheck());
         }
 
-        OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ALL), 5);
+        OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                     OCIO::COLORSPACE_ALL), 5);
         OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(), 2);
 
         std::stringstream ss;
@@ -3319,7 +3449,8 @@ OCIO_ADD_TEST(Config, inactive_color_space_read_write)
         OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
         OCIO_CHECK_NO_THROW(config->sanityCheck());
 
-        OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ALL), 5);
+        OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                     OCIO::COLORSPACE_ALL), 5);
         OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(), 3);
 
         std::string resultStr;
@@ -3346,7 +3477,8 @@ OCIO_ADD_TEST(Config, inactive_color_space_read_write)
         OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
         OCIO_CHECK_NO_THROW(config->sanityCheck());
 
-        OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ALL), 5);
+        OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                   OCIO::COLORSPACE_ALL), 5);
         OCIO_CHECK_EQUAL(config->getNumColorSpaces(), 5);
 
         std::string resultStr;
@@ -3379,7 +3511,8 @@ OCIO_ADD_TEST(Config, inactive_color_space_read_write)
                              "[OpenColorIO Warning]: Inactive color space 'unknown' does not exist.\n");
         }
 
-        OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ALL), 5);
+        OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                   OCIO::COLORSPACE_ALL), 5);
         OCIO_CHECK_EQUAL(config->getNumColorSpaces(), 5);
 
         std::stringstream ss;
@@ -3387,7 +3520,6 @@ OCIO_ADD_TEST(Config, inactive_color_space_read_write)
         OCIO_CHECK_EQUAL(ss.str(), configStr);
     }
 }
-
 
 OCIO_ADD_TEST(Config, two_configs)
 {
@@ -3513,4 +3645,245 @@ colorspaces:
     OCIO_CHECK_THROW_WHAT(OCIO::Config::GetProcessor(config1, "test", config3, "test"),
                           OCIO::Exception,
                           "The role 'aces_interchange' is missing in the destination config");
+}
+
+const std::string PROFILE_V2_DCS_START = PROFILE_V2 + SIMPLE_PROFILE_A + DEFAULT_RULES +
+                                         SIMPLE_PROFILE_DISPLAYS_LOOKS;
+
+OCIO_ADD_TEST(Config, display_color_spaces_serialization)
+{
+    {
+        const std::string strDCS =
+            "\n"
+            "view_transforms:\n"
+            "  - !<ViewTransform>\n"
+            "    name: display\n"
+            "    from_display_reference: !<MatrixTransform> {}\n"
+            "\n"
+            "  - !<ViewTransform>\n"
+            "    name: scene\n"
+            "    from_reference: !<MatrixTransform> {}\n"
+            "\n"
+            "display_colorspaces:\n"
+            "  - !<ColorSpace>\n"
+            "    name: dcs1\n"
+            "    family: \"\"\n"
+            "    equalitygroup: \"\"\n"
+            "    bitdepth: unknown\n"
+            "    isdata: false\n"
+            "    allocation: uniform\n"
+            "    from_display_reference: !<ExponentTransform> {value: 2.4, direction: inverse}\n"
+            "\n"
+            "  - !<ColorSpace>\n"
+            "    name: dcs2\n"
+            "    family: \"\"\n"
+            "    equalitygroup: \"\"\n"
+            "    bitdepth: unknown\n"
+            "    isdata: false\n"
+            "    allocation: uniform\n"
+            "    to_display_reference: !<ExponentTransform> {value: 2.4}\n";
+			
+        const std::string str = PROFILE_V2_DCS_START + strDCS + SIMPLE_PROFILE_CS;
+
+        std::istringstream is;
+        is.str(str);
+
+        OCIO::ConstConfigRcPtr config;
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+        std::stringstream ss;
+        ss << *config.get();
+        OCIO_CHECK_EQUAL(ss.str().size(), str.size());
+        OCIO_CHECK_EQUAL(ss.str(), str);
+    }
+}
+
+OCIO_ADD_TEST(Config, display_color_spaces_errors)
+{
+    {
+        const std::string strDCS =
+            "\n"
+            "display_colorspaces:\n"
+            "  - !<ColorSpace>\n"
+            "    name: dcs1\n"
+            "    family: \"\"\n"
+            "    equalitygroup: \"\"\n"
+            "    bitdepth: unknown\n"
+            "    isdata: false\n"
+            "    allocation: uniform\n"
+            "    from_reference: !<ExponentTransform> {value: [2.4, 2.4, 2.4, 1], direction: inverse}\n"
+            "\n"
+            "  - !<ColorSpace>\n"
+            "    name: dcs2\n"
+            "    family: \"\"\n"
+            "    equalitygroup: \"\"\n"
+            "    bitdepth: unknown\n"
+            "    isdata: false\n"
+            "    allocation: uniform\n"
+            "    to_display_reference: !<ExponentTransform> {value: [2.4, 2.4, 2.4, 1]}\n";
+        const std::string str = PROFILE_V2_DCS_START + strDCS + SIMPLE_PROFILE_CS;
+
+        std::istringstream is;
+        is.str(str);
+
+        OCIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(is), OCIO::Exception,
+                              "'from_reference' cannot be used for a display color space");
+    }
+    {
+        const std::string strDCS =
+            "\n"
+            "display_colorspaces:\n"
+            "  - !<ColorSpace>\n"
+            "    name: dcs1\n"
+            "    family: \"\"\n"
+            "    equalitygroup: \"\"\n"
+            "    bitdepth: unknown\n"
+            "    isdata: false\n"
+            "    allocation: uniform\n"
+            "    from_display_reference: !<ExponentTransform> {value: [2.4, 2.4, 2.4, 1], direction: inverse}\n"
+            "\n"
+            "  - !<ColorSpace>\n"
+            "    name: dcs2\n"
+            "    family: \"\"\n"
+            "    equalitygroup: \"\"\n"
+            "    bitdepth: unknown\n"
+            "    isdata: false\n"
+            "    allocation: uniform\n"
+            "    to_reference: !<ExponentTransform> {value: [2.4, 2.4, 2.4, 1]}\n";
+        const std::string str = PROFILE_V2_DCS_START + strDCS + SIMPLE_PROFILE_CS;
+
+        std::istringstream is;
+        is.str(str);
+
+        OCIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(is), OCIO::Exception,
+                              "'to_reference' cannot be used for a display color space");
+    }
+}
+
+OCIO_ADD_TEST(Config, view_transforms)
+{
+    const std::string str = PROFILE_V2_DCS_START + SIMPLE_PROFILE_CS;
+
+    std::istringstream is;
+    is.str(str);
+
+    OCIO::ConstConfigRcPtr config;
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    auto configEdit = config->createEditableCopy();
+    // Create display-referred view transform and add it to the config.
+    auto vt = OCIO::ViewTransform::Create(OCIO::REFERENCE_SPACE_DISPLAY);
+    OCIO_CHECK_THROW_WHAT(configEdit->addViewTransform(vt), OCIO::Exception,
+                          "Cannot add view transform with an empty name");
+    const std::string vtDisplay{ "display" };
+    vt->setName(vtDisplay.c_str());
+    OCIO_CHECK_THROW_WHAT(configEdit->addViewTransform(vt), OCIO::Exception,
+                          "Cannot add view transform with no transform");
+    OCIO_CHECK_NO_THROW(vt->setTransform(OCIO::MatrixTransform::Create(),
+                                         OCIO::VIEWTRANSFORM_DIR_FROM_REFERENCE));
+    OCIO_CHECK_NO_THROW(configEdit->addViewTransform(vt));
+    OCIO_CHECK_EQUAL(configEdit->getNumViewTransforms(), 1);
+    // Need at least one scene-referred view transform.
+    OCIO_CHECK_THROW_WHAT(configEdit->sanityCheck(), OCIO::Exception,
+                          "at least one must use the scene reference space");
+    OCIO_CHECK_ASSERT(!configEdit->getDefaultSceneToDisplayViewTransform());
+
+    // Create scene-referred view transform and add it to the config.
+    vt = OCIO::ViewTransform::Create(OCIO::REFERENCE_SPACE_SCENE);
+    const std::string vtScene{ "scene" };
+    vt->setName(vtScene.c_str());
+    OCIO_CHECK_NO_THROW(vt->setTransform(OCIO::MatrixTransform::Create(),
+                                         OCIO::VIEWTRANSFORM_DIR_FROM_REFERENCE));
+    OCIO_CHECK_NO_THROW(configEdit->addViewTransform(vt));
+    OCIO_REQUIRE_EQUAL(configEdit->getNumViewTransforms(), 2);
+    OCIO_CHECK_NO_THROW(configEdit->sanityCheck());
+
+    auto sceneVT = configEdit->getDefaultSceneToDisplayViewTransform();
+    OCIO_CHECK_ASSERT(sceneVT);
+
+    OCIO_CHECK_EQUAL(vtDisplay, configEdit->getViewTransformNameByIndex(0));
+    OCIO_CHECK_EQUAL(vtScene, configEdit->getViewTransformNameByIndex(1));
+    OCIO_CHECK_EQUAL(std::string(""), configEdit->getViewTransformNameByIndex(42));
+    OCIO_CHECK_ASSERT(configEdit->getViewTransform(vtScene.c_str()));
+    OCIO_CHECK_ASSERT(!configEdit->getViewTransform("not a view transform"));
+
+    // Save and reload to test file io for viewTransform.
+    std::stringstream os;
+    os << *configEdit.get();
+
+    is.clear();
+    is.str(os.str());
+
+    OCIO::ConstConfigRcPtr configReloaded;
+    OCIO_CHECK_NO_THROW(configReloaded = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_NO_THROW(configReloaded->sanityCheck());
+
+    // Setting a view transform with the same name replaces the earlier one.
+    OCIO_CHECK_NO_THROW(vt->setTransform(OCIO::LogTransform::Create(),
+                                         OCIO::VIEWTRANSFORM_DIR_FROM_REFERENCE));
+    OCIO_CHECK_NO_THROW(configEdit->addViewTransform(vt));
+    OCIO_REQUIRE_EQUAL(configEdit->getNumViewTransforms(), 2);
+    sceneVT = configEdit->getViewTransform(vtScene.c_str());
+    auto trans = sceneVT->getTransform(OCIO::VIEWTRANSFORM_DIR_FROM_REFERENCE);
+    OCIO_REQUIRE_ASSERT(trans);
+    OCIO_CHECK_ASSERT(OCIO_DYNAMIC_POINTER_CAST<const OCIO::LogTransform>(trans));
+
+    OCIO_CHECK_EQUAL(configReloaded->getNumViewTransforms(), 2);
+
+    configEdit->clearViewTransforms();
+    OCIO_CHECK_EQUAL(configEdit->getNumViewTransforms(), 0);
+}
+
+OCIO_ADD_TEST(Config, display_view)
+{
+    OCIO::ConfigRcPtr config = OCIO::Config::Create();
+    auto cs = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_SCENE);
+    cs->setName("scs");
+    config->addColorSpace(cs);
+    cs = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_DISPLAY);
+    cs->setName("dcs");
+    config->addColorSpace(cs);
+
+    auto vt = OCIO::ViewTransform::Create(OCIO::REFERENCE_SPACE_DISPLAY);
+    vt->setName("display");
+    OCIO_CHECK_NO_THROW(vt->setTransform(OCIO::MatrixTransform::Create(),
+                                         OCIO::VIEWTRANSFORM_DIR_FROM_REFERENCE));
+    OCIO_CHECK_NO_THROW(config->addViewTransform(vt));
+
+    vt = OCIO::ViewTransform::Create(OCIO::REFERENCE_SPACE_SCENE);
+    vt->setName("view_transform");
+    OCIO_CHECK_NO_THROW(vt->setTransform(OCIO::MatrixTransform::Create(),
+                                         OCIO::VIEWTRANSFORM_DIR_FROM_REFERENCE));
+    OCIO_CHECK_NO_THROW(config->addViewTransform(vt));
+
+    const std::string display{ "display" };
+    OCIO_CHECK_NO_THROW(config->addDisplay(display.c_str(), "view1", "scs", ""));
+
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    OCIO_CHECK_NO_THROW(config->addDisplay(display.c_str(), "view2", "view_transform", "scs", ""));
+    OCIO_CHECK_THROW_WHAT(config->sanityCheck(), OCIO::Exception,
+                          "color space, 'scs', that is not a display-referred");
+
+    OCIO_CHECK_NO_THROW(config->addDisplay(display.c_str(), "view2", "view_transform", "dcs", ""));
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    OCIO_CHECK_EQUAL(config->getNumDisplays(), 1);
+    OCIO_CHECK_EQUAL(config->getNumViews(display.c_str()), 2);
+    // Using nullptr for any parameter does nothing.
+    OCIO_CHECK_NO_THROW(config->addDisplay(nullptr, "view1", "scs", ""));
+    OCIO_CHECK_NO_THROW(config->addDisplay(display.c_str(), "view3", nullptr, ""));
+    OCIO_CHECK_NO_THROW(config->addDisplay(display.c_str(), "view4", "", nullptr));
+    OCIO_CHECK_NO_THROW(config->addDisplay(display.c_str(), "view4", "view_transform", "dcs", nullptr));
+    OCIO_CHECK_EQUAL(config->getNumDisplays(), 1);
+    OCIO_CHECK_EQUAL(config->getNumViews(display.c_str()), 2);
+
+    OCIO_CHECK_THROW_WHAT(config->addDisplay("", "view1", "scs", ""), OCIO::Exception,
+                          "Can't add a display with empty name");
+    OCIO_CHECK_THROW_WHAT(config->addDisplay(display.c_str(), "", "scs", ""), OCIO::Exception,
+                          "Can't add a display with empty view name");
+    OCIO_CHECK_THROW_WHAT(config->addDisplay(display.c_str(), "view1", "", ""), OCIO::Exception,
+                          "Can't add a display with empty color space name");
 }

--- a/tests/cpu/FileRules_tests.cpp
+++ b/tests/cpu/FileRules_tests.cpp
@@ -1042,8 +1042,10 @@ colorspaces:
         // 'Default' does not exist, 'Raw' is not a data color-space, so a new color-space has
         // been created with a unique name.
         OCIO_CHECK_EQUAL(config->getNumColorSpaces(), 3);
-        OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::COLORSPACE_ALL), 4);
-        OCIO_CHECK_EQUAL(std::string(config->getColorSpaceNameByIndex(OCIO::COLORSPACE_ALL, 3)),
+        OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                   OCIO::COLORSPACE_ALL), 4);
+        OCIO_CHECK_EQUAL(std::string(config->getColorSpaceNameByIndex(OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                                                                      OCIO::COLORSPACE_ALL, 3)),
                          "added_default_rule_colorspace");
     }
 

--- a/tests/cpu/UnitTest.h
+++ b/tests/cpu/UnitTest.h
@@ -36,6 +36,7 @@
 #include <iomanip>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
 

--- a/tests/cpu/ViewTransform_tests.cpp
+++ b/tests/cpu/ViewTransform_tests.cpp
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include "UnitTest.h"
+#include "ViewTransform.cpp"
+
+namespace OCIO = OCIO_NAMESPACE;
+
+OCIO_ADD_TEST(ViewTransform, basic)
+{
+    OCIO::ViewTransformRcPtr vt = OCIO::ViewTransform::Create(OCIO::REFERENCE_SPACE_SCENE);
+    OCIO_REQUIRE_ASSERT(vt);
+    OCIO_CHECK_EQUAL(OCIO::REFERENCE_SPACE_SCENE, vt->getReferenceSpaceType());
+    OCIO_CHECK_EQUAL(std::string(""), vt->getName());
+    OCIO_CHECK_EQUAL(std::string(""), vt->getFamily());
+    OCIO_CHECK_EQUAL(std::string(""), vt->getDescription());
+    OCIO_CHECK_EQUAL(0, vt->getNumCategories());
+
+    vt->setName("name");
+    OCIO_CHECK_EQUAL(std::string("name"), vt->getName());
+    vt->setFamily("family");
+    OCIO_CHECK_EQUAL(std::string("family"), vt->getFamily());
+    vt->setDescription("description");
+    OCIO_CHECK_EQUAL(std::string("description"), vt->getDescription());
+
+    OCIO_CHECK_EQUAL(vt->getNumCategories(), 0);
+
+    OCIO_CHECK_ASSERT(!vt->hasCategory("linear"));
+    OCIO_CHECK_ASSERT(!vt->hasCategory("rendering"));
+    OCIO_CHECK_ASSERT(!vt->hasCategory("log"));
+
+    OCIO_CHECK_NO_THROW(vt->addCategory("linear"));
+    OCIO_CHECK_NO_THROW(vt->addCategory("rendering"));
+    OCIO_CHECK_EQUAL(vt->getNumCategories(), 2);
+
+    OCIO_CHECK_ASSERT(vt->hasCategory("linear"));
+    OCIO_CHECK_ASSERT(vt->hasCategory("rendering"));
+    OCIO_CHECK_ASSERT(!vt->hasCategory("log"));
+
+    OCIO_CHECK_EQUAL(std::string(vt->getCategory(0)), std::string("linear"));
+    OCIO_CHECK_EQUAL(std::string(vt->getCategory(1)), std::string("rendering"));
+    // Check with an invalid index.
+    OCIO_CHECK_NO_THROW(vt->getCategory(2));
+    OCIO_CHECK_ASSERT(vt->getCategory(2) == nullptr);
+
+    OCIO_CHECK_NO_THROW(vt->removeCategory("linear"));
+    OCIO_CHECK_EQUAL(vt->getNumCategories(), 1);
+    OCIO_CHECK_ASSERT(!vt->hasCategory("linear"));
+    OCIO_CHECK_ASSERT(vt->hasCategory("rendering"));
+    OCIO_CHECK_ASSERT(!vt->hasCategory("log"));
+
+    // Remove a category not in the view transform.
+    OCIO_CHECK_NO_THROW(vt->removeCategory("log"));
+    OCIO_CHECK_EQUAL(vt->getNumCategories(), 1);
+    OCIO_CHECK_ASSERT(vt->hasCategory("rendering"));
+
+    OCIO_CHECK_NO_THROW(vt->clearCategories());
+    OCIO_CHECK_EQUAL(vt->getNumCategories(), 0);
+
+    OCIO::ViewTransformRcPtr vtd = OCIO::ViewTransform::Create(OCIO::REFERENCE_SPACE_DISPLAY);
+    OCIO_REQUIRE_ASSERT(vtd);
+    OCIO_CHECK_EQUAL(OCIO::REFERENCE_SPACE_DISPLAY, vtd->getReferenceSpaceType());
+}

--- a/tests/cpu/transforms/ColorSpaceTransform_tests.cpp
+++ b/tests/cpu/transforms/ColorSpaceTransform_tests.cpp
@@ -1,0 +1,587 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#include "transforms/ColorSpaceTransform.cpp"
+
+#include "ops/exponent/ExponentOp.h"
+#include "ops/fixedfunction/FixedFunctionOpData.h"
+#include "ops/log/LogOpData.h"
+#include "ops/matrix/MatrixOpData.h"
+
+#include "UnitTest.h"
+namespace OCIO = OCIO_NAMESPACE;
+
+OCIO_ADD_TEST(ColorSpaceTransform, basic)
+{
+    OCIO::ColorSpaceTransformRcPtr cst = OCIO::ColorSpaceTransform::Create();
+    OCIO_CHECK_EQUAL(cst->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    cst->setDirection(OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(cst->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+
+    const std::string empty;
+
+    OCIO_CHECK_EQUAL(empty, cst->getSrc());
+    const std::string src{ "source" };
+    cst->setSrc(src.c_str());
+    OCIO_CHECK_EQUAL(src, cst->getSrc());
+
+    OCIO_CHECK_EQUAL(empty, cst->getDst());
+    const std::string dst{ "destination" };
+    cst->setDst(dst.c_str());
+    OCIO_CHECK_EQUAL(dst, cst->getDst());
+
+    OCIO_CHECK_NO_THROW(cst->validate());
+
+    cst->setSrc("");
+    OCIO_CHECK_THROW_WHAT(cst->validate(), OCIO::Exception,
+                          "ColorSpaceTransform: empty source color space name");
+    cst->setSrc(src.c_str());
+
+    cst->setDst("");
+    OCIO_CHECK_THROW_WHAT(cst->validate(), OCIO::Exception,
+                          "ColorSpaceTransform: empty destination color space name");
+    cst->setDst(dst.c_str());
+
+    cst->setDirection(OCIO::TRANSFORM_DIR_UNKNOWN);
+    OCIO_CHECK_THROW_WHAT(cst->validate(), OCIO::Exception,
+                          "ColorSpaceTransform: invalid direction");
+}
+
+OCIO_ADD_TEST(ColorSpaceTransform, build_colorspace_ops)
+{
+    //
+    // Prepare.
+    //
+
+    OCIO::ColorSpaceTransformRcPtr cst = OCIO::ColorSpaceTransform::Create();
+    const std::string src{ "source" };
+    cst->setSrc(src.c_str());
+    const std::string dst{ "destination" };
+    cst->setDst(dst.c_str());
+
+    OCIO::ConfigRcPtr config = OCIO::Config::Create();
+    auto csSceneToRef = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_SCENE);
+    csSceneToRef->setName(src.c_str());
+    auto mat = OCIO::MatrixTransform::Create();
+    const double offset[4]{ 0., 0.1, 0.2, 0. };
+    mat->setOffset(offset);
+    csSceneToRef->setTransform(mat, OCIO::COLORSPACE_DIR_TO_REFERENCE);
+    config->addColorSpace(csSceneToRef);
+
+    auto csSceneFromRef = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_SCENE);
+    csSceneFromRef->setName(dst.c_str());
+    auto ff = OCIO::FixedFunctionTransform::Create();
+    ff->setStyle(OCIO::FIXED_FUNCTION_ACES_GLOW_03);
+    csSceneFromRef->setTransform(ff, OCIO::COLORSPACE_DIR_FROM_REFERENCE);
+    config->addColorSpace(csSceneFromRef);
+
+    config->addDisplay("display", "view", dst.c_str(), "");
+
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    {
+        // Test from source to destination.
+        // Source has the to_reference transform defined.
+        // Destination has the from_reference transform defined.
+        // Expecting source to_reference + destination from_reference.
+        // (The no-ops are the Allocation transforms.)
+
+        OCIO::OpRcPtrVec ops;
+        OCIO_CHECK_NO_THROW(OCIO::BuildColorSpaceOps(ops, *config, config->getCurrentContext(),
+                                                     *cst, OCIO::TRANSFORM_DIR_FORWARD));
+        OCIO_CHECK_NO_THROW(ops.finalize(OCIO::OPTIMIZATION_NONE));
+        OCIO_REQUIRE_EQUAL(ops.size(), 4);
+
+        // Allocation no-op.
+        auto op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[0]);
+        auto data = op->data();
+        OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+        // Src CS to reference.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[1]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::MatrixType);
+        auto matData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::MatrixOpData>(data);
+        OCIO_CHECK_EQUAL(offset[0], matData->getOffsetValue(0));
+        OCIO_CHECK_EQUAL(offset[1], matData->getOffsetValue(1));
+        OCIO_CHECK_EQUAL(offset[2], matData->getOffsetValue(2));
+        OCIO_CHECK_EQUAL(offset[3], matData->getOffsetValue(3));
+
+        // Reference to dst CS.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[2]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::FixedFunctionType);
+        auto ffData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::FixedFunctionOpData>(data);
+        OCIO_CHECK_EQUAL(ffData->getStyle(), OCIO::FixedFunctionOpData::ACES_GLOW_03_FWD);
+
+        // Allocation no-op.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[3]);
+        data = op->data();
+        OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+    }
+
+    {
+        // Test in other direction.
+        // Expecting destination-from reference inverted + source-to reference inverted.
+
+        OCIO::OpRcPtrVec ops;
+        OCIO_CHECK_NO_THROW(OCIO::BuildColorSpaceOps(ops, *config, config->getCurrentContext(),
+                                                     *cst, OCIO::TRANSFORM_DIR_INVERSE));
+        // Note: Need to finalize to have the inverted offset values below.
+        OCIO_CHECK_NO_THROW(ops.finalize(OCIO::OPTIMIZATION_NONE));
+        OCIO_REQUIRE_EQUAL(ops.size(), 4);
+
+        auto op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[0]);
+        auto data = op->data();
+        OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+        // Dst CS to reference.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[1]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::FixedFunctionType);
+        auto ffData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::FixedFunctionOpData>(data);
+        OCIO_CHECK_EQUAL(ffData->getStyle(), OCIO::FixedFunctionOpData::ACES_GLOW_03_INV);
+
+        // Reference to src CS.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[2]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::MatrixType);
+        auto matData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::MatrixOpData>(data);
+        OCIO_CHECK_EQUAL(-offset[0], matData->getOffsetValue(0));
+        OCIO_CHECK_EQUAL(-offset[1], matData->getOffsetValue(1));
+        OCIO_CHECK_EQUAL(-offset[2], matData->getOffsetValue(2));
+        OCIO_CHECK_EQUAL(-offset[3], matData->getOffsetValue(3));
+
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[3]);
+        data = op->data();
+        OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+    }
+
+    {
+        // Color space to reference ops: color space only defines from_reference, expecting the
+        // inverse of that transform.
+
+        OCIO::OpRcPtrVec ops;
+        OCIO_CHECK_NO_THROW(OCIO::BuildColorSpaceToReferenceOps(ops, *config,
+                                                                config->getCurrentContext(),
+                                                                csSceneFromRef));
+        OCIO_CHECK_NO_THROW(ops.finalize(OCIO::OPTIMIZATION_NONE));
+        OCIO_REQUIRE_EQUAL(ops.size(), 2);
+        auto op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[1]);
+        auto data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::FixedFunctionType);
+        auto ffData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::FixedFunctionOpData>(data);
+        OCIO_CHECK_EQUAL(ffData->getStyle(), OCIO::FixedFunctionOpData::ACES_GLOW_03_INV);
+    }
+
+    {
+        // Color space from reference ops: color space defines from_reference, expecting that
+        // transform.
+
+        OCIO::OpRcPtrVec ops;
+        OCIO_CHECK_NO_THROW(OCIO::BuildColorSpaceFromReferenceOps(ops, *config,
+                                                                  config->getCurrentContext(),
+                                                                  csSceneFromRef));
+        OCIO_CHECK_NO_THROW(ops.finalize(OCIO::OPTIMIZATION_NONE));
+        OCIO_REQUIRE_EQUAL(ops.size(), 2);
+        auto op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[0]);
+        auto data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::FixedFunctionType);
+        auto ffData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::FixedFunctionOpData>(data);
+        OCIO_CHECK_EQUAL(ffData->getStyle(), OCIO::FixedFunctionOpData::ACES_GLOW_03_FWD);
+    }
+
+    {
+        // Color space with both to_reference and from_reference transform defined. No inversion
+        // is made.
+
+        auto csSceneBoth = csSceneFromRef->createEditableCopy();
+        ff->setStyle(OCIO::FIXED_FUNCTION_ACES_GLOW_10);
+        csSceneBoth->setTransform(ff, OCIO::COLORSPACE_DIR_TO_REFERENCE);
+        OCIO::OpRcPtrVec ops;
+        OCIO_CHECK_NO_THROW(OCIO::BuildColorSpaceFromReferenceOps(ops, *config,
+                                                                  config->getCurrentContext(),
+                                                                  csSceneBoth));
+        OCIO_CHECK_NO_THROW(ops.finalize(OCIO::OPTIMIZATION_NONE));
+        OCIO_REQUIRE_EQUAL(ops.size(), 2);
+        auto op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[0]);
+        auto data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::FixedFunctionType);
+        auto ffData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::FixedFunctionOpData>(data);
+        OCIO_CHECK_EQUAL(ffData->getStyle(), OCIO::FixedFunctionOpData::ACES_GLOW_03_FWD);
+        ops.clear();
+        OCIO_CHECK_NO_THROW(OCIO::BuildColorSpaceToReferenceOps(ops, *config,
+                                                                config->getCurrentContext(),
+                                                                csSceneBoth));
+        OCIO_CHECK_NO_THROW(ops.finalize(OCIO::OPTIMIZATION_NONE));
+        OCIO_REQUIRE_EQUAL(ops.size(), 2);
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[1]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::FixedFunctionType);
+        ffData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::FixedFunctionOpData>(data);
+        OCIO_CHECK_EQUAL(ffData->getStyle(), OCIO::FixedFunctionOpData::ACES_GLOW_10_FWD);
+    }
+
+    // Replace the 2 color spaces by display-referred color spaces.
+    auto csDisplayToRef = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_DISPLAY);
+    csDisplayToRef->setName(src.c_str());
+    csDisplayToRef->setTransform(mat, OCIO::COLORSPACE_DIR_TO_REFERENCE);
+    config->addColorSpace(csDisplayToRef);
+
+    auto csDisplayFromRef = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_DISPLAY);
+    csDisplayFromRef->setName(dst.c_str());
+    csDisplayFromRef->setTransform(ff, OCIO::COLORSPACE_DIR_FROM_REFERENCE);
+    config->addColorSpace(csDisplayFromRef);
+
+    // Because there are display-referred color spaces, there need to be a view transform.
+    auto vt = OCIO::ViewTransform::Create(OCIO::REFERENCE_SPACE_SCENE);
+    vt->setName("view_transform");
+    vt->setTransform(mat, OCIO::VIEWTRANSFORM_DIR_FROM_REFERENCE);
+    OCIO_CHECK_NO_THROW(config->addViewTransform(vt));
+
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(), 2);
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    // cst is now from csDisplayToRef to csDisplayFromRef.
+    {
+        // Still getting 4 ops. View transform is not used.
+
+        OCIO::OpRcPtrVec ops;
+        OCIO_CHECK_NO_THROW(OCIO::BuildColorSpaceOps(ops, *config, config->getCurrentContext(),
+                                                     *cst, OCIO::TRANSFORM_DIR_FORWARD));
+        OCIO_CHECK_NO_THROW(ops.finalize(OCIO::OPTIMIZATION_NONE));
+        OCIO_REQUIRE_EQUAL(ops.size(), 4);
+
+        auto op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[0]);
+        auto data = op->data();
+        OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[1]);
+        data = op->data();
+        OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::MatrixType);
+
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[2]);
+        data = op->data();
+        OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::FixedFunctionType);
+
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[3]);
+        data = op->data();
+        OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+    }
+
+    {
+        // Errors.
+
+        cst = OCIO::ColorSpaceTransform::Create();
+        cst->setSrc("source_missing");
+        cst->setDst(dst.c_str());
+    
+        OCIO::OpRcPtrVec ops;
+    
+        OCIO_CHECK_THROW_WHAT(OCIO::BuildColorSpaceOps(ops, *config,
+                                                       config->getCurrentContext(), *cst,
+                                                       OCIO::TRANSFORM_DIR_FORWARD), OCIO::Exception,
+                              "source color space 'source_missing' could not be found");
+    
+        cst = OCIO::ColorSpaceTransform::Create();
+        cst->setSrc(src.c_str());
+        cst->setDst("destination_missing");
+    
+        OCIO_CHECK_THROW_WHAT(OCIO::BuildColorSpaceOps(ops, *config,
+                                                       config->getCurrentContext(), *cst,
+                                                       OCIO::TRANSFORM_DIR_FORWARD), OCIO::Exception,
+                              "destination color space 'destination_missing' could not be found");
+    }
+}
+
+OCIO_ADD_TEST(ColorSpaceTransform, build_reference_conversion_ops)
+{
+    const std::string scn{ "scene" };
+
+    OCIO::ConfigRcPtr config = OCIO::Config::Create();
+    auto cs = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_SCENE);
+    cs->setName(scn.c_str());
+    auto ff = OCIO::FixedFunctionTransform::Create();
+    ff->setStyle(OCIO::FIXED_FUNCTION_ACES_GLOW_03);
+    cs->setTransform(ff, OCIO::COLORSPACE_DIR_FROM_REFERENCE);
+    config->addColorSpace(cs);
+
+    config->addDisplay("display", "view", scn.c_str(), "");
+
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    //
+    // No view transform.
+    //
+    {
+        OCIO::OpRcPtrVec ops;
+        OCIO_CHECK_NO_THROW(OCIO::BuildReferenceConversionOps(ops, *config,
+                                                              config->getCurrentContext(), 
+                                                              OCIO::REFERENCE_SPACE_SCENE,
+                                                              OCIO::REFERENCE_SPACE_SCENE));
+        OCIO_CHECK_EQUAL(ops.size(), 0);
+    
+        OCIO_CHECK_NO_THROW(OCIO::BuildReferenceConversionOps(ops, *config,
+                                                              config->getCurrentContext(), 
+                                                              OCIO::REFERENCE_SPACE_DISPLAY,
+                                                              OCIO::REFERENCE_SPACE_DISPLAY));
+        OCIO_CHECK_EQUAL(ops.size(), 0);
+    
+        OCIO_CHECK_THROW_WHAT(OCIO::BuildReferenceConversionOps(ops, *config,
+                                                                config->getCurrentContext(),
+                                                                OCIO::REFERENCE_SPACE_SCENE,
+                                                                OCIO::REFERENCE_SPACE_DISPLAY),
+                              OCIO::Exception,
+                              "no view transform between the main scene-referred space and "
+                              "the display-referred space");
+        OCIO_CHECK_THROW_WHAT(OCIO::BuildReferenceConversionOps(ops, *config,
+                                                                config->getCurrentContext(),
+                                                                OCIO::REFERENCE_SPACE_DISPLAY,
+                                                                OCIO::REFERENCE_SPACE_SCENE),
+                              OCIO::Exception,
+                              "no view transform between the main scene-referred space and "
+                              "the display-referred space");
+    }
+
+    //
+    // Add scene-referred view transform.
+    //
+
+    auto vt = OCIO::ViewTransform::Create(OCIO::REFERENCE_SPACE_SCENE);
+    vt->setName("view_transform");
+    auto mat = OCIO::MatrixTransform::Create();
+    constexpr double offset[4] = { 0., 0.1, 0.2, 0. };
+    mat->setOffset(offset);
+    vt->setTransform(mat, OCIO::VIEWTRANSFORM_DIR_FROM_REFERENCE);
+    OCIO_CHECK_NO_THROW(config->addViewTransform(vt));
+
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    {
+        OCIO::OpRcPtrVec ops;
+        OCIO_CHECK_NO_THROW(OCIO::BuildReferenceConversionOps(ops, *config,
+                                                              config->getCurrentContext(),
+                                                              OCIO::REFERENCE_SPACE_SCENE,
+                                                              OCIO::REFERENCE_SPACE_DISPLAY));
+        OCIO_CHECK_NO_THROW(ops.finalize(OCIO::OPTIMIZATION_NONE));
+        OCIO_REQUIRE_EQUAL(ops.size(), 1);
+
+        // Scene reference to display reference.
+        auto op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[0]);
+        auto data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::MatrixType);
+        auto matData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::MatrixOpData>(data);
+        OCIO_CHECK_EQUAL(offset[0], matData->getOffsetValue(0));
+        OCIO_CHECK_EQUAL(offset[1], matData->getOffsetValue(1));
+        OCIO_CHECK_EQUAL(offset[2], matData->getOffsetValue(2));
+        OCIO_CHECK_EQUAL(offset[3], matData->getOffsetValue(3));
+    }
+
+    {
+        OCIO::OpRcPtrVec ops;
+        OCIO_CHECK_NO_THROW(OCIO::BuildReferenceConversionOps(ops, *config,
+                                                              config->getCurrentContext(),
+                                                              OCIO::REFERENCE_SPACE_DISPLAY,
+                                                              OCIO::REFERENCE_SPACE_SCENE));
+        // Note: Need to finalize to have the inverted offset values below.
+        OCIO_CHECK_NO_THROW(ops.finalize(OCIO::OPTIMIZATION_NONE));
+        OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    
+        // Dispaly reference to scene reference.
+        auto op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[0]);
+        auto data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::MatrixType);
+        auto matData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::MatrixOpData>(data);
+        OCIO_CHECK_EQUAL(-offset[0], matData->getOffsetValue(0));
+        OCIO_CHECK_EQUAL(-offset[1], matData->getOffsetValue(1));
+        OCIO_CHECK_EQUAL(-offset[2], matData->getOffsetValue(2));
+        OCIO_CHECK_EQUAL(-offset[3], matData->getOffsetValue(3));
+    }
+}
+
+OCIO_ADD_TEST(ColorSpaceTransform, build_colorspace_ops_with_reference_conversion)
+{
+    const std::string scn{ "scene" };
+
+    OCIO::ConfigRcPtr config = OCIO::Config::Create();
+    auto cs = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_SCENE);
+    cs->setName(scn.c_str());
+    auto ff = OCIO::FixedFunctionTransform::Create();
+    ff->setStyle(OCIO::FIXED_FUNCTION_ACES_GLOW_03);
+    cs->setTransform(ff, OCIO::COLORSPACE_DIR_FROM_REFERENCE);
+    config->addColorSpace(cs);
+
+    config->addDisplay("display", "view", scn.c_str(), "");
+
+    // Add scene-referred view transform.
+    auto vt = OCIO::ViewTransform::Create(OCIO::REFERENCE_SPACE_SCENE);
+    vt->setName("view_transform");
+    auto mat = OCIO::MatrixTransform::Create();
+    constexpr double offset[4] = { 0., 0.1, 0.2, 0. };
+    mat->setOffset(offset);
+    vt->setTransform(mat, OCIO::VIEWTRANSFORM_DIR_FROM_REFERENCE);
+    OCIO_CHECK_NO_THROW(config->addViewTransform(vt));
+
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    //
+    // Add display-referred color space.
+    //
+
+    cs = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_DISPLAY);
+    std::string dsp{ "display" };
+    cs->setName(dsp.c_str());
+    auto log = OCIO::LogTransform::Create();
+    cs->setTransform(log, OCIO::COLORSPACE_DIR_FROM_REFERENCE);
+    config->addColorSpace(cs);
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    OCIO::ColorSpaceTransformRcPtr cst = OCIO::ColorSpaceTransform::Create();
+    cst->setSrc(scn.c_str());
+    cst->setDst(dsp.c_str());
+
+    //
+    // Color space to color space with reference space conversion.
+    //
+
+    {
+        OCIO::OpRcPtrVec ops;
+        OCIO_CHECK_NO_THROW(OCIO::BuildColorSpaceOps(ops, *config,
+                                                     config->getCurrentContext(),
+                                                     *cst,
+                                                     OCIO::TRANSFORM_DIR_FORWARD));
+
+        // Expecting 5 transforms (including 2 no-ops).
+        OCIO_REQUIRE_EQUAL(ops.size(), 5);
+
+        auto op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[0]);
+        auto data = op->data();
+        OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+        // CS to scene reference.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[1]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::FixedFunctionType);
+        auto ffData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::FixedFunctionOpData>(data);
+        OCIO_CHECK_EQUAL(ffData->getStyle(), OCIO::FixedFunctionOpData::ACES_GLOW_03_INV);
+
+        // Scene reference to display reference.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[2]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::MatrixType);
+        auto matData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::MatrixOpData>(data);
+        OCIO_CHECK_EQUAL(offset[0], matData->getOffsetValue(0));
+        OCIO_CHECK_EQUAL(offset[1], matData->getOffsetValue(1));
+        OCIO_CHECK_EQUAL(offset[2], matData->getOffsetValue(2));
+        OCIO_CHECK_EQUAL(offset[3], matData->getOffsetValue(3));
+
+        // Display reference to CS.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[3]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::LogType);
+        auto logData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::LogOpData>(data);
+        OCIO_CHECK_EQUAL(logData->getBase(), 2.0);
+        OCIO_CHECK_EQUAL(logData->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[4]);
+        data = op->data();
+        OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+    }
+
+    //
+    // Same test in inverse direction.
+    //
+
+    {
+        OCIO::OpRcPtrVec ops;
+
+        OCIO_CHECK_NO_THROW(OCIO::BuildColorSpaceOps(ops, *config,
+                                                     config->getCurrentContext(),
+                                                     *cst,
+                                                     OCIO::TRANSFORM_DIR_INVERSE));
+        OCIO_CHECK_NO_THROW(ops.finalize(OCIO::OPTIMIZATION_NONE));
+
+        // Expecting 5 transforms (including 2 no-ops).
+        OCIO_REQUIRE_EQUAL(ops.size(), 5);
+
+        auto op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[0]);
+        auto data = op->data();
+        OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[1]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::LogType);
+        auto logData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::LogOpData>(data);
+        OCIO_CHECK_EQUAL(logData->getBase(), 2.0);
+        OCIO_CHECK_EQUAL(logData->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+
+        // Display reference to scene reference. The view transform only defines the other
+        // direction. Expecting the inverse of that transform.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[2]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::MatrixType);
+        auto matData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::MatrixOpData>(data);
+        OCIO_CHECK_EQUAL(-offset[0], matData->getOffsetValue(0));
+        OCIO_CHECK_EQUAL(-offset[1], matData->getOffsetValue(1));
+        OCIO_CHECK_EQUAL(-offset[2], matData->getOffsetValue(2));
+        OCIO_CHECK_EQUAL(-offset[3], matData->getOffsetValue(3));
+
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[3]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::FixedFunctionType);
+        auto ffData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::FixedFunctionOpData>(data);
+        OCIO_CHECK_EQUAL(ffData->getStyle(), OCIO::FixedFunctionOpData::ACES_GLOW_03_FWD);
+
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[4]);
+        data = op->data();
+        OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+    }
+
+    //
+    // Add a to_reference transform to the view transform.
+    //
+
+    auto exp = OCIO::ExponentTransform::Create();
+    vt->setTransform(exp, OCIO::VIEWTRANSFORM_DIR_TO_REFERENCE);
+    OCIO_CHECK_NO_THROW(config->addViewTransform(vt));
+    {
+        OCIO::OpRcPtrVec ops;
+
+        OCIO_CHECK_NO_THROW(OCIO::BuildColorSpaceOps(ops, *config,
+                                                     config->getCurrentContext(),
+                                                     *cst,
+                                                     OCIO::TRANSFORM_DIR_INVERSE));
+        OCIO_CHECK_NO_THROW(ops.finalize(OCIO::OPTIMIZATION_NONE));
+
+        // Expecting 5 transforms (including 2 no-ops).
+        OCIO_REQUIRE_EQUAL(ops.size(), 5);
+
+        auto op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[0]);
+        auto data = op->data();
+        OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[1]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::LogType);
+        auto logData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::LogOpData>(data);
+        OCIO_CHECK_EQUAL(logData->getBase(), 2.0);
+        OCIO_CHECK_EQUAL(logData->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+
+        // Display reference to scene reference.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[2]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::ExponentType);
+        auto expData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::ExponentOpData>(data);
+        OCIO_CHECK_EQUAL(expData->m_exp4[0], 1.0);
+
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[3]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::FixedFunctionType);
+        auto ffData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::FixedFunctionOpData>(data);
+        OCIO_CHECK_EQUAL(ffData->getStyle(), OCIO::FixedFunctionOpData::ACES_GLOW_03_FWD);
+
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[4]);
+        data = op->data();
+        OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+    }
+}

--- a/tests/cpu/transforms/ColorSpaceTransform_tests.cpp
+++ b/tests/cpu/transforms/ColorSpaceTransform_tests.cpp
@@ -43,8 +43,7 @@ OCIO_ADD_TEST(ColorSpaceTransform, basic)
     cst->setDst(dst.c_str());
 
     cst->setDirection(OCIO::TRANSFORM_DIR_UNKNOWN);
-    OCIO_CHECK_THROW_WHAT(cst->validate(), OCIO::Exception,
-                          "ColorSpaceTransform: invalid direction");
+    OCIO_CHECK_THROW_WHAT(cst->validate(), OCIO::Exception, "invalid direction");
 }
 
 OCIO_ADD_TEST(ColorSpaceTransform, build_colorspace_ops)

--- a/tests/cpu/transforms/DisplayTransform_tests.cpp
+++ b/tests/cpu/transforms/DisplayTransform_tests.cpp
@@ -1,0 +1,640 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#include "transforms/DisplayTransform.cpp"
+
+#include "ops/fixedfunction/FixedFunctionOpData.h"
+#include "ops/gamma/GammaOpData.h"
+#include "ops/log/LogOpData.h"
+#include "ops/matrix/MatrixOpData.h"
+#include "ops/range/RangeOpData.h"
+
+#include "UnitTest.h"
+namespace OCIO = OCIO_NAMESPACE;
+
+OCIO_ADD_TEST(DisplayTransform, basic)
+{
+    const std::string empty;
+    auto dt = OCIO::DisplayTransform::Create();
+
+    OCIO_CHECK_EQUAL(dt->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(empty, dt->getInputColorSpaceName());
+    OCIO_CHECK_ASSERT(!dt->getLinearCC());
+    OCIO_CHECK_ASSERT(!dt->getColorTimingCC());
+    OCIO_CHECK_ASSERT(!dt->getChannelView());
+    OCIO_CHECK_EQUAL(empty, dt->getDisplay());
+    OCIO_CHECK_EQUAL(empty, dt->getView());
+    OCIO_CHECK_ASSERT(!dt->getDisplayCC());
+    OCIO_CHECK_EQUAL(empty, dt->getLooksOverride());
+    OCIO_CHECK_ASSERT(!dt->getLooksOverrideEnabled());
+
+    const std::string inputCS{ "inputCS" };
+    dt->setInputColorSpaceName(inputCS.c_str());
+    OCIO_CHECK_EQUAL(inputCS, dt->getInputColorSpaceName());
+
+    const std::string display{ "display" };
+    dt->setDisplay(display.c_str());
+    OCIO_CHECK_EQUAL(display, dt->getDisplay());
+
+    const std::string view{ "view" };
+    dt->setView(view.c_str());
+    OCIO_CHECK_EQUAL(view, dt->getView());
+
+    OCIO_CHECK_NO_THROW(dt->validate());
+
+    dt->setDirection(OCIO::TRANSFORM_DIR_UNKNOWN);
+    OCIO_CHECK_THROW_WHAT(dt->validate(), OCIO::Exception, "DisplayTransform: invalid direction");
+    dt->setDirection(OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(dt->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+
+    dt->setInputColorSpaceName("");
+    OCIO_CHECK_THROW_WHAT(dt->validate(), OCIO::Exception,
+                          "DisplayTransform: empty input color space name");
+    dt->setInputColorSpaceName(inputCS.c_str());
+
+    dt->setDisplay("");
+    OCIO_CHECK_THROW_WHAT(dt->validate(), OCIO::Exception, "DisplayTransform: empty display name");
+    dt->setDisplay(display.c_str());
+
+    dt->setView("");
+    OCIO_CHECK_THROW_WHAT(dt->validate(), OCIO::Exception, "DisplayTransform: empty view name");
+    dt->setView(view.c_str());
+
+    OCIO_CHECK_NO_THROW(dt->validate());
+
+    OCIO::ConstTransformRcPtr linearCC = OCIO::MatrixTransform::Create();
+    dt->setLinearCC(linearCC);
+    auto linearCCBack = dt->getLinearCC();
+    OCIO_CHECK_ASSERT(OCIO_DYNAMIC_POINTER_CAST<const OCIO::MatrixTransform>(linearCCBack));
+
+    OCIO::ConstTransformRcPtr timimgCC = OCIO::ExponentTransform::Create();
+    dt->setColorTimingCC(timimgCC);
+    auto timingCCBack = dt->getColorTimingCC();
+    OCIO_CHECK_ASSERT(OCIO_DYNAMIC_POINTER_CAST<const OCIO::ExponentTransform>(timingCCBack));
+
+    OCIO::ConstTransformRcPtr cvTrans = OCIO::MatrixTransform::Create();
+    dt->setChannelView(cvTrans);
+    auto cvTransBack = dt->getChannelView();
+    OCIO_CHECK_ASSERT(OCIO_DYNAMIC_POINTER_CAST<const OCIO::MatrixTransform>(cvTransBack));
+
+    OCIO::ConstTransformRcPtr displayCC = OCIO::RangeTransform::Create();
+    dt->setDisplayCC(displayCC);
+    auto displayCCBack = dt->getDisplayCC();
+    OCIO_CHECK_ASSERT(OCIO_DYNAMIC_POINTER_CAST<const OCIO::RangeTransform>(displayCCBack));
+
+    const std::string looksOveride{ "looks_override" };
+    dt->setLooksOverride(looksOveride.c_str());
+    OCIO_CHECK_EQUAL(looksOveride, dt->getLooksOverride());
+
+    dt->setLooksOverrideEnabled(true);
+    OCIO_CHECK_ASSERT(dt->getLooksOverrideEnabled());
+}
+
+OCIO_ADD_TEST(DisplayTransform, build_ops)
+{
+    //
+    // Validate BuildDisplayOps where the display/view is a simple color space
+    // (i.e., no ViewTransform).
+    //
+
+    const std::string src{ "source" };
+    const std::string dst{ "destination" };
+    const std::string linearCS{ "linear_cs" };
+    const std::string timingCS{ "color_timing_cs" };
+
+    OCIO::ConfigRcPtr config = OCIO::Config::CreateRaw()->createEditableCopy();
+    auto csSource = OCIO::ColorSpace::Create();
+    csSource->setName(src.c_str());
+    auto mat = OCIO::MatrixTransform::Create();
+    constexpr double offset[4] = { 0., 0.1, 0.2, 0. };
+    mat->setOffset(offset);
+    csSource->setTransform(mat, OCIO::COLORSPACE_DIR_TO_REFERENCE);
+    config->addColorSpace(csSource);
+
+    auto cs = OCIO::ColorSpace::Create();
+    cs->setName(dst.c_str());
+    auto ff = OCIO::FixedFunctionTransform::Create();
+    ff->setStyle(OCIO::FIXED_FUNCTION_ACES_GLOW_03);
+    cs->setTransform(ff, OCIO::COLORSPACE_DIR_FROM_REFERENCE);
+    config->addColorSpace(cs);
+
+    cs = OCIO::ColorSpace::Create();
+    cs->setName(linearCS.c_str());
+    ff = OCIO::FixedFunctionTransform::Create();
+    ff->setStyle(OCIO::FIXED_FUNCTION_ACES_GLOW_10);
+    cs->setTransform(ff, OCIO::COLORSPACE_DIR_FROM_REFERENCE);
+    ff = OCIO::FixedFunctionTransform::Create();
+    ff->setStyle(OCIO::FIXED_FUNCTION_ACES_RED_MOD_10);
+    cs->setTransform(ff, OCIO::COLORSPACE_DIR_TO_REFERENCE);
+    config->addColorSpace(cs);
+    config->setRole(OCIO::ROLE_SCENE_LINEAR, linearCS.c_str());
+
+    cs = OCIO::ColorSpace::Create();
+    cs->setName(timingCS.c_str());
+    ff = OCIO::FixedFunctionTransform::Create();
+    ff->setStyle(OCIO::FIXED_FUNCTION_RGB_TO_HSV);
+    cs->setTransform(ff, OCIO::COLORSPACE_DIR_FROM_REFERENCE);
+    ff = OCIO::FixedFunctionTransform::Create();
+    ff->setStyle(OCIO::FIXED_FUNCTION_ACES_DARK_TO_DIM_10);
+    cs->setTransform(ff, OCIO::COLORSPACE_DIR_TO_REFERENCE);
+    config->addColorSpace(cs);
+    config->setRole(OCIO::ROLE_COLOR_TIMING, timingCS.c_str());
+
+    const std::string display{ "display" };
+    const std::string view{ "view" };
+    OCIO_CHECK_NO_THROW(config->addDisplay(display.c_str(), view.c_str(), dst.c_str(), ""));
+
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    auto dt = OCIO::DisplayTransform::Create();
+    dt->setInputColorSpaceName(src.c_str());
+
+    dt->setDisplay(display.c_str());
+    dt->setView(view.c_str());
+
+    auto linearCC = OCIO::MatrixTransform::Create();
+    constexpr double offsetLinearCC[4] = { 0.2, 0.3, 0.4, 0. };
+    linearCC->setOffset(offsetLinearCC);
+    dt->setLinearCC(linearCC);
+    auto timimgCC = OCIO::ExponentTransform::Create();
+    constexpr double valueTimingCC[4] = { 2.2, 2.3, 2.4, 1. };
+    timimgCC->setValue(valueTimingCC);
+    dt->setColorTimingCC(timimgCC);
+    auto cvTrans = OCIO::MatrixTransform::Create();
+    const std::string cv{ "channel view transform" };
+    cvTrans->getFormatMetadata().setValue(cv.c_str());
+    dt->setChannelView(cvTrans);
+    auto displayCC = OCIO::ExposureContrastTransform::Create();
+    dt->setDisplayCC(displayCC);
+
+    {
+        OCIO::OpRcPtrVec ops;
+        OCIO_CHECK_NO_THROW(OCIO::BuildDisplayOps(ops, *config,
+                                                  config->getCurrentContext(), *dt,
+                                                  OCIO::TRANSFORM_DIR_FORWARD));
+        OCIO_CHECK_EQUAL(ops.size(), 16);
+        ops.finalize(OCIO::OPTIMIZATION_NONE);
+
+        // 0-3. InputCS -> scene linear role:
+        //     0. GPU Allocation No-op.
+        //     1. Input to reference.
+        //     2. Scene linear role from reference.
+        //     3. GPU Allocation No-op.
+        // 4. LinearCC.
+        // 5-8. Scene linear -> color timing role:
+        //     5. GPU Allocation No-op.
+        //     6. Scene linear role to reference.
+        //     7. ColorTiming from reference. 
+        //     8. GPU Allocation No-op.
+        // 9. ColorTimingCC.
+        // * No look.
+        // 10. ChannelView.
+        // 11-14. Color timing role -> display/view color space:
+        //     11. GPU Allocation No-op.
+        //     12. ColorTiming to reference.
+        //     13. DisplayCS from reference.
+        //     14. GPU Allocation No-op.
+        // 15. DisplayCC.
+
+        // 0. GPU Allocation No-op.
+        auto op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[0]);
+        auto data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+        // 1. Input to reference.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[1]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::MatrixType);
+        auto matData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::MatrixOpData>(data);
+        OCIO_CHECK_EQUAL(offset[0], matData->getOffsetValue(0));
+        OCIO_CHECK_EQUAL(offset[1], matData->getOffsetValue(1));
+        OCIO_CHECK_EQUAL(offset[2], matData->getOffsetValue(2));
+        OCIO_CHECK_EQUAL(offset[3], matData->getOffsetValue(3));
+
+        // 2. Scene linear role from reference.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[2]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::FixedFunctionType);
+        auto ffData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::FixedFunctionOpData>(data);
+        OCIO_CHECK_EQUAL(ffData->getStyle(), OCIO::FixedFunctionOpData::ACES_GLOW_10_FWD);
+
+        // 3. GPU Allocation No-op.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[3]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+        // 4. LinearCC.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[4]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::MatrixType);
+        matData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::MatrixOpData>(data);
+        OCIO_CHECK_EQUAL(offsetLinearCC[0], matData->getOffsetValue(0));
+        OCIO_CHECK_EQUAL(offsetLinearCC[1], matData->getOffsetValue(1));
+        OCIO_CHECK_EQUAL(offsetLinearCC[2], matData->getOffsetValue(2));
+        OCIO_CHECK_EQUAL(offsetLinearCC[3], matData->getOffsetValue(3));
+
+        // 5. GPU Allocation No-op.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[5]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+        // 6. Scene linear role to reference.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[6]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::FixedFunctionType);
+        ffData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::FixedFunctionOpData>(data);
+        OCIO_CHECK_EQUAL(ffData->getStyle(), OCIO::FixedFunctionOpData::ACES_RED_MOD_10_FWD);
+
+        // 7. ColorTiming from reference. 
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[7]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::FixedFunctionType);
+        ffData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::FixedFunctionOpData>(data);
+        OCIO_CHECK_EQUAL(ffData->getStyle(), OCIO::FixedFunctionOpData::RGB_TO_HSV);
+
+        // 8. GPU Allocation No-op.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[8]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+        // 9. ColorTimingCC.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[9]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::GammaType);
+        auto gammaData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::GammaOpData>(data);
+        OCIO_CHECK_EQUAL(valueTimingCC[0], gammaData->getRedParams()[0]);
+        OCIO_CHECK_EQUAL(valueTimingCC[1], gammaData->getGreenParams()[0]);
+        OCIO_CHECK_EQUAL(valueTimingCC[2], gammaData->getBlueParams()[0]);
+        OCIO_CHECK_EQUAL(valueTimingCC[3], gammaData->getAlphaParams()[0]);
+
+        // 10. ChannelView.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[10]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::MatrixType);
+        OCIO_CHECK_EQUAL(cv, data->getFormatMetadata().getValue());
+
+        // 11. GPU Allocation No-op.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[11]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+        // 12. ColorTiming to reference.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[12]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::FixedFunctionType);
+        ffData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::FixedFunctionOpData>(data);
+        OCIO_CHECK_EQUAL(ffData->getStyle(), OCIO::FixedFunctionOpData::ACES_DARK_TO_DIM_10_FWD);
+
+        // 13. DisplayCS from reference.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[13]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::FixedFunctionType);
+        ffData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::FixedFunctionOpData>(data);
+        OCIO_CHECK_EQUAL(ffData->getStyle(), OCIO::FixedFunctionOpData::ACES_GLOW_03_FWD);
+
+        // 14. GPU Allocation No-op.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[14]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+        // 15. DisplayCC.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[15]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::ExposureContrastType);
+    }
+
+    //
+    // Using a scene-referred ViewTransform.
+    //
+
+    const std::string dsp{ "display" };
+    cs = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_DISPLAY);
+    cs->setName(dsp.c_str());
+    auto ec = OCIO::ExposureContrastTransform::Create();
+    cs->setTransform(ec, OCIO::COLORSPACE_DIR_FROM_REFERENCE);
+    config->addColorSpace(cs);
+
+    const std::string scenevt{ "scene_vt" };
+    auto vt = OCIO::ViewTransform::Create(OCIO::REFERENCE_SPACE_SCENE);
+    vt->setName(scenevt.c_str());
+    auto log = OCIO::LogTransform::Create();
+    log->setBase(4.2);
+    vt->setTransform(log, OCIO::VIEWTRANSFORM_DIR_FROM_REFERENCE);
+    config->addViewTransform(vt);
+
+    const std::string viewt{ "viewt" };
+    OCIO_CHECK_NO_THROW(config->addDisplay(display.c_str(), viewt.c_str(), scenevt.c_str(), dsp.c_str(), ""));
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    dt->setView(viewt.c_str());
+
+    {
+        OCIO::OpRcPtrVec ops;
+        OCIO_CHECK_NO_THROW(OCIO::BuildDisplayOps(ops, *config,
+                                                  config->getCurrentContext(), *dt,
+                                                  OCIO::TRANSFORM_DIR_FORWARD));
+
+        // Getting an additional op for the reference space change.
+        OCIO_CHECK_EQUAL(ops.size(), 17);
+        ops.finalize(OCIO::OPTIMIZATION_NONE);
+
+        // Same as previous up to colorTiming to reference.
+        //  0. GPU Allocation No-op.
+        //  1. Input to reference.
+        //  2. Scene linear role from reference.
+        //  3. GPU Allocation No-op.
+        //  4. LinearCC.
+        //  5. GPU Allocation No-op.
+        //  6. Scene linear role to reference.
+        //  7. ColorTiming from reference. 
+        //  8. GPU Allocation No-op.
+        //  9. ColorTimingCC.
+        // 10. ChannelView.
+        // 11. GPU Allocation No-op.
+        // 12. ColorTiming to reference.
+
+        // 13. Changing from scene-referred space to display-referred space done
+        // with the specified view transform.
+        auto op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[13]);
+        auto data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::LogType);
+        auto logData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::LogOpData>(data);
+        OCIO_CHECK_EQUAL(4.2, logData->getBase());
+
+        // 14. DisplayCS from reference.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[14]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::ExposureContrastType);
+
+        // 15. GPU Allocation No-op.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[15]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+        // 16. DisplayCC.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[16]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::ExposureContrastType);
+
+    }
+
+    //
+    // Adding a display-referred ViewTransform.
+    //
+
+    const std::string displayvt{ "display_vt" };
+    vt = OCIO::ViewTransform::Create(OCIO::REFERENCE_SPACE_DISPLAY);
+    vt->setName(displayvt.c_str());
+    log = OCIO::LogTransform::Create();
+    log->setBase(2.1);
+    vt->setTransform(log, OCIO::VIEWTRANSFORM_DIR_FROM_REFERENCE);
+    config->addViewTransform(vt);
+
+    // Replace view display.
+    OCIO_CHECK_NO_THROW(config->addDisplay(display.c_str(), viewt.c_str(), displayvt.c_str(), dsp.c_str(), ""));
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    {
+        OCIO::OpRcPtrVec ops;
+        OCIO_CHECK_NO_THROW(OCIO::BuildDisplayOps(ops, *config,
+                                                  config->getCurrentContext(), *dt,
+                                                  OCIO::TRANSFORM_DIR_FORWARD));
+
+        // Getting an additional op for the display to display view transform.
+        OCIO_CHECK_EQUAL(ops.size(), 18);
+        ops.finalize(OCIO::OPTIMIZATION_NONE);
+
+        // Same as previous up to scene-referred to display referred.
+        // 0. GPU Allocation No-op.
+        //  1. Input to reference.
+        //  2. Scene linear role from reference.
+        //  3. GPU Allocation No-op.
+        //  4. LinearCC.
+        //  5. GPU Allocation No-op.
+        //  6. Scene linear role to reference.
+        //  7. ColorTiming from reference. 
+        //  8. GPU Allocation No-op.
+        //  9. ColorTimingCC.
+        // 10. ChannelView.
+        // 11. GPU Allocation No-op.
+        // 12. ColorTiming to reference.
+        // 13. Changing from scene-referred space to display-referred space using the
+        //     default view transform.
+
+        // 14. Display-referred reference to display-referred reference using the specified view transform.
+        auto op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[14]);
+        auto data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::LogType);
+        auto logData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::LogOpData>(data);
+        OCIO_CHECK_EQUAL(2.1, logData->getBase());
+
+        // 15. DisplayCS from reference.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[15]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::ExposureContrastType);
+
+        // 16. GPU Allocation No-op.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[16]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+        // 17. DisplayCC.
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[17]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::ExposureContrastType);
+    }
+
+    csSource->setIsData(true);
+    config->addColorSpace(csSource);
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    {
+        OCIO::OpRcPtrVec ops;
+        OCIO_CHECK_NO_THROW(OCIO::BuildDisplayOps(ops, *config,
+                                                  config->getCurrentContext(), *dt,
+                                                  OCIO::TRANSFORM_DIR_FORWARD));
+
+        // Color space conversion is skipped.
+        OCIO_CHECK_EQUAL(ops.size(), 4);
+        ops.finalize(OCIO::OPTIMIZATION_NONE);
+
+        // With isData true, the view/display transform is not applied.  The CC and channelView
+        // are applied, but without converting to their usual process spaces.
+        // 0. LinearCC.
+        // 1. ColorTimingCC.
+        // 2. ChannelView.
+        // 3. DisplayCC.
+        auto op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[0]);
+        auto data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::MatrixType);
+
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[1]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::GammaType);
+
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[2]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::MatrixType);
+
+        op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[3]);
+        data = op->data();
+        OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::ExposureContrastType);
+    }
+}
+
+OCIO_ADD_TEST(DisplayTransform, build_ops_with_looks)
+{
+    //
+    // Validate BuildDisplayOps using a display-referred ViewTransform and a Look with a
+    // display-referred ProcessSpace.
+    //
+
+    const std::string in{ "displayCSIn" };
+    const std::string out{ "displayCSOut" };
+
+    OCIO::ConfigRcPtr config = OCIO::Config::CreateRaw()->createEditableCopy();
+    auto csIn = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_DISPLAY);
+    csIn->setName(in.c_str());
+    auto mat = OCIO::MatrixTransform::Create();
+    constexpr double offset[4] = { 0., 0.1, 0.2, 0. };
+    mat->setOffset(offset);
+    csIn->setTransform(mat, OCIO::COLORSPACE_DIR_TO_REFERENCE);
+    config->addColorSpace(csIn);
+
+    auto csOut = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_DISPLAY);
+    csOut->setName(out.c_str());
+    auto ff = OCIO::FixedFunctionTransform::Create();
+    ff->setStyle(OCIO::FIXED_FUNCTION_ACES_GLOW_03);
+    csOut->setTransform(ff, OCIO::COLORSPACE_DIR_FROM_REFERENCE);
+    config->addColorSpace(csOut);
+
+    const std::string display{ "display" };
+    const std::string view{ "view" };
+    const std::string look{ "look" };
+    const std::string displayCSProcess{ "displayCSProcess" };
+
+    auto csProcess = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_DISPLAY);
+    csProcess->setName(displayCSProcess.c_str());
+    auto expProcess = OCIO::ExponentTransform::Create();
+    constexpr double valueProcess[4] = { 2.2, 2.3, 2.4, 1. };
+    expProcess->setValue(valueProcess);
+    csProcess->setTransform(expProcess, OCIO::COLORSPACE_DIR_FROM_REFERENCE);
+
+    config->addColorSpace(csProcess);
+
+    // Create look.
+    auto lk = OCIO::Look::Create();
+    lk->setName(look.c_str());
+    lk->setProcessSpace(displayCSProcess.c_str());
+    auto cdl = OCIO::CDLTransform::Create();
+    cdl->setSat(1.5);
+    lk->setTransform(cdl);
+    config->addLook(lk);
+
+    auto defaultVT = OCIO::ViewTransform::Create(OCIO::REFERENCE_SPACE_SCENE);
+    defaultVT->setName("default_vt");
+    mat = OCIO::MatrixTransform::Create();
+    defaultVT->setTransform(mat, OCIO::VIEWTRANSFORM_DIR_FROM_REFERENCE);
+    config->addViewTransform(defaultVT);
+
+    // Add display-referred view transform.
+    const std::string displayvt{ "display_vt" };
+    auto vt = OCIO::ViewTransform::Create(OCIO::REFERENCE_SPACE_DISPLAY);
+    vt->setName(displayvt.c_str());
+    auto log = OCIO::LogTransform::Create();
+    log->setBase(2.1);
+    vt->setTransform(log, OCIO::VIEWTRANSFORM_DIR_FROM_REFERENCE);
+    config->addViewTransform(vt);
+
+    // Add view display.
+    OCIO_CHECK_NO_THROW(config->addDisplay(display.c_str(), view.c_str(), displayvt.c_str(),
+                                           out.c_str(), look.c_str()));
+
+    auto dt = OCIO::DisplayTransform::Create();
+    dt->setInputColorSpaceName(in.c_str());
+    dt->setDisplay(display.c_str());
+    dt->setView(view.c_str());
+
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    OCIO::OpRcPtrVec ops;
+    OCIO_CHECK_NO_THROW(OCIO::BuildDisplayOps(ops, *config,
+                                              config->getCurrentContext(), *dt,
+                                              OCIO::TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_EQUAL(ops.size(), 11);
+    ops.finalize(OCIO::OPTIMIZATION_NONE);
+
+    // 0-3. DisplayCSIn->displayCSProcess:
+    //     0. GPU Allocation No-op.
+    //     1. In to reference.
+    //     2. Look process space from reference.
+    //     3. GPU Allocation No-op.
+    // 4-5. Look-noop + look transform.
+    // 6-7. displayCSProcess->display reference:
+    //     6. GPU Allocation No-op.
+    //     7. DisplayCSProcess to display reference.
+    // 8. Display-referred VT.
+    // 9-10. Reference->DisplayCSOutput:
+    //     9. DisplayCSOutput from display reference.
+    //    10. GPU Allocation No-op.
+
+    // 0. GPU Allocation No-op.
+    auto op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[0]);
+    auto data = op->data();
+    OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+    // 1. In to reference.
+    op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[1]);
+    data = op->data();
+    OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::MatrixType);
+    auto matData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::MatrixOpData>(data);
+    OCIO_CHECK_EQUAL(offset[0], matData->getOffsetValue(0));
+    OCIO_CHECK_EQUAL(offset[1], matData->getOffsetValue(1));
+    OCIO_CHECK_EQUAL(offset[2], matData->getOffsetValue(2));
+    OCIO_CHECK_EQUAL(offset[3], matData->getOffsetValue(3));
+
+    // 2. Look process space from reference.
+    op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[2]);
+    data = op->data();
+    OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::GammaType);
+
+    // 3. GPU Allocation No-op.
+    op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[3]);
+    data = op->data();
+    OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+    // 4. Look No-op.
+    op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[4]);
+    data = op->data();
+    OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+    // 5. Look transform.
+    op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[5]);
+    data = op->data();
+    OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::CDLType);
+
+    // 6. GPU Allocation No-op.
+    op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[6]);
+    data = op->data();
+    OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+
+    // 7. DisplayCSProcess to display reference.
+    op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[7]);
+    data = op->data();
+    OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::GammaType);
+
+    // 8. Display-referred VT.
+    op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[8]);
+    data = op->data();
+    OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::LogType);
+
+    // 9. DisplayCSOutput from display reference.
+    op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[9]);
+    data = op->data();
+    OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::FixedFunctionType);
+
+    // 10. GPU Allocation No-op.
+    op = OCIO_DYNAMIC_POINTER_CAST<const OCIO::Op>(ops[10]);
+    data = op->data();
+    OCIO_CHECK_EQUAL(data->getType(), OCIO::OpData::NoOpType);
+}

--- a/tests/cpu/transforms/DisplayTransform_tests.cpp
+++ b/tests/cpu/transforms/DisplayTransform_tests.cpp
@@ -43,7 +43,7 @@ OCIO_ADD_TEST(DisplayTransform, basic)
     OCIO_CHECK_NO_THROW(dt->validate());
 
     dt->setDirection(OCIO::TRANSFORM_DIR_UNKNOWN);
-    OCIO_CHECK_THROW_WHAT(dt->validate(), OCIO::Exception, "DisplayTransform: invalid direction");
+    OCIO_CHECK_THROW_WHAT(dt->validate(), OCIO::Exception, "invalid direction");
     dt->setDirection(OCIO::TRANSFORM_DIR_INVERSE);
     OCIO_CHECK_EQUAL(dt->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
 


### PR DESCRIPTION
Introduce display reference space:
- Add ability to use display color spaces, view transforms in configs.
- Update ColorSpaceTransform, DisplayTransform to handle display reference space.
- Color space can either be scene-referred or display referred.

See issue #926 for more details.

Signed-off-by: Bernard Lefebvre <bernard.lefebvre@autodesk.com>