### PR TITLE
Add cmake support for OCIO_LIBNAME_SUFFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,10 @@ if(NOT OCIO_NAMESPACE)
 endif(NOT OCIO_NAMESPACE)
 messageonce("Setting Namespace to: ${OCIO_NAMESPACE}")
 
+set(OCIO_LIBNAME_SUFFIX "" CACHE STRING
+    "Specify a suffix to all libraries that are built")
+messageonce("Setting Libname suffix to: ${OCIO_LIBNAME_SUFFIX}")
+
 # If CMAKE_INSTALL_EXEC_PREFIX is not specified, install binaries
 # directly into the regular install prefix
 if(NOT CMAKE_INSTALL_EXEC_PREFIX)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -56,7 +56,7 @@ if(OCIO_BUILD_SHARED)
     endif()
 
     set_target_properties(OpenColorIO PROPERTIES
-        OUTPUT_NAME OpenColorIO
+        OUTPUT_NAME      OpenColorIO${OCIO_LIBNAME_SUFFIX}
         COMPILE_FLAGS   "${EXTERNAL_COMPILE_FLAGS}"
         LINK_FLAGS      "${EXTERNAL_LINK_FLAGS}")
     
@@ -84,7 +84,7 @@ if(OCIO_BUILD_STATIC)
     
 	set_target_properties(OpenColorIO_STATIC PROPERTIES COMPILE_DEFINITIONS "OpenColorIO_STATIC")
     set_target_properties(OpenColorIO_STATIC PROPERTIES
-        OUTPUT_NAME                 OpenColorIO
+        OUTPUT_NAME                 OpenColorIO${OCIO_LIBNAME_SUFFIX}
         ARCHIVE_OUTPUT_DIRECTORY    "${CMAKE_CURRENT_BINARY_DIR}/static"
         COMPILE_FLAGS               "${EXTERNAL_COMPILE_FLAGS}"
         LINK_FLAGS                  "${EXTERNAL_LINK_FLAGS}")


### PR DESCRIPTION
This patch from Lee Kerley makes it easier for people making custom builds to add an optional suffix to the library name itself.

The purpose is to prevent a studio build for internal tools from conflicting with a different build of OCIO that might be embedded in a DCC app. The existing option to customize the inner namespace does a good job preventing symbol clashes at link time, but does not address the problem where both the DCC app and the plugin we write end up callled libOpenColorIO.so, so whichever is first in the `LD_LIBRARY_PATH` will win and the other won't be found. 

This is a patch against RB-1.1, because that's what we need ASAP, but after this is merged, we will submit another one against master (the build system has changed enough it won't just cherry pick).

Signed-off-by: Lee Kerley <lkerley@imageworks.com>
Signed-off-by: Larry Gritz <lg@larrygritz.com>