### PR TITLE
Add Carol Payne to TSC

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -118,6 +118,7 @@ project at all ASWF TAC meetings.
 * Sean Cooper - DNEG
 * Michael Dolan - Epic Games
 * Patrick Hodoul - Autodesk
+* Carol Payne - Netflix
 * Carl Rand - Weta Digital
 * Doug Walker - Autodesk
 * Kevin Wheatley - Framestore

--- a/docs/tsc/meetings/template.md
+++ b/docs/tsc/meetings/template.md
@@ -14,6 +14,7 @@ Attendees:
   * [ ] Michael Dolan (_TSC Chair_) - Epic Games
   * [ ] Patrick Hodoul (_TSC_) - Autodesk
   * [ ] John Mertic - Academy Software Foundation / Linux Foundation
+  * [ ] Carol Payne (_TSC_) - Netflix
   * [ ] Carl Rand (_TSC_) - Weta Digital
   * [ ] Doug Walker (_TSC Chief Architect_) - Autodesk
   * [ ] Kevin Wheatley (_TSC_) - Framestore


### PR DESCRIPTION
The motion to add Carol Payne to the OCIO TSC has been accepted. Welcome Carol!

Resolves #999 