### PR TITLE
Add pybind11 install to "latest" ci job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,6 +123,7 @@ jobs:
       share/ci/scripts/linux/install_openexr.sh latest
       share/ci/scripts/linux/install_oiio.sh latest
       share/ci/scripts/linux/install_sphinx.sh latest
+      share/ci/scripts/linux/install_pybind11.sh latest
     displayName: Install dependencies
 
   - template: share/ci/templates/configure.yml

--- a/share/ci/scripts/linux/install_pybind11.sh
+++ b/share/ci/scripts/linux/install_pybind11.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+set -ex
+
+PYBIND11_VERSION="$1"
+
+git clone https://github.com/pybind/pybind11.git
+cd pybind11
+
+if [ "$PYBIND11_VERSION" == "latest" ]; then
+    LATEST_TAG=$(git describe --abbrev=0 --tags)
+    git checkout tags/${LATEST_TAG} -b ${LATEST_TAG}
+else
+    git checkout tags/v${PYBIND11_VERSION} -b v${PYBIND11_VERSION}
+fi
+
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local \
+      -DPYBIND11_INSTALL:BOOL=ON \
+      -DPYBIND11_TEST:BOOL=OFF \
+      ../.
+make -j4
+sudo make install
+
+cd ../..
+rm -rf pybind11


### PR DESCRIPTION
This PR is intended to fix the failed cron "latest" build in AZP CI. This "latest" build installs the latest tag from each of OCIO's upstream dependency repos with the intent of catching breaking upstream changes early. With the merged pybind11 bindings however, I had forgotten to add a pybind11 install script to that build (which does not use OCIO_INSTALL_EXT_PACKAGES, since that installs the minimum supported versions).

This was successfully tested in #988 but I am submitting a new PR as the checks were completed, but stuck reporting that they were waiting for a response.

Signed-off-by: Michael Dolan <michdolan@gmail.com>