### PR TITLE
Fixes #527: Parsing error on whitespace

### DIFF
--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -1060,7 +1060,7 @@ inline void load(const YAML::Node& node, FileTransformRcPtr& t)
 
         load(first, key);
 
-        if (key.find(":") != std::string::npos && second.IsNull() || !second.IsDefined()) continue;
+        if (key.find(":") != std::string::npos && (second.IsNull() || !second.IsDefined())) continue;
 
         if(key == "src")
         {

--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -1060,7 +1060,7 @@ inline void load(const YAML::Node& node, FileTransformRcPtr& t)
 
         load(first, key);
 
-        if (second.IsNull() || !second.IsDefined()) continue;
+        if (key.find(":") != std::string::npos && second.IsNull() || !second.IsDefined()) continue;
 
         if(key == "src")
         {

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -181,6 +181,39 @@ OCIO_ADD_TEST(Config, simple_config)
     OCIO_CHECK_NO_THROW(config->sanityCheck());
 }
 
+OCIO_ADD_TEST(Config, missing_space_key_value_pair)
+{
+
+    constexpr char SIMPLE_PROFILE[] =
+        "ocio_profile_version: 2\n"
+        "search_path: luts\n"
+        "roles:\n"
+        "  default: raw\n"
+        "file_rules:\n"
+        "  - !<Rule> {name: Default, colorspace: default}\n"
+        "displays:\n"
+        "  Disp1:\n"
+        "    - !<View> {name: View1, colorspace: raw}\n"
+        "active_displays: []\n"
+        "active_views: []\n"
+        "colorspaces:\n"
+        "  - to_reference: !<FileTransform> {direction:inverse}\n"
+        "\n";
+
+    std::istringstream is;
+    is.str(SIMPLE_PROFILE);
+
+    OCIO::ConstConfigRcPtr config;
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+
+    {
+        OCIO::LogGuard log;
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_EQUAL(log.output(), 
+                         "[OpenColorIO Warning]: Unknown key in FileTransform: 'direction:inverse'.\n");
+    }
+}
+
 OCIO_ADD_TEST(Config, simple_config_with_duplicate)
 {
 

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -181,6 +181,40 @@ OCIO_ADD_TEST(Config, simple_config)
     OCIO_CHECK_NO_THROW(config->sanityCheck());
 }
 
+OCIO_ADD_TEST(Config, missing_space_key_value_pair)
+{
+
+    constexpr char SIMPLE_PROFILE[] =
+        "ocio_profile_version: 2\n"
+        "search_path: luts\n"
+        "roles:\n"
+        "  default: raw\n"
+        "file_rules:\n"
+        "  - !<Rule> {name: Default, colorspace: default}\n"
+        "displays:\n"
+        "  Disp1:\n"
+        "    - !<View> {name: View1, colorspace: raw}\n"
+        "active_displays: []\n"
+        "active_views: []\n"
+        "colorspaces:\n"
+        "  - to_reference: !<FileTransform> {direction:inverse}\n"
+        "\n";
+
+    std::istringstream is;
+    is.str(SIMPLE_PROFILE);
+
+    OCIO::ConstConfigRcPtr config;
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+
+    {
+        OCIO::LogGuard log;
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_EQUAL(log.output(), 
+                         "[OpenColorIO Warning]: Unknown key in FileTransform: 'direction:inverse'.\n");
+    }
+}
+
+
 OCIO_ADD_TEST(Config, roles)
 {
 


### PR DESCRIPTION
Checks the key for a colon character to make sure the value is not included within the key and not being misinterpreted as a null value. Therefore, an error message should be returned for a missing colon delimiter. 
Signed-off-by: Ishita Bhimavarapu ishitarb5@gmail.com