### PR TITLE
Adsk Contrib - Improve config sanity check and tests

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -1143,7 +1143,9 @@ public:
     //!cpp:function:: Will return null if the name is not found.
     ConstColorSpaceRcPtr getColorSpace(const char * name) const;
     //!cpp:function:: Will return -1 if the name is not found.
-    int getIndexForColorSpace(const char * name) const;
+    int getColorSpaceIndex(const char * name) const;
+    //!cpp:function::
+    bool hasColorSpace(const char * name) const;
 
     //!cpp:function:: Add color space(s).
     //

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -175,33 +175,26 @@ void GetColorSpaceReferences(std::set<std::string> & colorSpaceNames,
     else if(ConstLookTransformRcPtr lookTransform = \
         DynamicPtrCast<const LookTransform>(transform))
     {
-        colorSpaceNames.insert(context->resolveStringVar(colorSpaceTransform->getSrc()));
-        colorSpaceNames.insert(context->resolveStringVar(colorSpaceTransform->getDst()));
+        colorSpaceNames.insert(context->resolveStringVar(lookTransform->getSrc()));
+        colorSpaceNames.insert(context->resolveStringVar(lookTransform->getDst()));
     }
 }
 
-bool FindColorSpaceIndex(int * index,
-                         const ColorSpaceSetRcPtr & colorspaces,
-                         const std::string & csname)
-{
-    *index = colorspaces->getIndexForColorSpace(csname.c_str());
-    return *index!=-1;
-}
+static constexpr char AddedDefault[]{ "added_default_rule_colorspace" };
 
-static constexpr char AddedRaw[]{ "added_default_rule_colorspace" };
-
-void FindAvailableName(const ColorSpaceSetRcPtr & colorspaces,
-                       std::string & csname)
+void FindAvailableName(const ColorSpaceSetRcPtr & colorspaces, std::string & csname)
 {
     int i = 0;
-    csname = AddedRaw;
-    while (1)
+    csname = AddedDefault;
+    while (true)
     {
-        if (-1 == colorspaces->getIndexForColorSpace(csname.c_str()))
+        if (!colorspaces->hasColorSpace(csname.c_str()))
         {
             break;
         }
-        csname = "added_default_rule_colorspace" + std::to_string(i);
+
+        csname = AddedDefault + std::to_string(i);
+        ++i;
     }
 }
 
@@ -364,10 +357,16 @@ public:
         return *this;
     }
 
-    bool findColorSpaceIndex(int * index, const std::string & csname) const
+    // Only search for a color space name (i.e. not for a role name).
+    int getColorSpaceIndex(const char * csname) const
     {
-        *index = m_allColorSpaces->getIndexForColorSpace(csname.c_str());
-        return *index!=-1;
+        return m_allColorSpaces->getColorSpaceIndex(csname);
+    }
+
+    // Only search for a color space name (i.e. not for a role name).
+    bool hasColorSpace(const char * csname) const
+    {
+        return m_allColorSpaces->hasColorSpace(csname);
     }
 
     StringUtils::StringVec buildInactiveColorSpaceList() const;
@@ -395,15 +394,15 @@ public:
         m_majorVersion = 2;
         m_minorVersion = 0;
 
-        int csindex = -1;
         const char * rname = LookupRole(m_roles, ROLE_DEFAULT);
-        if (!FindColorSpaceIndex(&csindex, m_allColorSpaces, rname))
+        if (!hasColorSpace(rname))
         {
             std::string defaultCS;
             bool addNewDefault = true;
             // The default role doesn't exist so look for a color space named "raw"
             // (not case-sensitive) with isdata true.
-            if (FindColorSpaceIndex(&csindex, m_allColorSpaces, "raw"))
+            const int csindex = getColorSpaceIndex("raw");
+            if (-1 != csindex)
             {
                 auto cs = m_allColorSpaces->getColorSpaceByIndex(csindex);
                 if (cs->isData())
@@ -650,8 +649,7 @@ void Config::sanityCheck() const
         for(StringMap::const_iterator iter = getImpl()->m_roles.begin(),
             end = getImpl()->m_roles.end(); iter!=end; ++iter)
         {
-            int csindex = -1;
-            if(!getImpl()->findColorSpaceIndex(&csindex, iter->second))
+            if(!getImpl()->hasColorSpace(iter->second.c_str()))
             {
                 std::ostringstream os;
                 os << "Config failed sanitycheck. ";
@@ -663,7 +661,7 @@ void Config::sanityCheck() const
             }
 
             // Confirm no name conflicts between colorspaces and roles
-            if(getImpl()->findColorSpaceIndex(&csindex, iter->first))
+            if(getImpl()->hasColorSpace(iter->first.c_str()))
             {
                 std::ostringstream os;
                 os << "Config failed sanitycheck. ";
@@ -725,8 +723,7 @@ void Config::sanityCheck() const
                 throw Exception(getImpl()->m_sanitytext.c_str());
             }
 
-            int csindex = -1;
-            if(!getImpl()->findColorSpaceIndex(&csindex, views[i].m_colorspace))
+            if(!getImpl()->hasColorSpace(views[i].m_colorspace.c_str()))
             {
                 std::ostringstream os;
                 os << "Config failed sanitycheck. ";
@@ -753,7 +750,8 @@ void Config::sanityCheck() const
                     getImpl()->m_sanitytext = os.str();
                     throw Exception(getImpl()->m_sanitytext.c_str());
                 }
-                auto cs = getImpl()->m_allColorSpaces->getColorSpaceByIndex(csindex);
+
+                auto cs = getImpl()->m_allColorSpaces->getColorSpace(views[i].m_colorspace.c_str());
                 if (cs->getReferenceSpaceType() != REFERENCE_SPACE_DISPLAY)
                 {
                     std::ostringstream os;
@@ -893,7 +891,7 @@ void Config::sanityCheck() const
         getImpl()->getAllInternalTransforms(allTransforms);
 
         std::set<std::string> colorSpaceNames;
-        for(unsigned int i=0; i<allTransforms.size(); ++i)
+        for (unsigned int i = 0; i < allTransforms.size(); ++i)
         {
             allTransforms[i]->validate();
 
@@ -901,52 +899,82 @@ void Config::sanityCheck() const
             GetColorSpaceReferences(colorSpaceNames, allTransforms[i], context);
         }
 
-        for(std::set<std::string>::iterator iter = colorSpaceNames.begin();
-            iter != colorSpaceNames.end(); ++iter)
+        for (const auto & name : colorSpaceNames)
         {
-            int csindex = -1;
-            if(!getImpl()->findColorSpaceIndex(&csindex, *iter))
+            if (!getImpl()->hasColorSpace(name.c_str()))
             {
+                // Check to see if the name is a role.
+                const char * csname = LookupRole(getImpl()->m_roles, name);
+
                 std::ostringstream os;
                 os << "Config failed sanitycheck. ";
-                os << "This config references a color space, '" << *iter << "', ";
-                os << "which is not defined.";
-                getImpl()->m_sanitytext = os.str();
-                throw Exception(getImpl()->m_sanitytext.c_str());
+                os << "This config references a color space, '";
+
+                if (!csname || !*csname)
+                {
+                    os << name << "', which is not defined.";
+                    getImpl()->m_sanitytext = os.str();
+                    throw Exception(getImpl()->m_sanitytext.c_str());
+                }
+                else if(!getImpl()->hasColorSpace(csname))
+                {
+                    os << csname << "' (for role '" << name << "'), which is not defined.";
+                    getImpl()->m_sanitytext = os.str();
+                    throw Exception(getImpl()->m_sanitytext.c_str());
+                }
             }
         }
     }
 
     ///// LOOKS
 
-    // For all looks, confirm the process space exists and the look is named
+    // For all looks, confirm the process space exists and the look is named.
     for(unsigned int i=0; i<getImpl()->m_looksList.size(); ++i)
     {
-        // Note: Config::addLook validates that looks have a unique, non-empty name.
-
-        const std::string name = getImpl()->m_looksList[i]->getName();
-
-        const std::string processSpace = getImpl()->m_looksList[i]->getProcessSpace();
-        if(processSpace.empty())
+        const char * lookName = getImpl()->m_looksList[i]->getName();
+        if (!lookName || !*lookName)
         {
             std::ostringstream os;
             os << "Config failed sanitycheck. ";
-            os << "The look '" << name << "' ";
-            os << "does not specify a process color space.";
+            os << "The look at index '" << i << "' ";
+            os << "does not specify a name.";
             getImpl()->m_sanitytext = os.str();
             throw Exception(getImpl()->m_sanitytext.c_str());
         }
 
-        int csindex=0;
-        if(!getImpl()->findColorSpaceIndex(&csindex, processSpace))
+        const char * processSpace = getImpl()->m_looksList[i]->getProcessSpace();
+        if (!processSpace || !*processSpace)
         {
             std::ostringstream os;
             os << "Config failed sanitycheck. ";
-            os << "The look '" << name << "' ";
-            os << "specifies a process color space, '";
-            os << processSpace << "', which is not defined.";
+            os << "The look '" << lookName << "' ";
+            os << "does not specify a process space.";
             getImpl()->m_sanitytext = os.str();
             throw Exception(getImpl()->m_sanitytext.c_str());
+        }
+
+        if (!getImpl()->hasColorSpace(processSpace))
+        {
+            // Check to see if the processSpace is a role.
+            const char * csname = LookupRole(getImpl()->m_roles, processSpace);
+
+            std::ostringstream os;
+            os << "Config failed sanitycheck. ";
+            os << "The look '" << lookName << "' ";
+            os << "specifies a process color space, '";
+
+            if (!csname || !*csname)
+            {
+                os << processSpace << "', which is not defined.";
+                getImpl()->m_sanitytext = os.str();
+                throw Exception(getImpl()->m_sanitytext.c_str());
+            }
+            else if (!getImpl()->hasColorSpace(csname))
+            {
+                os << csname << "' (for role '" << processSpace << "'), which is not defined.";
+                getImpl()->m_sanitytext = os.str();
+                throw Exception(getImpl()->m_sanitytext.c_str());
+            }
         }
     }
 
@@ -1437,11 +1465,10 @@ const char * Config::parseColorSpaceFromString(const char * str) const
         const char* csname = LookupRole(getImpl()->m_roles, ROLE_DEFAULT);
         if(csname && *csname)
         {
-            int csindex = -1;
-            if (getImpl()->findColorSpaceIndex(&csindex, csname))
+            const int csindex = getImpl()->getColorSpaceIndex(csname);
+            if (-1 != csindex)
             {
-                // This is necessary to not return a reference to
-                // a local variable.
+                // This is necessary to not return a reference to a local variable.
                 return getImpl()->m_allColorSpaces->getColorSpaceNameByIndex(csindex);
             }
         }
@@ -2371,12 +2398,16 @@ void Config::Impl::getAllInternalTransforms(ConstTransformVec & transformVec) co
     }
 
     // Grab all transforms from the Looks
-    for(unsigned int i=0; i<m_looksList.size(); ++i)
+    for (unsigned int i=0; i < m_looksList.size(); ++i)
     {
-        if(m_looksList[i]->getTransform())
+        if (m_looksList[i]->getTransform())
+        {
             transformVec.push_back(m_looksList[i]->getTransform());
-        if(m_looksList[i]->getInverseTransform())
+        }
+        if (m_looksList[i]->getInverseTransform())
+        {
             transformVec.push_back(m_looksList[i]->getInverseTransform());
+        }
     }
 
 }

--- a/src/apps/ociocheck/main.cpp
+++ b/src/apps/ociocheck/main.cpp
@@ -82,10 +82,18 @@ int main(int argc, const char **argv)
         std::cout << "** General **" << std::endl;
         std::cout << "Search Path: " << config->getSearchPath() << std::endl;
         std::cout << "Working Dir: " << config->getWorkingDir() << std::endl;
-
         std::cout << std::endl;
-        std::cout << "Default Display: " << config->getDefaultDisplay() << std::endl;
-        std::cout << "Default View: " << config->getDefaultView(config->getDefaultDisplay()) << std::endl;
+
+        if (config->getNumDisplays() == 0)
+        {
+            std::cout << "Error: At least one (display, view) pair must be defined." << std::endl;
+            errorcount += 1;
+        }
+        else
+        {
+            std::cout << "Default Display: " << config->getDefaultDisplay() << std::endl;
+            std::cout << "Default View: " << config->getDefaultView(config->getDefaultDisplay()) << std::endl;
+        }
 
         {
             std::cout << std::endl;

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -3746,6 +3746,7 @@ colorspaces:
                           "The role 'aces_interchange' is missing in the destination config");
 }
 
+
 const std::string PROFILE_V2_DCS_START = PROFILE_V2 + SIMPLE_PROFILE_A + DEFAULT_RULES +
                                          SIMPLE_PROFILE_DISPLAYS_LOOKS;
 
@@ -3985,4 +3986,156 @@ OCIO_ADD_TEST(Config, display_view)
                           "Can't add a display with empty view name");
     OCIO_CHECK_THROW_WHAT(config->addDisplay(display.c_str(), "view1", "", ""), OCIO::Exception,
                           "Can't add a display with empty color space name");
+}
+
+OCIO_ADD_TEST(Config, not_case_sensitive)
+{
+    // Validate that the color spaces and roles are case insensitive.
+
+    std::istringstream is;
+    is.str(PROFILE_V2_START);
+
+    OCIO::ConstConfigRcPtr config;
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    OCIO::ConstColorSpaceRcPtr cs;
+    OCIO_CHECK_NO_THROW(cs = config->getColorSpace("lnh"));
+    OCIO_CHECK_ASSERT(cs);
+
+    OCIO_CHECK_NO_THROW(cs = config->getColorSpace("LNH"));
+    OCIO_CHECK_ASSERT(cs);
+
+    OCIO_CHECK_NO_THROW(cs = config->getColorSpace("RaW"));
+    OCIO_CHECK_ASSERT(cs);
+
+    OCIO_CHECK_ASSERT(config->hasRole("default"));
+    OCIO_CHECK_ASSERT(config->hasRole("Default"));
+    OCIO_CHECK_ASSERT(config->hasRole("DEFAULT"));
+
+    OCIO_CHECK_ASSERT(config->hasRole("scene_linear"));
+    OCIO_CHECK_ASSERT(config->hasRole("Scene_Linear"));
+
+    OCIO_CHECK_ASSERT(!config->hasRole("reference"));
+    OCIO_CHECK_ASSERT(!config->hasRole("REFERENCE"));
+}
+
+OCIO_ADD_TEST(Config, transform_with_roles)
+{
+    // Validate that Config::sanityCheck() on config file containing transforms 
+    // with color space names (such as ColorSpaceTransform), correctly checks for role names
+    // for those transforms.
+
+    constexpr const char * OCIO_CONFIG{ R"(
+ocio_profile_version: 1
+
+roles:
+  DEFAULT: raw
+  scene_linear: cs1
+
+displays:
+  Disp1:
+  - !<View> {name: View1, colorspace: RaW, looks: beauty}
+
+looks:
+  - !<Look>
+    name: beauty
+    process_space: SCENE_LINEAR
+    transform: !<ColorSpaceTransform> {src: SCENE_LINEAR, dst: raw}
+
+colorspaces:
+  - !<ColorSpace>
+    name: RAW
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: CS1
+    allocation: uniform
+    from_reference: !<MatrixTransform> {offset: [0.11, 0.12, 0.13, 0]}
+
+  - !<ColorSpace>
+    name: cs2
+    allocation: uniform
+    to_reference: !<ColorSpaceTransform> {src: SCENE_LINEAR, dst: raw}
+)" };
+
+    std::istringstream is;
+    is.str(OCIO_CONFIG);
+
+    OCIO::ConstConfigRcPtr config;
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    // Validate the color spaces.
+
+    OCIO::ConstProcessorRcPtr processor;
+    OCIO_CHECK_NO_THROW(processor = config->getProcessor("raw", "cs1"));
+    OCIO_CHECK_ASSERT(processor);
+
+    OCIO_CHECK_NO_THROW(processor = config->getProcessor("raw", "cs2"));
+    OCIO_CHECK_ASSERT(processor);
+
+    OCIO_CHECK_NO_THROW(processor = config->getProcessor("cs1", "cs2"));
+    OCIO_CHECK_ASSERT(processor);
+
+    // Validate the (display, view) pair with looks.
+
+    OCIO::DisplayTransformRcPtr display = OCIO::DisplayTransform::Create();
+    display->setInputColorSpaceName("raw");
+    display->setDisplay("Disp1");
+    display->setView("View1");
+
+    OCIO_CHECK_NO_THROW(processor = config->getProcessor(display));
+    OCIO_CHECK_ASSERT(processor);
+
+    display->setInputColorSpaceName("cs1");
+
+    OCIO_CHECK_NO_THROW(processor = config->getProcessor(display));
+    OCIO_CHECK_ASSERT(processor);
+
+    display->setInputColorSpaceName("cs2");
+
+    OCIO_CHECK_NO_THROW(processor = config->getProcessor(display));
+    OCIO_CHECK_ASSERT(processor);
+}    
+
+OCIO_ADD_TEST(Config, look_transform)
+{
+    // Validate Config::sanityCheck() on config file containing look transforms.
+
+    constexpr const char * OCIO_CONFIG{ R"(
+ocio_profile_version: 2
+
+roles:
+  default: raw
+
+file_rules:
+  - !<Rule> {name: Default, colorspace: default}
+
+displays:
+  Disp1:
+  - !<View> {name: View1, colorspace: raw, looks: look1}
+
+looks:
+  - !<Look>
+    name: look1
+    process_space: default
+    transform: !<ColorSpaceTransform> {src: default, dst: raw}
+  - !<Look>
+    name: look2
+    process_space: default
+    transform: !<LookTransform> {src: default, dst: raw, looks:+look1}
+
+colorspaces:
+  - !<ColorSpace>
+    name: raw
+    allocation: uniform
+)" };
+
+    std::istringstream is;
+    is.str(OCIO_CONFIG);
+
+    OCIO::ConstConfigRcPtr config;
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
 }


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

The pull request starts by validating that the color space and role names are case insensitive to end on improving the `Config::sanityCheck()` around the look transforms.