### PR TITLE
Adsk Contrib - Complete the CDL style support

### DIFF
--- a/include/OpenColorIO/OpenColorTransforms.h
+++ b/include/OpenColorIO/OpenColorTransforms.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BSD-3-Clause
+﻿// SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
 
@@ -170,12 +170,12 @@ extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const AllocationTrans
 
 //!rst:: //////////////////////////////////////////////////////////////////
 
-//!cpp:class:: An implementation of the ASC CDL Transfer Functions and
-// Interchange - Syntax (Based on the version 1.2 document)
+//!cpp:class:: An implementation of the ASC Color Decision List (CDL), based on the ASC v1.2
+// specification.
 //
-// .. note::
-//    the clamping portion of the CDL is only applied if a non-identity
-//    power is specified.
+// ​.. note::
+//    If the config version is 1, negative values are clamped if the power is not 1.0.
+//    For config version 2 and higher, the negative handling is controlled by the CDL style.
 class OCIOEXPORT CDLTransform : public Transform
 {
 public:
@@ -198,12 +198,15 @@ public:
 
     //!cpp:function::
     virtual CDLStyle getStyle() const = 0;
-    //!cpp:function::
+    //!cpp:function:: Use CDL_ASC to clamp values to [0,1] per the ASC spec.  Use NO_CLAMP to
+    // never clamp values (regardless of whether power is 1.0).  The NO_CLAMP option passes
+    // negatives through unchanged (like the NEGATIVE_PASS_THRU style of ExponentTransform).
+    // The default style is CDL_NO_CLAMP.
     virtual void setStyle(CDLStyle style) = 0;
 
     //!cpp:function::
     virtual const char * getXML() const = 0;
-    //!cpp:function::
+    //!cpp:function:: The default style is CDL_NO_CLAMP.
     virtual void setXML(const char * xml) = 0;
 
     //!rst:: **ASC_SOP**
@@ -458,11 +461,12 @@ protected:
 
 //!rst:: //////////////////////////////////////////////////////////////////
 
-//!cpp:class:: Represents exponent transform: pow( clamp(color), value)
+//!cpp:class:: Represents exponent transform: pow( clamp(color), value ).
 //
-// For configs with version == 1: If the exponent is 1.0, this will not clamp.
-// Otherwise, the input color will be clamped between [0.0, inf].
-// For configs with version > 1: Negative value handling may be specified via setNegativeStyle.
+// ​.. note::
+//    For configs with version == 1: Negative style is ignored and if the exponent is 1.0,
+//    this will not clamp. Otherwise, the input color will be clamped between [0.0, inf].
+//    For configs with version > 1: Negative value handling may be specified via setNegativeStyle.
 class OCIOEXPORT ExponentTransform : public Transform
 {
 public:
@@ -692,6 +696,12 @@ public:
     const char * getCCCId() const;
     //!cpp:function::
     void setCCCId(const char * id);
+
+    //!cpp:function::
+    CDLStyle getCDLStyle() const;
+    //!cpp:function:: Can be used with CDL, CC & CCC formats to specify the clamping behavior of
+    // the CDLTransform. Default is CDL_NO_CLAMP.
+    void setCDLStyle(CDLStyle);
 
     //!cpp:function::
     Interpolation getInterpolation() const;

--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -418,7 +418,9 @@ enum ExposureContrastStyle
 enum CDLStyle
 {
     CDL_ASC = 0,    //! ASC CDL specification v1.2
-    CDL_NO_CLAMP    //! CDL that does not clamp
+    CDL_NO_CLAMP,   //! CDL that does not clamp
+
+    CDL_TRANSFORM_DEFAULT = CDL_NO_CLAMP
 };
 
 //!cpp:type:: Negative values handling style for :cpp:class:`ExponentTransform` and
@@ -578,6 +580,11 @@ extern OCIOEXPORT GpuLanguage GpuLanguageFromString(const char * s);
 extern OCIOEXPORT const char * EnvironmentModeToString(EnvironmentMode mode);
 //!cpp:function::
 extern OCIOEXPORT EnvironmentMode EnvironmentModeFromString(const char * s);
+
+//!cpp:function::
+extern OCIOEXPORT const char * CDLStyleToString(CDLStyle style);
+//!cpp:function::
+extern OCIOEXPORT CDLStyle CDLStyleFromString(const char * style);
 
 //!cpp:function::
 extern OCIOEXPORT const char * RangeStyleToString(RangeStyle style);

--- a/src/OpenColorIO/ParseUtils.cpp
+++ b/src/OpenColorIO/ParseUtils.cpp
@@ -309,7 +309,7 @@ CDLStyle CDLStyleFromString(const char * style)
 {
     if (style && *style)
     {
-        const std::string str = pystring::lower(style);
+        const std::string str = StringUtils::Lower(style);
         if      (str == "asc")     return CDL_ASC;
         else if (str == "noclamp") return CDL_NO_CLAMP;
     }

--- a/src/OpenColorIO/ParseUtils.cpp
+++ b/src/OpenColorIO/ParseUtils.cpp
@@ -296,6 +296,28 @@ EnvironmentMode EnvironmentModeFromString(const char * s)
     return ENV_ENVIRONMENT_UNKNOWN;
 }
 
+const char * CDLStyleToString(CDLStyle style)
+{
+    if      (style == CDL_ASC)      return "asc";
+    else if (style == CDL_NO_CLAMP) return "noClamp";
+    return "asc";
+}
+
+CDLStyle CDLStyleFromString(const char * style)
+{
+    if (style && *style)
+    {
+        const std::string str = pystring::lower(style);
+        if      (str == "asc")     return CDL_ASC;
+        else if (str == "noclamp") return CDL_NO_CLAMP;
+    }
+
+    std::string msg("Wrong CDL style: ");
+    msg += (style && *style) ? style : "<null>";
+
+    throw Exception(msg.c_str());
+}
+
 const char * RangeStyleToString(RangeStyle style)
 {
     if(style == RANGE_NO_CLAMP) return "noClamp";

--- a/src/OpenColorIO/fileformats/FileFormatCCC.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCCC.cpp
@@ -45,16 +45,15 @@ public:
 
     void getFormatInfo(FormatInfoVec & formatInfoVec) const override;
 
-    CachedFileRcPtr read(
-        std::istream & istream,
-        const std::string & fileName) const override;
+    CachedFileRcPtr read(std::istream & istream,
+                         const std::string & fileName) const override;
 
     void buildFileOps(OpRcPtrVec & ops,
-                        const Config & config,
-                        const ConstContextRcPtr & context,
-                        CachedFileRcPtr untypedCachedFile,
-                        const FileTransform & fileTransform,
-                        TransformDirection dir) const override;
+                      const Config & config,
+                      const ConstContextRcPtr & context,
+                      CachedFileRcPtr untypedCachedFile,
+                      const FileTransform & fileTransform,
+                      TransformDirection dir) const override;
 };
 
 void LocalFileFormat::getFormatInfo(FormatInfoVec & formatInfoVec) const
@@ -95,16 +94,15 @@ void LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
     LocalCachedFileRcPtr cachedFile = DynamicPtrCast<LocalCachedFile>(untypedCachedFile);
 
     // This should never happen.
-    if(!cachedFile)
+    if (!cachedFile)
     {
         std::ostringstream os;
         os << "Cannot build .ccc Op. Invalid cache type.";
         throw Exception(os.str().c_str());
     }
 
-    TransformDirection newDir = CombineTransformDirections(dir,
-        fileTransform.getDirection());
-    if(newDir == TRANSFORM_DIR_UNKNOWN)
+    TransformDirection newDir = CombineTransformDirections(dir, fileTransform.getDirection());
+    if (newDir == TRANSFORM_DIR_UNKNOWN)
     {
         std::ostringstream os;
         os << "Cannot build ASC FileTransform,";
@@ -131,7 +129,7 @@ void LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
     std::string cccid = fileTransform.getCCCId();
     cccid = context->resolveStringVar(cccid.c_str());
 
-    if(cccid.empty())
+    if (cccid.empty())
     {
         std::ostringstream os;
         os << "You must specify which cccid to load from the ccc file";
@@ -141,26 +139,31 @@ void LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
 
     bool success=false;
 
+    const auto fileCDLStyle = fileTransform.getCDLStyle();
+
     // Try to parse the cccid as a string id
     CDLTransformMap::const_iterator iter = cachedFile->transformMap.find(cccid);
-    if(iter != cachedFile->transformMap.end())
+    if (iter != cachedFile->transformMap.end())
     {
+        auto cdl = iter->second;
+        if (fileCDLStyle != CDL_TRANSFORM_DEFAULT)
+        {
+            cdl = OCIO_DYNAMIC_POINTER_CAST<CDLTransform>(cdl->createEditableCopy());
+            cdl->setStyle(fileCDLStyle);
+        }
         success = true;
-        BuildCDLOp(ops,
-                   config,
-                   *(iter->second),
-                   newDir);
+        BuildCDLOp(ops, config, *cdl, newDir);
     }
 
     // Try to parse the cccid as an integer index
     // We want to be strict, so fail if leftover chars in the parse.
-    if(!success)
+    if (!success)
     {
         int cccindex=0;
-        if(StringToInt(&cccindex, cccid.c_str(), true))
+        if (StringToInt(&cccindex, cccid.c_str(), true))
         {
             int maxindex = ((int)cachedFile->transformVec.size())-1;
-            if(cccindex<0 || cccindex>maxindex)
+            if (cccindex<0 || cccindex>maxindex)
             {
                 std::ostringstream os;
                 os << "The specified cccindex " << cccindex;
@@ -169,15 +172,18 @@ void LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
                 throw ExceptionMissingFile(os.str().c_str());
             }
 
+            auto cdl = cachedFile->transformVec[cccindex];
+            if (fileCDLStyle != CDL_TRANSFORM_DEFAULT)
+            {
+                cdl = OCIO_DYNAMIC_POINTER_CAST<CDLTransform>(cdl->createEditableCopy());
+                cdl->setStyle(fileCDLStyle);
+            }
             success = true;
-            BuildCDLOp(ops,
-                       config,
-                       *cachedFile->transformVec[cccindex],
-                       newDir);
+            BuildCDLOp(ops, config, *cdl, newDir);
         }
     }
 
-    if(!success)
+    if (!success)
     {
         std::ostringstream os;
         os << "You must specify a valid cccid to load from the ccc file";

--- a/src/OpenColorIO/ops/cdl/CDLOp.cpp
+++ b/src/OpenColorIO/ops/cdl/CDLOp.cpp
@@ -248,8 +248,6 @@ void BuildCDLOp(OpRcPtrVec & ops,
 
         double sat = cdlTransform.getSat();
 
-        const double p[4] = { power4[0], power4[1], power4[2], power4[3] };
-
         if (combinedDir == TRANSFORM_DIR_FORWARD)
         {
             // 1) Scale + Offset
@@ -257,7 +255,7 @@ void BuildCDLOp(OpRcPtrVec & ops,
 
             // 2) Power + Clamp at 0 (NB: This is not in accord with the
             //    ASC v1.2 spec since it also requires clamping at 1.)
-            CreateExponentOp(ops, p, TRANSFORM_DIR_FORWARD);
+            CreateExponentOp(ops, power4, TRANSFORM_DIR_FORWARD);
 
             // 3) Saturation (NB: Does not clamp at 0 and 1
             //    as per ASC v1.2 spec)
@@ -271,7 +269,7 @@ void BuildCDLOp(OpRcPtrVec & ops,
 
             // 2) Power + Clamp at 0 (NB: This is not in accord with the
             //    ASC v1.2 spec since it also requires clamping at 1.)
-            CreateExponentOp(ops, p, TRANSFORM_DIR_INVERSE);
+            CreateExponentOp(ops, power4, TRANSFORM_DIR_INVERSE);
 
             // 1) Scale + Offset
             CreateScaleOffsetOp(ops, slope4, offset4, TRANSFORM_DIR_INVERSE);

--- a/src/OpenColorIO/ops/cdl/CDLOpCPU.cpp
+++ b/src/OpenColorIO/ops/cdl/CDLOpCPU.cpp
@@ -164,8 +164,8 @@ inline void ApplyClamp<false>(__m128&)
 {
 }
 
-// Apply the power component to the the pixel's values
-// When the template argument is true, the the values in pix
+// Apply the power component to the the pixel's values.
+// When the template argument is true, the values in pix
 // are clamped to the range [0,1] and the power operation is
 // applied. When the argument is false, the values in pix are
 // not clamped before the power operation is applied. When the
@@ -264,8 +264,8 @@ inline void ApplyClamp<false>(float *)
 {
 }
 
-// Apply the power component to the the pixel's values
-// When the template argument is true, the the values in pix
+// Apply the power component to the the pixel's values.
+// When the template argument is true, the values in pix
 // are clamped to the range [0,1] and the power operation is
 // applied. When the argument is false, the values in pix are
 // not clamped before the power operation is applied. When the

--- a/src/OpenColorIO/ops/cdl/CDLOpData.h
+++ b/src/OpenColorIO/ops/cdl/CDLOpData.h
@@ -31,7 +31,8 @@ public:
         CDL_NO_CLAMP_REV   // Reverse no clamping style
     };
 
-    static inline Style GetDefaultStyle() { return CDL_V1_2_FWD; }
+    static inline Style GetDefaultStyle() { return ConvertStyle(CDL_TRANSFORM_DEFAULT,
+                                                                TRANSFORM_DIR_FORWARD); }
 
     static Style GetStyle(const char * name);
     static const char * GetStyleName(Style style);

--- a/src/OpenColorIO/ops/gamma/GammaOp.cpp
+++ b/src/OpenColorIO/ops/gamma/GammaOp.cpp
@@ -213,14 +213,17 @@ void BuildExponentOp(OpRcPtrVec & ops,
                      const ExponentTransform & transform,
                      TransformDirection dir)
 {
-    if(config.getMajorVersion()==1)
+    if (config.getMajorVersion() == 1)
     {
+        // Ignore style, use a simple exponent.
         TransformDirection combinedDir = CombineTransformDirections(dir, transform.getDirection());
 
         double vec4[4] = { 1., 1., 1., 1. };
         transform.getValue(vec4);
+        ExponentOpDataRcPtr expData = std::make_shared<ExponentOpData>(vec4);
+        expData->getFormatMetadata() = transform.getFormatMetadata();
         CreateExponentOp(ops,
-                         vec4,
+                         expData,
                          combinedDir);
     }
     else

--- a/src/OpenColorIO/transforms/CDLTransform.cpp
+++ b/src/OpenColorIO/transforms/CDLTransform.cpp
@@ -595,6 +595,7 @@ std::ostream & operator<< (std::ostream & os, const CDLTransform & t)
         os << sop[i];
     }
     os << ", sat=" << t.getSat();
+    os << ", style=" << CDLStyleToString(t.getStyle());
     os << ">";
     return os;
 }

--- a/src/OpenColorIO/transforms/FileTransform.cpp
+++ b/src/OpenColorIO/transforms/FileTransform.cpp
@@ -31,14 +31,14 @@ void FileTransform::deleter(FileTransform* t)
 class FileTransform::Impl
 {
 public:
-    TransformDirection m_dir;
+    TransformDirection m_dir{ TRANSFORM_DIR_FORWARD };
+    Interpolation m_interp{ INTERP_UNKNOWN };
     std::string m_src;
-    std::string m_cccid;
-    Interpolation m_interp;
 
-    Impl() :
-        m_dir(TRANSFORM_DIR_FORWARD),
-        m_interp(INTERP_UNKNOWN)
+    std::string m_cccid;
+    CDLStyle m_cdlStyle{ CDL_TRANSFORM_DEFAULT };
+
+    Impl()
     { }
 
     Impl(const Impl &) = delete;
@@ -51,9 +51,10 @@ public:
         if (this != &rhs)
         {
             m_dir = rhs.m_dir;
+            m_interp = rhs.m_interp;
             m_src = rhs.m_src;
             m_cccid = rhs.m_cccid;
-            m_interp = rhs.m_interp;
+            m_cdlStyle = rhs.m_cdlStyle;
         }
         return *this;
     }
@@ -128,6 +129,16 @@ void FileTransform::setCCCId(const char * cccid)
     getImpl()->m_cccid = cccid;
 }
 
+CDLStyle FileTransform::getCDLStyle() const
+{
+    return getImpl()->m_cdlStyle;
+}
+
+void FileTransform::setCDLStyle(CDLStyle style)
+{
+    getImpl()->m_cdlStyle = style;
+}
+
 Interpolation FileTransform::getInterpolation() const
 {
     return getImpl()->m_interp;
@@ -164,6 +175,7 @@ std::ostream& operator<< (std::ostream& os, const FileTransform& t)
     os << "interpolation=" << InterpolationToString(t.getInterpolation());
     os << ", src=" << t.getSrc() << ", ";
     os << "cccid=" << t.getCCCId();
+    os << "cdl_style=" << CDLStyleToString(t.getCDLStyle());
     os << ">";
 
     return os;

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -277,7 +277,7 @@ OCIO_ADD_TEST(Config, serialize_group_transform)
     "    allocation: uniform\n"
     "    from_reference: !<GroupTransform>\n"
     "      children:\n"
-    "        - !<FileTransform> {src: \"\", interpolation: unknown}\n"
+    "        - !<FileTransform> {src: \"\"}\n"
     "\n"
     "  - !<ColorSpace>\n"
     "    name: testing2\n"
@@ -2822,6 +2822,83 @@ OCIO_ADD_TEST(Config, matrix_serialization)
     std::stringstream ss;
     ss << *config.get();
     OCIO_CHECK_EQUAL(ss.str(), str);
+}
+
+OCIO_ADD_TEST(Config, cdl_serialization)
+{
+    // Config v2.
+    {
+        const std::string strEnd =
+            "    from_reference: !<GroupTransform>\n"
+            "      children:\n"
+            "        - !<CDLTransform> {slope: [1, 2, 1]}\n"
+            "        - !<CDLTransform> {offset: [0.1, 0.2, 0.1]}\n"
+            "        - !<CDLTransform> {power: [1.1, 1.2, 1.1]}\n"
+            "        - !<CDLTransform> {sat: 0.1, direction: inverse}\n"
+            "        - !<CDLTransform> {slope: [2, 2, 3], offset: [0.2, 0.3, 0.1], power: [1.2, 1.1, 1], sat: 0.2, style: asc}\n";
+
+        const std::string str = PROFILE_V2_START + strEnd;
+
+        std::istringstream is;
+        is.str(str);
+
+        OCIO::ConstConfigRcPtr config;
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+        std::ostringstream oss;
+        OCIO_CHECK_NO_THROW(oss << *config.get());
+        OCIO_CHECK_EQUAL(oss.str(), str);
+    }
+
+    // Config v1.
+    {
+        const std::string strEnd =
+            "    from_reference: !<GroupTransform>\n"
+            "      children:\n"
+            "        - !<CDLTransform> {slope: [1, 2, 1]}\n"
+            "        - !<CDLTransform> {offset: [0.1, 0.2, 0.1]}\n"
+            "        - !<CDLTransform> {power: [1.1, 1.2, 1.1]}\n"
+            "        - !<CDLTransform> {sat: 0.1}\n";
+
+        const std::string str = PROFILE_V1 + SIMPLE_PROFILE_A + SIMPLE_PROFILE_B + strEnd;
+
+        std::istringstream is;
+        is.str(str);
+
+        OCIO::ConstConfigRcPtr config;
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+        std::ostringstream oss;
+        OCIO_CHECK_NO_THROW(oss << *config.get());
+        OCIO_CHECK_EQUAL(oss.str(), str);
+    }
+}
+
+OCIO_ADD_TEST(Config, file_transform_serialization)
+{
+    // Config v2.
+    const std::string strEnd =
+        "    from_reference: !<GroupTransform>\n"
+        "      children:\n"
+        "        - !<FileTransform> {src: a.clf}\n"
+        "        - !<FileTransform> {src: b.ccc, cccid: cdl1, interpolation: best}\n"
+        "        - !<FileTransform> {src: b.ccc, cccid: cdl2, cdl_style: asc, interpolation: linear}\n"
+        "        - !<FileTransform> {src: a.clf, direction: inverse}\n";
+
+    const std::string str = PROFILE_V2_START + strEnd;
+
+    std::istringstream is;
+    is.str(str);
+
+    OCIO::ConstConfigRcPtr config;
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    std::ostringstream oss;
+    OCIO_CHECK_NO_THROW(oss << *config.get());
+    OCIO_CHECK_EQUAL(oss.str(), str);
 }
 
 OCIO_ADD_TEST(Config, add_color_space)

--- a/tests/cpu/fileformats/FileFormatCCC_tests.cpp
+++ b/tests/cpu/fileformats/FileFormatCCC_tests.cpp
@@ -238,7 +238,8 @@ OCIO_ADD_TEST(FileFormatCCC, test_ccc)
     // Check that the Descriptive element children of <ColorCorrection> are preserved.
     // Note that Descriptive element children of <ColorCorrectionCollection> are only
     // available in the CachedFile, not in the OpData.
-    auto & metadata = op->data()->getFormatMetadata();
+    auto data = op->data();
+    auto & metadata = data->getFormatMetadata();
     OCIO_REQUIRE_EQUAL(metadata.getNumChildrenElements(), 7);
     OCIO_CHECK_EQUAL(std::string(metadata.getChildElement(0).getName()), "Description");
     OCIO_CHECK_EQUAL(std::string(metadata.getChildElement(0).getValue()), "CC-level description 2a");
@@ -255,4 +256,20 @@ OCIO_ADD_TEST(FileFormatCCC, test_ccc)
     OCIO_CHECK_EQUAL(std::string(metadata.getChildElement(5).getValue()), "another example");
     OCIO_CHECK_EQUAL(std::string(metadata.getChildElement(6).getName()), "SATDescription");
     OCIO_CHECK_EQUAL(std::string(metadata.getChildElement(6).getValue()), "dropping sat");
+
+    OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::CDLType);
+    auto cdlData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::CDLOpData>(data);
+    OCIO_CHECK_EQUAL(cdlData->getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_FWD);
+
+    // Test with ASC style.
+    fileTransform->setCDLStyle(OCIO::CDL_ASC);
+
+    ops.clear();
+    tester.buildFileOps(ops, *config, context, cccFile, *fileTransform, OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    op = ops[0];
+    data = op->data();
+    OCIO_REQUIRE_EQUAL(data->getType(), OCIO::OpData::CDLType);
+    cdlData = OCIO_DYNAMIC_POINTER_CAST<const OCIO::CDLOpData>(data);
+    OCIO_CHECK_EQUAL(cdlData->getStyle(), OCIO::CDLOpData::CDL_V1_2_FWD);
 }

--- a/tests/cpu/fileformats/FileFormatCTF_tests.cpp
+++ b/tests/cpu/fileformats/FileFormatCTF_tests.cpp
@@ -4297,7 +4297,7 @@ OCIO_ADD_TEST(CTFTransform, cdl_clf)
             <Director FirstName="David" LastName="Lean"></Director>
         </Directors>
     </Info>
-    <ASC_CDL id="CDL42" name="TestCDL" inBitDepth="32f" outBitDepth="32f" style="Fwd">
+    <ASC_CDL id="CDL42" name="TestCDL" inBitDepth="32f" outBitDepth="32f" style="FwdNoClamp">
         <Description>CDL node for unit test</Description>
         <Description>Adding another description</Description>
         <InputDescription>Input</InputDescription>
@@ -4328,6 +4328,8 @@ OCIO_ADD_TEST(CTFTransform, cdl_ctf)
     config->setMajorVersion(2);
 
     OCIO::CDLTransformRcPtr cdl = OCIO::CDLTransform::Create();
+    cdl->setStyle(OCIO::CDL_ASC);
+
     const double sop[] = { 1.0, 1.1, 1.2,
                            0.2, 0.3, 0.4,
                            3.1, 3.2, 3.3 };
@@ -6069,6 +6071,7 @@ OCIO_ADD_TEST(FileFormatCTF, bake_1d_3d)
 
         // Set saturation to cause channel crosstalk, making a 3D LUT
         OCIO::CDLTransformRcPtr transform1 = OCIO::CDLTransform::Create();
+        transform1->setStyle(OCIO::CDL_ASC);
         transform1->setSat(0.5f);
         cs->setTransform(transform1, OCIO::COLORSPACE_DIR_FROM_REFERENCE);
 

--- a/tests/cpu/ops/cdl/CDLOpData_tests.cpp
+++ b/tests/cpu/ops/cdl/CDLOpData_tests.cpp
@@ -64,7 +64,7 @@ OCIO_ADD_TEST(CDLOpData, constructors)
     OCIO_CHECK_ASSERT(cdlOpDefault.getFormatMetadata().getChildrenElements().empty());
 
     OCIO_CHECK_EQUAL(cdlOpDefault.getStyle(),
-                     OCIO::CDLOpData::CDL_V1_2_FWD);
+                     OCIO::CDLOpData::CDL_NO_CLAMP_FWD);
 
     OCIO_CHECK_ASSERT(!cdlOpDefault.isReverse());
 

--- a/tests/cpu/transforms/ExponentTransform_tests.cpp
+++ b/tests/cpu/transforms/ExponentTransform_tests.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include "ops/exponent/ExponentOp.h"
 #include "transforms/ExponentTransform.cpp"
 
 #include "UnitTest.h"
@@ -62,3 +63,82 @@ OCIO_ADD_TEST(ExponentTransform, double)
     CheckValues(val4, {1., 2.1234567, 1., 1.});
 }
 
+OCIO_ADD_TEST(ExponentTransform, build_ops)
+{
+    OCIO::ExponentTransformRcPtr exp = OCIO::ExponentTransform::Create();
+    const std::string id{ "sample exponent" };
+    exp->getFormatMetadata().addAttribute(OCIO::METADATA_ID, id.c_str());
+    OCIO_CHECK_EQUAL(exp->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(exp->getNegativeStyle(), OCIO::NEGATIVE_CLAMP);
+
+    // With v1 config, exponent transform is converted to ExponentOp that does not handle
+    // negative styles.
+    OCIO::ConfigRcPtr config = OCIO::Config::Create();
+    config->setMajorVersion(1);
+    {
+        OCIO::OpRcPtrVec ops;
+        OCIO::BuildExponentOp(ops, *config, *exp, OCIO::TRANSFORM_DIR_FORWARD);
+        OCIO_REQUIRE_EQUAL(ops.size(), 1);
+        auto op = OCIO::DynamicPtrCast<const OCIO::Op>(ops[0]);
+        auto data = OCIO::DynamicPtrCast<const OCIO::ExponentOpData>(op->data());
+        OCIO_REQUIRE_ASSERT(data);
+        // In v1 identity exponent is considered a No-op and will be removed (losing the clamp).
+        OCIO_CHECK_ASSERT(data->isNoOp());
+        OCIO_CHECK_EQUAL(id, data->getID());
+    }
+    exp->setNegativeStyle(OCIO::NEGATIVE_MIRROR);
+    {
+        OCIO::OpRcPtrVec ops;
+        OCIO::BuildExponentOp(ops, *config, *exp, OCIO::TRANSFORM_DIR_FORWARD);
+        OCIO_REQUIRE_EQUAL(ops.size(), 1);
+        auto op = OCIO::DynamicPtrCast<const OCIO::Op>(ops[0]);
+        // Style is ignored, still getting a simple ExponentOpData.
+        auto data = OCIO::DynamicPtrCast<const OCIO::ExponentOpData>(op->data());
+        OCIO_REQUIRE_ASSERT(data);
+        OCIO_CHECK_ASSERT(data->isNoOp());
+    }
+
+    // With v2 config, exponent transform is converted to GammaOp that handles negative styles.
+    config->setMajorVersion(2);
+    exp->setNegativeStyle(OCIO::NEGATIVE_CLAMP);
+    {
+        OCIO::OpRcPtrVec ops;
+        OCIO::BuildExponentOp(ops, *config, *exp, OCIO::TRANSFORM_DIR_FORWARD);
+        OCIO_REQUIRE_EQUAL(ops.size(), 1);
+        auto op = OCIO::DynamicPtrCast<const OCIO::Op>(ops[0]);
+        auto data = OCIO::DynamicPtrCast<const OCIO::GammaOpData>(op->data());
+        OCIO_REQUIRE_ASSERT(data);
+        OCIO_CHECK_EQUAL(data->getStyle(), OCIO::GammaOpData::BASIC_FWD);
+        OCIO_CHECK_ASSERT(data->isIdentity());
+        // With v2 config clamping is preserved.
+        OCIO_CHECK_ASSERT(!data->isNoOp());
+        OCIO_CHECK_EQUAL(id, data->getID());
+    }
+    exp->setNegativeStyle(OCIO::NEGATIVE_MIRROR);
+    {
+        OCIO::OpRcPtrVec ops;
+        OCIO::BuildExponentOp(ops, *config, *exp, OCIO::TRANSFORM_DIR_FORWARD);
+        OCIO_REQUIRE_EQUAL(ops.size(), 1);
+        auto op = OCIO::DynamicPtrCast<const OCIO::Op>(ops[0]);
+        auto data = OCIO::DynamicPtrCast<const OCIO::GammaOpData>(op->data());
+        OCIO_REQUIRE_ASSERT(data);
+        OCIO_CHECK_EQUAL(data->getStyle(), OCIO::GammaOpData::BASIC_MIRROR_FWD);
+        OCIO_CHECK_ASSERT(data->isIdentity());
+        OCIO_CHECK_ASSERT(data->isNoOp());
+    }
+    exp->setNegativeStyle(OCIO::NEGATIVE_PASS_THRU);
+    {
+        OCIO::OpRcPtrVec ops;
+        OCIO::BuildExponentOp(ops, *config, *exp, OCIO::TRANSFORM_DIR_FORWARD);
+        OCIO_REQUIRE_EQUAL(ops.size(), 1);
+        auto op = OCIO::DynamicPtrCast<const OCIO::Op>(ops[0]);
+        auto data = OCIO::DynamicPtrCast<const OCIO::GammaOpData>(op->data());
+        OCIO_REQUIRE_ASSERT(data);
+        OCIO_CHECK_EQUAL(data->getStyle(), OCIO::GammaOpData::BASIC_PASS_THRU_FWD);
+        OCIO_CHECK_ASSERT(data->isIdentity());
+        OCIO_CHECK_ASSERT(data->isNoOp());
+    }
+
+    OCIO_CHECK_THROW_WHAT(exp->setNegativeStyle(OCIO::NEGATIVE_LINEAR), OCIO::Exception,
+                          "Linear negative extrapolation is not valid for basic exponent style");
+}

--- a/tests/cpu/transforms/FileTransform_tests.cpp
+++ b/tests/cpu/transforms/FileTransform_tests.cpp
@@ -10,6 +10,32 @@
 
 namespace OCIO = OCIO_NAMESPACE;
 
+OCIO_ADD_TEST(FileTransform, basic)
+{
+    auto ft = OCIO::FileTransform::Create();
+    OCIO_CHECK_EQUAL(ft->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    ft->setDirection(OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(ft->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+
+    OCIO_CHECK_EQUAL(std::string(ft->getSrc()), "");
+    const std::string src{ "source" };
+    ft->setSrc(src.c_str());
+    OCIO_CHECK_EQUAL(src, ft->getSrc());
+
+    OCIO_CHECK_EQUAL(std::string(ft->getCCCId()), "");
+    const std::string cccid{ "cccid" };
+    ft->setCCCId(cccid.c_str());
+    OCIO_CHECK_EQUAL(cccid, ft->getCCCId());
+
+    OCIO_CHECK_EQUAL(ft->getCDLStyle(), OCIO::CDL_NO_CLAMP);
+    ft->setCDLStyle(OCIO::CDL_ASC);
+    OCIO_CHECK_EQUAL(ft->getCDLStyle(), OCIO::CDL_ASC);
+
+    OCIO_CHECK_EQUAL(ft->getInterpolation(), OCIO::INTERP_UNKNOWN);
+    ft->setInterpolation(OCIO::INTERP_LINEAR);
+    OCIO_CHECK_EQUAL(ft->getInterpolation(), OCIO::INTERP_LINEAR);
+}
+
 OCIO_ADD_TEST(FileTransform, load_file_ok)
 {
     OCIO::ConstProcessorRcPtr proc;


### PR DESCRIPTION
CDL style was introduced earlier but there was some missing pieces:
* Add missing support for CDL style in config files.
* Change the default to no-clamp so that the default is aligned with v1 (i.e. to be backward compatible as requested during the last Working Group meeting).
* Add tests.

Signed-off-by: Bernard Lefebvre <bernard.lefebvre@autodesk.com>