### PR TITLE
Adsk Contrib - Add Built-in Transform and ociomakeclf app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,12 @@ option(OCIO_USE_SSE "Specify whether to enable SSE CPU performance optimizations
 option(OCIO_INLINES_HIDDEN "Specify whether to build with -fvisibility-inlines-hidden" ${UNIX})
 
 ###############################################################################
+# Supplemental builtins
+
+# Add supplemental built-in transformations such as camera related one.
+option(OCIO_ADD_EXTRA_BUILTINS "Specify whether to add supplemental built-in transforms" ON)
+
+###############################################################################
 # Platform & Compiler dependent compilation flags
 
 set(PLATFORM_COMPILE_FLAGS "")

--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -2566,7 +2566,7 @@ class OCIOEXPORT BuiltinTransformRegistry
 {
 public:
     //!cpp:function:: Get the current built-in transform registry.
-    static ConstBuiltinTransformRegistryRcPtr Get() noexcept;
+    static BuiltinTransformRegistryRcPtr Get() noexcept;
 
     //!cpp:function:: Get the number of built-in transforms available.
     virtual size_t getNumBuiltins() const noexcept = 0;
@@ -2576,9 +2576,11 @@ public:
     //!cpp:function:: Get the description string for the i-th built-in transform.
     virtual const char * getBuiltinDescription(size_t index) const = 0;
 
+    //!cpp:function:: To never use i.e. only needed for the Python bindings with pybind11. 
+    virtual ~BuiltinTransformRegistry() = default;
+
 protected:
     BuiltinTransformRegistry() = default;
-    virtual ~BuiltinTransformRegistry() = default;
 
 private:
     BuiltinTransformRegistry(const BuiltinTransformRegistry &) = delete;

--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -1404,39 +1404,37 @@ public:
     const char * getCacheID() const;
 
     //!cpp:function:: The ProcessorMetadata contains technical information
-    //                such as the number of files and looks used in the processor.
+    // such as the number of files and looks used in the processor.
     ConstProcessorMetadataRcPtr getProcessorMetadata() const;
 
     //!cpp:function:: Get a FormatMetadata containing the top level metadata
-    //                for the processor.  For a processor from a CLF file,
-    //                this corresponds to the ProcessList metadata.
+    // for the processor.  For a processor from a CLF file, this corresponds to
+    // the ProcessList metadata.
     const FormatMetadata & getFormatMetadata() const;
 
     //!cpp:function:: Get the number of transforms that comprise the processor.
-    //                Each transform has a (potentially empty) FormatMetadata.
+    // Each transform has a (potentially empty) FormatMetadata.
     int getNumTransforms() const;
     //!cpp:function:: Get a FormatMetadata containing the metadata for a
-    //                transform within the processor. For a processor from
-    //                a CLF file, this corresponds to the metadata associated
-    //                with an individual process node.
+    // transform within the processor. For a processor from a CLF file, this 
+    // corresponds to the metadata associated with an individual process node.
     const FormatMetadata & getTransformFormatMetadata(int index) const;
 
     //!cpp:function:: Return a cpp:class:`GroupTransform` that contains a
-    //                copy of the transforms that comprise the processor.
-    //                (Changes to it will not modify the original processor.)
+    // copy of the transforms that comprise the processor.
+    // (Changes to it will not modify the original processor.)
     GroupTransformRcPtr createGroupTransform() const;
 
     //!cpp:function:: Write the transforms comprising the processor to the stream.
-    //                Writing (as opposed to Baking) is a lossless process.
-    //                An exception is thrown if the processor cannot be
-    //                losslessly written to the specified file format.
+    // Writing (as opposed to Baking) is a lossless process. An exception is thrown
+    // if the processor cannot be losslessly written to the specified file format.
     void write(const char * formatName, std::ostream & os) const;
 
     //!cpp:function:: Get the number of writers.
     static int getNumWriteFormats();
 
     //!cpp:function:: Get the writer at index, return empty string if
-    //                an invalid index is specified.
+    // an invalid index is specified.
     static const char * getFormatNameByIndex(int index);
     static const char * getFormatExtensionByIndex(int index);
 
@@ -2554,6 +2552,39 @@ private:
 };
 
 extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const Context&);
+
+
+///////////////////////////////////////////////////////////////////////////
+//!rst::
+// BuiltinTransformRegistry
+// ************************
+// The built-in transform registry contains all the existing built-in transforms which can
+// be used by a configuration (version 2 or higher only).
+
+//!cpp:class::
+class OCIOEXPORT BuiltinTransformRegistry
+{
+public:
+    //!cpp:function:: Get the current built-in transform registry.
+    static ConstBuiltinTransformRegistryRcPtr Get() noexcept;
+
+    //!cpp:function:: Get the number of built-in transforms available.
+    virtual size_t getNumBuiltins() const noexcept = 0;
+    //!cpp:function:: Get the style string for the i-th built-in transform.
+    // The style is the ID string that identifies a given transform.
+    virtual const char * getBuiltinStyle(size_t index) const = 0;
+    //!cpp:function:: Get the description string for the i-th built-in transform.
+    virtual const char * getBuiltinDescription(size_t index) const = 0;
+
+protected:
+    BuiltinTransformRegistry() = default;
+    virtual ~BuiltinTransformRegistry() = default;
+
+private:
+    BuiltinTransformRegistry(const BuiltinTransformRegistry &) = delete;
+    BuiltinTransformRegistry & operator= (const BuiltinTransformRegistry &) = delete;
+};
+
 
 } // namespace OCIO_NAMESPACE
 

--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -2566,7 +2566,7 @@ class OCIOEXPORT BuiltinTransformRegistry
 {
 public:
     //!cpp:function:: Get the current built-in transform registry.
-    static BuiltinTransformRegistryRcPtr Get() noexcept;
+    static ConstBuiltinTransformRegistryRcPtr Get() noexcept;
 
     //!cpp:function:: Get the number of built-in transforms available.
     virtual size_t getNumBuiltins() const noexcept = 0;
@@ -2576,11 +2576,9 @@ public:
     //!cpp:function:: Get the description string for the i-th built-in transform.
     virtual const char * getBuiltinDescription(size_t index) const = 0;
 
-    //!cpp:function:: To never use i.e. only needed for the Python bindings with pybind11. 
-    virtual ~BuiltinTransformRegistry() = default;
-
 protected:
     BuiltinTransformRegistry() = default;
+    virtual ~BuiltinTransformRegistry() = default;
 
 private:
     BuiltinTransformRegistry(const BuiltinTransformRegistry &) = delete;

--- a/include/OpenColorIO/OpenColorTransforms.h
+++ b/include/OpenColorIO/OpenColorTransforms.h
@@ -175,6 +175,40 @@ extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const AllocationTrans
 
 //!rst:: //////////////////////////////////////////////////////////////////
 
+//!cpp:class:: A built-in transform is similar to a FileTransform, but without the file.
+// OCIO knows how to build a set of commonly used transforms on-demand, thus avoiding the need
+// for external files and simplifying config authoring.
+class OCIOEXPORT BuiltinTransform : public Transform
+{
+public:
+    //!cpp:function::
+    static BuiltinTransformRcPtr Create();
+
+    //!cpp:function::
+    virtual const char * getStyle() const noexcept = 0;
+    //!cpp:function:: Select an existing built-in transform style from the list accessible
+    // through :cpp:class:`BuiltinTransformRegistry`. The style is the ID string that identifies
+    // which transform to apply.
+    virtual void setStyle(const char * style) = 0;
+
+    //!cpp:function::
+    virtual const char * getDescription() const noexcept = 0;
+
+protected:
+    BuiltinTransform() = default;
+    virtual ~BuiltinTransform() = default;
+
+private:
+    BuiltinTransform(const BuiltinTransform &) = delete;
+    BuiltinTransform & operator= (const BuiltinTransform &) = delete;
+};
+
+//!cpp:function::
+extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const BuiltinTransform &) noexcept;
+
+
+//!rst:: //////////////////////////////////////////////////////////////////
+
 //!cpp:class:: An implementation of the ASC Color Decision List (CDL), based on the ASC v1.2
 // specification.
 //

--- a/include/OpenColorIO/OpenColorTransforms.h
+++ b/include/OpenColorIO/OpenColorTransforms.h
@@ -194,9 +194,11 @@ public:
     //!cpp:function::
     virtual const char * getDescription() const noexcept = 0;
 
+    //!cpp:function:: To never use i.e. only needed for the Python bindings with pybind11. 
+    virtual ~BuiltinTransform() = default;
+
 protected:
     BuiltinTransform() = default;
-    virtual ~BuiltinTransform() = default;
 
 private:
     BuiltinTransform(const BuiltinTransform &) = delete;

--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -121,6 +121,12 @@ typedef OCIO_SHARED_PTR<GpuShaderDesc> GpuShaderDescRcPtr;
 //!cpp:type::
 typedef OCIO_SHARED_PTR<const GpuShaderDesc> ConstGpuShaderDescRcPtr;
 
+class OCIOEXPORT BuiltinTransformRegistry;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<BuiltinTransformRegistry> BuiltinTransformRegistryRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const BuiltinTransformRegistry> ConstBuiltinTransformRegistryRcPtr;
+
 
 //!rst::
 // Transforms
@@ -137,6 +143,12 @@ class OCIOEXPORT AllocationTransform;
 typedef OCIO_SHARED_PTR<const AllocationTransform> ConstAllocationTransformRcPtr;
 //!cpp:type::
 typedef OCIO_SHARED_PTR<AllocationTransform> AllocationTransformRcPtr;
+
+class OCIOEXPORT BuiltinTransform;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<const BuiltinTransform> ConstBuiltinTransformRcPtr;
+//!cpp:type::
+typedef OCIO_SHARED_PTR<BuiltinTransform> BuiltinTransformRcPtr;
 
 class OCIOEXPORT CDLTransform;
 //!cpp:type::

--- a/src/OpenColorIO/Baker.cpp
+++ b/src/OpenColorIO/Baker.cpp
@@ -112,15 +112,18 @@ const char * Baker::getFormatExtensionByIndex(int index)
 
 void Baker::setFormat(const char * formatName)
 {
-    FileFormat* fmt = FormatRegistry::GetInstance().getFileFormatByName(formatName);
-    FormatInfoVec formatInfoVec;
-    fmt->getFormatInfo(formatInfoVec);
-    for(unsigned int i=0; i<formatInfoVec.size(); ++i)
+    FileFormat * fmt = FormatRegistry::GetInstance().getFileFormatByName(formatName);
+    if (fmt)
     {
-        if(formatInfoVec[i].capabilities & FORMAT_CAPABILITY_BAKE)
+        FormatInfoVec formatInfoVec;
+        fmt->getFormatInfo(formatInfoVec);
+        for (unsigned int i = 0; i < formatInfoVec.size(); ++i)
         {
-            getImpl()->m_formatName = formatName;
-            return;
+            if (formatInfoVec[i].capabilities & FORMAT_CAPABILITY_BAKE)
+            {
+                getImpl()->m_formatName = formatName;
+                return;
+            }
         }
     }
 

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -143,6 +143,8 @@ if(OCIO_ADD_EXTRA_BUILTINS)
 	)
 
 	list(INSERT SOURCES 0 ${SOURCES_BUILTINS})
+else()
+	message(WARNING "Disabling supplemental built-in transforms removes built-in camera transforms.")
 endif()
 
 if(WIN32 AND BUILD_SHARED_LIBS)

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -108,6 +108,11 @@ set(SOURCES
 	ScanlineHelper.cpp
 	Transform.cpp
 	transforms/AllocationTransform.cpp
+	transforms/builtins/ACES.cpp
+	transforms/builtins/BuiltinTransformRegistry.cpp
+	transforms/builtins/ColorMatrixHelpers.cpp
+	transforms/builtins/OpHelpers.cpp
+	transforms/BuiltinTransform.cpp
 	transforms/CDLTransform.cpp
 	transforms/ColorSpaceTransform.cpp
 	transforms/DisplayTransform.cpp
@@ -127,6 +132,18 @@ set(SOURCES
 	transforms/RangeTransform.cpp
 	ViewTransform.cpp
 )
+
+if(OCIO_ADD_EXTRA_BUILTINS)
+	set(SOURCES_BUILTINS
+		transforms/builtins/ArriCameras.cpp
+		transforms/builtins/CanonCameras.cpp
+		transforms/builtins/PanasonicCameras.cpp
+		transforms/builtins/RedCameras.cpp
+		transforms/builtins/SonyCameras.cpp
+	)
+
+	list(INSERT SOURCES 0 ${SOURCES_BUILTINS})
+endif()
 
 if(WIN32 AND BUILD_SHARED_LIBS)
 
@@ -188,6 +205,13 @@ if(OCIO_USE_SSE)
 	target_compile_definitions(OpenColorIO
 		PRIVATE
 			USE_SSE
+	)
+endif()
+
+if(OCIO_ADD_EXTRA_BUILTINS)
+	target_compile_definitions(OpenColorIO
+		PRIVATE
+			ADD_EXTRA_BUILTINS
 	)
 endif()
 

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -144,7 +144,7 @@ if(OCIO_ADD_EXTRA_BUILTINS)
 
 	list(INSERT SOURCES 0 ${SOURCES_BUILTINS})
 else()
-	message(WARNING "Disabling supplemental built-in transforms removes built-in camera transforms.")
+	message(WARNING "Disabling supplemental built-in transforms removes all built-in camera transforms, limiting OCIO configuration compatibility.")
 endif()
 
 if(WIN32 AND BUILD_SHARED_LIBS)

--- a/src/OpenColorIO/Context.cpp
+++ b/src/OpenColorIO/Context.cpp
@@ -354,7 +354,7 @@ const char * Context::resolveFileLocation(const char * filename) const
     // Loop over each path, and try to find the file
     std::ostringstream errortext;
     errortext << "The specified file reference ";
-    errortext << " '" << filename << "' could not be located. ";
+    errortext << "'" << filename << "' could not be located. ";
     errortext << "The following attempts were made: ";
 
     for (unsigned int i = 0; i < searchpaths.size(); ++i)
@@ -368,8 +368,9 @@ const char * Context::resolveFileLocation(const char * filename) const
             return getImpl()->m_resultsCache[filename].c_str();
         }
         if(i!=0) errortext << " : ";
-        errortext << expandedfullpath;
+        errortext << "'" << expandedfullpath << "'";
     }
+    errortext << ".";
 
     throw ExceptionMissingFile(errortext.str().c_str());
 }

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -459,9 +459,6 @@ bool FloatsDiffer(const float expected, const float actual,
     const unsigned expectedBits = FloatAsInt(expected);
     const unsigned actualBits = FloatAsInt(actual);
 
-    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> expectedBits = " << expectedBits << ", 0x" << std::hex << expectedBits << std::dec << "\n";
-    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> actualBits = " << actualBits << ", 0x" << std::hex << actualBits << std::dec << "\n";
-
     unsigned es, ee, em, as, ae, am;
     ExtractFloatComponents(expectedBits, es, ee, em);
     ExtractFloatComponents(actualBits, as, ae, am);

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -504,7 +504,7 @@ bool FloatsDiffer(const float expected, const float actual,
     }
 
     // Comparing regular floats
-    int expectedBitsComp, actualBitsComp;
+    unsigned expectedBitsComp, actualBitsComp;
     if (compressDenorms)
     {
         expectedBitsComp = FloatForCompareCompressDenorms(expectedBits);
@@ -520,9 +520,6 @@ bool FloatsDiffer(const float expected, const float actual,
     // integer arithmetic overflow even if previous AppleClang (i.e. 11.0.0.11000033)
     // works fine. And the cppreference documentation mentions that std::abs() & abs()
     // have undefined behaviors for INT_MIN & INT_MAX.
-    // For all compilers (in case newer version of gcc / msvc also fail in the future)
-    // re-implement the integer difference to have the arithmetic overflow outside
-    // the abs() call.
 
     const int diff = (expectedBitsComp > actualBitsComp)
                    ? (expectedBitsComp - actualBitsComp)

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -529,14 +529,15 @@ bool FloatsDiffer(const float expected, const float actual,
 
     const bool ret = diff_abs > tolerance;
 
+    return ret;
+
 #if defined(__clang__) && defined(__APPLE__)
 
 #pragma clang optimize on
 
 #endif
-
-    return ret;
 }
+
 
 inline int HalfForCompare(const half h)
 {

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -514,13 +514,10 @@ bool FloatsDiffer(const float expected, const float actual,
         actualBitsComp = FloatForCompare(actualBits);
     }
 
-    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> expectedBitsComp = " << expectedBitsComp << ", 0x" << std::hex << expectedBitsComp << std::dec << "\n";
-    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> actualBitsComp = " << actualBitsComp << ", 0x" << std::hex << actualBitsComp << std::dec << "\n";
-
-    // Impose to process 'int' type to have the overflow. 
+    // Impose to process 'int' types to have the overflow. 
     const int diff = expectedBitsComp - actualBitsComp;
-    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> diff = " << diff << ", 0x" << std::hex << diff << std::dec << "\n";
 
+    // Impose to process 'int' type. 
     const int diff_abs = abs(diff);
     if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> abs(diff) = " << diff_abs << ", 0x" << std::hex << diff_abs << std::dec << "\n";
 

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -525,7 +525,7 @@ bool FloatsDiffer(const float expected, const float actual,
 
     const int diff = expectedBitsComp - actualBitsComp;
 
-    const int diff_abs = abs(diff);
+    const int diff_abs = std::abs(diff);
 
     const bool ret = diff_abs > tolerance;
 

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -504,7 +504,7 @@ bool FloatsDiffer(const float expected, const float actual,
     }
 
     // Comparing regular floats
-    int expectedBitsComp, actualBitsComp;
+    unsigned expectedBitsComp, actualBitsComp;
     if (compressDenorms)
     {
         expectedBitsComp = FloatForCompareCompressDenorms(expectedBits);
@@ -516,13 +516,18 @@ bool FloatsDiffer(const float expected, const float actual,
         actualBitsComp = FloatForCompare(actualBits);
     }
 
-    // Note: AppleClang 11.0.3.11030032 has trouble when merging the next three lines.
-    //       But AppleClang 11.0.0.11000033 works fine.
+    // Note: AppleClang 11.0.3.11030032 has trouble with abs() & std::abs() versus
+    // integer arithmetic overflow even if previous AppleClang (i.e. 11.0.0.11000033)
+    // works fine. And the cppreference documentation mentions that std::abs() & abs()
+    // have undefined behaviors for INT_MIN & INT_MAX.
+    // For all compilers (in case newer version of gcc / msvc also fail in the future)
+    // re-implement the integer difference to have the arithmetic overflow outside
+    // the abs() call.
 
-    const int diff = expectedBitsComp - actualBitsComp;
-    const int diff_abs = std::abs(diff);
-    const bool ret = diff_abs > tolerance;
-    return ret;
+    const int diff_abs = (expectedBitsComp > actualBitsComp)
+                       ? (expectedBitsComp - actualBitsComp)
+                       : (actualBitsComp - expectedBitsComp);
+    return std::fabs(diff_abs) > tolerance;
 }
 
 

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -520,13 +520,15 @@ bool FloatsDiffer(const float expected, const float actual,
     // integer arithmetic overflow even if previous AppleClang (i.e. 11.0.0.11000033)
     // works fine. And the cppreference documentation mentions that std::abs() & abs()
     // have undefined behaviors for INT_MIN & INT_MAX.
+    // For all compilers (in case newer version of gcc / msvc also fail in the future)
+    // re-implement the integer difference to have the arithmetic overflow outside
+    // the abs() call.
 
     const int diff = (expectedBitsComp > actualBitsComp)
                    ? (expectedBitsComp - actualBitsComp)
                    : (actualBitsComp - expectedBitsComp);
     return std::abs(diff) > tolerance;
 }
-
 
 inline int HalfForCompare(const half h)
 {

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -527,7 +527,7 @@ bool FloatsDiffer(const float expected, const float actual,
     const int diff_abs = (expectedBitsComp > actualBitsComp)
                        ? (expectedBitsComp - actualBitsComp)
                        : (actualBitsComp - expectedBitsComp);
-    return std::fabs(diff_abs) > tolerance;
+    return std::abs(diff_abs) > tolerance;
 }
 
 

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+
+#include <cmath>
 #include <sstream>
 #include <string.h>
 #include <type_traits>
@@ -11,9 +13,6 @@
 
 namespace OCIO_NAMESPACE
 {
-
-bool PrintValues = false;
-
 
 template<typename T>
 bool IsScalarEqualToZero(T v)
@@ -456,6 +455,9 @@ inline void ExtractFloatComponents(const unsigned floatBits, unsigned& sign,
 bool FloatsDiffer(const float expected, const float actual,
                   const int tolerance, const bool compressDenorms)
 {
+    static_assert(sizeof(int)==4,
+                  "Mathematical operations based on 32-bits integers.");
+
     const unsigned expectedBits = FloatAsInt(expected);
     const unsigned actualBits = FloatAsInt(actual);
 
@@ -517,25 +519,10 @@ bool FloatsDiffer(const float expected, const float actual,
     // Note: AppleClang 11.0.3.11030032 has trouble when merging the next three lines.
     //       But AppleClang 11.0.0.11000033 works fine.
 
-#if defined(__clang__) && defined(__APPLE__)
-
-#pragma clang optimize off
-
-#endif
-
     const int diff = expectedBitsComp - actualBitsComp;
-
     const int diff_abs = std::abs(diff);
-
     const bool ret = diff_abs > tolerance;
-
     return ret;
-
-#if defined(__clang__) && defined(__APPLE__)
-
-#pragma clang optimize on
-
-#endif
 }
 
 

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -12,11 +12,16 @@
 namespace OCIO_NAMESPACE
 {
 
+bool PrintValues = false;
+
+
 template<typename T>
 bool IsScalarEqualToZero(T v)
 {
     static_assert(std::is_floating_point<T>::value,
                   "Only single and double precision floats are supported");
+
+    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> v = " << v << "\n";
 
     return !FloatsDiffer(0.0f, (float)v, 2, false);
 }
@@ -453,8 +458,14 @@ inline void ExtractFloatComponents(const unsigned floatBits, unsigned& sign,
 bool FloatsDiffer(const float expected, const float actual,
                   const int tolerance, const bool compressDenorms)
 {
+    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> expected = " << expected << "\n";
+    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> actual = " << actual << "\n";
+
     const unsigned expectedBits = FloatAsInt(expected);
     const unsigned actualBits = FloatAsInt(actual);
+
+    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> expectedBits = " << expectedBits << ", 0x" << std::hex << expectedBits << std::dec << "\n";
+    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> actualBits = " << actualBits << ", 0x" << std::hex << actualBits << std::dec << "\n";
 
     unsigned es, ee, em, as, ae, am;
     ExtractFloatComponents(expectedBits, es, ee, em);
@@ -511,9 +522,17 @@ bool FloatsDiffer(const float expected, const float actual,
         actualBitsComp = FloatForCompare(actualBits);
     }
 
+    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> expectedBitsComp = " << expectedBitsComp << ", 0x" << std::hex << expectedBitsComp << std::dec << "\n";
+    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> actualBitsComp = " << actualBitsComp << ", 0x" << std::hex << actualBitsComp << std::dec << "\n";
+
     // Impose to process 'int' type to have the overflow. 
     const int diff = expectedBitsComp - actualBitsComp;
-    return abs(diff) > tolerance;
+    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> diff = " << diff << ", 0x" << std::hex << diff << std::dec << "\n";
+
+    const int diff_abs = abs(diff);
+    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> abs(diff) = " << diff_abs << ", 0x" << std::hex << diff_abs << std::dec << "\n";
+
+    return diff_abs > tolerance;
 }
 
 inline int HalfForCompare(const half h)

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -504,7 +504,7 @@ bool FloatsDiffer(const float expected, const float actual,
     }
 
     // Comparing regular floats
-    unsigned expectedBitsComp, actualBitsComp;
+    int expectedBitsComp, actualBitsComp;
     if (compressDenorms)
     {
         expectedBitsComp = FloatForCompareCompressDenorms(expectedBits);
@@ -524,10 +524,10 @@ bool FloatsDiffer(const float expected, const float actual,
     // re-implement the integer difference to have the arithmetic overflow outside
     // the abs() call.
 
-    const int diff_abs = (expectedBitsComp > actualBitsComp)
-                       ? (expectedBitsComp - actualBitsComp)
-                       : (actualBitsComp - expectedBitsComp);
-    return std::abs(diff_abs) > tolerance;
+    const int diff = (expectedBitsComp > actualBitsComp)
+                   ? (expectedBitsComp - actualBitsComp)
+                   : (actualBitsComp - expectedBitsComp);
+    return std::abs(diff) > tolerance;
 }
 
 

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -499,7 +499,7 @@ bool FloatsDiffer(const float expected, const float actual,
     }
 
     // Comparing regular floats
-    int expectedBitsComp, actualBitsComp;
+    long expectedBitsComp, actualBitsComp;
     if (compressDenorms)
     {
         expectedBitsComp = FloatForCompareCompressDenorms(expectedBits);

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -499,7 +499,7 @@ bool FloatsDiffer(const float expected, const float actual,
     }
 
     // Comparing regular floats
-    long expectedBitsComp, actualBitsComp;
+    int expectedBitsComp, actualBitsComp;
     if (compressDenorms)
     {
         expectedBitsComp = FloatForCompareCompressDenorms(expectedBits);
@@ -511,7 +511,9 @@ bool FloatsDiffer(const float expected, const float actual,
         actualBitsComp = FloatForCompare(actualBits);
     }
 
-    return labs(expectedBitsComp - actualBitsComp) > tolerance;
+    // Impose to process 'int' type to have the overflow. 
+    const int diff = expectedBitsComp - actualBitsComp;
+    return abs(diff) > tolerance;
 }
 
 inline int HalfForCompare(const half h)

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -511,7 +511,7 @@ bool FloatsDiffer(const float expected, const float actual,
         actualBitsComp = FloatForCompare(actualBits);
     }
 
-    return abs(expectedBitsComp - actualBitsComp) > tolerance;
+    return labs(expectedBitsComp - actualBitsComp) > tolerance;
 }
 
 inline int HalfForCompare(const half h)

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -514,12 +514,14 @@ bool FloatsDiffer(const float expected, const float actual,
         actualBitsComp = FloatForCompare(actualBits);
     }
 
+    // Note: AppleClang 11.0.3.11030032 has trouble when merging the next three lines.
+    //       But AppleClang 11.0.0.11000033 works fine.
+
     // Impose to process 'int' types to have the overflow. 
     const int diff = expectedBitsComp - actualBitsComp;
 
     // Impose to process 'int' type. 
     const int diff_abs = abs(diff);
-    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> abs(diff) = " << diff_abs << ", 0x" << std::hex << diff_abs << std::dec << "\n";
 
     return diff_abs > tolerance;
 }

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -21,8 +21,6 @@ bool IsScalarEqualToZero(T v)
     static_assert(std::is_floating_point<T>::value,
                   "Only single and double precision floats are supported");
 
-    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> v = " << v << "\n";
-
     return !FloatsDiffer(0.0f, (float)v, 2, false);
 }
 
@@ -458,9 +456,6 @@ inline void ExtractFloatComponents(const unsigned floatBits, unsigned& sign,
 bool FloatsDiffer(const float expected, const float actual,
                   const int tolerance, const bool compressDenorms)
 {
-    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> expected = " << expected << "\n";
-    if (PrintValues) std::cout << __FUNCTION__ << "(" << __LINE__ << ") -> actual = " << actual << "\n";
-
     const unsigned expectedBits = FloatAsInt(expected);
     const unsigned actualBits = FloatAsInt(actual);
 

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -517,13 +517,25 @@ bool FloatsDiffer(const float expected, const float actual,
     // Note: AppleClang 11.0.3.11030032 has trouble when merging the next three lines.
     //       But AppleClang 11.0.0.11000033 works fine.
 
-    // Impose to process 'int' types to have the overflow. 
+#if defined(__clang__) && defined(__APPLE__)
+
+#pragma clang optimize off
+
+#endif
+
     const int diff = expectedBitsComp - actualBitsComp;
 
-    // Impose to process 'int' type. 
     const int diff_abs = abs(diff);
 
-    return diff_abs > tolerance;
+    const bool ret = diff_abs > tolerance;
+
+#if defined(__clang__) && defined(__APPLE__)
+
+#pragma clang optimize on
+
+#endif
+
+    return ret;
 }
 
 inline int HalfForCompare(const half h)

--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -472,6 +472,55 @@ inline void save(YAML::Emitter& out, ConstAllocationTransformRcPtr t)
     out << YAML::EndMap;
 }
 
+// BuiltinTransform
+
+inline void load(const YAML::Node & node, BuiltinTransformRcPtr & t)
+{
+    t = BuiltinTransform::Create();
+
+    std::string key;
+
+    for (const auto & iter : node)
+    {
+        const YAML::Node & first  = iter.first;
+        const YAML::Node & second = iter.second;
+
+        load(first, key);
+
+        if (second.IsNull() || !second.IsDefined()) continue;
+
+        if (key == "style")
+        {
+            std::string transformStyle;
+            load(second, transformStyle);
+            t->setStyle(transformStyle.c_str());
+        }
+        else if (key == "direction")
+        {
+            TransformDirection dir = TRANSFORM_DIR_UNKNOWN;
+            load(second, dir);
+            t->setDirection(dir);
+        }
+        else
+        {
+            LogUnknownKeyWarning(node, first);
+        }
+    }
+}
+
+inline void save(YAML::Emitter & out, const ConstBuiltinTransformRcPtr & t)
+{
+    out << YAML::VerbatimTag("BuiltinTransform");
+    out << YAML::Flow << YAML::BeginMap;
+
+    out << YAML::Key << "style";
+    out << YAML::Value << YAML::Flow << t->getStyle();
+
+    EmitBaseTransformKeyValues(out, t);
+
+    out << YAML::EndMap;
+}
+
 // CDLTransform
 
 inline void load(const YAML::Node& node, CDLTransformRcPtr& t)
@@ -1890,6 +1939,12 @@ void load(const YAML::Node& node, TransformRcPtr& t)
         load(node, temp);
         t = temp;
     }
+    else if(type == "BuiltinTransform")
+    {
+        BuiltinTransformRcPtr temp;
+        load(node, temp);
+        t = temp;
+    }
     else if(type == "CDLTransform")
     {
         CDLTransformRcPtr temp;
@@ -1998,6 +2053,9 @@ void save(YAML::Emitter& out, ConstTransformRcPtr t)
     if(ConstAllocationTransformRcPtr Allocation_tran = \
         DynamicPtrCast<const AllocationTransform>(t))
         save(out, Allocation_tran);
+    else if (ConstBuiltinTransformRcPtr builtin_tran = \
+        DynamicPtrCast<const BuiltinTransform>(t))
+        save(out, builtin_tran);
     else if(ConstCDLTransformRcPtr CDL_tran = \
         DynamicPtrCast<const CDLTransform>(t))
         save(out, CDL_tran);

--- a/src/OpenColorIO/OpBuilders.h
+++ b/src/OpenColorIO/OpBuilders.h
@@ -26,6 +26,11 @@ void BuildAllocationOp(OpRcPtrVec & ops,
                        const AllocationTransform & transform,
                        TransformDirection dir);
 
+void BuildBuiltinOps(OpRcPtrVec & ops,
+                     const Config & config,
+                     const BuiltinTransform & transform,
+                     TransformDirection dir);
+
 void BuildCDLOp(OpRcPtrVec & ops,
                 const Config & config,
                 const CDLTransform & transform,

--- a/src/OpenColorIO/Processor.cpp
+++ b/src/OpenColorIO/Processor.cpp
@@ -316,7 +316,7 @@ void Processor::Impl::write(const char * formatName, std::ostream & os) const
     catch (std::exception & e)
     {
         std::ostringstream err;
-        err << "Error writing " << formatName << ":";
+        err << "Error writing format '" << formatName << "': ";
         err << e.what();
         throw Exception(err.str().c_str());
     }

--- a/src/OpenColorIO/Transform.cpp
+++ b/src/OpenColorIO/Transform.cpp
@@ -21,6 +21,7 @@
 #include "Processor.h"
 #include "TransformBuilder.h"
 
+
 namespace OCIO_NAMESPACE
 {
 void Transform::validate() const
@@ -36,10 +37,10 @@ void Transform::validate() const
 }
 
 void BuildOps(OpRcPtrVec & ops,
-                const Config & config,
-                const ConstContextRcPtr & context,
-                const ConstTransformRcPtr & transform,
-                TransformDirection dir)
+              const Config & config,
+              const ConstContextRcPtr & context,
+              const ConstTransformRcPtr & transform,
+              TransformDirection dir)
 {
     // A null transform is valid, and corresponds to a no-op.
     if(!transform)
@@ -49,6 +50,11 @@ void BuildOps(OpRcPtrVec & ops,
         DynamicPtrCast<const AllocationTransform>(transform))
     {
         BuildAllocationOp(ops, config, *allocationTransform, dir);
+    }
+    else if(ConstBuiltinTransformRcPtr builtInTransform = \
+        DynamicPtrCast<const BuiltinTransform>(transform))
+    {
+        BuildBuiltinOps(ops, config, *builtInTransform, dir);
     }
     else if(ConstCDLTransformRcPtr cdlTransform = \
         DynamicPtrCast<const CDLTransform>(transform))
@@ -153,6 +159,11 @@ std::ostream& operator<< (std::ostream & os, const Transform & transform)
         dynamic_cast<const AllocationTransform*>(t))
     {
         os << *allocationTransform;
+    }
+    if(const BuiltinTransform * builtInTransform = \
+        dynamic_cast<const BuiltinTransform*>(t))
+    {
+        os << *builtInTransform;
     }
     else if(const CDLTransform * cdlTransform = \
         dynamic_cast<const CDLTransform*>(t))

--- a/src/OpenColorIO/fileformats/FileFormatCTF.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCTF.cpp
@@ -203,7 +203,7 @@ public:
         {
             std::string error("CTF/CLF parsing error (no closing tag for '");
             error += m_elms.back()->getName().c_str();
-            error += "). ";
+            error += ") ";
             throwMessage(error);
         }
 
@@ -211,14 +211,14 @@ public:
         if (pT.use_count() == 0)
         {
             static const std::string error(
-                "CTF/CLF parsing error: Invalid transform. ");
+                "CTF/CLF parsing error: Invalid transform.");
             throwMessage(error);
         }
 
         if (pT->getOps().empty())
         {
             static const std::string error(
-                "CTF/CLF parsing error: No color operator in file. ");
+                "CTF/CLF parsing error: No color operator in file.");
             throwMessage(error);
         }
     }
@@ -239,7 +239,7 @@ public:
                     // It could be an Op or an Attribute.
                     std::string error("CTF/CLF parsing error (no closing tag for '");
                     error += m_elms.back()->getName().c_str();
-                    error += "'). ";
+                    error += "').";
                     throwMessage(error);
                 }
                 else
@@ -247,7 +247,7 @@ public:
                     // Completely lost, something went wrong,
                     // but nothing detected with the stack.
                     static const std::string error(
-                        "CTF/CLF parsing error (unbalanced element tags). ");
+                        "CTF/CLF parsing error (unbalanced element tags).");
                     throwMessage(error);
                 }
             }
@@ -851,7 +851,7 @@ private:
         auto pElt(pImpl->m_elms.back());
         if (!pElt.get())
         {
-            pImpl->throwMessage("CTF/CLF parsing error: Tag is missing. ");
+            pImpl->throwMessage("CTF/CLF parsing error: Tag is missing.");
         }
 
         // Is it the expected element?
@@ -860,7 +860,7 @@ private:
             std::stringstream ss;
             ss << "CTF/CLF parsing error: Tag '";
             ss << (name ? name : "");
-            ss << "' is missing";
+            ss << "' is missing.";
             pImpl->throwMessage(ss.str());
         }
 
@@ -881,7 +881,7 @@ private:
                 std::stringstream ss;
                 ss << "CTF/CLF parsing error: Attribute end '";
                 ss << (name ? name : "");
-                ss << "' is illegal. ";
+                ss << "' is illegal.";
                 pImpl->throwMessage(ss.str());
             }
 
@@ -1157,8 +1157,8 @@ void LocalFileFormat::bake(const Baker & baker,
                            const std::string & formatName,
                            std::ostream & ostream) const
 {
-    constexpr int DEFAULT_1D_SIZE = 4096;
-    constexpr int DEFAULT_3D_SIZE = 64;
+    static constexpr int DEFAULT_1D_SIZE = 4096;
+    static constexpr int DEFAULT_3D_SIZE = 64;
 
     // NB: By default, the shaper uses a half-domain LUT1D, which is always 65536 entries.
     // If the user requests some other size, a typical (non-half-domain) LUT1D will be used.

--- a/src/OpenColorIO/fileformats/ctf/CTFReaderHelper.cpp
+++ b/src/OpenColorIO/fileformats/ctf/CTFReaderHelper.cpp
@@ -69,7 +69,7 @@ void CTFReaderTransformElt::start(const char ** atts)
         {
             if (!atts[i + 1] || !*atts[i + 1])
             {
-                throwMessage("Required attribute 'id' does not have a value. ");
+                throwMessage("Required attribute 'id' does not have a value.");
             }
 
             m_transform->setID(atts[i + 1]);
@@ -79,7 +79,7 @@ void CTFReaderTransformElt::start(const char ** atts)
         {
             if (!atts[i + 1] || !*atts[i + 1])
             {
-                throwMessage("If the attribute 'name' is present, it must have a value. ");
+                throwMessage("If the attribute 'name' is present, it must have a value.");
             }
 
             m_transform->setName(atts[i + 1]);
@@ -88,7 +88,7 @@ void CTFReaderTransformElt::start(const char ** atts)
         {
             if (!atts[i + 1] || !*atts[i + 1])
             {
-                throwMessage("If the attribute 'inverseOf' is present, it must have a value. ");
+                throwMessage("If the attribute 'inverseOf' is present, it must have a value.");
             }
 
             m_transform->setInverseOfId(atts[i + 1]);
@@ -97,17 +97,17 @@ void CTFReaderTransformElt::start(const char ** atts)
         {
             if (isCLFVersionFound)
             {
-                throwMessage("'compCLFversion' and 'Version' cannot both be present. ");
+                throwMessage("'compCLFversion' and 'Version' cannot both be present.");
             }
             if (isVersionFound)
             {
-                throwMessage("'Version' can only be there once. ");
+                throwMessage("'Version' can only be there once.");
             }
 
             const char* pVer = atts[i + 1];
             if (!pVer || !*pVer)
             {
-                throwMessage("If the attribute 'version' is present, it must have a value. ");
+                throwMessage("If the attribute 'version' is present, it must have a value.");
             }
 
             try
@@ -126,17 +126,17 @@ void CTFReaderTransformElt::start(const char ** atts)
         {
             if (isCLFVersionFound)
             {
-                throwMessage("'compCLFversion' can only be there once. ");
+                throwMessage("'compCLFversion' can only be there once.");
             }
             if (isVersionFound)
             {
-                throwMessage("'compCLFversion' and 'Version' cannot be both present. ");
+                throwMessage("'compCLFversion' and 'Version' cannot be both present.");
             }
 
             const char* pVer = atts[i + 1];
             if (!pVer || !*pVer)
             {
-                throwMessage("Required attribute 'compCLFversion' does not have a value. ");
+                throwMessage("Required attribute 'compCLFversion' does not have a value.");
             }
 
             try
@@ -155,7 +155,7 @@ void CTFReaderTransformElt::start(const char ** atts)
             if (maxCLF < requestedCLFVersion)
             {
                 ThrowM(*this, "Unsupported transform file version '", pVer,
-                       "' supplied. ");
+                       "' supplied.");
             }
             // We currently interpret CLF versions <= 2.0 as CTF version 1.7.
             if (requestedCLFVersion <= CTFVersion(2, 0))
@@ -187,7 +187,7 @@ void CTFReaderTransformElt::start(const char ** atts)
     // Check mandatory elements.
     if (!isIdFound)
     {
-        throwMessage("Required attribute 'id' is missing. ");
+        throwMessage("Required attribute 'id' is missing.");
     }
 
     // Transform file format with no version means that
@@ -196,7 +196,7 @@ void CTFReaderTransformElt::start(const char ** atts)
     {
         if (m_isCLF && !isCLFVersionFound)
         {
-            throwMessage("Required attribute 'compCLFversion' is missing. ");
+            throwMessage("Required attribute 'compCLFversion' is missing.");
         }
         setVersion(CTF_PROCESS_LIST_VERSION_1_2);
     }
@@ -234,7 +234,7 @@ void CTFReaderTransformElt::setVersion(const CTFVersion & ver)
 {
     if (CTF_PROCESS_LIST_VERSION < ver)
     {
-        ThrowM(*this, "Unsupported transform file version '", ver, "' supplied. ");
+        ThrowM(*this, "Unsupported transform file version '", ver, "' supplied.");
     }
     getTransform()->setCTFVersion(ver);
 }
@@ -298,7 +298,7 @@ void CTFReaderArrayElt::start(const char ** atts)
             catch (Exception& /*ce*/)
             {
                 ThrowM(*this, "Illegal '", getTypeName(), "' array dimensions ",
-                       TruncateString(dimStr, len));
+                       TruncateString(dimStr, len), ".");
             }
 
             CTFArrayMgt* pArr = dynamic_cast<CTFArrayMgt*>(getParent().get());
@@ -313,14 +313,14 @@ void CTFReaderArrayElt::start(const char ** atts)
                 if (max == 0)
                 {
                     ThrowM(*this, "Illegal '", getTypeName(), "' array dimensions ",
-                           TruncateString(dimStr, len));
+                           TruncateString(dimStr, len), ".");
                 }
 
                 m_array = pArr->updateDimension(dims);
                 if (!m_array)
                 {
                     ThrowM(*this, "'", getTypeName(), "' Illegal array dimensions ",
-                           TruncateString(dimStr, len));
+                           TruncateString(dimStr, len), ".");
                 }
             }
         }
@@ -376,7 +376,7 @@ void CTFReaderArrayElt::setRawData(const char * s,
         catch (Exception& /*ce*/)
         {
             ThrowM(*this, "Illegal values '", TruncateString(s, len),
-                   "' in array of ", getTypeName());
+                   "' in array of ", getTypeName(), ".");
         }
 
         if (m_position<maxValues)
@@ -466,28 +466,28 @@ void CTFReaderIndexMapElt::start(const char ** atts)
             catch (Exception& /*ce*/)
             {
                 ThrowM(*this, "Illegal '", getTypeName(),
-                       "' IndexMap dimensions ", TruncateString(dimStr, len));
+                       "' IndexMap dimensions ", TruncateString(dimStr, len), ".");
             }
 
             CTFIndexMapMgt * pArr = dynamic_cast<CTFIndexMapMgt*>(getParent().get());
             if (!pArr)
             {
                 ThrowM(*this, "Illegal '", getTypeName(),
-                       "' IndexMap dimensions ", TruncateString(dimStr, len));
+                       "' IndexMap dimensions ", TruncateString(dimStr, len), ".");
             }
             else
             {
                 if (dims.empty() || dims.size() != 1)
                 {
                     ThrowM(*this, "Illegal '", getTypeName(),
-                           "' IndexMap dimensions ", TruncateString(dimStr, len));
+                           "' IndexMap dimensions ", TruncateString(dimStr, len), ".");
                 }
 
                 m_indexMap = pArr->updateDimensionIM(dims);
                 if (!m_indexMap)
                 {
                     ThrowM(*this, "Illegal '", getTypeName(),
-                           "' IndexMap dimensions ", TruncateString(dimStr, len));
+                           "' IndexMap dimensions ", TruncateString(dimStr, len), ".");
                 }
             }
         }
@@ -502,7 +502,7 @@ void CTFReaderIndexMapElt::start(const char ** atts)
     // Check mandatory elements
     if (!isDimFound)
     {
-        throwMessage("Required attribute 'dim' is missing. ");
+        throwMessage("Required attribute 'dim' is missing.");
     }
 
     m_position = 0;
@@ -648,7 +648,7 @@ void CTFReaderIndexMapElt::setRawData(const char * s,
         catch (Exception& /*ce*/)
         {
             ThrowM(*this, "Illegal values '", TruncateString(s, len),
-                   "' in '", getTypeName(), "' IndexMap");
+                   "' in '", getTypeName(), "' IndexMap.");
         }
 
         if (m_position<maxValues)
@@ -870,7 +870,7 @@ void CTFReaderOpElt::start(const char ** atts)
             BitDepth bitdepth = GetBitDepth(atts[i + 1]);
             if (bitdepth == BIT_DEPTH_UNKNOWN)
             {
-                ThrowM(*this, "inBitDepth unknown value (", atts[i + 1], ")");
+                ThrowM(*this, "inBitDepth unknown value (", atts[i + 1], ").");
             }
             m_inBitDepth = bitdepth;
             bitDepthFound |= INPUT_BIT_DEPTH;
@@ -880,7 +880,7 @@ void CTFReaderOpElt::start(const char ** atts)
             BitDepth bitdepth = GetBitDepth(atts[i + 1]);
             if (bitdepth == BIT_DEPTH_UNKNOWN)
             {
-                ThrowM(*this, "outBitDepth unknown value (", atts[i + 1], ")");
+                ThrowM(*this, "outBitDepth unknown value (", atts[i + 1], ").");
             }
             m_outBitDepth = bitdepth;
             bitDepthFound |= OUTPUT_BIT_DEPTH;
@@ -1274,7 +1274,7 @@ void CTFReaderACESParamsElt::start(const char **atts)
         {
             ThrowM(*this, "Missing required parameter ", ATTR_GAMMA,
                    "for ACES FixedFunction element with style ",
-                   FixedFunctionOpData::ConvertStyleToString(style, false));
+                   FixedFunctionOpData::ConvertStyleToString(style, false), ".");
         }
         params.push_back(gamma);
         // Assign the parameters to the object.
@@ -1326,7 +1326,7 @@ void CTFReaderCDLElt::start(const char ** atts)
 
     if (!isStyleFound)
     {
-        throwMessage("CTF/CLF CDL parsing. Required attribute 'style' is missing. ");
+        throwMessage("CTF/CLF CDL parsing. Required attribute 'style' is missing.");
     }
 }
 
@@ -1431,7 +1431,7 @@ void CTFReaderFixedFunctionElt::start(const char **atts)
             catch (Exception& /*ce*/)
             {
                 ThrowM(*this, "Illegal '", getTypeName(), "' params ",
-                       TruncateString(paramsStr, len));
+                       TruncateString(paramsStr, len), ".");
             }
             m_fixedFunction->setParams(data);
         }
@@ -1440,7 +1440,7 @@ void CTFReaderFixedFunctionElt::start(const char **atts)
     }
     if (!isStyleFound)
     {
-        throwMessage("style parameter for FixedFunction is missing.");
+        throwMessage("Style parameter for FixedFunction is missing.");
     }
 }
 
@@ -1502,7 +1502,7 @@ void CTFReaderFunctionElt::start(const char **atts)
     }
     if (!isStyleFound)
     {
-        throwMessage("style parameter for FixedFunction is missing.");
+        throwMessage("Style parameter for FixedFunction is missing.");
     }
 }
 
@@ -1556,7 +1556,7 @@ void CTFReaderDynamicParamElt::start(const char ** atts)
                 {
                     ThrowM(*this, "Dynamic parameter '", atts[i + 1],
                            "' is not supported in '",
-                           container->getName().c_str(), "'");
+                           container->getName().c_str(), "'.");
                 }
 
                 ExposureContrastOpDataRcPtr pECOp = pEC->getExposureContrast();
@@ -1570,7 +1570,7 @@ void CTFReaderDynamicParamElt::start(const char ** atts)
                 {
                     ThrowM(*this, "Dynamic parameter '", atts[i + 1],
                            "' is not supported in '",
-                           container->getName().c_str(), "'");
+                           container->getName().c_str(), "'.");
                 }
 
                 ExposureContrastOpDataRcPtr pECOp = pEC->getExposureContrast();
@@ -1584,7 +1584,7 @@ void CTFReaderDynamicParamElt::start(const char ** atts)
                 {
                     ThrowM(*this, "Dynamic parameter '", atts[i + 1],
                            "' is not supported in '",
-                           container->getName().c_str(), "'");
+                           container->getName().c_str(), "'.");
                 }
 
                 ExposureContrastOpDataRcPtr pECOp = pEC->getExposureContrast();
@@ -1605,7 +1605,7 @@ void CTFReaderDynamicParamElt::start(const char ** atts)
             {
                 ThrowM(*this, "Dynamic parameter '", atts[i + 1],
                        "' is not valid in '",
-                       container->getName().c_str(), "'");
+                       container->getName().c_str(), "'.");
             }
         }
 
@@ -1843,7 +1843,7 @@ void CTFReaderGammaElt::start(const char ** atts)
     }
     if (!isStyleFound)
     {
-        throwMessage("Missing parameter 'style'. ");
+        throwMessage("Missing parameter 'style'.");
     }
 }
 
@@ -1868,7 +1868,7 @@ void CTFReaderGammaElt::end()
     }
     catch (Exception & ce)
     {
-        ThrowM(*this, "Invalid parameters: ", ce.what(), ". ");
+        ThrowM(*this, "Invalid parameters: ", ce.what(), ".");
     }
 }
 
@@ -1917,7 +1917,7 @@ void CTFReaderGammaElt_1_5::end()
     }
     catch (Exception & ce)
     {
-        ThrowM(*this, "Invalid parameters: ", ce.what(), ". ");
+        ThrowM(*this, "Invalid parameters: ", ce.what(), ".");
     }
 }
 
@@ -1994,7 +1994,7 @@ void CTFReaderGammaParamsElt::start(const char ** atts)
             // Chan is optional but, if present, must be legal.
             if (chan == -1)
             {
-                ThrowM(*this, "Invalid channel: ", atts[i + 1], ". ");
+                ThrowM(*this, "Invalid channel: ", atts[i + 1], ".");
             }
         }
         else if (0 == Platform::Strcasecmp(ATTR_GAMMA, atts[i]) ||
@@ -2036,7 +2036,7 @@ void CTFReaderGammaParamsElt::start(const char ** atts)
         {
             ThrowM(*this, "Missing required gamma parameter for style: ",
                    GammaOpData::ConvertStyleToString(style),
-                   ". ");
+                   ".");
         }
         params.push_back(gamma);
 
@@ -2044,7 +2044,7 @@ void CTFReaderGammaParamsElt::start(const char ** atts)
         {
             ThrowM(*this, "Illegal offset parameter for style: ",
                    GammaOpData::ConvertStyleToString(style),
-                   ". ");
+                   ".");
         }
         break;
     }
@@ -2058,7 +2058,7 @@ void CTFReaderGammaParamsElt::start(const char ** atts)
         {
             ThrowM(*this, "Missing required gamma parameter for style: ",
                    GammaOpData::ConvertStyleToString(style),
-                   ". ");
+                   ".");
         }
         params.push_back(gamma);
 
@@ -2066,7 +2066,7 @@ void CTFReaderGammaParamsElt::start(const char ** atts)
         {
             ThrowM(*this, "Missing required offset parameter for style: ",
                    GammaOpData::ConvertStyleToString(style),
-                   ". ");
+                   ".");
         }
         params.push_back(offset);
         break;
@@ -2192,7 +2192,7 @@ void CTFReaderInvLut1DElt::start(const char ** atts)
             {
                 std::ostringstream oss;
                 oss << "Unknown halfDomain value: '" << atts[i + 1];
-                oss << "' while parsing InvLut1D. ";
+                oss << "' while parsing InvLut1D.";
                 throwMessage(oss.str());
             }
 
@@ -2205,7 +2205,7 @@ void CTFReaderInvLut1DElt::start(const char ** atts)
             {
                 std::ostringstream oss;
                 oss << "Unknown rawHalfs value: '" << atts[i + 1];
-                oss << "' while parsing InvLut1D. ";
+                oss << "' while parsing InvLut1D.";
                 throwMessage(oss.str());
             }
 
@@ -2218,7 +2218,7 @@ void CTFReaderInvLut1DElt::start(const char ** atts)
             {
                 std::ostringstream oss;
                 oss << "Unknown hueAdjust value: '" << atts[i + 1];
-                oss << "' while parsing InvLut1D. ";
+                oss << "' while parsing InvLut1D.";
                 throwMessage(oss.str());
             }
 
@@ -2306,7 +2306,7 @@ void CTFReaderInvLut1DElt::endArray(unsigned int position)
         {
             std::ostringstream arg;
             arg << "Expected " << dimensions << "x" << numColorComponents;
-            arg << " Array values, found " << position << ". ";
+            arg << " Array values, found " << position << ".";
             throwMessage(arg.str());
         }
 
@@ -2428,7 +2428,7 @@ void CTFReaderInvLut3DElt::endArray(unsigned int position)
         std::ostringstream arg;
         arg << "Expected " << len << "x" << len << "x" << len << "x";
         arg << pArray->getNumColorComponents();
-        arg << " Array values, found " << position << ". ";
+        arg << " Array values, found " << position << ".";
         throwMessage(arg.str());
     }
 
@@ -2467,7 +2467,7 @@ void CTFReaderLogElt::start(const char ** atts)
             }
             catch (Exception &)
             {
-                ThrowM(*this, "Required attribute 'style' '", atts[i + 1], "' is invalid. ");
+                ThrowM(*this, "Required attribute 'style' '", atts[i + 1], "' is invalid.");
             }
             isStyleFound = true;
         }
@@ -2475,7 +2475,7 @@ void CTFReaderLogElt::start(const char ** atts)
 
     if (!isStyleFound)
     {
-        throwMessage("CTF/CLF Log parsing. Required attribute 'style' is missing. ");
+        throwMessage("CTF/CLF Log parsing. Required attribute 'style' is missing.");
     }
 }
 
@@ -2501,7 +2501,7 @@ void CTFReaderLogElt::end()
     }
     catch (Exception& ce)
     {
-        ThrowM(*this, "Parameters are not valid: '", ce.what(), "'. ");
+        ThrowM(*this, "Parameters are not valid: '", ce.what(), "'.");
     }
 
     m_log->setBase(base);
@@ -2517,7 +2517,7 @@ void CTFReaderLogElt::end()
     }
     catch (Exception& ce)
     {
-        ThrowM(*this, "Log is not valid: '", ce.what(), "'. ");
+        ThrowM(*this, "Log is not valid: '", ce.what(), "'.");
     }
 }
 
@@ -2534,7 +2534,7 @@ void CTFReaderLogElt::setBase(double base)
         if (curBase != base)
         {
             ThrowM(*this, "Log base has to be the same on all components: ",
-                   "Current base: ", curBase, ", new base: ", base, ". ");
+                   "Current base: ", curBase, ", new base: ", base, ".");
         }
     }
     else
@@ -2580,7 +2580,7 @@ void CTFReaderLogElt_2_0::end()
         }
         catch (Exception& ce)
         {
-            ThrowM(*this, "Parameters are not valid: '", ce.what(), "'. ");
+            ThrowM(*this, "Parameters are not valid: '", ce.what(), "'.");
         }
 
         getLog()->setBase(base);
@@ -2612,7 +2612,7 @@ void CTFReaderLogElt_2_0::end()
     }
     catch (Exception& ce)
     {
-        ThrowM(*this, "Log is not valid: '", ce.what(), "'. ");
+        ThrowM(*this, "Log is not valid: '", ce.what(), "'.");
     }
 }
 
@@ -2709,7 +2709,7 @@ void CTFReaderLogParamsElt::start(const char ** atts)
             {
                 std::ostringstream arg;
                 arg << "Illegal channel attribute value '";
-                arg << atts[i + 1] << "'. ";
+                arg << atts[i + 1] << "'.";
 
                 throwMessage(arg.str());
             }
@@ -2731,31 +2731,31 @@ void CTFReaderLogParamsElt::start(const char ** atts)
 
     if (IsNan(gamma))
     {
-        ThrowM(*this, "Required attribute '", ATTR_GAMMA, "' is missing. ");
+        ThrowM(*this, "Required attribute '", ATTR_GAMMA, "' is missing.");
     }
     ctfValues[LogUtil::CTFParams::gamma] = gamma;
 
     if (IsNan(refWhite))
     {
-        ThrowM(*this, "Required attribute '", ATTR_REFWHITE, "' is missing. ");
+        ThrowM(*this, "Required attribute '", ATTR_REFWHITE, "' is missing.");
     }
     ctfValues[LogUtil::CTFParams::refWhite] = refWhite;
 
     if (IsNan(refBlack))
     {
-        ThrowM(*this, "Required attribute '", ATTR_REFBLACK, "' is missing. ");
+        ThrowM(*this, "Required attribute '", ATTR_REFBLACK, "' is missing.");
     }
     ctfValues[LogUtil::CTFParams::refBlack] = refBlack;
 
     if (IsNan(highlight))
     {
-        ThrowM(*this, "Required attribute '", ATTR_HIGHLIGHT, "' is missing. ");
+        ThrowM(*this, "Required attribute '", ATTR_HIGHLIGHT, "' is missing.");
     }
     ctfValues[LogUtil::CTFParams::highlight] = highlight;
 
     if (IsNan(shadow))
     {
-        ThrowM(*this, "Required attribute '", ATTR_SHADOW, "' is missing. ");
+        ThrowM(*this, "Required attribute '", ATTR_SHADOW, "' is missing.");
     }
     ctfValues[LogUtil::CTFParams::shadow] = shadow;
 
@@ -2845,7 +2845,7 @@ void CTFReaderLogParamsElt_2_0::start(const char ** atts)
             {
                 std::ostringstream arg;
                 arg << "Illegal channel attribute value '";
-                arg << atts[i + 1] << "'. ";
+                arg << atts[i + 1] << "'.";
 
                 throwMessage(arg.str());
             }
@@ -2896,7 +2896,7 @@ void CTFReaderLogParamsElt_2_0::start(const char ** atts)
 
         if (!validType)
         {
-            ThrowM(*this, "CLF type and Cineon types parameters can not be mixed. ");
+            ThrowM(*this, "CLF type and Cineon types parameters can not be mixed.");
         }
 
         i += 2;
@@ -2928,7 +2928,7 @@ void CTFReaderLogParamsElt_2_0::start(const char ** atts)
         {
             ThrowM(*this, "Parameters '", ATTR_LINSIDEBREAK, "' should be defined for style '",
                    LogUtil::ConvertStyleToString(LogUtil::CAMERA_LOG_TO_LIN), "' or '",
-                   LogUtil::ConvertStyleToString(LogUtil::CAMERA_LIN_TO_LOG), "'. ");
+                   LogUtil::ConvertStyleToString(LogUtil::CAMERA_LIN_TO_LOG), "'.");
         }
 
         if (!IsNan(linearSlope))
@@ -3003,7 +3003,7 @@ void CTFReaderLut1DElt::start(const char ** atts)
             if (0 != Platform::Strcasecmp("true", atts[i + 1]))
             {
                 ThrowM(*this, "Illegal 'halfDomain' attribute '", atts[i + 1],
-                       "' while parsing Lut1D. ");
+                       "' while parsing Lut1D.");
             }
 
             m_lut->setInputHalfDomain(true);
@@ -3014,7 +3014,7 @@ void CTFReaderLut1DElt::start(const char ** atts)
             if (0 != Platform::Strcasecmp("true", atts[i + 1]))
             {
                 ThrowM(*this, "Illegal 'rawHalfs' attribute '", atts[i + 1],
-                       "' while parsing Lut1D. ");
+                       "' while parsing Lut1D.");
             }
 
             m_lut->setOutputRawHalfs(true);
@@ -3096,7 +3096,7 @@ void CTFReaderLut1DElt::endArray(unsigned int position)
         if (numColorComponents != 1 || position != dimensions)
         {
             ThrowM(*this, "Expected ", dimensions, "x", numColorComponents,
-                   " Array values, found ", position, ". ");
+                   " Array values, found ", position, ".");
         }
 
         // Convert a 1D LUT to a 3by1D LUT
@@ -3141,7 +3141,7 @@ void CTFReaderLut1DElt::endIndexMap(unsigned int position)
     if (m_indexMapping.getDimension() != position)
     {
         ThrowM(*this, "Expected ", m_indexMapping.getDimension(),
-               " IndexMap values, found ", position, ". ");
+               " IndexMap values, found ", position, ".");
     }
 
     m_indexMapping.validate();
@@ -3180,7 +3180,7 @@ void CTFReaderLut1DElt_1_4::start(const char ** atts)
             if (0 != Platform::Strcasecmp("true", atts[i + 1]))
             {
                 ThrowM(*this, "Illegal 'halfDomain' attribute '", atts[i + 1],
-                       "' while parsing Lut1D. ");
+                       "' while parsing Lut1D.");
             }
 
             m_lut->setInputHalfDomain(true);
@@ -3191,7 +3191,7 @@ void CTFReaderLut1DElt_1_4::start(const char ** atts)
             if (0 != Platform::Strcasecmp("true", atts[i + 1]))
             {
                 ThrowM(*this, "Illegal 'rawHalfs' attribute '", atts[i + 1],
-                       "' while parsing Lut1D. ");
+                       "' while parsing Lut1D.");
             }
 
             m_lut->setOutputRawHalfs(true);
@@ -3203,7 +3203,7 @@ void CTFReaderLut1DElt_1_4::start(const char ** atts)
             if (0 != Platform::Strcasecmp("dw3", atts[i + 1]))
             {
                 ThrowM(*this, "Illegal 'hueAdjust' attribute '", atts[i + 1],
-                       "' while parsing Lut1D. ");
+                       "' while parsing Lut1D.");
             }
 
             m_lut->setHueAdjust(HUE_DW3);
@@ -3352,7 +3352,7 @@ void CTFReaderLut3DElt::endArray(unsigned int position)
     {
         ThrowM(*this, "Expected ", pArray->getLength(), "x", pArray->getLength(),
                "x", pArray->getLength(), "x", pArray->getNumColorComponents(),
-               " Array values, found ", position);
+               " Array values, found ", position, ".");
     }
 
     pArray->validate();
@@ -3382,7 +3382,7 @@ void CTFReaderLut3DElt::endIndexMap(unsigned int position)
     if (m_indexMapping.getDimension() != position)
     {
         ThrowM(*this, "Expected ", m_indexMapping.getDimension(),
-               " IndexMap values, found ", position, ". ");
+               " IndexMap values, found ", position, ".");
     }
 
     m_indexMapping.validate();

--- a/src/OpenColorIO/fileformats/ctf/CTFReaderUtils.cpp
+++ b/src/OpenColorIO/fileformats/ctf/CTFReaderUtils.cpp
@@ -13,12 +13,9 @@ namespace OCIO_NAMESPACE
 namespace
 {
 static constexpr char INTERPOLATION_1D_LINEAR[] = "linear";
-static constexpr char INTERPOLATION_1D_CUBIC[] = "cubic";
-static constexpr char INTERPOLATION_DEFAULT[] = "default";
 
 static constexpr char INTERPOLATION_3D_LINEAR[] = "trilinear";
 static constexpr char INTERPOLATION_3D_TETRAHEDRAL[] = "tetrahedral";
-
 }
 
 Interpolation GetInterpolation1D(const char * str)
@@ -28,14 +25,6 @@ Interpolation GetInterpolation1D(const char * str)
         if (0 == Platform::Strcasecmp(str, INTERPOLATION_1D_LINEAR))
         {
             return INTERP_LINEAR;
-        }
-        else if (0 == Platform::Strcasecmp(str, INTERPOLATION_1D_CUBIC))
-        {
-            return INTERP_CUBIC;
-        }
-        else if (0 == Platform::Strcasecmp(str, INTERPOLATION_DEFAULT))
-        {
-            return INTERP_DEFAULT;
         }
 
         std::ostringstream oss;
@@ -52,18 +41,19 @@ const char * GetInterpolation1DName(Interpolation interp)
     {
     case INTERP_LINEAR:
         return INTERPOLATION_1D_LINEAR;
-    case INTERP_CUBIC:
-        return INTERPOLATION_1D_CUBIC;
 
+    // Note: In CLF v3, some options were removed and the only legal Lut1D value is now "linear".
+
+    case INTERP_CUBIC:
     case INTERP_DEFAULT:
     case INTERP_NEAREST:
     case INTERP_TETRAHEDRAL:
     case INTERP_BEST:
     case INTERP_UNKNOWN:
-        return INTERPOLATION_DEFAULT;
+        return nullptr;
     };
 
-    return INTERPOLATION_DEFAULT;
+    return nullptr;
 }
 
 Interpolation GetInterpolation3D(const char * str)
@@ -77,10 +67,6 @@ Interpolation GetInterpolation3D(const char * str)
         else if (0 == Platform::Strcasecmp(str, INTERPOLATION_3D_TETRAHEDRAL))
         {
             return INTERP_TETRAHEDRAL;
-        }
-        else if (0 == Platform::Strcasecmp(str, INTERPOLATION_DEFAULT))
-        {
-            return INTERP_DEFAULT;
         }
 
         std::ostringstream oss;
@@ -105,10 +91,10 @@ const char * GetInterpolation3DName(Interpolation interp)
     case INTERP_CUBIC:
     case INTERP_BEST:
     case INTERP_UNKNOWN:
-        return INTERPOLATION_DEFAULT;
+        return nullptr;
     };
 
-    return INTERPOLATION_DEFAULT;
+    return nullptr;
 }
 
 } // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/fileformats/ctf/CTFTransform.cpp
+++ b/src/OpenColorIO/fileformats/ctf/CTFTransform.cpp
@@ -1364,35 +1364,32 @@ const char * Lut1DWriter::getTagName() const
 void Lut1DWriter::getAttributes(XmlFormatter::Attributes & attributes) const
 {
     OpWriter::getAttributes(attributes);
-    Interpolation interpolation = m_lut->getInterpolation();
+
     // If the client requests INTERP_LINEAR, we want to write it to the
     // attribute (even though linear is what CLF specifies as its default,
     // some clients may want to lock down that behavior). INTERP_DEFAULT
     // means "do not write the attribute".
-    if (interpolation != INTERP_DEFAULT)
+    const Interpolation interpolation = m_lut->getInterpolation();
+    const char * interpolationName = GetInterpolation1DName(interpolation);
+    if (interpolationName && *interpolationName)
     {
-        const char * interpolationName = GetInterpolation1DName(interpolation);
-        attributes.push_back(XmlFormatter::Attribute(ATTR_INTERPOLATION,
-                                                     interpolationName));
+        attributes.push_back(XmlFormatter::Attribute(ATTR_INTERPOLATION, interpolationName));
     }
 
     if (m_lut->isInputHalfDomain())
     {
-        attributes.push_back(XmlFormatter::Attribute(ATTR_HALF_DOMAIN,
-                                                     "true"));
+        attributes.push_back(XmlFormatter::Attribute(ATTR_HALF_DOMAIN, "true"));
     }
 
     if (m_lut->isOutputRawHalfs())
     {
-        attributes.push_back(XmlFormatter::Attribute(ATTR_RAW_HALFS,
-                                                     "true"));
+        attributes.push_back(XmlFormatter::Attribute(ATTR_RAW_HALFS, "true"));
     }
 
-    Lut1DHueAdjust hueAdjust = m_lut->getHueAdjust();
+    const Lut1DHueAdjust hueAdjust = m_lut->getHueAdjust();
     if (hueAdjust == HUE_DW3)
     {
-        attributes.push_back(XmlFormatter::Attribute(ATTR_HUE_ADJUST,
-                                                     "dw3"));
+        attributes.push_back(XmlFormatter::Attribute(ATTR_HUE_ADJUST, "dw3"));
     }
 }
 
@@ -1506,13 +1503,15 @@ const char * Lut3DWriter::getTagName() const
 void Lut3DWriter::getAttributes(XmlFormatter::Attributes & attributes) const
 {
     OpWriter::getAttributes(attributes);
+
     Interpolation interpolation = m_lut->getInterpolation();
+    const char * interpolationName = GetInterpolation3DName(interpolation);
+
     // Please see comment in Lut1DWriter.
-    if (interpolation != INTERP_DEFAULT)
+    if (interpolationName && *interpolationName)
     {
-        const char* interpolationName = GetInterpolation3DName(interpolation);
-        attributes.push_back(XmlFormatter::Attribute(ATTR_INTERPOLATION,
-                                                     interpolationName));
+
+        attributes.push_back(XmlFormatter::Attribute(ATTR_INTERPOLATION, interpolationName));
     }
 }
 
@@ -1914,7 +1913,7 @@ namespace
 void ThrowWriteOp(const std::string & type)
 {
     std::ostringstream oss;
-    oss << "Transform uses the " << type << " op which cannot be written "
+    oss << "Transform uses the '" << type << "' op which cannot be written "
            "as CLF.  Use CTF format or Bake the transform.";
     throw Exception(oss.str().c_str());
 }

--- a/src/OpenColorIO/ops/OpArray.h
+++ b/src/OpenColorIO/ops/OpArray.h
@@ -18,6 +18,7 @@ public:
     ArrayBase() {}
     virtual ~ArrayBase() {}
     virtual void setDoubleValue(unsigned long index, double value) = 0;
+    virtual double getDoubleValue(unsigned long index) = 0;
     virtual unsigned long getLength() const = 0;
     virtual unsigned long getNumColorComponents() const = 0;
 
@@ -70,6 +71,11 @@ public:
     void setDoubleValue(unsigned long index, double value) override
     {
         m_data[index] = (T)value;
+    }
+
+    double getDoubleValue(unsigned long index) override
+    {
+        return double(m_data[index]);
     }
 
     unsigned long getLength() const override

--- a/src/OpenColorIO/ops/log/LogOpData.cpp
+++ b/src/OpenColorIO/ops/log/LogOpData.cpp
@@ -99,11 +99,11 @@ LogOpData::LogOpData(double base,
     setParameters(logSlope, logOffset, linSlope, linOffset);
 }
 
-LogOpData::LogOpData(TransformDirection dir,
-                     double base,
+LogOpData::LogOpData(double base,
                      const Params & redParams,
                      const Params & greenParams,
-                     const Params & blueParams)
+                     const Params & blueParams,
+                     TransformDirection dir)
     : OpData()
     , m_redParams(redParams)
     , m_greenParams(greenParams)
@@ -355,11 +355,11 @@ bool LogOpData::operator==(const OpData& other) const
 
 LogOpDataRcPtr LogOpData::clone() const
 {
-    auto clone = std::make_shared<LogOpData>(m_direction,
-                                             getBase(),
+    auto clone = std::make_shared<LogOpData>(getBase(),
                                              getRedParams(),
                                              getGreenParams(),
-                                             getBlueParams());
+                                             getBlueParams(),
+                                             m_direction);
     clone->getFormatMetadata() = getFormatMetadata();
     return clone;
 }

--- a/src/OpenColorIO/ops/log/LogOpData.h
+++ b/src/OpenColorIO/ops/log/LogOpData.h
@@ -55,11 +55,11 @@ public:
               const double(&linOffset)[3],
               TransformDirection direction);
 
-    LogOpData(TransformDirection dir,
-              double base,
+    LogOpData(double base,
               const Params & redParams,
               const Params & greenParams,
-              const Params & blueParams);
+              const Params & blueParams,
+              TransformDirection dir);
 
     virtual ~LogOpData();
 

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpData.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpData.cpp
@@ -21,14 +21,18 @@ namespace OCIO_NAMESPACE
 // Number of possible values for the Half domain.
 static const unsigned long HALF_DOMAIN_REQUIRED_ENTRIES = 65536;
 
-Lut1DOpData::Lut3by1DArray::Lut3by1DArray(HalfFlags halfFlags,
-                                          unsigned long length)
+Lut1DOpData::Lut3by1DArray::Lut3by1DArray(HalfFlags halfFlags, unsigned long numChannels, unsigned long length)
 {
     if (length < 2)
     {
         throw Exception("LUT 1D length needs to be at least 2.");
     }
-    resize(length, getMaxColorComponents());
+    if (numChannels != 1 && numChannels != 3)
+    {
+        throw Exception("LUT 1D channels needs to be 1 or 3.");
+    }
+
+    resize(length, numChannels);
     fill(halfFlags);
 }
 
@@ -38,8 +42,8 @@ Lut1DOpData::Lut3by1DArray::~Lut3by1DArray()
 
 void Lut1DOpData::Lut3by1DArray::fill(HalfFlags halfFlags)
 {
-    const unsigned long dim = getLength();
-    const unsigned long maxChannels = getMaxColorComponents();
+    const unsigned long dim         = getLength();
+    const unsigned long maxChannels = getNumColorComponents();
 
     Array::Values& values = getValues();
     if (Lut1DOpData::IsInputHalfDomain(halfFlags))
@@ -173,7 +177,7 @@ bool Lut1DOpData::Lut3by1DArray::isIdentity(HalfFlags halfFlags) const
 Lut1DOpData::Lut1DOpData(unsigned long dimension)
     : OpData()
     , m_interpolation(INTERP_DEFAULT)
-    , m_array(LUT_STANDARD, dimension)
+    , m_array(LUT_STANDARD, 3, dimension)
     , m_halfFlags(LUT_STANDARD)
     , m_hueAdjust(HUE_NONE)
     , m_direction(TRANSFORM_DIR_FORWARD)
@@ -183,18 +187,17 @@ Lut1DOpData::Lut1DOpData(unsigned long dimension)
 Lut1DOpData::Lut1DOpData(unsigned long dimension, TransformDirection dir)
     : OpData()
     , m_interpolation(INTERP_DEFAULT)
-    , m_array(LUT_STANDARD, dimension)
+    , m_array(LUT_STANDARD, 3, dimension)
     , m_halfFlags(LUT_STANDARD)
     , m_hueAdjust(HUE_NONE)
     , m_direction(dir)
 {
 }
 
-Lut1DOpData::Lut1DOpData(HalfFlags halfFlags,
-                         unsigned long dimension)
+Lut1DOpData::Lut1DOpData(HalfFlags halfFlags, unsigned long dimension)
     : OpData()
     , m_interpolation(INTERP_DEFAULT)
-    , m_array(halfFlags, dimension)
+    , m_array(halfFlags, 3, dimension)
     , m_halfFlags(halfFlags)
     , m_hueAdjust(HUE_NONE)
     , m_direction(TRANSFORM_DIR_FORWARD)

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpData.h
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpData.h
@@ -86,8 +86,7 @@ public:
 
     Lut1DOpData(unsigned long dimension, TransformDirection dir);
 
-    Lut1DOpData(HalfFlags halfFlags,
-                unsigned long dimension);
+    Lut1DOpData(HalfFlags halfFlags, unsigned long dimension);
 
     virtual ~Lut1DOpData();
 
@@ -206,11 +205,8 @@ public:
     class Lut3by1DArray : public Array
     {
     public:
-        Lut3by1DArray(HalfFlags halfFlags);
-
-        Lut3by1DArray(HalfFlags halfFlags,
-                      unsigned long length);
-
+        explicit Lut3by1DArray(HalfFlags halfFlags);
+        Lut3by1DArray(HalfFlags halfFlags, unsigned long numChannels, unsigned long length);
         ~Lut3by1DArray();
 
         bool isIdentity(HalfFlags halfFlags) const;

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpData.cpp
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpData.cpp
@@ -361,7 +361,7 @@ void Lut3DOpData::validate() const
 {
     if (!IsValid(m_interpolation))
     {
-        throw Exception("Lut3D has an invalid interpolation type. ");
+        throw Exception("Lut3D has an invalid interpolation type.");
     }
 
     try

--- a/src/OpenColorIO/ops/matrix/MatrixOp.cpp
+++ b/src/OpenColorIO/ops/matrix/MatrixOp.cpp
@@ -75,8 +75,8 @@ typedef OCIO_SHARED_PTR<const MatrixOffsetOp> ConstMatrixOffsetOpRcPtr;
 
 
 MatrixOffsetOp::MatrixOffsetOp(const double * m44,
-                                const double * offset4,
-                                TransformDirection direction)
+                               const double * offset4,
+                               TransformDirection direction)
     : Op()
 {
     MatrixOpDataRcPtr mat = std::make_shared<MatrixOpData>(direction);
@@ -207,7 +207,7 @@ void CreateScaleOp(OpRcPtrVec & ops,
                    const double * scale4,
                    TransformDirection direction)
 {
-    const double offset4[4] = { 0, 0, 0, 0 };
+    static constexpr double offset4[4] { 0, 0, 0, 0 };
     CreateScaleOffsetOp(ops, scale4, offset4, direction);
 }
 
@@ -215,7 +215,7 @@ void CreateMatrixOp(OpRcPtrVec & ops,
                     const double * m44,
                     TransformDirection direction)
 {
-    const double offset4[4] = { 0.0, 0.0, 0.0, 0.0 };
+    static constexpr double offset4[4] { 0.0, 0.0, 0.0, 0.0 };
     CreateMatrixOffsetOp(ops, m44, offset4, direction);
 }
 
@@ -223,7 +223,7 @@ void CreateOffsetOp(OpRcPtrVec & ops,
                     const double * offset4,
                     TransformDirection direction)
 {
-    const double scale4[4] = { 1.0, 1.0, 1.0, 1.0 };
+    static constexpr double scale4[4] { 1.0, 1.0, 1.0, 1.0 };
     CreateScaleOffsetOp(ops, scale4, offset4, direction);
 }
 
@@ -238,9 +238,7 @@ void CreateScaleOffsetOp(OpRcPtrVec & ops,
     m44[10] = scale4[2];
     m44[15] = scale4[3];
 
-    CreateMatrixOffsetOp(ops,
-                            m44, offset4,
-                            direction);
+    CreateMatrixOffsetOp(ops, m44, offset4, direction);
 }
 
 void CreateSaturationOp(OpRcPtrVec & ops,
@@ -250,8 +248,7 @@ void CreateSaturationOp(OpRcPtrVec & ops,
 {
     double matrix[16];
     double offset[4];
-    MatrixTransform::Sat(matrix, offset,
-                            sat, lumaCoef3);
+    MatrixTransform::Sat(matrix, offset, sat, lumaCoef3);
 
     CreateMatrixOffsetOp(ops, matrix, offset, direction);
 }
@@ -282,8 +279,7 @@ void CreateFitOp(OpRcPtrVec & ops,
     CreateMatrixOffsetOp(ops, matrix, offset, direction);
 }
 
-void CreateIdentityMatrixOp(OpRcPtrVec & ops,
-                            TransformDirection direction)
+void CreateIdentityMatrixOp(OpRcPtrVec & ops, TransformDirection direction)
 {
     double matrix[16]{ 0.0 };
     matrix[0] = 1.0;
@@ -327,6 +323,14 @@ void CreateMinMaxOp(OpRcPtrVec & ops,
     const double min[3] = { from_min, from_min, from_min };
     const double max[3] = { from_max, from_max, from_max };
     CreateMinMaxOp(ops, min, max, direction);
+}
+
+void CreateMatrixOp(OpRcPtrVec & ops,
+                    MatrixOpData::MatrixArrayPtr & matrix,
+                    TransformDirection direction)
+{
+    MatrixOpDataRcPtr mat = std::make_shared<MatrixOpData>(*matrix.get());
+    CreateMatrixOp(ops, mat, direction);
 }
 
 void CreateMatrixOp(OpRcPtrVec & ops, MatrixOpDataRcPtr & matrix, TransformDirection direction)

--- a/src/OpenColorIO/ops/matrix/MatrixOp.h
+++ b/src/OpenColorIO/ops/matrix/MatrixOp.h
@@ -68,6 +68,10 @@ void CreateMinMaxOp(OpRcPtrVec & ops,
                     TransformDirection direction);
 
 void CreateMatrixOp(OpRcPtrVec & ops,
+                    MatrixOpData::MatrixArrayPtr & matrix,
+                    TransformDirection direction);
+
+void CreateMatrixOp(OpRcPtrVec & ops,
                     MatrixOpDataRcPtr & matrix,
                     TransformDirection direction);
 

--- a/src/OpenColorIO/transforms/BuiltinTransform.cpp
+++ b/src/OpenColorIO/transforms/BuiltinTransform.cpp
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <sstream>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "Op.h"
+#include "transforms/builtins/BuiltinTransformRegistry.h"
+#include "transforms/BuiltinTransform.h"
+#include "Platform.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+BuiltinTransformRcPtr BuiltinTransform::Create()
+{
+    return BuiltinTransformRcPtr(new BuiltinTransformImpl(), &BuiltinTransformImpl::deleter);
+}
+
+void BuiltinTransformImpl::deleter(BuiltinTransform * t)
+{
+    delete static_cast<BuiltinTransformImpl *>(t);
+}
+
+TransformRcPtr BuiltinTransformImpl::createEditableCopy() const
+{
+    BuiltinTransformRcPtr transform = BuiltinTransform::Create();
+
+    transform->setDirection(getDirection());
+    transform->setStyle(getStyle());
+
+    return transform;
+}
+
+TransformDirection BuiltinTransformImpl::getDirection() const noexcept
+{
+    return m_direction;
+}
+
+void BuiltinTransformImpl::setDirection(TransformDirection dir) noexcept
+{
+    m_direction = dir;
+}
+
+const char * BuiltinTransformImpl::getStyle() const noexcept
+{
+    return BuiltinTransformRegistry::Get()->getBuiltinStyle(m_transformIndex);
+}
+
+const char * BuiltinTransformImpl::getDescription() const noexcept
+{
+    return BuiltinTransformRegistry::Get()->getBuiltinDescription(m_transformIndex);
+}
+
+size_t BuiltinTransformImpl::getTransformIndex() const noexcept
+{
+    return m_transformIndex;
+}
+
+void BuiltinTransformImpl::setStyle(const char * style)
+{
+    for (size_t index = 0; index < BuiltinTransformRegistry::Get()->getNumBuiltins(); ++index)
+    {
+        if (0 == Platform::Strcasecmp(style, BuiltinTransformRegistry::Get()->getBuiltinStyle(index)))
+        {
+            m_transformIndex = index;
+            return;
+        }
+    }
+
+    std::ostringstream oss;
+    oss << "BuiltinTransform: invalid built-in transform style '" << style << "'.";
+
+    throw Exception(oss.str().c_str());
+}
+
+
+void BuildBuiltinOps(OpRcPtrVec & ops,
+                     const Config & /*config*/,
+                     const BuiltinTransform & transform,
+                     TransformDirection dir)
+{
+    const TransformDirection combinedDir = CombineTransformDirections(dir, transform.getDirection());
+
+    const BuiltinTransformImpl * pImpl = dynamic_cast<const BuiltinTransformImpl*>(&transform);
+
+    CreateBuiltinTransformOps(ops, pImpl->getTransformIndex(), combinedDir);
+}
+
+
+std::ostream & operator<< (std::ostream & os, const BuiltinTransform & t) noexcept
+{
+    os << "<BuiltinTransform "
+       << "style = " << t.getStyle() << ", "
+       << "direction = " << TransformDirectionToString(t.getDirection())
+       << ">";
+    return os;
+}
+
+
+
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/transforms/BuiltinTransform.h
+++ b/src/OpenColorIO/transforms/BuiltinTransform.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#ifndef INCLUDED_OCIO_BUILTINTRANSFORM_H
+#define INCLUDED_OCIO_BUILTINTRANSFORM_H
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+
+namespace OCIO_NAMESPACE
+{
+
+class BuiltinTransformImpl : public BuiltinTransform
+{
+public:
+    BuiltinTransformImpl() = default;
+    BuiltinTransformImpl(const BuiltinTransformImpl &) = delete;
+    BuiltinTransformImpl & operator=(const BuiltinTransformImpl &) = delete;
+    ~BuiltinTransformImpl() override = default;
+
+    TransformRcPtr createEditableCopy() const override;
+
+    TransformDirection getDirection() const noexcept override;
+    void setDirection(TransformDirection dir) noexcept override;
+
+    const char * getStyle() const noexcept override;
+    void setStyle(const char * style) override;
+
+    const char * getDescription() const noexcept override;
+
+    size_t getTransformIndex() const noexcept;
+
+    static void deleter(BuiltinTransform * t);
+
+private:
+    TransformDirection m_direction{ TRANSFORM_DIR_FORWARD };
+    size_t m_transformIndex{ 0 }; // Index of the built-in transform.
+};
+
+
+} // namespace OCIO_NAMESPACE
+
+#endif  // INCLUDED_OCIO_BUILTINTRANSFORM_H

--- a/src/OpenColorIO/transforms/FileTransform.cpp
+++ b/src/OpenColorIO/transforms/FileTransform.cpp
@@ -420,21 +420,21 @@ std::string FileFormat::getName() const
 }
 
 void FileFormat::bake(const Baker & /*baker*/,
-                        const std::string & formatName,
-                        std::ostream & /*ostream*/) const
+                      const std::string & formatName,
+                      std::ostream & /*ostream*/) const
 {
     std::ostringstream os;
-    os << "Format " << formatName << " does not support baking.";
+    os << "Format '" << formatName << "' does not support baking.";
     throw Exception(os.str().c_str());
 }
 
 void FileFormat::write(const OpRcPtrVec & /*ops*/,
-                        const FormatMetadataImpl & /*metadata*/,
-                        const std::string & formatName,
-                        std::ostream & /*ostream*/) const
+                       const FormatMetadataImpl & /*metadata*/,
+                       const std::string & formatName,
+                       std::ostream & /*ostream*/) const
 {
     std::ostringstream os;
-    os << "Format " << formatName << " does not support writing.";
+    os << "Format '" << formatName << "' does not support writing.";
     throw Exception(os.str().c_str());
 }
 
@@ -454,7 +454,8 @@ void LoadFileUncached(FileFormat * & returnFormat,
     }
 
     // Try the initial format.
-    std::string primaryErrorText;
+    std::string primaryErrorText("\n"); // Add a separator for the first reader error.
+
     std::string root, extension;
     pystring::os::path::splitext(root, extension, filepath);
     // remove the leading '.'
@@ -512,11 +513,10 @@ void LoadFileUncached(FileFormat * & returnFormat,
                 filestream.close();
             }
 
-            primaryErrorText += "\t";
+            primaryErrorText += "\t'";
             primaryErrorText += tryFormat->getName();
-            primaryErrorText += " failed with: '";
+            primaryErrorText += "' failed with: ";
             primaryErrorText += e.what();
-            primaryErrorText += "'.\n";
 
             if(IsDebugLoggingEnabled())
             {
@@ -598,7 +598,8 @@ void LoadFileUncached(FileFormat * & returnFormat,
     // No formats succeeded. Error out with a sensible message.
     std::ostringstream os;
     os << "The specified transform file '";
-    os << filepath << "' could not be loaded. All formats have been tried. ";
+    os << filepath << "' could not be loaded.\n";
+    os << "All formats have been tried. ";
 
     if (IsDebugLoggingEnabled())
     {

--- a/src/OpenColorIO/transforms/Lut1DTransform.cpp
+++ b/src/OpenColorIO/transforms/Lut1DTransform.cpp
@@ -102,7 +102,7 @@ bool Lut1DTransformImpl::equals(const Lut1DTransform & other) const noexcept
 void Lut1DTransformImpl::setLength(unsigned long length)
 {
     auto & lutArray = m_data.getArray();
-    lutArray = Lut1DOpData::Lut3by1DArray(m_data.getHalfFlags(), length);
+    lutArray = Lut1DOpData::Lut3by1DArray(m_data.getHalfFlags(), 3, length);
 }
 
 namespace

--- a/src/OpenColorIO/transforms/builtins/ACES.cpp
+++ b/src/OpenColorIO/transforms/builtins/ACES.cpp
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <cmath>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "OpenEXR/half.h"
+#include "ops/log/LogOp.h"
+#include "ops/matrix/MatrixOp.h"
+#include "ops/range/RangeOp.h"
+#include "transforms/builtins/ACES.h"
+#include "transforms/builtins/BuiltinTransformRegistry.h"
+#include "transforms/builtins/OpHelpers.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+namespace ACEScct_to_LINEAR
+{
+static constexpr double linSideSlope  = 1.;
+static constexpr double linSideOffset = 0.;
+static constexpr double logSideSlope  = 1. / 17.52;
+static constexpr double logSideOffset = 9.72 / 17.52;
+static constexpr double linSideBreak  = 0.0078125;
+static constexpr double base          = 2.;
+
+static const LogOpData::Params 
+    params { logSideSlope, logSideOffset, linSideSlope, linSideOffset, linSideBreak };
+
+static const LogOpData log(base, params, params, params, TRANSFORM_DIR_INVERSE);
+}
+
+namespace ADX_to_ACES
+{
+static constexpr unsigned lutSize = 11;
+static constexpr double nonuniform_LUT[lutSize * 2]
+{
+    -0.190000000000000, -6.000000000000000,
+     0.010000000000000, -2.721718645000000,
+     0.028000000000000, -2.521718645000000,
+     0.054000000000000, -2.321718645000000,
+     0.095000000000000, -2.121718645000000,
+     0.145000000000000, -1.921718645000000,
+     0.220000000000000, -1.721718645000000,
+     0.300000000000000, -1.521718645000000,
+     0.400000000000000, -1.321718645000000,
+     0.500000000000000, -1.121718645000000,
+     0.600000000000000, -0.926545676714876
+};
+
+void GenerateOps(OpRcPtrVec & ops)
+{
+    static constexpr double CDD_TO_CID[4 * 4]
+    {
+        0.75573,  0.22197,  0.02230,  0.,
+        0.05901,  0.96928, -0.02829,  0.,
+        0.16134,  0.07406,  0.76460,  0.,
+        0.,       0.,       0.,       1.
+    };
+
+    // Convert Channel Dependent Density values into Channel Independent Density values.
+    CreateMatrixOp(ops, &CDD_TO_CID[0], TRANSFORM_DIR_FORWARD);
+
+    auto GenerateLutValues = [](double in) -> float
+    {
+        double out = 0.;
+
+        if (in < nonuniform_LUT[0]) // Lower bound i.e. in < nonuniform_LUT[0, 0].
+        {
+            // Extrapolate to ease conversion to LUT1D.
+            const double slope = (nonuniform_LUT[3] - nonuniform_LUT[1])
+                                    / (nonuniform_LUT[2] - nonuniform_LUT[0]);
+
+            out = nonuniform_LUT[1] - slope * (nonuniform_LUT[0] - in);
+
+            if (out < -10.) out = -10.;
+        }
+        else if (in <= nonuniform_LUT[(lutSize-1) * 2])
+        {
+            out = Interpolate1D(lutSize, &nonuniform_LUT[0], in);
+        }
+        else // Upper bound i.e. in > nonuniform_LUT[lutSize-1, 0].
+        {
+            const double REF_PT
+                = (7120. - 1520.) / 8000. * (100. / 55.) - std::log10(0.18);
+
+            out = (100. / 55.) * in - REF_PT;
+
+            if (out > 4.8162678) out = 4.8162678;  // log10(HALF_MAX)
+        }
+
+        return float(out);
+    };
+
+    // Convert Channel Independent Density values to Relative Log Exposure values.
+    CreateHalfLut(ops, GenerateLutValues);
+
+    // Convert Relative Log Exposure values to Relative Exposure values.
+    CreateLogOp(ops, 10., TRANSFORM_DIR_INVERSE);
+
+    static constexpr double EXP_TO_ACES[4 * 4]
+    {
+        0.72286,  0.12630,  0.15084,  0.,
+        0.11923,  0.76418,  0.11659,  0.,
+        0.01427,  0.08213,  0.90359,  0.,
+        0.,       0.,       0.,       1.
+    };
+
+    // Convert Relative Exposure values to ACES values.
+    CreateMatrixOp(ops, &EXP_TO_ACES[0], TRANSFORM_DIR_FORWARD);            
+}
+
+}  // namespace ADX
+
+
+namespace ACES
+{
+
+// Register all the ACES related built-in tranforms.
+void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
+{
+    {
+        auto ACES_AP0_to_CIE_XYZ_D65_BFD_Functor = [](OpRcPtrVec & ops)
+        {
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix(ACES_AP0::primaries, CIE_XYZ_D65::primaries, ADAPTATION_BRADFORD);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("ACES-AP0_to_CIE-XYZ-D65_BFD", 
+                            "Convert ACES AP0 primaries to CIE XYZ with a D65 white point with Bradford adaptation",
+                            ACES_AP0_to_CIE_XYZ_D65_BFD_Functor);
+    }
+    {
+        auto ACES_AP1_to_CIE_XYZ_D65_BFD_Functor = [](OpRcPtrVec & ops)
+        {
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix(ACES_AP1::primaries, CIE_XYZ_D65::primaries, ADAPTATION_BRADFORD);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("ACES-AP1_to_CIE-XYZ-D65_BFD", 
+                            "Convert ACES AP1 primaries to CIE XYZ with a D65 white point with Bradford adaptation",
+                            ACES_AP1_to_CIE_XYZ_D65_BFD_Functor);
+    }
+    {
+        auto ACES_AP1_to_LINEAR_REC709_BFD_Functor = [](OpRcPtrVec & ops)
+        {
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix(ACES_AP1::primaries, REC709::primaries, ADAPTATION_BRADFORD);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("ACES-AP1_to_LINEAR-REC709_BFD", 
+                            "Convert ACES AP1 primaries to linear Rec.709 primaries with Bradford adaptation",
+                            ACES_AP1_to_LINEAR_REC709_BFD_Functor);
+    }
+    {
+        auto ACEScct_LOG_to_LIN_Functor = [](OpRcPtrVec & ops)
+        {
+            LogOpDataRcPtr log = ACEScct_to_LINEAR::log.clone();
+            CreateLogOp(ops, log, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("ACEScct-LOG_to_LIN", 
+                            "Apply the log-to-lin curve used in ACEScct",
+                            ACEScct_LOG_to_LIN_Functor);
+    }
+    {
+        auto ACEScct_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)
+        {
+            LogOpDataRcPtr log = ACEScct_to_LINEAR::log.clone();
+            CreateLogOp(ops, log, TRANSFORM_DIR_FORWARD);
+
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix(ACES_AP1::primaries, ACES_AP0::primaries, ADAPTATION_NONE);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("ACEScct_to_ACES2065-1", 
+                            "Convert ACEScct to ACES2065-1",
+                            ACEScct_to_ACES2065_1_Functor);
+    }
+    {
+        auto ACEScc_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)
+        {
+            auto GenerateLutValues = [](double in) -> float
+            {
+                double out = 0.0f;
+
+                if (in < ((9.72 - 15.0) / 17.52))
+                {
+                    out = (std::pow( 2., in * 17.52 - 9.72) - std::pow( 2., -16.)) * 2.0;
+                }
+                else if (in < (log2(HALF_MAX) + 9.72) / 17.52)
+                {
+                    out = std::pow( 2., in * 17.52 - 9.72);
+                }
+                else // (in >= (log2(HALF_MAX) + 9.72) / 17.52)
+                {
+                    out = HALF_MAX;
+                }
+
+                return float(out);
+            };
+
+            CreateLut(ops, 4096, GenerateLutValues);
+
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix(ACES_AP1::primaries, ACES_AP0::primaries, ADAPTATION_NONE);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("ACEScc_to_ACES2065-1", 
+                            "Convert ACEScc to ACES2065-1",
+                            ACEScc_to_ACES2065_1_Functor);
+    }
+    {
+        auto ACEScg_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)
+        {
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix(ACES_AP1::primaries, ACES_AP0::primaries, ADAPTATION_NONE);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("ACEScg_to_ACES2065-1",
+                            "Convert ACEScg to ACES2065-1",
+                            ACEScg_to_ACES2065_1_Functor);
+    }
+    {
+        auto ACESproxy10i_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)
+        {
+            CreateRangeOp(ops, 
+                          64. / 1023.,                940. / 1023., 
+                          (( 64 - 425.) / 50.) - 2.5, ((940 - 425.) / 50.) - 2.5,
+                          TRANSFORM_DIR_FORWARD);
+
+            CreateLogOp(ops, 2., TRANSFORM_DIR_INVERSE);
+
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix(ACES_AP1::primaries, ACES_AP0::primaries, ADAPTATION_NONE);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("ACESproxy10i_to_ACES2065-1", 
+                            "Convert ACESproxy 10i to ACES2065-1",
+                            ACESproxy10i_to_ACES2065_1_Functor);
+    }
+    {
+        auto ADX10_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)
+        {
+            static constexpr double scale     = 1023. / 500.;
+            static constexpr double scale4[4] = { scale, scale, scale, 1. };
+    
+            static constexpr double offset     = -95. / 500.;
+            static constexpr double offset4[4] = { offset, offset, offset, 0. };
+
+            // Convert ADX10 values to Channel Dependent Density values.
+            CreateScaleOffsetOp(ops, scale4, offset4, TRANSFORM_DIR_FORWARD);
+
+            // Convert to ACES2065-1.
+            ADX_to_ACES::GenerateOps(ops);
+        };
+
+        registry.addBuiltin("ADX10_to_ACES2065-1",
+                            "Convert ADX10 to ACES2065-1",
+                            ADX10_to_ACES2065_1_Functor);
+    }
+    {
+        auto ADX16_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)
+        {
+            static constexpr double scale     = 65535. / 8000.;
+            static constexpr double scale4[4] = { scale, scale, scale, 1. };
+    
+            static constexpr double offset     = -1520. / 8000.;
+            static constexpr double offset4[4] = { offset, offset, offset, 0. };
+
+            // Convert ADX16 values to Channel Dependent Density values.
+            CreateScaleOffsetOp(ops, scale4, offset4, TRANSFORM_DIR_FORWARD);
+
+            // Convert to ACES2065-1.
+            ADX_to_ACES::GenerateOps(ops);
+        };
+
+        registry.addBuiltin("ADX16_to_ACES2065-1",
+                            "Convert ADX16 to ACES2065-1",
+                            ADX16_to_ACES2065_1_Functor);
+    }
+}
+
+} // namespace ACES
+
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/transforms/builtins/ACES.h
+++ b/src/OpenColorIO/transforms/builtins/ACES.h
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#ifndef INCLUDED_OCIO_ACES_H
+#define INCLUDED_OCIO_ACES_H
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "transforms/builtins/ColorMatrixHelpers.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+class BuiltinTransformRegistryImpl;
+
+namespace ACES
+{
+
+void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept;
+
+} // namespace ACES
+
+} // namespace OCIO_NAMESPACE
+
+#endif // INCLUDED_OCIO_ACES_H

--- a/src/OpenColorIO/transforms/builtins/ArriCameras.cpp
+++ b/src/OpenColorIO/transforms/builtins/ArriCameras.cpp
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "ops/log/LogOp.h"
+#include "ops/matrix/MatrixOp.h"
+#include "transforms/builtins/ACES.h"
+#include "transforms/builtins/ArriCameras.h"
+#include "transforms/builtins/BuiltinTransformRegistry.h"
+#include "transforms/builtins/ColorMatrixHelpers.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+namespace ARRI_ALEXA_WIDE_GAMUT
+{
+static const Chromaticities red_xy(0.68400,  0.31300);
+static const Chromaticities grn_xy(0.22100,  0.84800);
+static const Chromaticities blu_xy(0.08610, -0.10200);
+static const Chromaticities wht_xy(0.31270,  0.32900);
+
+const Primaries primaries(red_xy, grn_xy, blu_xy, wht_xy);
+}
+
+namespace ARRI_ALEXA_LOGC_EI800_to_LINEAR
+{
+static constexpr double linSideSlope  = 1. / (0.18 * 0.005 * (800. / 400.) / 0.01);
+static constexpr double linSideOffset = 0.0522722750;
+static constexpr double logSideSlope  = 0.2471896383;
+static constexpr double logSideOffset = 0.3855369987;
+static constexpr double linSideBreak  = ((1. / 9.) - linSideOffset) / linSideSlope;
+static constexpr double base          = 10.;
+
+static const LogOpData::Params 
+    params { logSideSlope, logSideOffset, linSideSlope, linSideOffset, linSideBreak };
+
+static const LogOpData log(base, params, params, params, TRANSFORM_DIR_INVERSE);
+}
+
+
+namespace CAMERA
+{
+
+namespace ARRI
+{
+
+void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
+{
+    {
+        auto ARRI_ALEXA_LOGC_EI800_AWG_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)
+        {
+            LogOpDataRcPtr log = ARRI_ALEXA_LOGC_EI800_to_LINEAR::log.clone();
+            CreateLogOp(ops, log, TRANSFORM_DIR_FORWARD);
+
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix(ARRI_ALEXA_WIDE_GAMUT::primaries, ACES_AP0::primaries, ADAPTATION_CAT02);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("ARRI_ALEXA-LOGC-EI800-AWG_to_ACES2065-1",
+                            "Convert ARRI ALEXA LogC (EI800) ALEXA Wide Gamut to ACES2065-1",
+                            ARRI_ALEXA_LOGC_EI800_AWG_to_ACES2065_1_Functor);
+    }
+}
+
+} // namespace ARRI
+
+} // namespace CAMERA
+
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/transforms/builtins/ArriCameras.h
+++ b/src/OpenColorIO/transforms/builtins/ArriCameras.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#ifndef INCLUDED_OCIO_ARRI_CAMERAS_H
+#define INCLUDED_OCIO_ARRI_CAMERAS_H
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+
+namespace OCIO_NAMESPACE
+{
+
+class BuiltinTransformRegistryImpl;
+
+namespace CAMERA
+{
+
+namespace ARRI
+{
+
+void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept;
+
+} // namespace ARRI
+
+} // namespace CAMERA
+
+} // namespace OCIO_NAMESPACE
+
+#endif // INCLUDED_OCIO_ARRI_CAMERAS_H

--- a/src/OpenColorIO/transforms/builtins/BuiltinTransformRegistry.cpp
+++ b/src/OpenColorIO/transforms/builtins/BuiltinTransformRegistry.cpp
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <memory>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "Mutex.h"
+#include "ops/matrix/MatrixOp.h"
+#include "OpBuilders.h"
+#include "Platform.h"
+#include "transforms/builtins/ACES.h"
+#include "transforms/builtins/BuiltinTransformRegistry.h"
+#include "utils/StringUtils.h"
+
+#ifdef ADD_EXTRA_BUILTINS
+
+#include "transforms/builtins/ArriCameras.h"
+#include "transforms/builtins/PanasonicCameras.h"
+#include "transforms/builtins/CanonCameras.h"
+#include "transforms/builtins/RedCameras.h"
+#include "transforms/builtins/SonyCameras.h"
+
+#endif // ADD_EXTRA_BUILTINS
+
+namespace OCIO_NAMESPACE
+{
+
+namespace
+{
+
+static BuiltinTransformRegistryRcPtr globalRegistry;
+static Mutex globalRegistryMutex;
+
+
+void AddCameraBuiltins(BuiltinTransformRegistryImpl & registry)
+{
+#ifdef ADD_EXTRA_BUILTINS
+
+    // Camera support.
+    CAMERA::ARRI::RegisterAll(registry);
+    CAMERA::CANON::RegisterAll(registry);
+    CAMERA::PANASONIC::RegisterAll(registry);
+    CAMERA::RED::RegisterAll(registry);
+    CAMERA::SONY::RegisterAll(registry);
+
+#endif // ADD_EXTRA_BUILTINS
+}
+
+} // anon.
+
+ConstBuiltinTransformRegistryRcPtr BuiltinTransformRegistry::Get() noexcept
+{
+    AutoMutex guard(globalRegistryMutex);
+
+    if (!globalRegistry)
+    {
+        globalRegistry = std::make_shared<BuiltinTransformRegistryImpl>();
+        DynamicPtrCast<BuiltinTransformRegistryImpl>(globalRegistry)->registerAll();
+    }
+
+    return globalRegistry;
+}
+
+void BuiltinTransformRegistryImpl::addBuiltin(const char * style, const char * description, OpCreator creator)
+{
+    BuiltinData data{ style, description ? description : "", creator };
+
+    for (auto & builtin : m_builtins)
+    {
+        if (0==Platform::Strcasecmp(data.m_style.c_str(), builtin.m_style.c_str()))
+        {
+            builtin = data;
+            return;
+        }
+    }
+
+    m_builtins.push_back(data);
+}
+
+size_t BuiltinTransformRegistryImpl::getNumBuiltins() const noexcept
+{
+    return m_builtins.size();
+}
+
+const char * BuiltinTransformRegistryImpl::getBuiltinStyle(size_t index) const
+{
+    if (index >= m_builtins.size())
+    {
+        throw Exception("Invalid index.");
+    }
+
+    return m_builtins[index].m_style.c_str();
+}
+
+const char * BuiltinTransformRegistryImpl::getBuiltinDescription(size_t index) const
+{
+    if (index >= m_builtins.size())
+    {
+        throw Exception("Invalid index.");
+    }
+
+    return m_builtins[index].m_description.c_str();
+}
+
+void BuiltinTransformRegistryImpl::createOps(size_t index, OpRcPtrVec & ops) const
+{
+    if (index >= m_builtins.size())
+    {
+        throw Exception("Invalid index.");
+    }
+    
+    m_builtins[index].m_creator(ops);
+}
+
+void BuiltinTransformRegistryImpl::registerAll() noexcept
+{
+    m_builtins.clear();
+
+    m_builtins.push_back({"IDENTITY", "", [](OpRcPtrVec & ops) -> void
+                                            {
+                                                CreateIdentityMatrixOp(ops);
+                                            } } );
+
+    ACES::RegisterAll(*this);
+
+    AddCameraBuiltins(*this);
+}
+
+
+void CreateBuiltinTransformOps(OpRcPtrVec & ops, size_t nameIndex, TransformDirection direction)
+{
+    if (nameIndex > BuiltinTransformRegistry::Get()->getNumBuiltins())
+    {
+        throw Exception("Invalid built-in transform name.");
+    }
+
+    if (direction == TRANSFORM_DIR_UNKNOWN)
+    {
+        throw Exception("Unsupported direction.");
+    }
+
+    const BuiltinTransformRegistryImpl * registry
+        = dynamic_cast<const BuiltinTransformRegistryImpl *>(BuiltinTransformRegistry::Get().get());
+
+    if (direction == TRANSFORM_DIR_FORWARD)
+    {
+        registry->createOps(nameIndex, ops);
+    }
+    else
+    {
+        OpRcPtrVec tmp;
+        registry->createOps(nameIndex, tmp);
+
+        OpRcPtrVec t = tmp.invert();
+        ops.insert(ops.end(), t.begin(), t.end());
+    }
+}
+
+
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/transforms/builtins/BuiltinTransformRegistry.cpp
+++ b/src/OpenColorIO/transforms/builtins/BuiltinTransformRegistry.cpp
@@ -50,7 +50,7 @@ void AddCameraBuiltins(BuiltinTransformRegistryImpl & registry)
 
 } // anon.
 
-BuiltinTransformRegistryRcPtr BuiltinTransformRegistry::Get() noexcept
+ConstBuiltinTransformRegistryRcPtr BuiltinTransformRegistry::Get() noexcept
 {
     AutoMutex guard(globalRegistryMutex);
 

--- a/src/OpenColorIO/transforms/builtins/BuiltinTransformRegistry.cpp
+++ b/src/OpenColorIO/transforms/builtins/BuiltinTransformRegistry.cpp
@@ -50,7 +50,7 @@ void AddCameraBuiltins(BuiltinTransformRegistryImpl & registry)
 
 } // anon.
 
-ConstBuiltinTransformRegistryRcPtr BuiltinTransformRegistry::Get() noexcept
+BuiltinTransformRegistryRcPtr BuiltinTransformRegistry::Get() noexcept
 {
     AutoMutex guard(globalRegistryMutex);
 

--- a/src/OpenColorIO/transforms/builtins/BuiltinTransformRegistry.h
+++ b/src/OpenColorIO/transforms/builtins/BuiltinTransformRegistry.h
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#ifndef INCLUDED_OCIO_BUILTIN_TRANSFORM_REGISTRY_H
+#define INCLUDED_OCIO_BUILTIN_TRANSFORM_REGISTRY_H
+
+
+#include <vector>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "Op.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+class BuiltinTransformRegistryImpl : public BuiltinTransformRegistry
+{
+    using OpCreator = std::function<void(OpRcPtrVec & ops)>;
+
+    struct BuiltinData
+    {
+        std::string m_style;       // The built-in transform style.
+        std::string m_description; // The optional built-in transform description.
+        OpCreator   m_creator;     // Functor to create the op(s).
+    };
+    using Builtins = std::vector<BuiltinData>;
+
+public:
+    BuiltinTransformRegistryImpl() = default;
+    BuiltinTransformRegistryImpl(const BuiltinTransformRegistryImpl &) = delete;
+    BuiltinTransformRegistryImpl & operator=(const BuiltinTransformRegistryImpl &) = delete;
+    ~BuiltinTransformRegistryImpl() = default;
+
+    size_t getNumBuiltins() const noexcept override;
+    const char * getBuiltinStyle(size_t index) const override;
+    const char * getBuiltinDescription(size_t index) const override;
+
+    void addBuiltin(const char * style, const char * description, OpCreator creator);
+
+    void createOps(size_t index, OpRcPtrVec & ops) const;
+
+    void registerAll() noexcept;
+
+private:
+    Builtins m_builtins;
+};
+
+void CreateBuiltinTransformOps(OpRcPtrVec & ops, size_t nameIndex, TransformDirection direction);
+
+
+} // namespace OCIO_NAMESPACE
+
+#endif // INCLUDED_OCIO_BUILTIN_TRANSFORM_REGISTRY_H

--- a/src/OpenColorIO/transforms/builtins/CanonCameras.cpp
+++ b/src/OpenColorIO/transforms/builtins/CanonCameras.cpp
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <cmath>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "ops/matrix/MatrixOp.h"
+#include "transforms/builtins/ACES.h"
+#include "transforms/builtins/BuiltinTransformRegistry.h"
+#include "transforms/builtins/CanonCameras.h"
+#include "transforms/builtins/ColorMatrixHelpers.h"
+#include "transforms/builtins/OpHelpers.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+namespace CANON_CGAMUT
+{
+static const Chromaticities red_xy(0.7400,  0.2700);
+static const Chromaticities grn_xy(0.1700,  1.1400);
+static const Chromaticities blu_xy(0.0800, -0.1000);
+static const Chromaticities wht_xy(0.3127,  0.3290);
+
+const Primaries primaries(red_xy, grn_xy, blu_xy, wht_xy);
+}
+
+
+namespace CAMERA
+{
+
+namespace CANON
+{
+
+void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
+{
+    {
+        auto CANON_CLOG2_CGAMUT_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)
+        {
+            auto GenerateLutValues = [](double in) -> float
+            {
+                double out = 0.;
+
+                if (in < 0.092864125)
+                {
+                    out = -(std::pow(10, (0.092864125 - in) / 0.24136077) - 1) / 87.099375;
+                }
+                else
+                {
+                    out = (std::pow(10, (in - 0.092864125) / 0.24136077) - 1) / 87.099375;
+                }
+
+                return float(out * 0.9);
+            };
+
+            CreateLut(ops, 4096, GenerateLutValues);
+
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix(CANON_CGAMUT::primaries, ACES_AP0::primaries, ADAPTATION_CAT02);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("CANON_CLOG2-CGAMUT_to_ACES2065-1",
+                            "Convert Canon Log 2 Cinema Gamut to ACES2065-1",
+                            CANON_CLOG2_CGAMUT_to_ACES2065_1_Functor);
+    }
+    {
+        auto CANON_CLOG3_CGAMUT_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)
+        {
+            auto GenerateLutValues = [](double in) -> float
+            {
+                double out = 0.;
+
+                if (in < 0.097465473)
+                {
+                    out = -(std::pow(10, (0.12783901 - in) / 0.36726845) - 1) / 14.98325;
+                }
+                else if (in <= 0.15277891)
+                {
+                    out = (in - 0.12512219) / 1.9754798;
+                }
+                else
+                {
+                    out = (std::pow(10, (in - 0.12240537) / 0.36726845) - 1) / 14.98325;
+                }
+
+                return float(out * 0.9);
+            };
+
+            CreateLut(ops, 4096, GenerateLutValues);
+
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix(CANON_CGAMUT::primaries, ACES_AP0::primaries, ADAPTATION_CAT02);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("CANON_CLOG3-CGAMUT_to_ACES2065-1",
+                            "Convert Canon Log 3 Cinema Gamut to ACES2065-1",
+                            CANON_CLOG3_CGAMUT_to_ACES2065_1_Functor);
+    }
+}
+
+} // namespace CANON
+
+} // namespace CAMERA
+
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/transforms/builtins/CanonCameras.h
+++ b/src/OpenColorIO/transforms/builtins/CanonCameras.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#ifndef INCLUDED_OCIO_CANON_CAMERAS_H
+#define INCLUDED_OCIO_CANON_CAMERAS_H
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+
+namespace OCIO_NAMESPACE
+{
+
+class BuiltinTransformRegistryImpl;
+
+namespace CAMERA
+{
+
+namespace CANON
+{
+
+void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept;
+
+} // namespace CANON
+
+} // namespace CAMERA
+
+} // namespace OCIO_NAMESPACE
+
+#endif // INCLUDED_OCIO_CANON_CAMERAS_H

--- a/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.cpp
+++ b/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.cpp
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "transforms/builtins/ColorMatrixHelpers.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+namespace CIE_XYZ_D65
+{
+static const Chromaticities red_xy(1.,     0.    );
+static const Chromaticities grn_xy(0.,     1.    );
+static const Chromaticities blu_xy(0.,     0.    );
+static const Chromaticities wht_xy(0.3127, 0.3290);
+
+const Primaries primaries(red_xy, grn_xy, blu_xy, wht_xy);
+}
+
+// ACES Primaries from SMPTE ST2065-1.
+namespace ACES_AP0
+{
+static const Chromaticities red_xy(0.7347,  0.2653 );
+static const Chromaticities grn_xy(0.0000,  1.0000 );
+static const Chromaticities blu_xy(0.0001, -0.0770 );
+static const Chromaticities wht_xy(0.32168, 0.33767);
+
+const Primaries primaries(red_xy, grn_xy, blu_xy, wht_xy);
+}
+
+namespace ACES_AP1
+{
+static const Chromaticities red_xy(0.713,   0.293  );
+static const Chromaticities grn_xy(0.165,   0.830  );
+static const Chromaticities blu_xy(0.128,   0.044  );
+static const Chromaticities wht_xy(0.32168, 0.33767);
+
+const Primaries primaries(red_xy, grn_xy, blu_xy, wht_xy);
+}
+
+namespace REC709
+{
+static const Chromaticities red_xy(0.64,   0.33  );
+static const Chromaticities grn_xy(0.30,   0.60  );
+static const Chromaticities blu_xy(0.15,   0.06  );
+static const Chromaticities wht_xy(0.3127, 0.3290);
+
+const Primaries primaries(red_xy, grn_xy, blu_xy, wht_xy);
+}
+
+namespace P3_DCI
+{
+static const Chromaticities red_xy(0.680, 0.320);
+static const Chromaticities grn_xy(0.265, 0.690);
+static const Chromaticities blu_xy(0.150, 0.060);
+static const Chromaticities wht_xy(0.314, 0.351);
+
+const Primaries primaries(red_xy, grn_xy, blu_xy, wht_xy);
+}
+
+namespace P3_D65
+{
+static const Chromaticities red_xy(0.680,  0.320 );
+static const Chromaticities grn_xy(0.265,  0.690 );
+static const Chromaticities blu_xy(0.150,  0.060 );
+static const Chromaticities wht_xy(0.3127, 0.3290);
+
+const Primaries primaries(red_xy, grn_xy, blu_xy, wht_xy);
+}
+
+
+// Here are some notes on how one derives the color space conversion
+// matrix starting with chromaticity coordinates.
+// 
+// We're looking for a 3x3 matrix M that converts tristimulus values to
+// standard CIE XYZ primaries from some other set of RGB primaries.
+// I.e.:
+// 
+//    [ X Y Z ] = [ R G B ] * M
+//
+// (This note uses row * matrix rather than matrix * column notation, since
+// it's easier to type, but keep in mind that OCIO uses RGB as columns.)
+// 
+// If the red primary occurs at [ R G B] = [ 1 0 0] and similarly for
+// green and blue, then we have:
+// 
+//  [ rX rY rZ ]   [  1  0  0 ]   
+//  | gX gY gZ | = |  0  1  0 | *  M  =  I * M
+//  [ bX bY bZ ]   [  0  0  1 ]   
+//  
+// where [ rX rY rZ ] are the tristimulus values of the red primary
+// (likewise for green and blue) and the rows of M are simply the
+// measurements of the RGB primaries.  The problem then is how to
+// find the matrix M.
+// 
+// We may proceed as follows:
+// 
+// Recall the definition of chromaticity coordinates:
+// 
+//  x = X / ( X + Y + Z),  y = Y / ( X + Y + Z),  z = Z / ( X + Y + Z),
+// 
+// implying z = 1 - x - y, and also X = Y * x / y, and Z = Y * z / y.
+// 
+// For the red primary, call the chromaticity coordinates [ rx ry rz ]
+// and let rS = ( rX + rY + rZ) be the sum of its tristimulus values
+// (and likewise for green and blue).  Then, by definition:
+// 
+//  [ rX rY rZ ]   [ rS  0  0 ]   [ rx ry rz ]
+//  | gX gY gZ | = |  0 gS  0 | * | gx gy gz | =  I * M         ( eq 1)
+//  [ bX bY bZ ]   [  0  0 bS ]   [ bx by bz ]
+// 
+// The left-most two matrices are unknowns.  However, we can add the
+// constraint that the sum of the tristimulus values of the primaries
+// should give the tristimulus values of white, i.e.:
+// 
+//  [ wX wY wZ ] = [ 1 1 1 ] * M                                ( eq 2)
+// 
+// We then arbitrarily choose the luminance of white based on how we
+// want to scale the CIE tristimulus values.  E.g., to scale Y from
+// [0,1], we would set the luminance of white wY = 1.  Then calculate
+// wX and wZ as:
+// 
+//    wX = wY * wx / wy,  wZ = wY * ( 1 - wx - wy) / wy.
+// 
+// Then, combining equations 1 and 2, we have:
+// 
+//                               [ rx ry rz ]
+// [ wX wY wZ ] = [ rS gS bS ] * | gx gy gz |                   ( eq 3)
+//                               [ bx by bz ]
+// 
+// where only rS, gS, and bS are unknown and may be solved for by
+// factoring (or inverting) the matrix on the right.  Plugging these
+// into equation 1 gives the desired matrix M.
+
+MatrixOpData::MatrixArrayPtr rgb2xyz_from_xy(const Primaries & primaries)
+{
+    double wht_XYZ[3] { 0., 0., 0. };
+    double gains[3]   { 0., 0., 0. };
+
+    // Create a 4x4 identity matrix.
+    MatrixOpData::MatrixArrayPtr matrix = std::make_shared<MatrixOpData::MatrixArray>();
+
+    matrix->setDoubleValue( 0, primaries.m_red.m_xy[0]);
+    matrix->setDoubleValue( 4, primaries.m_red.m_xy[1]);
+    matrix->setDoubleValue( 8, 1. - primaries.m_red.m_xy[0] - primaries.m_red.m_xy[1]);
+
+    matrix->setDoubleValue( 1, primaries.m_grn.m_xy[0]);
+    matrix->setDoubleValue( 5, primaries.m_grn.m_xy[1]);
+    matrix->setDoubleValue( 9, 1. - primaries.m_grn.m_xy[0] - primaries.m_grn.m_xy[1]);
+
+    matrix->setDoubleValue( 2, primaries.m_blu.m_xy[0]);
+    matrix->setDoubleValue( 6, primaries.m_blu.m_xy[1]);
+    matrix->setDoubleValue(10, 1. - primaries.m_blu.m_xy[0] - primaries.m_blu.m_xy[1]);
+
+    // 'matrix' is always well-conditioned, forming inverse is okay.
+    MatrixOpData::MatrixArrayPtr invMatrix = matrix->inverse();
+
+    wht_XYZ[0] = primaries.m_wht.m_xy[0] / primaries.m_wht.m_xy[1];
+    wht_XYZ[1] = 1.0;  // Set scaling of XYZ values to [0, 1].
+    wht_XYZ[2] = (1.0 - primaries.m_wht.m_xy[0] - primaries.m_wht.m_xy[1]) / primaries.m_wht.m_xy[1];
+
+    // Tristimulus value conversion matrix, initialized to a 4x4 identity matrix for now.
+    MatrixOpData::MatrixArrayPtr rgb2xyz = std::make_shared<MatrixOpData::MatrixArray>();
+
+    for (unsigned i = 0; i < 3; i++)
+    {
+        gains[i] =    wht_XYZ[0] * invMatrix->getDoubleValue(i * 4 + 0)
+                    + wht_XYZ[1] * invMatrix->getDoubleValue(i * 4 + 1)
+                    + wht_XYZ[2] * invMatrix->getDoubleValue(i * 4 + 2);
+
+        for (unsigned j = 0; j < 3; j++)
+        {
+            rgb2xyz->setDoubleValue(j * 4 + i, gains[i] * matrix->getDoubleValue(j * 4 + i));
+        }
+    }
+
+    return rgb2xyz;
+}
+
+MatrixOpData::MatrixArrayPtr build_vonkries_adapt(const MatrixOpData::Offsets & src_XYZ, 
+                                                  const MatrixOpData::Offsets & dst_XYZ,
+                                                  AdaptationMethod method)
+{
+    static constexpr double CONE_RESP_MAT_BRADFORD[16]{
+             0.8951,  0.2664, -0.1614,  0.,
+            -0.7502,  1.7135,  0.0367,  0.,
+             0.0389, -0.0685,  1.0296,  0.,
+             0.,      0.,      0.,      1. };
+
+    static constexpr double CONE_RESP_MAT_CAT02[16]{
+             0.7328,  0.4296, -0.1624,  0.,
+            -0.7036,  1.6975,  0.0061,  0.,
+             0.0030,  0.0136,  0.9834,  0.,
+             0.,      0.,      0.,      1. };
+
+    MatrixOpData::MatrixArrayPtr xyz2rgb = std::make_shared<MatrixOpData::MatrixArray>();
+    if (method == ADAPTATION_CAT02)
+    {
+        xyz2rgb->setRGBA(&CONE_RESP_MAT_CAT02[0]);
+    }
+    else
+    {
+        xyz2rgb->setRGBA(&CONE_RESP_MAT_BRADFORD[0]);
+    }
+
+    MatrixOpData::MatrixArrayPtr rgb2xyz = xyz2rgb->inverse();
+
+    // Convert white point XYZ values to cone primary RGBs.
+    const MatrixOpData::Offsets src_RGB(xyz2rgb->inner(src_XYZ));
+    const MatrixOpData::Offsets dst_RGB(xyz2rgb->inner(dst_XYZ));
+    const double scaleFactor[4] { dst_RGB[0] / src_RGB[0], 
+                                  dst_RGB[1] / src_RGB[1],
+                                  dst_RGB[2] / src_RGB[2],
+                                  1. };
+
+    // Make a diagonal matrix with the scale factors.
+    MatrixOpData::MatrixArrayPtr scaleMat = std::make_shared<MatrixOpData::MatrixArray>();
+    scaleMat->setDoubleValue( 0, scaleFactor[0]);
+    scaleMat->setDoubleValue( 5, scaleFactor[1]);
+    scaleMat->setDoubleValue(10, scaleFactor[2]);
+    scaleMat->setDoubleValue(15, scaleFactor[3]);
+
+    // Compose into the adaptation matrix.
+    return rgb2xyz->inner(scaleMat->inner(xyz2rgb));
+}
+
+MatrixOpData::MatrixArrayPtr build_conversion_matrix(const Primaries & src_prims,
+                                                     const Primaries & dst_prims,
+                                                     AdaptationMethod method)
+{
+    static const MatrixOpData::Offsets ones(1., 1., 1., 0.);
+
+    // Calculate the primary conversion matrices.
+    MatrixOpData::MatrixArrayPtr rgb2xyz = rgb2xyz_from_xy(src_prims);
+    MatrixOpData::MatrixArrayPtr dst_rgb2xyz = rgb2xyz_from_xy(dst_prims);
+    MatrixOpData::MatrixArrayPtr xyz2rgb = dst_rgb2xyz->inverse();
+
+    // If the white points are equal, don't need to adapt.
+    if ( method == ADAPTATION_NONE ||
+        (src_prims.m_wht.m_xy[0] == dst_prims.m_wht.m_xy[0] &&
+         src_prims.m_wht.m_xy[1] == dst_prims.m_wht.m_xy[1]) )
+    {
+        return xyz2rgb->inner(rgb2xyz);
+    }
+
+    // Calculate src and dst white XYZ.
+    MatrixOpData::Offsets dst_whtxyz = dst_rgb2xyz->inner(ones);
+    MatrixOpData::Offsets src_whtxyz = rgb2xyz->inner(ones);
+
+    // Build the adaptation matrix (may be an identity).
+    MatrixOpData::MatrixArrayPtr vkmat = build_vonkries_adapt(src_whtxyz, dst_whtxyz, method);
+
+    // Compose into the conversion matrix.
+    return xyz2rgb->inner(vkmat->inner(rgb2xyz));
+}
+
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.h
+++ b/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.h
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#ifndef INCLUDED_OCIO_COLOR_MATRIX_HELPERS_H
+#define INCLUDED_OCIO_COLOR_MATRIX_HELPERS_H
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "ops/matrix/MatrixOpData.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+struct Chromaticities
+{
+    Chromaticities() = delete;
+
+    Chromaticities(double x, double y)
+    {
+        m_xy[0] = x;
+        m_xy[1] = y;
+    }
+
+    Chromaticities(const Chromaticities & xy)
+    {
+        m_xy[0] = xy.m_xy[0];
+        m_xy[1] = xy.m_xy[1];
+    }
+
+    Chromaticities & operator=(const Chromaticities & xy)
+    {
+        if (this == &xy) return *this;
+
+        m_xy[0] = xy.m_xy[0];
+        m_xy[1] = xy.m_xy[1];
+
+        return *this;
+    }
+
+    double m_xy[2] { 0., 0. };
+};
+
+struct Primaries
+{
+    Primaries() = delete;
+
+    Primaries(const Chromaticities & red, const Chromaticities & grn, const Chromaticities & blu,
+              const Chromaticities & wht)
+        :   m_red(red)
+        ,   m_grn(grn)
+        ,   m_blu(blu)
+        ,   m_wht(wht)
+    {}
+
+    Primaries(const Primaries & primaries)
+        :   m_red(primaries.m_red)
+        ,   m_grn(primaries.m_grn)
+        ,   m_blu(primaries.m_blu)
+        ,   m_wht(primaries.m_wht)
+    {}
+
+    Primaries & operator=(const Primaries & primaries)
+    {
+        if (this == &primaries) return *this;
+
+        m_red = primaries.m_red;
+        m_grn = primaries.m_grn;
+        m_blu = primaries.m_blu;
+        m_wht = primaries.m_wht;
+
+        return *this;
+    }
+
+    Chromaticities m_red; // CIE xy chromaticity coordinates for red primary.
+    Chromaticities m_grn; // CIE xy chromaticity coordinates for green primary.
+    Chromaticities m_blu; // CIE xy chromaticity coordinates for blue primary.
+    Chromaticities m_wht; // CIE xy chromaticities for white (or gray).
+};
+
+namespace CIE_XYZ_D65
+{
+extern const Primaries primaries;
+}
+
+namespace ACES_AP0
+{
+extern const Primaries primaries;
+}
+
+namespace ACES_AP1
+{
+extern const Primaries primaries;
+}
+
+namespace REC709
+{
+extern const Primaries primaries;
+}
+
+namespace P3_DCI
+{
+extern const Primaries primaries;
+}
+
+namespace P3_D65
+{
+extern const Primaries primaries;
+}
+
+
+// Calculate a matrix to convert arbitrary RGB primary tristimulus values
+// to CIE XYZ tristimulus values using the CIE xy chromaticity coordinates
+// of the RGB primaries and white.  The matrix is scaled to take RGB values
+// on [0,1] and produce XYZ values on [0,1].  Apply the matrix as follows:
+//        X = rgb2xyz[0][0] * R + rgb2xyz[0][1] * G + rgb2xyz[0][2] * B;
+//        Y = rgb2xyz[1][0] * R + rgb2xyz[1][1] * G + rgb2xyz[1][2] * B;
+//        Z = rgb2xyz[2][0] * R + rgb2xyz[2][1] * G + rgb2xyz[2][2] * B;
+
+MatrixOpData::MatrixArrayPtr rgb2xyz_from_xy(const Primaries & chromaticities);
+
+enum AdaptationMethod
+{
+    ADAPTATION_NONE = 0,
+    ADAPTATION_BRADFORD,
+    ADAPTATION_CAT02
+};
+
+// Build a von Kries type chromatic adaptation matrix from source white point src_XYZ to 
+// destination white point dst_XYZ, using the chosen cone primary matrix.
+
+MatrixOpData::MatrixArrayPtr build_vonkries_adapt(const MatrixOpData::Offsets & src_XYZ,
+                                                  const MatrixOpData::Offsets & dst_XYZ,
+                                                  AdaptationMethod method);
+
+// Build a conversion matrix from source primaries to destination primaries.
+
+MatrixOpData::MatrixArrayPtr build_conversion_matrix(const Primaries & src_prims,
+                                                     const Primaries & dst_prims,
+                                                     AdaptationMethod method);
+
+} // namespace OCIO_NAMESPACE
+
+#endif // INCLUDED_OCIO_COLOR_MATRIX_HELPERS_H

--- a/src/OpenColorIO/transforms/builtins/OpHelpers.cpp
+++ b/src/OpenColorIO/transforms/builtins/OpHelpers.cpp
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "OpenEXR/half.h"
+#include "ops/lut1d/Lut1DOp.h"
+#include "transforms/builtins/OpHelpers.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+double Interpolate1D(unsigned lutSize, const double * lutValues, double in)
+{
+    // The LUT values are organized that way:
+    // { in[0], out[0],
+    //   in[1], out[1],
+    //   ...
+    //   in[N], out[N] }
+    //
+    // where N is lutSize, and
+    // in[n] is lutValues[n * 2] & out[n] is lutValues[n * 2 + 1].
+
+    // Clamp if values are outside the domain of the LUT.
+    if (in < lutValues[0])
+    {
+        return lutValues[1];
+    }
+    else if (in >= lutValues[2 * (lutSize-1)])
+    {
+        return lutValues[2 * (lutSize-1) + 1];
+    }
+
+    for (unsigned idx = 1; idx < lutSize; ++idx)
+    {
+        if (in < lutValues[2 * idx])
+        {
+            const unsigned minIdx = 2 * (idx - 1);
+            const unsigned maxIdx = 2 * idx;
+
+            const double inCoeff
+                = (in - lutValues[minIdx]) / (lutValues[maxIdx] - lutValues[minIdx]);
+
+            return lutValues[minIdx + 1] * (1.0 - inCoeff) 
+                    + lutValues[maxIdx + 1] * inCoeff;
+        }
+    }
+
+    throw Exception("Invalid interpolation value.");
+}
+
+void CreateLut(OpRcPtrVec & ops, 
+               unsigned long lutDimension,
+               std::function<float(double)> lutValueGenerator)
+{
+    Lut1DOpDataRcPtr lut = std::make_shared<Lut1DOpData>(Lut1DOpData::LUT_STANDARD, lutDimension);
+    lut->setInterpolation(INTERP_LINEAR);
+    lut->setDirection(TRANSFORM_DIR_FORWARD);
+
+    Array & array = lut->getArray();
+    Array::Values & values = array.getValues();
+
+    for (unsigned long idx = 0; idx < lutDimension; ++idx)
+    {
+        values[idx * 3 + 0] = lutValueGenerator(double(idx) / (lutDimension - 1.));
+        values[idx * 3 + 1] = lutValueGenerator(double(idx) / (lutDimension - 1.));
+        values[idx * 3 + 2] = lutValueGenerator(double(idx) / (lutDimension - 1.));
+    }
+
+    CreateLut1DOp(ops, lut, TRANSFORM_DIR_FORWARD);
+}
+
+void CreateLut(OpRcPtrVec & ops,
+               unsigned long lutDimension,
+               std::function<void(const double *, double *)> lutValueGenerator)
+{
+    Lut1DOpDataRcPtr lut = std::make_shared<Lut1DOpData>(lutDimension);
+    lut->setInterpolation(INTERP_LINEAR);
+    lut->setDirection(TRANSFORM_DIR_FORWARD);
+
+    Array::Values & values = lut->getArray().getValues();
+
+    for (unsigned long idx = 0; idx < lutDimension; ++idx)
+    {
+        const double in[3]
+        {
+            double(idx) / (lutDimension - 1.),
+            double(idx) / (lutDimension - 1.),
+            double(idx) / (lutDimension - 1.)
+        };
+    
+        double out[3] {0., 0., 0.};
+
+        lutValueGenerator(in, out);
+
+        values[3 * idx + 0] = float(out[0]);
+        values[3 * idx + 1] = float(out[1]);
+        values[3 * idx + 2] = float(out[2]);
+    }
+
+    CreateLut1DOp(ops, lut, TRANSFORM_DIR_FORWARD);
+}
+
+void CreateHalfLut(OpRcPtrVec & ops, std::function<float(double)> lutValueGenerator)
+{
+    Lut1DOpDataRcPtr lut = std::make_shared<Lut1DOpData>(Lut1DOpData::LUT_INPUT_HALF_CODE, 65536);
+    lut->setInterpolation(INTERP_LINEAR);
+    lut->setDirection(TRANSFORM_DIR_FORWARD);
+    lut->setFileOutputBitDepth(BIT_DEPTH_F16);
+
+    Array & array = lut->getArray();
+    Array::Values & values = array.getValues();
+
+    const unsigned long lutDimension = array.getLength();
+    for (unsigned long idx = 0; idx < lutDimension; ++idx)
+    {
+        half halfValue;
+        halfValue.setBits((unsigned short)idx);
+
+        double value = static_cast<float>(halfValue);
+
+        if (halfValue.isNan())
+        {
+            value = 0.;
+        }
+        else if (halfValue.isInfinity())
+        {
+            value = halfValue.isNegative() ? -HALF_MAX : HALF_MAX;
+        }
+
+        values[idx * 3 + 0] = lutValueGenerator(value);
+        values[idx * 3 + 1] = lutValueGenerator(value);
+        values[idx * 3 + 2] = lutValueGenerator(value);
+    }
+
+    CreateLut1DOp(ops, lut, TRANSFORM_DIR_FORWARD);
+}
+
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/transforms/builtins/OpHelpers.h
+++ b/src/OpenColorIO/transforms/builtins/OpHelpers.h
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#ifndef INCLUDED_OCIO_TRANSFORM_HELPERS_H
+#define INCLUDED_OCIO_TRANSFORM_HELPERS_H
+
+
+#include <functional>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+
+namespace OCIO_NAMESPACE
+{
+
+// Linearly interpolate a single input value through a non-uniformly spaced LUT.
+// The lutValues are ordered as: [in0, out0, in1, out1, in2, out2, ...].
+// The lutSize is the number of in/out pairs, so there are 2*lutSize lutValues.
+double Interpolate1D(unsigned lutSize, const double * lutValues, double in);
+
+// Create a LUT 1D transform where values are the same for the three color components.
+// The input values are linearly spaced on [0,1].  The output values from the functor
+// should be nominally [0,1], although they may exceed that if needed.
+void CreateLut(OpRcPtrVec & ops,
+               unsigned long lutDimension,
+               std::function<float(double)> lutValueGenerator);
+
+// Create a LUT 1D transform where values may be different for the three color components.
+// The first argument is an array of RGB inputs to the functor, the second argument is for
+// the RGB outputs.
+void CreateLut(OpRcPtrVec & ops,
+               unsigned long lutDimension,
+               std::function<void(const double *, double *)> lutValueGenerator);
+
+// The input values to the functor are all possible values of a half-float.
+// However NaNs are mapped to 0 and +/-Inf is mapped to +/-HALF_MAX.
+void CreateHalfLut(OpRcPtrVec & ops,
+                   std::function<float(double)> lutValueGenerator);
+
+} // namespace OCIO_NAMESPACE
+
+
+#endif // INCLUDED_OCIO_TRANSFORM_HELPERS_H

--- a/src/OpenColorIO/transforms/builtins/PanasonicCameras.cpp
+++ b/src/OpenColorIO/transforms/builtins/PanasonicCameras.cpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <cmath>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "ops/matrix/MatrixOp.h"
+#include "ops/log/LogOp.h"
+#include "transforms/builtins/ACES.h"
+#include "transforms/builtins/BuiltinTransformRegistry.h"
+#include "transforms/builtins/ColorMatrixHelpers.h"
+#include "transforms/builtins/OpHelpers.h"
+#include "transforms/builtins/PanasonicCameras.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+namespace PANASONIC_VLOG_VGAMUT
+{
+static const Chromaticities red_xy(0.730,   0.280);
+static const Chromaticities grn_xy(0.165,   0.840);
+static const Chromaticities blu_xy(0.100,  -0.030);
+static const Chromaticities wht_xy(0.3127,  0.3290);
+
+const Primaries primaries(red_xy, grn_xy, blu_xy, wht_xy);
+}
+
+namespace PANASONIC_VLOG_VGAMUT_to_LINEAR
+{
+static constexpr double cut1 = 0.01;
+static constexpr double b    = 0.00873;
+static constexpr double c    = 0.241514;
+static constexpr double d    = 0.598206;
+
+static constexpr double linSideSlope  = 1.;
+static constexpr double linSideOffset = b;
+static constexpr double logSideSlope  = c;
+static constexpr double logSideOffset = d;
+static constexpr double linSideBreak  = cut1;
+static constexpr double base          = 10.;
+
+static const LogOpData::Params 
+    params { logSideSlope, logSideOffset, linSideSlope, linSideOffset, linSideBreak };
+
+static const LogOpData log(base, params, params, params, TRANSFORM_DIR_INVERSE);
+}
+
+
+namespace CAMERA
+{
+
+namespace PANASONIC
+{
+
+void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
+{
+    {
+        auto PANASONIC_VLOG_VGAMUT_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)
+        {
+            LogOpDataRcPtr log = PANASONIC_VLOG_VGAMUT_to_LINEAR::log.clone();
+            CreateLogOp(ops, log, TRANSFORM_DIR_FORWARD);
+
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix(PANASONIC_VLOG_VGAMUT::primaries, ACES_AP0::primaries, ADAPTATION_BRADFORD);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("PANASONIC_VLOG-VGAMUT_to_ACES2065-1",
+                            "Convert Panasonic Varicam V-Log V-Gamut to ACES2065-1",
+                            PANASONIC_VLOG_VGAMUT_to_ACES2065_1_Functor);
+    }
+}
+
+} // namespace PANASONIC
+
+} // namespace CAMERA
+
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/transforms/builtins/PanasonicCameras.h
+++ b/src/OpenColorIO/transforms/builtins/PanasonicCameras.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#ifndef INCLUDED_OCIO_PANASONIC_CAMERAS_H
+#define INCLUDED_OCIO_PANASONIC_CAMERAS_H
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+
+namespace OCIO_NAMESPACE
+{
+
+class BuiltinTransformRegistryImpl;
+
+namespace CAMERA
+{
+
+namespace PANASONIC
+{
+
+void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept;
+
+} // namespace PANASONIC
+
+} // namespace CAMERA
+
+} // namespace OCIO_NAMESPACE
+
+#endif // INCLUDED_OCIO_PANASONIC_CAMERAS_H

--- a/src/OpenColorIO/transforms/builtins/RedCameras.cpp
+++ b/src/OpenColorIO/transforms/builtins/RedCameras.cpp
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <cmath>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "ops/log/LogOp.h"
+#include "ops/matrix/MatrixOp.h"
+#include "transforms/builtins/ACES.h"
+#include "transforms/builtins/BuiltinTransformRegistry.h"
+#include "transforms/builtins/ColorMatrixHelpers.h"
+#include "transforms/builtins/RedCameras.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+namespace RED_WIDE_GAMUT_RGB
+{
+static const Chromaticities red_xy(0.780308,  0.304253);
+static const Chromaticities grn_xy(0.121595,  1.493994);
+static const Chromaticities blu_xy(0.095612, -0.084589);
+static const Chromaticities wht_xy(0.3127,    0.3290);
+
+const Primaries primaries(red_xy, grn_xy, blu_xy, wht_xy);
+}
+
+namespace RED_REDLOGFILM_RWG_to_LINEAR
+{
+static constexpr double refWhite    = 685. / 1023.;
+static constexpr double refBlack    = 95. / 1023.;
+static constexpr double range       = 0.002 * 1023.;
+static constexpr double gamma       = 0.6;
+static constexpr double highlight   = 1.;
+static constexpr double shadow      = 0.;
+static constexpr double multiFactor = range / gamma;
+static const     double gain        = (highlight - shadow)
+                                        / (1. - std::pow(10., multiFactor * (refBlack - refWhite)));
+static const     double offset      = gain - (highlight - shadow);
+
+static constexpr double logSideSlope  = 1. / multiFactor;
+static constexpr double logSideOffset = refWhite;
+static const     double linSideSlope  = 1. / gain;
+static const     double linSideOffset = (offset - shadow) / gain;
+static constexpr double base          = 10.;
+
+static const LogOpData::Params 
+    params { logSideSlope, logSideOffset, linSideSlope, linSideOffset };
+
+static const LogOpData log(base, params, params, params, TRANSFORM_DIR_INVERSE);
+}
+
+namespace RED_LOG3G10_RWG_to_LINEAR
+{
+static constexpr double linSideSlope  = 155.975327;
+static constexpr double linSideOffset = 0.01 * linSideSlope + 1.0;
+static constexpr double logSideSlope  = 0.224282;
+static constexpr double logSideOffset = 0.0;
+static constexpr double linSideBreak  = -0.01;
+static constexpr double base          = 10.;
+
+static const LogOpData::Params 
+    params { logSideSlope, logSideOffset, linSideSlope, linSideOffset, linSideBreak };
+
+static const LogOpData log(base, params, params, params, TRANSFORM_DIR_INVERSE);
+}
+
+
+namespace CAMERA
+{
+
+namespace RED
+{
+
+void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
+{
+    {
+        auto RED_REDLOGFILM_RWG_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)
+        {
+            LogOpDataRcPtr log = RED_REDLOGFILM_RWG_to_LINEAR::log.clone();
+            CreateLogOp(ops, log, TRANSFORM_DIR_FORWARD);
+
+            MatrixOpData::MatrixArrayPtr
+                rwg = build_conversion_matrix(RED_WIDE_GAMUT_RGB::primaries,
+                                              ACES_AP0::primaries,
+                                              ADAPTATION_BRADFORD); 
+            CreateMatrixOp(ops, rwg, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("RED_REDLOGFILM-RWG_to_ACES2065-1",
+                            "Convert RED LogFilm RED Wide Gamut to ACES2065-1",
+                            RED_REDLOGFILM_RWG_to_ACES2065_1_Functor);
+    }
+    {
+        auto RED_LOG3G10_RWG_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)
+        {
+            LogOpDataRcPtr log = RED_LOG3G10_RWG_to_LINEAR::log.clone();
+            CreateLogOp(ops, log, TRANSFORM_DIR_FORWARD);
+
+            MatrixOpData::MatrixArrayPtr
+                rwg = build_conversion_matrix(RED_WIDE_GAMUT_RGB::primaries,
+                                              ACES_AP0::primaries,
+                                              ADAPTATION_BRADFORD); 
+            CreateMatrixOp(ops, rwg, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("RED_LOG3G10-RWG_to_ACES2065-1", 
+                            "Convert RED Log3G10 RED Wide Gamut to ACES2065-1",
+                            RED_LOG3G10_RWG_to_ACES2065_1_Functor);
+    }
+}
+
+} // namespace RED
+
+} // namespace CAMERA
+
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/transforms/builtins/RedCameras.h
+++ b/src/OpenColorIO/transforms/builtins/RedCameras.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#ifndef INCLUDED_OCIO_RED_CAMERAS_H
+#define INCLUDED_OCIO_RED_CAMERAS_H
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+
+namespace OCIO_NAMESPACE
+{
+
+class BuiltinTransformRegistryImpl;
+
+namespace CAMERA
+{
+
+namespace RED
+{
+
+void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept;
+
+} // namespace RED
+
+} // namespace CAMERA
+
+} // namespace OCIO_NAMESPACE
+
+#endif // INCLUDED_OCIO_RED_CAMERAS_H

--- a/src/OpenColorIO/transforms/builtins/SonyCameras.cpp
+++ b/src/OpenColorIO/transforms/builtins/SonyCameras.cpp
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <cmath>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "ops/log/LogOp.h"
+#include "ops/matrix/MatrixOp.h"
+#include "transforms/builtins/ACES.h"
+#include "transforms/builtins/BuiltinTransformRegistry.h"
+#include "transforms/builtins/OpHelpers.h"
+#include "transforms/builtins/SonyCameras.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+namespace SONY_SGAMUT3
+{
+static const Chromaticities red_xy(0.730,  0.280);
+static const Chromaticities grn_xy(0.140,  0.855);
+static const Chromaticities blu_xy(0.100, -0.050);
+static const Chromaticities wht_xy(0.3127, 0.3290);
+
+const Primaries primaries(red_xy, grn_xy, blu_xy, wht_xy);
+}
+
+namespace SONY_SGAMUT3_CINE
+{
+static const Chromaticities red_xy(0.766,  0.275);
+static const Chromaticities grn_xy(0.225,  0.800);
+static const Chromaticities blu_xy(0.089, -0.087);
+static const Chromaticities wht_xy(0.3127, 0.3290);
+
+const Primaries primaries(red_xy, grn_xy, blu_xy, wht_xy);
+}
+
+
+namespace SONY_SLOG3_to_LINEAR
+{
+static constexpr double linSideSlope  = 1. / (0.18 + 0.01);
+static constexpr double linSideOffset = 0.01 / (0.18 + 0.01);
+static constexpr double logSideSlope  = 261.5 / 1023.;
+static constexpr double logSideOffset = 420. / 1023.;
+static constexpr double linSideBreak  = 0.01125000;
+static constexpr double linearSlope   = ( (171.2102946929 - 95.) / 0.01125000) / 1023.;
+static constexpr double base          = 10.;
+
+static const LogOpData::Params 
+    params { logSideSlope, logSideOffset, linSideSlope, linSideOffset, linSideBreak, linearSlope };
+
+static const LogOpData log(base, params, params, params, TRANSFORM_DIR_INVERSE);
+}
+
+
+namespace CAMERA
+{
+
+namespace SONY
+{
+
+void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
+{
+    {
+        auto SONY_SLOG3_SGAMUT3_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)
+        {
+            LogOpDataRcPtr log = SONY_SLOG3_to_LINEAR::log.clone();
+            CreateLogOp(ops, log, TRANSFORM_DIR_FORWARD);
+
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix(SONY_SGAMUT3::primaries, ACES_AP0::primaries, ADAPTATION_CAT02);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("SONY_SLOG3-SGAMUT3_to_ACES2065-1",
+                            "Convert Sony S-Log3 S-Gamut3 to ACES2065-1",
+                            SONY_SLOG3_SGAMUT3_to_ACES2065_1_Functor);
+    }
+
+    {
+        auto SONY_SLOG3_SGAMUT3_CINE_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)
+        {
+            LogOpDataRcPtr log = SONY_SLOG3_to_LINEAR::log.clone();
+            CreateLogOp(ops, log, TRANSFORM_DIR_FORWARD);
+
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix(SONY_SGAMUT3_CINE::primaries, ACES_AP0::primaries, ADAPTATION_CAT02);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("SONY_SLOG3-SGAMUT3.CINE_to_ACES2065-1", 
+                            "Convert Sony S-Log3 S-Gamut3.Cine to ACES2065-1",
+                            SONY_SLOG3_SGAMUT3_CINE_to_ACES2065_1_Functor);
+    }
+}
+
+} // namespace SONY
+
+} // namespace CAMERA
+
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/transforms/builtins/SonyCameras.h
+++ b/src/OpenColorIO/transforms/builtins/SonyCameras.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#ifndef INCLUDED_OCIO_SONY_CAMERAS_H
+#define INCLUDED_OCIO_SONY_CAMERAS_H
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+
+namespace OCIO_NAMESPACE
+{
+
+class BuiltinTransformRegistryImpl;
+
+namespace CAMERA
+{
+
+namespace SONY
+{
+
+void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept;
+
+} // namespace SONY
+
+} // namespace CAMERA
+
+} // namespace OCIO_NAMESPACE
+
+#endif // INCLUDED_OCIO_SONY_CAMERAS_H

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -5,6 +5,7 @@ if(OCIO_BUILD_APPS)
 	add_subdirectory(ociobakelut)
 	add_subdirectory(ociocheck)
 	add_subdirectory(ociochecklut)
+	add_subdirectory(ociomakeclf)
 	add_subdirectory(ociowrite)
 
 	if(TARGET OpenImageIO)

--- a/src/apps/ociomakeclf/CMakeLists.txt
+++ b/src/apps/ociomakeclf/CMakeLists.txt
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+set(SOURCES
+    main.cpp
+)
+
+add_executable(ociomakeclf ${SOURCES})
+
+if(NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(ociomakeclf
+        PRIVATE
+        OpenColorIO_SKIP_IMPORTS
+    )
+endif()
+
+if(MSVC)
+    set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /wd4996")
+endif()
+
+set_target_properties(ociomakeclf PROPERTIES 
+    COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
+
+target_link_libraries(ociomakeclf 
+    PRIVATE 
+        apputils
+        OpenColorIO
+        utils::strings
+)
+
+install(TARGETS ociomakeclf
+    RUNTIME DESTINATION bin
+)

--- a/src/apps/ociomakeclf/main.cpp
+++ b/src/apps/ociomakeclf/main.cpp
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include <iostream>
 #include <fstream>
+#include <string.h>
 
 #include <OpenColorIO/OpenColorIO.h>
 namespace OCIO = OCIO_NAMESPACE;

--- a/src/apps/ociomakeclf/main.cpp
+++ b/src/apps/ociomakeclf/main.cpp
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <cstdio>
+#include <iostream>
+#include <fstream>
+
+#include <OpenColorIO/OpenColorIO.h>
+namespace OCIO = OCIO_NAMESPACE;
+
+#include "apputils/argparse.h"
+#include "utils/StringUtils.h"
+
+
+// Array of non OpenColorIO arguments.
+static std::vector<std::string> args;
+
+// Fill 'args' array with OpenColorIO arguments.
+static int parse_end_args(int argc, const char * argv[])
+{
+    while ( argc > 0)
+    {
+        args.push_back(argv[0]);
+        argc--;
+        argv++;
+    }
+
+    return 0;
+}
+
+void CreateOutputLutFile(const std::string & outLutFilepath, OCIO::ConstGroupTransformRcPtr transform)
+{
+    // Get the processor.
+
+    // Create an empty config but with the latest version.
+    OCIO::ConfigRcPtr config = OCIO::Config::Create();
+    config->upgradeToLatestVersion();
+
+    OCIO::ConstProcessorRcPtr processor = config->getProcessor(transform);
+
+    // CLF file format does not support inverse 1D LUTs, optimize the processor
+    // to replace inverse 1D LUTs by 'fast forward' 1D LUTs. 
+    OCIO::ConstProcessorRcPtr optProcessor
+        = processor->getOptimizedProcessor(OCIO::BIT_DEPTH_F32, 
+                                           OCIO::BIT_DEPTH_F32,
+                                           OCIO::OPTIMIZATION_LUT_INV_FAST);
+
+    // Create the CLF file.
+
+    std::ofstream outfs(outLutFilepath, std::ios::out | std::ios::trunc);
+    if (outfs.good())
+    {
+        try
+        {
+            optProcessor->write("Academy/ASC Common LUT Format", outfs);
+        }
+        catch (OCIO::Exception)
+        {
+            outfs.close();
+            remove(outLutFilepath.c_str());
+            throw;
+        }
+
+        outfs.close();
+    }
+    else
+    {
+        std::ostringstream oss;
+        oss << "Could not open the file '"
+            << outLutFilepath
+            << "'."
+            << std::endl;
+        throw OCIO::Exception(oss.str().c_str());
+    }
+}
+
+int main(int argc, const char ** argv)
+{
+    bool help = false, verbose = false, listCSCColorSpaces = false;
+    std::string cscColorSpace;
+
+    ArgParse ap;
+    ap.options("ociomakeclf -- Convert a LUT into CLF format and optionally add conversions from/to ACES2065-1 to make it an LMT.\n"
+               "               If the csc argument is used, the CLF will contain the transforms:\n"
+               "               [ACES2065-1 to CSC space] [the LUT] [CSC space to ACES2065-1].\n\n"
+               "usage: ociomakeclf inLutFilepath outLutFilepath --csc cscColorSpace\n"
+               "  or   ociomakeclf inLutFilepath outLutFilepath\n"
+               "  or   ociomakeclf --list\n",
+               "%*", parse_end_args, "",
+               "<SEPARATOR>", "Options:",
+               "--help",      &help,               "Print help message",
+               "--verbose",   &verbose,            "Display general information",
+               "--list",      &listCSCColorSpaces, "List of the supported CSC color spaces",
+               "--csc %s",    &cscColorSpace,      "The color space that the input LUT expects and produces",
+               nullptr);
+
+    if (ap.parse(argc, argv) < 0)
+    {
+        std::cerr << std::endl << ap.geterror() << std::endl << std::endl;
+        ap.usage();
+        return 1;
+    }
+
+    if (help)
+    {
+        ap.usage();
+        return 0;
+    }
+
+    // The LMT must accept and produce ACES2065-1 so look for all built-in transforms that produce 
+    // that (based on the naming conventions).
+    static constexpr char BuiltinSuffix[] = "_to_ACES2065-1";
+
+    if (listCSCColorSpaces)
+    {
+        OCIO::ConstBuiltinTransformRegistryRcPtr registry = OCIO::BuiltinTransformRegistry::Get();
+
+        std::cout << "The list of supported color spaces converting to ACES2065-1, is:";
+        for (size_t idx = 0; idx < registry->getNumBuiltins(); ++idx)
+        {
+            std::string cscName = registry->getBuiltinStyle(idx);
+            if (StringUtils::EndsWith(cscName, BuiltinSuffix))
+            {
+                cscName.resize(cscName.size() - strlen(BuiltinSuffix));
+                std::cout << std::endl << "\t" << cscName;
+            }
+        }
+        std::cout << std::endl << std::endl;
+
+        return 0;
+    }
+
+    if (args.size() != 2)
+    {
+        std::cerr << "ERROR: Expecting 2 arguments, found " << args.size() << "." << std::endl;
+        ap.usage();
+        return 1;
+    }
+    
+    const std::string inLutFilepath   = args[0].c_str();
+    const std::string outLutFilepath  = args[1].c_str();
+
+    const std::string originalCSC = cscColorSpace;
+
+    if (!cscColorSpace.empty())
+    {
+        cscColorSpace += BuiltinSuffix;
+    
+        OCIO::ConstBuiltinTransformRegistryRcPtr registry = OCIO::BuiltinTransformRegistry::Get();
+
+        bool cscFound = false;
+        for (size_t idx = 0; idx < registry->getNumBuiltins() && !cscFound; ++idx)
+        {
+            if (StringUtils::Compare(cscColorSpace.c_str(), registry->getBuiltinStyle(idx)))
+            {
+                cscFound = true;
+
+                // Save the builtin transform name with the right cases.
+                cscColorSpace = registry->getBuiltinStyle(idx);
+            }
+        }
+
+        if (!cscFound)
+        {
+            std::cerr << "ERROR: The LUT color space name '"
+                      << originalCSC
+                      << "' is not supported."
+                      << std::endl;
+            return 1;
+        }
+    }
+
+    if (outLutFilepath.empty())
+    {
+        std::cerr << "ERROR: The output file path is missing." << std::endl;
+        return 1;
+    }
+    else
+    {
+        const std::string filepath = StringUtils::Lower(outLutFilepath);
+        if (!StringUtils::EndsWith(filepath, ".clf"))
+        {
+            std::cerr << "ERROR: The output LUT file path '"
+                      << outLutFilepath
+                      << "' must have a .clf extension."
+                      << std::endl;
+            return 1;
+        }
+    }
+
+    if (verbose)
+    {
+        std::cout << "OCIO Version: " << OCIO::GetVersion() << std::endl;
+    }
+
+    try
+    {
+        if (verbose)
+        {
+            std::cout << "Building the transformation." << std::endl;
+        }
+
+        OCIO::GroupTransformRcPtr grp = OCIO::GroupTransform::Create();
+        grp->setDirection(OCIO::TRANSFORM_DIR_FORWARD);
+
+        if (!cscColorSpace.empty())
+        {
+            std::string description;
+            description += "ACES LMT transform built from a look LUT expecting color space: ";
+            description += originalCSC;
+
+            grp->getFormatMetadata().addChildElement(OCIO::METADATA_DESCRIPTION, description.c_str());
+        }
+
+        std::string description;
+        description += "Original LUT name: ";
+        description += inLutFilepath;
+        grp->getFormatMetadata().addChildElement(OCIO::METADATA_DESCRIPTION, description.c_str());
+
+        if (!cscColorSpace.empty())
+        {
+            // TODO: It should overwrite existing input and output descriptors if any.
+            grp->getFormatMetadata().addChildElement(OCIO::METADATA_INPUT_DESCRIPTOR,  "ACES2065-1");
+            grp->getFormatMetadata().addChildElement(OCIO::METADATA_OUTPUT_DESCRIPTOR, "ACES2065-1");
+        }
+
+        if (!cscColorSpace.empty())
+        {
+            // Create the color transformation from ACES2065-1 to the CSC color space.
+            OCIO::BuiltinTransformRcPtr inBuiltin = OCIO::BuiltinTransform::Create();
+            inBuiltin->setStyle(cscColorSpace.c_str());
+            inBuiltin->setDirection(OCIO::TRANSFORM_DIR_INVERSE);
+            grp->appendTransform(inBuiltin);
+        }
+
+        // Create the file transform for the input LUT file.
+        OCIO::FileTransformRcPtr file = OCIO::FileTransform::Create();
+        file->setSrc(inLutFilepath.c_str());
+        file->setDirection(OCIO::TRANSFORM_DIR_FORWARD);
+        file->setInterpolation(OCIO::INTERP_BEST);
+        grp->appendTransform(file);
+
+        if (!cscColorSpace.empty())
+        {
+            // Create the color transformation from the CSC color space to ACES2065-1.
+            OCIO::BuiltinTransformRcPtr outBuiltin = OCIO::BuiltinTransform::Create();
+            outBuiltin->setStyle(cscColorSpace.c_str());
+            outBuiltin->setDirection(OCIO::TRANSFORM_DIR_FORWARD);
+            grp->appendTransform(outBuiltin);
+        }
+
+        if (verbose)
+        {
+            std::cout << "Creating the CLF lut file." << std::endl;
+        }
+
+        // Create the CLF file.
+        CreateOutputLutFile(outLutFilepath, grp);
+    }
+    catch (OCIO::Exception & exception)
+    {
+        std::cerr << "ERROR: " << exception.what() << std::endl;
+        return 1;
+    }
+    catch (...)
+    {
+        std::cerr << "ERROR: Unknown error encountered." << std::endl;
+        return 1;
+    }
+
+    return 0; // Success.
+}

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -32,6 +32,8 @@ set(SOURCES
 	PyDynamicProperty.cpp
 	PyTransform.cpp
 	PyAllocationTransform.cpp
+	PyBuiltinTransform.cpp
+	PyBuiltinTransformRegistry.cpp
 	PyCDLTransform.cpp
 	PyColorSpaceTransform.cpp
 	PyDisplayTransform.cpp

--- a/src/bindings/python/PyBuiltinTransform.cpp
+++ b/src/bindings/python/PyBuiltinTransform.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#include "PyTransform.h"
+
+namespace OCIO_NAMESPACE
+{
+
+void bindPyBuiltinTransform(py::module & m)
+{
+    py::class_<BuiltinTransform, 
+               BuiltinTransformRcPtr /* holder */, 
+               Transform /* base */>(m, "BuiltinTransform")
+        .def(py::init(&BuiltinTransform::Create))
+
+        .def("setStyle",       &BuiltinTransform::setStyle, "style"_a)
+        .def("getStyle",       &BuiltinTransform::getStyle)
+        .def("getDescription", &BuiltinTransform::getDescription);
+}
+
+} // namespace OCIO_NAMESPACE

--- a/src/bindings/python/PyBuiltinTransformRegistry.cpp
+++ b/src/bindings/python/PyBuiltinTransformRegistry.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#include "PyOpenColorIO.h"
+#include "PyUtils.h"
+
+namespace OCIO_NAMESPACE
+{
+
+void bindPyBuiltinTransformRegistry(py::module & m)
+{
+    py::class_<BuiltinTransformRegistry, BuiltinTransformRegistryRcPtr>(m, "BuiltinTransformRegistry")
+        .def(py::init([]() { return BuiltinTransformRegistry::Get(); }))
+
+        .def("getNumBuiltins", &BuiltinTransformRegistry::getNumBuiltins)
+        .def("getBuiltinStyle", &BuiltinTransformRegistry::getBuiltinStyle)
+        .def("getBuiltinDescription", &BuiltinTransformRegistry::getBuiltinDescription);
+}
+
+} // namespace OCIO_NAMESPACE

--- a/src/bindings/python/PyBuiltinTransformRegistry.cpp
+++ b/src/bindings/python/PyBuiltinTransformRegistry.cpp
@@ -9,12 +9,37 @@ namespace OCIO_NAMESPACE
 
 void bindPyBuiltinTransformRegistry(py::module & m)
 {
-    py::class_<BuiltinTransformRegistry, BuiltinTransformRegistryRcPtr>(m, "BuiltinTransformRegistry")
-        .def(py::init([]() { return BuiltinTransformRegistry::Get(); }))
+    // Wrapper to preserve the BuiltinTransformRegistry singleton.
+    class Wrapper
+    {
+    public:
+        Wrapper() = default;
+        Wrapper(const Wrapper &) = delete;
+        Wrapper & operator=(const Wrapper &) = delete;
+        ~Wrapper() = default;
 
-        .def("getNumBuiltins", &BuiltinTransformRegistry::getNumBuiltins)
-        .def("getBuiltinStyle", &BuiltinTransformRegistry::getBuiltinStyle)
-        .def("getBuiltinDescription", &BuiltinTransformRegistry::getBuiltinDescription);
+        size_t getNumBuiltins() const noexcept
+        {
+        	return BuiltinTransformRegistry::Get()->getNumBuiltins();
+        }
+
+        const char * getBuiltinStyle(size_t idx) const
+        {
+        	return BuiltinTransformRegistry::Get()->getBuiltinStyle(idx);
+        }
+
+        const char * getBuiltinDescription(size_t idx) const
+        {
+        	return BuiltinTransformRegistry::Get()->getBuiltinDescription(idx);
+        }
+    };
+
+    py::class_<Wrapper>(m, "BuiltinTransformRegistry")
+        .def(py::init<>())
+
+        .def("getNumBuiltins",        &Wrapper::getNumBuiltins)
+        .def("getBuiltinStyle",       &Wrapper::getBuiltinStyle)
+        .def("getBuiltinDescription", &Wrapper::getBuiltinDescription);
 }
 
 } // namespace OCIO_NAMESPACE

--- a/src/bindings/python/PyTransform.cpp
+++ b/src/bindings/python/PyTransform.cpp
@@ -15,11 +15,13 @@ void bindPyTransform(py::module & m)
 
     defStr(cls);
 
+    bindPyBuiltinTransformRegistry(m);
     bindPyFormatMetadata(m);
     bindPyDynamicProperty(m);
 
     // Subclasses
     bindPyAllocationTransform(m);
+    bindPyBuiltinTransform(m);
     bindPyCDLTransform(m);
     bindPyColorSpaceTransform(m);
     bindPyDisplayTransform(m);

--- a/src/bindings/python/PyTransform.h
+++ b/src/bindings/python/PyTransform.h
@@ -12,11 +12,13 @@
 namespace OCIO_NAMESPACE
 {
 
+void bindPyBuiltinTransformRegistry(py::module & m);
 void bindPyFormatMetadata(py::module & m);
 void bindPyDynamicProperty(py::module & m);
 
 // Subclasses
 void bindPyAllocationTransform(py::module & m);
+void bindPyBuiltinTransform(py::module & m);
 void bindPyCDLTransform(py::module & m);
 void bindPyColorSpaceTransform(py::module & m);
 void bindPyDisplayTransform(py::module & m);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,8 @@
 add_subdirectory(data)
 
 if(OCIO_BUILD_TESTS)
+    # Test order is from low-level (i.e. no dependencies)
+    # to high-level layers.
     add_subdirectory(testutils)
     add_subdirectory(utils)
 	add_subdirectory(cpu)

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -41,6 +41,12 @@ function(add_ocio_test NAME SOURCES PRIVATE_INCLUDES)
 				USE_SSE
 		)
 	endif(OCIO_USE_SSE)
+	if(OCIO_ADD_EXTRA_BUILTINS)
+		target_compile_definitions(${TEST_BINARY}
+			PRIVATE
+				ADD_EXTRA_BUILTINS
+		)
+	endif(OCIO_ADD_EXTRA_BUILTINS)
 	if(WIN32)
 		# A windows application linking to eXpat static libraries must
 		# have the global macro XML_STATIC defined
@@ -87,8 +93,23 @@ set(SOURCES
 	ops/range/RangeOpGPU.cpp
 	ScanlineHelper.cpp
 	Transform.cpp
+	transforms/builtins/ACES.cpp
+	transforms/builtins/ColorMatrixHelpers.cpp
+	transforms/builtins/OpHelpers.cpp
 	transforms/LookTransform.cpp
 )
+
+if(OCIO_ADD_EXTRA_BUILTINS)
+	set(SOURCES_BUILTINS
+		transforms/builtins/ArriCameras.cpp
+		transforms/builtins/CanonCameras.cpp
+		transforms/builtins/PanasonicCameras.cpp
+		transforms/builtins/RedCameras.cpp
+		transforms/builtins/SonyCameras.cpp
+	)
+
+	list(INSERT SOURCES 0 ${SOURCES_BUILTINS})
+endif()
 
 set(TESTS
 	Baker_tests.cpp
@@ -169,6 +190,8 @@ set(TESTS
 	Platform_tests.cpp
 	Processor_tests.cpp
 	SSE_tests.cpp
+	transforms/builtins/BuiltinTransformRegistry_tests.cpp
+	transforms/BuiltinTransform_tests.cpp
 	transforms/FileTransform_tests.cpp
 	transforms/FixedFunctionTransform_tests.cpp
 	transforms/RangeTransform_tests.cpp

--- a/tests/cpu/MathUtils_tests.cpp
+++ b/tests/cpu/MathUtils_tests.cpp
@@ -25,26 +25,13 @@ OCIO_ADD_TEST(MathUtils, is_scalar_equal_to_zero)
     OCIO_CHECK_EQUAL(OCIO::IsScalarEqualToZero(0.0f), true);
     OCIO_CHECK_EQUAL(OCIO::IsScalarEqualToZero(-0.0f), true);
 
-
-    struct Guard
-    {
-        Guard()  { OCIO::PrintValues = false; }
-        ~Guard() { OCIO::PrintValues = false; }
-    } guard;
-
-    if (OCIO::PrintValues) std::cout << "\n" << __FUNCTION__ << "(" << __LINE__ << ")\n";
     OCIO_CHECK_EQUAL(OCIO::IsScalarEqualToZero(-1.072883670794056e-09f), false);
-    if (OCIO::PrintValues) std::cout << "\n" << __FUNCTION__ << "(" << __LINE__ << ")\n";
     OCIO_CHECK_EQUAL(OCIO::IsScalarEqualToZero(1.072883670794056e-09f), false);
 
-    if (OCIO::PrintValues) std::cout << "\n" << __FUNCTION__ << "(" << __LINE__ << ")\n";
     OCIO_CHECK_EQUAL(OCIO::IsScalarEqualToZero(-1.072883670794056e-03f), false);
-    if (OCIO::PrintValues) std::cout << "\n" << __FUNCTION__ << "(" << __LINE__ << ")\n";
     OCIO_CHECK_EQUAL(OCIO::IsScalarEqualToZero(1.072883670794056e-03f), false);
 
-    if (OCIO::PrintValues) std::cout << "\n" << __FUNCTION__ << "(" << __LINE__ << ")\n";
     OCIO_CHECK_EQUAL(OCIO::IsScalarEqualToZero(-1.072883670794056e-01f), false);
-    if (OCIO::PrintValues) std::cout << "\n" << __FUNCTION__ << "(" << __LINE__ << ")\n";
     OCIO_CHECK_EQUAL(OCIO::IsScalarEqualToZero(1.072883670794056e-01f), false);
 }
 

--- a/tests/cpu/MathUtils_tests.cpp
+++ b/tests/cpu/MathUtils_tests.cpp
@@ -28,7 +28,7 @@ OCIO_ADD_TEST(MathUtils, is_scalar_equal_to_zero)
 
     struct Guard
     {
-        Guard()  { OCIO::PrintValues = true; }
+        Guard()  { OCIO::PrintValues = false; }
         ~Guard() { OCIO::PrintValues = false; }
     } guard;
 

--- a/tests/cpu/MathUtils_tests.cpp
+++ b/tests/cpu/MathUtils_tests.cpp
@@ -25,13 +25,26 @@ OCIO_ADD_TEST(MathUtils, is_scalar_equal_to_zero)
     OCIO_CHECK_EQUAL(OCIO::IsScalarEqualToZero(0.0f), true);
     OCIO_CHECK_EQUAL(OCIO::IsScalarEqualToZero(-0.0f), true);
 
+
+    struct Guard
+    {
+        Guard()  { OCIO::PrintValues = true; }
+        ~Guard() { OCIO::PrintValues = false; }
+    } guard;
+
+    if (OCIO::PrintValues) std::cout << "\n" << __FUNCTION__ << "(" << __LINE__ << ")\n";
     OCIO_CHECK_EQUAL(OCIO::IsScalarEqualToZero(-1.072883670794056e-09f), false);
+    if (OCIO::PrintValues) std::cout << "\n" << __FUNCTION__ << "(" << __LINE__ << ")\n";
     OCIO_CHECK_EQUAL(OCIO::IsScalarEqualToZero(1.072883670794056e-09f), false);
 
+    if (OCIO::PrintValues) std::cout << "\n" << __FUNCTION__ << "(" << __LINE__ << ")\n";
     OCIO_CHECK_EQUAL(OCIO::IsScalarEqualToZero(-1.072883670794056e-03f), false);
+    if (OCIO::PrintValues) std::cout << "\n" << __FUNCTION__ << "(" << __LINE__ << ")\n";
     OCIO_CHECK_EQUAL(OCIO::IsScalarEqualToZero(1.072883670794056e-03f), false);
 
+    if (OCIO::PrintValues) std::cout << "\n" << __FUNCTION__ << "(" << __LINE__ << ")\n";
     OCIO_CHECK_EQUAL(OCIO::IsScalarEqualToZero(-1.072883670794056e-01f), false);
+    if (OCIO::PrintValues) std::cout << "\n" << __FUNCTION__ << "(" << __LINE__ << ")\n";
     OCIO_CHECK_EQUAL(OCIO::IsScalarEqualToZero(1.072883670794056e-01f), false);
 }
 

--- a/tests/cpu/UnitTestLogUtils.h
+++ b/tests/cpu/UnitTestLogUtils.h
@@ -17,7 +17,7 @@ public:
     LogGuard();
     LogGuard(const LogGuard &) = delete;
     LogGuard & operator=(const LogGuard &) = delete;
-    virtual ~LogGuard();
+    ~LogGuard();
 
     // Return the output message or null.
     const std::string & output() const;
@@ -34,7 +34,7 @@ class MuteLogging : public LogGuard
 {
 public:
     MuteLogging();
-    ~MuteLogging() = default;
+    virtual ~MuteLogging() = default;
 };
 
 } // namespace OCIO_NAMESPACE

--- a/tests/cpu/UnitTestUtils.h
+++ b/tests/cpu/UnitTestUtils.h
@@ -76,7 +76,7 @@ inline bool EqualWithSafeRelError(T value,
     // If value and expected are infinity, return true.
     if (value == expected) return true;
     if (IsNan(value) && IsNan(expected)) return true;
-    const float div = (expected > 0) ?
+    const T div = (expected > 0) ?
         ((expected < minExpected) ? minExpected : expected) :
         ((-expected < minExpected) ? minExpected : -expected);
 

--- a/tests/cpu/fileformats/FileFormatCTF_tests.cpp
+++ b/tests/cpu/fileformats/FileFormatCTF_tests.cpp
@@ -4077,7 +4077,7 @@ OCIO_ADD_TEST(CTFTransform, matrix_offset_alpha_ctf)
     // Alpha not handled by CLF.
     OCIO_CHECK_THROW_WHAT(processorGroup->write(OCIO::FILEFORMAT_CLF, outputTransform),
                           OCIO::Exception, 
-                          "Matrix with alpha component op which cannot be written as CLF");
+                          "Transform uses the 'Matrix with alpha component' op which cannot be written as CLF");
 }
 
 OCIO_ADD_TEST(CTFTransform, matrix_offset_alpha_bitdepth_ctf)
@@ -4783,7 +4783,7 @@ OCIO_ADD_TEST(CTFTransform, gamma2_ctf)
     std::ostringstream outputTransformCLF;
     OCIO_CHECK_THROW_WHAT(processorGroup->write(OCIO::FILEFORMAT_CLF, outputTransformCLF),
                           OCIO::Exception,
-                          "Gamma with alpha component op which cannot be written as CLF");
+                          "Transform uses the 'Gamma with alpha component' op which cannot be written as CLF");
 }
 
 OCIO_ADD_TEST(CTFTransform, gamma3_ctf)
@@ -5328,7 +5328,8 @@ OCIO_ADD_TEST(CTFTransform, lut1d_inverse_clf)
     OCIO::ConstProcessorRcPtr processorGroup = config->getProcessor(group);
     std::ostringstream outputTransform;
     OCIO_CHECK_THROW_WHAT(processorGroup->write(OCIO::FILEFORMAT_CLF, outputTransform),
-                          OCIO::Exception, "InverseLUT1D op which cannot be written as CLF");
+                          OCIO::Exception,
+                          "Transform uses the 'InverseLUT1D' op which cannot be written as CLF");
 }
 
 OCIO_ADD_TEST(CTFTransform, lut1d_ctf)
@@ -5734,7 +5735,8 @@ OCIO_ADD_TEST(CTFTransform, lut3d_inverse_clf)
     OCIO::ConstProcessorRcPtr processorGroup = config->getProcessor(group);
     std::ostringstream outputTransform;
     OCIO_CHECK_THROW_WHAT(processorGroup->write(OCIO::FILEFORMAT_CLF, outputTransform),
-                          OCIO::Exception, "InverseLUT3D op which cannot be written as CLF");
+                          OCIO::Exception,
+                          "Transform uses the 'InverseLUT3D' op which cannot be written as CLF");
 }
 
 OCIO_ADD_TEST(CTFTransform, lut3d_inverse_ctf)

--- a/tests/cpu/ops/log/LogOpCPU_tests.cpp
+++ b/tests/cpu/ops/log/LogOpCPU_tests.cpp
@@ -229,8 +229,8 @@ OCIO_ADD_TEST(LogOpCPU, log2lin_test)
     OCIO::TransformDirection dir = OCIO::LogUtil::GetLogDirection(params.m_style);
     OCIO::LogUtil::ConvertLogParameters(params, base, paramsR, paramsG, paramsB);
 
-    OCIO::ConstLogOpDataRcPtr logOp = std::make_shared<OCIO::LogOpData>(
-        dir, base, paramsR, paramsG, paramsB);
+    OCIO::ConstLogOpDataRcPtr logOp
+        = std::make_shared<OCIO::LogOpData>(base, paramsR, paramsG, paramsB, dir);
 
     OCIO::ConstOpCPURcPtr pRenderer = OCIO::GetLogRenderer(logOp);
     pRenderer->apply(rgbaImage, rgba, 8);
@@ -367,8 +367,8 @@ OCIO_ADD_TEST(LogOpCPU, lin2log_test)
     OCIO::TransformDirection dir = OCIO::LogUtil::GetLogDirection(params.m_style);
     OCIO::LogUtil::ConvertLogParameters(params, base, paramsR, paramsG, paramsB);
 
-    OCIO::ConstLogOpDataRcPtr logOp = std::make_shared<OCIO::LogOpData>(
-        dir, base, paramsR, paramsG, paramsB);
+    OCIO::ConstLogOpDataRcPtr logOp 
+        = std::make_shared<OCIO::LogOpData>(base, paramsR, paramsG, paramsB, dir);
 
     OCIO::ConstOpCPURcPtr pRenderer = OCIO::GetLogRenderer(logOp);
     pRenderer->apply(rgbaImage, rgba, 8);
@@ -448,8 +448,8 @@ OCIO_ADD_TEST(LogOpCPU, cameralog2lin_test)
     OCIO::LogOpData::Params params{ 0.2, 0.6, 1.1, 0.05, 0.1, 1.2 };
     const double base = 2.0;
     OCIO::TransformDirection dir{ OCIO::TRANSFORM_DIR_FORWARD };
-    OCIO::ConstLogOpDataRcPtr logOp = std::make_shared<OCIO::LogOpData>(
-        dir, base, params, params, params);
+    OCIO::ConstLogOpDataRcPtr logOp
+        = std::make_shared<OCIO::LogOpData>(base, params, params, params, dir);
 
     OCIO::ConstOpCPURcPtr pRenderer = OCIO::GetLogRenderer(logOp);
     pRenderer->apply(rgbaImage, rgba, numPixels);
@@ -486,8 +486,8 @@ OCIO_ADD_TEST(LogOpCPU, cameralog2lin_test)
 
     // Set linearSlope to default.
     params.pop_back();
-    OCIO::ConstLogOpDataRcPtr lognols = std::make_shared<OCIO::LogOpData>(
-        dir, base, params, params, params);
+    OCIO::ConstLogOpDataRcPtr lognols
+        = std::make_shared<OCIO::LogOpData>(base, params, params, params, dir);
 
     OCIO::ConstOpCPURcPtr pRendererNoLS = OCIO::GetLogRenderer(lognols);
     pRendererNoLS->apply(rgbaImage, rgba_nols, numPixels);
@@ -516,8 +516,8 @@ OCIO_ADD_TEST(LogOpCPU, cameralog2lin_test)
 
     // Don't use break.
     params.pop_back();
-    OCIO::ConstLogOpDataRcPtr lognobreak = std::make_shared<OCIO::LogOpData>(
-        dir, base, params, params, params);
+    OCIO::ConstLogOpDataRcPtr lognobreak
+        = std::make_shared<OCIO::LogOpData>(base, params, params, params, dir);
 
     OCIO::ConstOpCPURcPtr pRendererNoBreak = OCIO::GetLogRenderer(lognobreak);
     pRendererNoBreak->apply(rgbaImage, rgba_nobreak, numPixels);
@@ -560,8 +560,8 @@ OCIO_ADD_TEST(LogOpCPU, cameralin2log_test)
     OCIO::LogOpData::Params params{ 0.2, 0.6, 1.1, 0.05, 0.1, 1.2 };
     const double base = 2.0;
     OCIO::TransformDirection dir{ OCIO::TRANSFORM_DIR_INVERSE };
-    OCIO::ConstLogOpDataRcPtr logOp = std::make_shared<OCIO::LogOpData>(
-        dir, base, params, params, params);
+    OCIO::ConstLogOpDataRcPtr logOp
+        = std::make_shared<OCIO::LogOpData>(base, params, params, params, dir);
 
     OCIO::ConstOpCPURcPtr pRenderer = OCIO::GetLogRenderer(logOp);
     pRenderer->apply(rgbaImage, rgba, 3);

--- a/tests/cpu/ops/log/LogOpData_tests.cpp
+++ b/tests/cpu/ops/log/LogOpData_tests.cpp
@@ -40,8 +40,7 @@ OCIO_ADD_TEST(LogOpData, accessor_test)
     OCIO::TransformDirection dir = OCIO::LogUtil::GetLogDirection(ctfParams.m_style);
     OCIO::LogUtil::ConvertLogParameters(ctfParams, base, paramsR, paramsG, paramsB);
 
-    OCIO::LogOpData logOp(dir,
-                          base, paramsR, paramsG, paramsB);
+    OCIO::LogOpData logOp(base, paramsR, paramsG, paramsB, dir);
 
     OCIO_CHECK_EQUAL(logOp.getType(), OCIO::OpData::LogType);
 
@@ -57,7 +56,7 @@ OCIO_ADD_TEST(LogOpData, accessor_test)
     dir = OCIO::LogUtil::GetLogDirection(ctfParams.m_style);
     OCIO::LogUtil::ConvertLogParameters(ctfParams, base, paramsR, paramsG, paramsB);
 
-    OCIO::LogOpData logOp2(dir, base, paramsR, paramsG, paramsB);
+    OCIO::LogOpData logOp2(base, paramsR, paramsG, paramsB, dir);
 
     OCIO_CHECK_ASSERT(logOp2.allComponentsEqual());
     OCIO_CHECK_ASSERT(logOp2.getRedParams() == paramsR);
@@ -74,7 +73,7 @@ OCIO_ADD_TEST(LogOpData, accessor_test)
     dir = OCIO::LogUtil::GetLogDirection(ctfParams.m_style);
     OCIO::LogUtil::ConvertLogParameters(ctfParams, base, paramsR, paramsG, paramsB);
 
-    OCIO::LogOpData logOp3(dir, base, paramsR, paramsG, paramsB);
+    OCIO::LogOpData logOp3(base, paramsR, paramsG, paramsB, dir);
 
     OCIO_CHECK_ASSERT(!logOp3.allComponentsEqual());
     OCIO_CHECK_ASSERT(logOp3.getRedParams() == paramsR);
@@ -92,7 +91,7 @@ OCIO_ADD_TEST(LogOpData, accessor_test)
     dir = OCIO::LogUtil::GetLogDirection(ctfParams.m_style);
     OCIO::LogUtil::ConvertLogParameters(ctfParams, base, paramsR, paramsG, paramsB);
 
-    OCIO::LogOpData logOp4(dir, base, paramsR, paramsG, paramsB);
+    OCIO::LogOpData logOp4(base, paramsR, paramsG, paramsB, dir);
     OCIO_CHECK_ASSERT(!logOp4.allComponentsEqual());
     OCIO_CHECK_ASSERT(logOp4.getRedParams() == paramsR);
     OCIO_CHECK_ASSERT(logOp4.getGreenParams() == paramsG);
@@ -109,7 +108,7 @@ OCIO_ADD_TEST(LogOpData, accessor_test)
     dir = OCIO::LogUtil::GetLogDirection(ctfParams.m_style);
     OCIO::LogUtil::ConvertLogParameters(ctfParams, base, paramsR, paramsG, paramsB);
 
-    OCIO::LogOpData logOp5(dir, base, paramsR, paramsG, paramsB);
+    OCIO::LogOpData logOp5(base, paramsR, paramsG, paramsB, dir);
     OCIO_CHECK_ASSERT(!logOp5.allComponentsEqual());
     OCIO_CHECK_ASSERT(logOp5.getRedParams() == paramsR);
     OCIO_CHECK_ASSERT(logOp5.getGreenParams() == paramsG);
@@ -200,8 +199,7 @@ OCIO_ADD_TEST(LogOpData, log_inverse)
     OCIO::LogOpData::Params paramB{ 1.7, 30.0, 1.3, 3.0 };
     const double base = 10.0;
 
-    OCIO::LogOpData logOp0(OCIO::TRANSFORM_DIR_FORWARD,
-                           base, paramR, paramG, paramB);
+    OCIO::LogOpData logOp0(base, paramR, paramG, paramB, OCIO::TRANSFORM_DIR_FORWARD);
     OCIO::ConstLogOpDataRcPtr invLogOp0 = logOp0.inverse();
 
     OCIO_CHECK_ASSERT(logOp0.getRedParams() == invLogOp0->getRedParams());
@@ -212,8 +210,7 @@ OCIO_ADD_TEST(LogOpData, log_inverse)
     OCIO_CHECK_ASSERT(!logOp0.isInverse(invLogOp0));
 
     // Using equal components.
-    OCIO::LogOpData logOp1(OCIO::TRANSFORM_DIR_FORWARD,
-                           base, paramR, paramR, paramR);
+    OCIO::LogOpData logOp1(base, paramR, paramR, paramR, OCIO::TRANSFORM_DIR_FORWARD);
     OCIO::ConstLogOpDataRcPtr invLogOp1 = logOp1.inverse();
 
     OCIO_CHECK_ASSERT(logOp1.isInverse(invLogOp1));
@@ -225,14 +222,12 @@ OCIO_ADD_TEST(LogOpData, identity_replacement)
     OCIO::LogOpData::Params paramsR{ 1.5, 10.0, 2.0, 1.0 };
     const double base = 2.0;
     {
-        OCIO::LogOpData logOp(OCIO::TRANSFORM_DIR_INVERSE,
-                              base, paramsR, paramsR, paramsR);
+        OCIO::LogOpData logOp(base, paramsR, paramsR, paramsR, OCIO::TRANSFORM_DIR_INVERSE);
         OCIO_CHECK_EQUAL(logOp.getIdentityReplacement()->getType(),
                          OCIO::OpData::MatrixType);
     }
     {
-        OCIO::LogOpData logOp(OCIO::TRANSFORM_DIR_FORWARD,
-                              base, paramsR, paramsR, paramsR);
+        OCIO::LogOpData logOp(base, paramsR, paramsR, paramsR, OCIO::TRANSFORM_DIR_FORWARD);
         auto op = logOp.getIdentityReplacement();
         OCIO_CHECK_EQUAL(op->getType(),
                          OCIO::OpData::RangeType);

--- a/tests/cpu/ops/log/LogUtils_tests.cpp
+++ b/tests/cpu/ops/log/LogUtils_tests.cpp
@@ -72,7 +72,7 @@ OCIO_ADD_TEST(LogUtil, ctf_to_ocio_ok)
     OCIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_OFFSET], 0.);
     OCIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_FORWARD);
 
-    OCIO::LogOpData logOp(dir, base, paramsR, paramsG, paramsB);
+    OCIO::LogOpData logOp(base, paramsR, paramsG, paramsB, dir);
 
     OCIO_CHECK_ASSERT(!logOp.isIdentity());
     OCIO_CHECK_ASSERT(!logOp.hasChannelCrosstalk());
@@ -89,7 +89,7 @@ OCIO_ADD_TEST(LogUtil, ctf_to_ocio_ok)
     OCIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_OFFSET], 0.);
     OCIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_FORWARD);
 
-    OCIO::LogOpData logOp2(dir, base, paramsR, paramsG, paramsB);
+    OCIO::LogOpData logOp2(base, paramsR, paramsG, paramsB, dir);
     OCIO_CHECK_NO_THROW(logOp2.validate());
 
     ctfParams.m_style = OCIO::LogUtil::ANTI_LOG10;
@@ -103,7 +103,7 @@ OCIO_ADD_TEST(LogUtil, ctf_to_ocio_ok)
     OCIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_OFFSET], 0.);
     OCIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_INVERSE);
 
-    OCIO::LogOpData logOp3(dir, base, paramsR, paramsG, paramsB);
+    OCIO::LogOpData logOp3(base, paramsR, paramsG, paramsB, dir);
     OCIO_CHECK_NO_THROW(logOp3.validate());
 
     ctfParams.m_style = OCIO::LogUtil::ANTI_LOG2;
@@ -117,7 +117,7 @@ OCIO_ADD_TEST(LogUtil, ctf_to_ocio_ok)
     OCIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_OFFSET], 0.);
     OCIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_INVERSE);
 
-    OCIO::LogOpData logOp4(dir, base, paramsR, paramsG, paramsB);
+    OCIO::LogOpData logOp4(base, paramsR, paramsG, paramsB, dir);
     OCIO_CHECK_NO_THROW(logOp4.validate());
 
     auto & redP = ctfParams.get(OCIO::LogUtil::CTFParams::red);
@@ -155,7 +155,7 @@ OCIO_ADD_TEST(LogUtil, ctf_to_ocio_ok)
 
     OCIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_FORWARD);
 
-    OCIO::LogOpData logOp5(dir, base, paramsR, paramsG, paramsB);
+    OCIO::LogOpData logOp5(base, paramsR, paramsG, paramsB, dir);
     OCIO_CHECK_NO_THROW(logOp5.validate());
 
     ctfParams.m_style = OCIO::LogUtil::LOG_TO_LIN;
@@ -163,7 +163,7 @@ OCIO_ADD_TEST(LogUtil, ctf_to_ocio_ok)
     OCIO::LogUtil::ConvertLogParameters(ctfParams, base, paramsR, paramsG, paramsB);
     OCIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_INVERSE);
 
-    OCIO::LogOpData logOp6(dir, base, paramsR, paramsG, paramsB);
+    OCIO::LogOpData logOp6(base, paramsR, paramsG, paramsB, dir);
     OCIO_CHECK_NO_THROW(logOp6.validate());
 }
 

--- a/tests/cpu/transforms/BuiltinTransform_tests.cpp
+++ b/tests/cpu/transforms/BuiltinTransform_tests.cpp
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <map>
+#include <utility>
+#include <vector>
+
+#include "transforms/BuiltinTransform.cpp"
+
+#include "ops/matrix/MatrixOp.h"
+#include "Platform.h"
+#include "transforms/builtins/ACES.h"
+#include "transforms/builtins/ColorMatrixHelpers.h"
+#include "transforms/builtins/OpHelpers.h"
+#include "testutils/UnitTest.h"
+#include "UnitTestUtils.h"
+
+namespace OCIO = OCIO_NAMESPACE;
+
+
+OCIO_ADD_TEST(BuiltinTransform, creation)
+{
+    // Tests around the creation of a built-in transform instance.
+
+    OCIO::BuiltinTransformRcPtr blt = OCIO::BuiltinTransform::Create();
+
+    OCIO_CHECK_EQUAL(blt->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(std::string(blt->getStyle()), "IDENTITY");
+    OCIO_CHECK_NO_THROW(blt->validate());
+
+    OCIO_CHECK_NO_THROW(blt->setStyle("ACES-AP0_to_CIE-XYZ-D65_BFD"));
+    OCIO_CHECK_EQUAL(std::string(blt->getStyle()), "ACES-AP0_to_CIE-XYZ-D65_BFD");
+    OCIO_CHECK_NO_THROW(blt->validate());
+
+    OCIO_CHECK_EQUAL(std::string("Convert ACES AP0 primaries to CIE XYZ with a D65 white point with Bradford adaptation"),
+                     blt->getDescription());
+
+    OCIO_CHECK_NO_THROW(blt->setDirection(OCIO::TRANSFORM_DIR_INVERSE));
+    OCIO_CHECK_EQUAL(blt->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_NO_THROW(blt->validate());
+
+    // The style is case insensitive.
+    OCIO_CHECK_NO_THROW(blt->setStyle("ACES-AP0_to_cie-xyz-D65_BFD"));
+    OCIO_CHECK_NO_THROW(blt->validate());
+
+    // Try an unknown style.
+    OCIO_CHECK_THROW_WHAT(blt->setStyle("ACES-AP0_to_CIE-XYZ-D65_BFD_UNKNOWN"),
+                          OCIO::Exception,
+                          "BuiltinTransform: invalid built-in transform style 'ACES-AP0_to_CIE-XYZ-D65_BFD_UNKNOWN'.");
+}
+
+OCIO_ADD_TEST(BuiltinTransform, access)
+{
+    // Only test some default built-in transforms.
+
+    OCIO_CHECK_EQUAL(std::string("IDENTITY"),
+                     OCIO::BuiltinTransformRegistry::Get()->getBuiltinStyle(0));
+
+    OCIO_CHECK_EQUAL(std::string("ACES-AP0_to_CIE-XYZ-D65_BFD"),
+                     OCIO::BuiltinTransformRegistry::Get()->getBuiltinStyle(1));
+
+    OCIO_CHECK_EQUAL(std::string("Convert ACES AP0 primaries to CIE XYZ with a D65 white point with Bradford adaptation"),
+                     OCIO::BuiltinTransformRegistry::Get()->getBuiltinDescription(1));
+}
+
+OCIO_ADD_TEST(BuiltinTransform, forward_inverse)
+{
+    // A forward and inverse built-in transform must be optimized out.
+
+    // Note: As the optimization is performed using the Ops (i.e. resulting from the built-in
+    // transforms), it depends on the op list optimizations and not on the transform list. 
+
+    OCIO::BuiltinTransformRcPtr fwdBuiltin = OCIO::BuiltinTransform::Create();
+    OCIO_CHECK_NO_THROW(fwdBuiltin->setStyle("ACEScct_to_ACES2065-1"));
+    OCIO_CHECK_NO_THROW(fwdBuiltin->setDirection(OCIO::TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(fwdBuiltin->validate());
+
+    OCIO::BuiltinTransformRcPtr invBuiltin = OCIO::BuiltinTransform::Create();
+    OCIO_CHECK_NO_THROW(invBuiltin->setStyle("ACEScct_to_ACES2065-1"));
+    OCIO_CHECK_NO_THROW(invBuiltin->setDirection(OCIO::TRANSFORM_DIR_INVERSE));
+    OCIO_CHECK_NO_THROW(invBuiltin->validate());
+
+    OCIO::GroupTransformRcPtr grp = OCIO::GroupTransform::Create();
+    OCIO_CHECK_NO_THROW(grp->appendTransform(fwdBuiltin));
+    OCIO_CHECK_NO_THROW(grp->appendTransform(invBuiltin));
+    // Content is [BuiltinTransform, BuiltinTransform].
+    OCIO_CHECK_EQUAL(grp->getNumTransforms(), 2);
+
+    OCIO::ConstConfigRcPtr config = OCIO::Config::CreateRaw();
+    OCIO::ConstProcessorRcPtr proc;
+    OCIO_CHECK_NO_THROW(proc = config->getProcessor(grp));
+
+    // Without any optimizations.
+    {
+        OCIO_CHECK_NO_THROW(proc = proc->getOptimizedProcessor(OCIO::BIT_DEPTH_F32,
+                                                               OCIO::BIT_DEPTH_F32,
+                                                               OCIO::OPTIMIZATION_NONE));
+
+        OCIO_CHECK_NO_THROW(grp = proc->createGroupTransform());
+        // Content is [Lut1DTransform, MatrixTransform, MatrixTransform, Lut1DTransform].
+        OCIO_CHECK_EQUAL(4, grp->getNumTransforms());
+    }
+
+    // With default optimizations.
+    {
+        OCIO_CHECK_NO_THROW(proc = proc->getOptimizedProcessor(OCIO::BIT_DEPTH_F32,
+                                                               OCIO::BIT_DEPTH_F32,
+                                                               OCIO::OPTIMIZATION_DEFAULT));
+
+        OCIO_CHECK_NO_THROW(grp = proc->createGroupTransform());
+        // All transforms have been optimized out.
+        OCIO_CHECK_EQUAL(0, grp->getNumTransforms());
+    }
+}
+
+
+namespace
+{
+
+template<typename T>
+void ValidateValues(const char * prefixMsg, T in, T out, T errorThreshold, int lineNo)
+{
+    // Using rel error with a large minExpected value of 1 will transition
+    // from absolute error for expected values < 1 and
+    // relative error for values > 1.
+    if (!OCIO::EqualWithSafeRelError(in, out, errorThreshold, T(1.)))
+    {
+        std::ostringstream errorMsg;
+        errorMsg.precision(std::numeric_limits<T>::max_digits10);
+        if (prefixMsg && *prefixMsg)
+        {
+            errorMsg << prefixMsg << ": ";
+        }
+        errorMsg << "value = " << in << " but expected = " << out;
+        OCIO_CHECK_ASSERT_MESSAGE_FROM(0, errorMsg.str(), lineNo);
+    }
+}
+
+template<typename T>
+void ValidateValues(unsigned idx, T in, T out, T errorThreshold, int lineNo)
+{
+    std::ostringstream oss;
+    oss << "Index = " << idx << " with threshold = " << errorThreshold;
+
+    ValidateValues<T>(oss.str().c_str(), in, out, errorThreshold, lineNo);
+}
+
+template<typename T>
+void ValidateValues(T in, T out, int lineNo)
+{
+    ValidateValues<T>(nullptr, in, out, T(1e-7), lineNo);
+}
+
+} // anon.
+
+
+OCIO_ADD_TEST(Builtins, color_matrix_helpers)
+{
+    // Test all the color matrix helper methods.
+
+    {
+        OCIO::MatrixOpData::MatrixArrayPtr matrix = OCIO::rgb2xyz_from_xy(OCIO::ACES_AP1::primaries);
+
+        ValidateValues( 0U, matrix->getDoubleValue( 0),  0.66245418, 1e-7, __LINE__);
+        ValidateValues( 1U, matrix->getDoubleValue( 1),  0.13400421, 1e-7, __LINE__);
+        ValidateValues( 2U, matrix->getDoubleValue( 2),  0.15618769, 1e-7, __LINE__);
+
+        ValidateValues( 4U, matrix->getDoubleValue( 4),  0.27222872, 1e-7, __LINE__);
+        ValidateValues( 5U, matrix->getDoubleValue( 5),  0.67408177, 1e-7, __LINE__);
+        ValidateValues( 6U, matrix->getDoubleValue( 6),  0.05368952, 1e-7, __LINE__);
+
+        ValidateValues( 8U, matrix->getDoubleValue( 8), -0.00557465, 1e-7, __LINE__);
+        ValidateValues( 9U, matrix->getDoubleValue( 9),  0.00406073, 1e-7, __LINE__);
+        ValidateValues(10U, matrix->getDoubleValue(10),  1.0103391 , 1e-6, __LINE__);
+
+
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue( 3), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue( 7), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(11), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(12), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(13), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(14), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(15), 1.);
+    }
+
+    {
+        // D65 to D60.
+        static const OCIO::MatrixOpData::Offsets src_XYZ(0.9504559270516716, 1., 1.0890577507598784, 0.);
+        static const OCIO::MatrixOpData::Offsets dst_XYZ(0.9526460745698463, 1., 1.0088251843515859, 0.);
+
+        OCIO::MatrixOpData::MatrixArrayPtr matrix = OCIO::build_vonkries_adapt(
+            src_XYZ, dst_XYZ, OCIO::ADAPTATION_BRADFORD);
+
+        ValidateValues( 0U, matrix->getDoubleValue( 0),  1.01303491, 1e-7, __LINE__);
+        ValidateValues( 1U, matrix->getDoubleValue( 1),  0.00610526, 1e-7, __LINE__);
+        ValidateValues( 2U, matrix->getDoubleValue( 2), -0.01497094, 1e-7, __LINE__);
+
+        ValidateValues( 4U, matrix->getDoubleValue( 4),  0.00769823, 1e-7, __LINE__);
+        ValidateValues( 5U, matrix->getDoubleValue( 5),  0.99816335, 1e-7, __LINE__);
+        ValidateValues( 6U, matrix->getDoubleValue( 6), -0.00503204, 1e-7, __LINE__);
+
+        ValidateValues( 8U, matrix->getDoubleValue( 8), -0.00284132, 1e-7, __LINE__);
+        ValidateValues( 9U, matrix->getDoubleValue( 9),  0.00468516, 1e-7, __LINE__);
+        ValidateValues(10U, matrix->getDoubleValue(10),  0.92450614, 1e-7, __LINE__);
+
+
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue( 3), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue( 7), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(11), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(12), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(13), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(14), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(15), 1.);
+    }
+
+    {
+        // Note: Source and dest white points are equal.
+        OCIO::MatrixOpData::MatrixArrayPtr matrix
+            = build_conversion_matrix(OCIO::P3_D65::primaries, OCIO::REC709::primaries,
+                                      OCIO::ADAPTATION_BRADFORD);
+
+        ValidateValues( 0U, matrix->getDoubleValue( 0),  1.22494018, 1e-7, __LINE__);
+        ValidateValues( 1U, matrix->getDoubleValue( 1), -0.22494018, 1e-7, __LINE__);
+        ValidateValues( 2U, matrix->getDoubleValue( 2),  0.        , 1e-7, __LINE__);
+
+        ValidateValues( 4U, matrix->getDoubleValue( 4), -0.04205695, 1e-7, __LINE__);
+        ValidateValues( 5U, matrix->getDoubleValue( 5),  1.04205695, 1e-7, __LINE__);
+        ValidateValues( 6U, matrix->getDoubleValue( 6),  0.        , 1e-7, __LINE__);
+
+        ValidateValues( 8U, matrix->getDoubleValue( 8), -0.01963755, 1e-7, __LINE__);
+        ValidateValues( 9U, matrix->getDoubleValue( 9), -0.07863605, 1e-7, __LINE__);
+        ValidateValues(10U, matrix->getDoubleValue(10),  1.09827360, 1e-7, __LINE__);
+
+
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue( 3), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue( 7), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(11), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(12), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(13), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(14), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(15), 1.);
+    }
+
+    {
+        // Note: Source and dest white points differ.
+        OCIO::MatrixOpData::MatrixArrayPtr matrix
+            = build_conversion_matrix(OCIO::ACES_AP1::primaries, OCIO::REC709::primaries,
+                                      OCIO::ADAPTATION_BRADFORD);
+
+        ValidateValues( 0U, matrix->getDoubleValue( 0),  1.70505099, 1e-7, __LINE__);
+        ValidateValues( 1U, matrix->getDoubleValue( 1), -0.62179212, 1e-7, __LINE__);
+        ValidateValues( 2U, matrix->getDoubleValue( 2), -0.08325887, 1e-7, __LINE__);
+
+        ValidateValues( 4U, matrix->getDoubleValue( 4), -0.13025642, 1e-7, __LINE__);
+        ValidateValues( 5U, matrix->getDoubleValue( 5),  1.14080474, 1e-7, __LINE__);
+        ValidateValues( 6U, matrix->getDoubleValue( 6), -0.01054832, 1e-7, __LINE__);
+
+        ValidateValues( 8U, matrix->getDoubleValue( 8), -0.02400336, 1e-7, __LINE__);
+        ValidateValues( 9U, matrix->getDoubleValue( 9), -0.12896898, 1e-7, __LINE__);
+        ValidateValues(10U, matrix->getDoubleValue(10),  1.15297233, 1e-7, __LINE__);
+
+
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue( 3), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue( 7), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(11), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(12), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(13), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(14), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(15), 1.);
+    }
+
+    {
+        // Note: Source and dest white points differ.
+        OCIO::MatrixOpData::MatrixArrayPtr matrix
+            = build_conversion_matrix(OCIO::ACES_AP0::primaries, OCIO::CIE_XYZ_D65::primaries,
+                                      OCIO::ADAPTATION_BRADFORD);
+
+        ValidateValues( 0U, matrix->getDoubleValue( 0),  0.987189224216, 1e-7, __LINE__);
+        ValidateValues( 1U, matrix->getDoubleValue( 1), -0.004683484721, 1e-7, __LINE__);
+        ValidateValues( 2U, matrix->getDoubleValue( 2),  0.017494260505, 1e-7, __LINE__);
+
+        ValidateValues( 4U, matrix->getDoubleValue( 4),  0.337368890788, 1e-7, __LINE__);
+        ValidateValues( 5U, matrix->getDoubleValue( 5),  0.729521566690 , 1e-7, __LINE__);
+        ValidateValues( 6U, matrix->getDoubleValue( 6), -0.066890457478, 1e-7, __LINE__);
+
+        ValidateValues( 8U, matrix->getDoubleValue( 8),  0.001077950962, 1e-7, __LINE__);
+        ValidateValues( 9U, matrix->getDoubleValue( 9), -0.003407263205, 1e-7, __LINE__);
+        ValidateValues(10U, matrix->getDoubleValue(10),  1.002329312243, 1e-7, __LINE__);
+
+
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue( 3), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue( 7), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(11), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(12), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(13), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(14), 0.);
+        OCIO_CHECK_EQUAL(matrix->getDoubleValue(15), 1.);
+    }
+}
+
+OCIO_ADD_TEST(Builtins, interpolate)
+{
+    // Test the non-uniform 1D linear interpolation helper function.
+
+    static constexpr unsigned lutSize = 4;
+    static constexpr double lutValues[lutSize * 2]
+    {
+        0.,    1.0,
+        0.50,  2.0,
+        0.75,  2.5,
+        1.,    3.
+    };
+
+    ValidateValues(OCIO::Interpolate1D(lutSize, &lutValues[0], -1.  ), 1.  , __LINE__);
+    ValidateValues(OCIO::Interpolate1D(lutSize, &lutValues[0],  0.  ), 1.  , __LINE__);
+    ValidateValues(OCIO::Interpolate1D(lutSize, &lutValues[0],  0.1 ), 1.2 , __LINE__);
+    ValidateValues(OCIO::Interpolate1D(lutSize, &lutValues[0],  0.5 ), 2.  , __LINE__);
+    ValidateValues(OCIO::Interpolate1D(lutSize, &lutValues[0],  0.99), 2.98, __LINE__);
+    ValidateValues(OCIO::Interpolate1D(lutSize, &lutValues[0],  2.  ), 3.  , __LINE__);
+}
+
+namespace
+{
+
+using Values = std::vector<float>;
+using AllValues = std::map<std::string, std::pair<Values, Values>>;
+
+void ValidateBuiltinTransform(const char * style, const Values & in, const Values & out, int lineNo)
+{
+    OCIO::BuiltinTransformRcPtr builtin = OCIO::BuiltinTransform::Create();
+    OCIO_CHECK_NO_THROW_FROM(builtin->setStyle(style), lineNo);
+    OCIO_CHECK_NO_THROW_FROM(builtin->setDirection(OCIO::TRANSFORM_DIR_FORWARD), lineNo);
+    OCIO_CHECK_NO_THROW_FROM(builtin->validate(), lineNo);
+
+    OCIO::ConstConfigRcPtr config = OCIO::Config::CreateRaw();
+
+    OCIO::ConstProcessorRcPtr proc;
+    OCIO_CHECK_NO_THROW_FROM(proc = config->getProcessor(builtin), lineNo);
+
+    OCIO::ConstCPUProcessorRcPtr cpu;
+    OCIO_CHECK_NO_THROW_FROM(cpu = proc->getDefaultCPUProcessor(), lineNo);
+
+    OCIO::PackedImageDesc inDesc((void *)&in[0], long(in.size() / 3), 1, 3);
+
+    Values vals(in.size(), -1.0f);
+    OCIO::PackedImageDesc outDesc((void *)&vals[0], long(vals.size() / 3), 1, 3);
+
+    OCIO_CHECK_NO_THROW_FROM(cpu->apply(inDesc, outDesc), lineNo);
+
+    static constexpr float errorThreshold = 1e-5f; 
+
+    for (size_t idx = 0; idx < out.size(); ++idx)
+    {
+        std::ostringstream oss;
+        oss << style << ": for index = " << idx << " with threshold = " << errorThreshold;
+        ValidateValues(oss.str().c_str(), vals[idx], out[idx], errorThreshold, lineNo);
+    }
+}
+
+AllValues UnitTestValues
+{
+    // Contains the name, the input values and the expected output values.
+
+    { "IDENTITY",
+        { { 0.5f, 0.4f, 0.3f }, { 0.5f,            0.4f,            0.3f } } },
+    { "ACES-AP0_to_CIE-XYZ-D65_BFD",
+        { { 0.5f, 0.4f, 0.3f }, { 0.496969496371f, 0.440425934827f, 0.299874863872f } } },
+    { "ACES-AP1_to_CIE-XYZ-D65_BFD",
+        { { 0.5f, 0.4f, 0.3f }, { 0.450739364025f, 0.420968434905f, 0.299137367021f } } },
+    { "ACES-AP1_to_LINEAR-REC709_BFD",
+        { { 0.5f, 0.4f, 0.3f }, { 0.578830986466f, 0.388029190156f, 0.282302431033f } } },
+    { "ACEScct-LOG_to_LIN",
+        { { 0.5f, 0.4f, 0.3f }, { 0.514056913328f, 0.152618314084f, 0.045310838527f } } },
+    { "ACEScct_to_ACES2065-1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.386397222658f, 0.158557251811f, 0.043152537925f } } },
+    { "ACEScc_to_ACES2065-1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.386397222658f, 0.158557251811f, 0.043152537925f } } },
+    { "ACEScg_to_ACES2065-1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.453158317919f, 0.394926024520f, 0.299297344519f } } },
+    { "ACESproxy10i_to_ACES2065-1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.433437174444f, 0.151629880817f, 0.031769555400f } } },
+    { "ADX10_to_ACES2065-1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.210518101020f, 0.148655364394f, 0.085189053481f } } },
+    { "ADX16_to_ACES2065-1",
+        { { 0.125f, 0.1f, 0.075f }, { 0.211320835792f, 0.149169650771f, 0.085452970479f } } },
+    { "ARRI_ALEXA-LOGC-EI800-AWG_to_ACES2065-1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.401621427766f, 0.236455447604f,  0.064830001192f } } },
+    { "CANON_CLOG2-CGAMUT_to_ACES2065-1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.408435767126f, 0.197486903378f,  0.034204558318f } } },
+    { "CANON_CLOG3-CGAMUT_to_ACES2065-1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.496034919950f, 0.301015360499f,  0.083691829261f } } },
+    { "PANASONIC_VLOG-VGAMUT_to_ACES2065-1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.306918773245f, 0.148128050597f,  0.046334439047f } } },
+    { "RED_REDLOGFILM-RWG_to_ACES2065-1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.216116808829f, 0.121529105934f,  0.008171766322f } } },
+    { "RED_LOG3G10-RWG_to_ACES2065-1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.887988237100f, 0.416932247547f, -0.025442210717f } } },
+    { "SONY_SLOG3-SGAMUT3_to_ACES2065-1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.342259707137f, 0.172043362337f,  0.057188031769f } } },
+    { "SONY_SLOG3-SGAMUT3.CINE_to_ACES2065-1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.314942672433f, 0.170408017753f,  0.046854940520f } } }
+};
+
+} // anon.
+
+OCIO_ADD_TEST(Builtins, validate)
+{
+    OCIO::ConstBuiltinTransformRegistryRcPtr reg = OCIO::BuiltinTransformRegistry::Get();
+
+    for (size_t index = 0; index < reg->getNumBuiltins(); ++index)
+    {
+        const char * name = reg->getBuiltinStyle(index);
+        const auto values = UnitTestValues[name];
+
+        if (values.first.empty() || values.second.empty())
+        {
+            std::ostringstream errorMsg;
+            errorMsg << "For the built-in transform '" << name << "' the values are missing.";
+            OCIO_CHECK_ASSERT_MESSAGE(0, errorMsg.str());
+        }
+        else if (values.first.size() != values.second.size())
+        {
+            std::ostringstream errorMsg;
+            errorMsg << "For the built-in transform '" << name 
+                     << "' the input and output values do not match.";
+            OCIO_CHECK_ASSERT_MESSAGE(0, errorMsg.str());
+        }
+        else if ((values.first.size() % 3) != 0)
+        {
+            std::ostringstream errorMsg;
+            errorMsg << "For the built-in transform '" << name 
+                     << "' only RGB values are supported.";
+            OCIO_CHECK_ASSERT_MESSAGE(0, errorMsg.str());
+        }
+        else
+        {
+            ValidateBuiltinTransform(name, values.first, values.second, __LINE__);
+        }
+    }
+}

--- a/tests/cpu/transforms/builtins/BuiltinTransformRegistry_tests.cpp
+++ b/tests/cpu/transforms/builtins/BuiltinTransformRegistry_tests.cpp
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include "transforms/builtins/BuiltinTransformRegistry.cpp"
+
+#include "testutils/UnitTest.h"
+
+namespace OCIO = OCIO_NAMESPACE;
+
+
+OCIO_ADD_TEST(Builtins, basic)
+{
+    // Create an empty built-in transform registry.
+
+    OCIO::BuiltinTransformRegistryImpl registry;
+    OCIO_CHECK_EQUAL(registry.getNumBuiltins(), 0);
+    OCIO_CHECK_THROW_WHAT(registry.getBuiltinStyle(0), OCIO::Exception, "Invalid index.");
+
+    OCIO::OpRcPtrVec ops;
+    OCIO_CHECK_THROW_WHAT(registry.createOps(0, ops),
+                          OCIO::Exception,
+                          "Invalid index.");
+
+    // Add a built-in transform.
+
+    auto EmptyFunctor = [](OCIO::OpRcPtrVec & /*ops*/) {};
+    OCIO_CHECK_NO_THROW(registry.addBuiltin("trans1", nullptr, EmptyFunctor));
+
+    OCIO_CHECK_EQUAL(registry.getNumBuiltins(), 1);
+    OCIO_CHECK_EQUAL(OCIO::Platform::Strcasecmp(registry.getBuiltinStyle(0), "trans1"), 0);
+
+    // Add an existing built-in transform i.e. replace the existing one.
+
+    OCIO_CHECK_NO_THROW(registry.addBuiltin("trans1", nullptr, EmptyFunctor));
+    OCIO_CHECK_EQUAL(registry.getNumBuiltins(), 1);
+    OCIO_CHECK_EQUAL(OCIO::Platform::Strcasecmp(registry.getBuiltinStyle(0), "trans1"), 0);
+
+    OCIO_CHECK_NO_THROW(registry.createOps(0, ops));
+}
+
+namespace
+{
+
+void CreateOps(const char * name, OCIO::TransformDirection dir, OCIO::OpRcPtrVec & ops, int lineNo)
+{
+    OCIO::ConstBuiltinTransformRegistryRcPtr reg = OCIO::BuiltinTransformRegistry::Get();
+
+    for (size_t index = 0; index < reg->getNumBuiltins(); ++index)
+    {
+        if (0 == OCIO::Platform::Strcasecmp(name, reg->getBuiltinStyle(index)))
+        {
+            OCIO::CreateBuiltinTransformOps(ops, index, dir);
+            return;
+        }
+    }
+
+    std::ostringstream errorMsg;
+    errorMsg << "Unknown built-in transform name '" << name << "'.";
+    OCIO_CHECK_ASSERT_MESSAGE_FROM(0, errorMsg.str(), lineNo);
+}
+
+}
+
+OCIO_ADD_TEST(Builtins, aces)
+{
+    // Tests only few default built-in transforms.
+
+    OCIO::OpRcPtrVec ops;
+
+    {
+        ops.clear();
+        CreateOps("IDENTITY", OCIO::TRANSFORM_DIR_FORWARD, ops, __LINE__);
+        OCIO_REQUIRE_EQUAL(ops.size(), 1);
+        OCIO_REQUIRE_EQUAL(std::string(ops[0]->getInfo()), "<MatrixOffsetOp>");
+    }
+
+    {
+        ops.clear();
+        CreateOps("ACES-AP0_to_CIE-XYZ-D65_BFD", OCIO::TRANSFORM_DIR_FORWARD, ops, __LINE__);
+        OCIO_REQUIRE_EQUAL(ops.size(), 1);
+        OCIO_REQUIRE_EQUAL(std::string(ops[0]->getInfo()), "<MatrixOffsetOp>");
+    }
+
+    {
+        ops.clear();
+        CreateOps("ACEScct-LOG_to_LIN", OCIO::TRANSFORM_DIR_FORWARD, ops, __LINE__);
+        OCIO_REQUIRE_EQUAL(ops.size(), 1);
+        OCIO_REQUIRE_EQUAL(std::string(ops[0]->getInfo()), "<LogOp>");
+    }
+}
+
+OCIO_ADD_TEST(Builtins, read_write)
+{
+
+    static constexpr char CONFIG_BUILTIN_TRANSFORMS[] {
+R"(ocio_profile_version: 2
+
+search_path: ""
+strictparsing: true
+luma: [0.2126, 0.7152, 0.0722]
+
+roles:
+  default: ref
+
+file_rules:
+  - !<Rule> {name: Default, colorspace: default}
+
+displays:
+  Disp1:
+    - !<View> {name: View1, colorspace: test}
+
+active_displays: []
+active_views: []
+
+colorspaces:
+  - !<ColorSpace>
+    name: ref
+    family: ""
+    equalitygroup: ""
+    bitdepth: unknown
+    isdata: false
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: test
+    family: ""
+    equalitygroup: ""
+    bitdepth: unknown
+    isdata: false
+    allocation: uniform
+    from_reference: !<GroupTransform>
+      children:)" };
+
+    // Tests all built-in transforms.
+
+    OCIO::ConstBuiltinTransformRegistryRcPtr reg;
+    OCIO_CHECK_NO_THROW(reg = OCIO::BuiltinTransformRegistry::Get());
+
+    std::string configStr;
+    configStr += CONFIG_BUILTIN_TRANSFORMS;
+
+    const size_t numBuiltins = reg->getNumBuiltins();
+    for (size_t idx = 0; idx < numBuiltins; ++idx)
+    {
+        const char * style = reg->getBuiltinStyle(idx);
+        configStr += "\n"
+                     "        - !<BuiltinTransform> {style: ";
+        configStr += style;
+        configStr += "}";
+    }
+    configStr += "\n";
+
+    // Load all the existing builtin transforms.
+
+    std::istringstream iss;
+    iss.str(configStr);
+
+    OCIO::ConstConfigRcPtr config;
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(iss));
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+
+    // Serialize all the existing builtin transforms.
+
+    {
+        std::ostringstream oss;
+        OCIO_CHECK_NO_THROW(oss << *config.get());
+        OCIO_CHECK_EQUAL(oss.str(), configStr);
+    }
+
+    // Create a processor using all the existing builtin transforms.
+
+    {
+        OCIO::ConstProcessorRcPtr processor;
+        OCIO_CHECK_NO_THROW(processor = config->getProcessor("ref", "test"));
+    }
+}


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

The pull request mainly adds the "Built-in Transform" feature as explained by issue #980.

* For a config author the use of a built-in transform is like using a transform. For example `- !<BuiltinTransform> {style: ACEScct_to_ACES2065-1}` adds a transform to convert from `ACEScct` to `ACES2065-1`. Like any other transform the direction is supported.

* The implementation of the built-in transforms are implemented using existing transforms (i.e. built using Ops) so optimizations & finalizations are all done. For example, the  `ACEScct_to_ACES2065-1` is built [here](https://github.com/AcademySoftwareFoundation/OpenColorIO/compare/master...autodesk-forks:adsk_contrib/builtin_transform?expand=1#diff-9674d0f3d8abc42afd63b497346ac9a5R173) in the file src/OpenColorIO/transforms/builtins/ACES.cpp, and the implementation only uses a `LogTransform` and a `MatrixTransform`.

* Some camera built-in transforms are already available (but could be disabled with the cmake option `-DOCIO_ADD_EXTRA_BUILTINS=OFF`). For example, the `SONY_SLOG3-SGAMUT3_to_ACES2065-1` is built [here](https://github.com/AcademySoftwareFoundation/OpenColorIO/compare/master...autodesk-forks:adsk_contrib/builtin_transform?expand=1#diff-a78117aefe7fd2eeebea64d0f9065eaeR77) in the file src/OpenColorIO/transforms/builtins/SonyCameras.cpp.

* The new app `ociomakeclf` converts from any supported LUT file format to the ACES CLF file format and optionally adds conversions from/to ACES2065-1 to make it an LMT. Note that OCIO currently supports the Academy/ASC Common LUT Format v3 (refer to #709 ).
Some usages are:
  * `./src/apps/ociomakeclf/ociomakeclf ./testdata/lut1d_1.spi1d ./res.clf` converts from `spi1d` to the `CLF` file format.
  * `./src/apps/ociomakeclf/ociomakeclf --list` lists the ACES Color Space Conversion transforms (all of which convert to `ACES2065-1`) usable for building an ACES LMT.
  * `./src/apps/ociomakeclf/ociomakeclf ./testdata/discreet-3d-lut.3dl ./res.clf --csc ACEScct` creates a `CLF` file containing three blocks: the conversion from `ACES2065-1` to `ACEScct`, the input LUT file content and finally, the conversion from  `ACEScct` to `ACES-2065-1`. All the blocks could be comprised of one or several transforms.  The result is an ACES LMT file usable with an ACES Metadata File (AMF).

The pull request currently supports a starter set built-in transforms, including all of the ACES CSC transforms. From the public API, the class `BuiltinTransformRegistry` gets access to all the existing styles (i.e. built-in transform names) with a short description. 

This PR puts the foundation mechanism in place for built-in transforms and it should now be straight-forward to add more additional transform instances over time.  The initial set in this PR is intended as an example (which are also useful for building LMTs), not as the complete set.