### PR TITLE
GHA Analysis pybind11 Fix

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -7,23 +7,6 @@
 name: Analysis
 
 on:
-  push:
-    # Versioned branches and tags are ignored for OCIO <= 1.x.x
-    branches-ignore:
-      - RB-0.*
-      - RB-1.*
-      - gh-pages
-    tags-ignore:
-      - v0.*
-      - v1.*
-  pull_request:
-    branches-ignore:
-      - RB-0.*
-      - RB-1.*
-      - gh-pages
-    tags-ignore:
-      - v0.*
-      - v1.*
   schedule:
     # Nightly build
     - cron: "0 0 * * *"

--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -7,6 +7,23 @@
 name: Analysis
 
 on:
+  push:
+    # Versioned branches and tags are ignored for OCIO <= 1.x.x
+    branches-ignore:
+      - RB-0.*
+      - RB-1.*
+      - gh-pages
+    tags-ignore:
+      - v0.*
+      - v1.*
+  pull_request:
+    branches-ignore:
+      - RB-0.*
+      - RB-1.*
+      - gh-pages
+    tags-ignore:
+      - v0.*
+      - v1.*
   schedule:
     # Nightly build
     - cron: "0 0 * * *"

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -16,9 +16,6 @@ on:
     tags-ignore:
       - v0.*
       - v1.*
-    # Jobs are skipped when ONLY Markdown (*.md) files are changed
-    paths-ignore:
-      - '**.md'
   pull_request:
     branches-ignore:
       - RB-0.*
@@ -27,8 +24,6 @@ on:
     tags-ignore:
       - v0.*
       - v1.*
-    paths-ignore:
-      - '**.md'
 
 jobs:
   # Linux jobs run in Docker containers, so the latest OS version is OK. macOS 

--- a/share/cmake/modules/Findpybind11.cmake
+++ b/share/cmake/modules/Findpybind11.cmake
@@ -14,11 +14,6 @@
 # downloaded at build time.
 #
 
-if(NOT TARGET pybind11::module)
-    add_library(pybind11::module INTERFACE IMPORTED GLOBAL)
-    set(_pybind11_TARGET_CREATE TRUE)
-endif()
-
 ###############################################################################
 ### Try to find package ###
 
@@ -131,6 +126,14 @@ if(NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL ALL)
         VERSION_VAR
             pybind11_VERSION
     )
+endif()
+
+###############################################################################
+### Create target ###
+
+if(NOT TARGET pybind11::module)
+    add_library(pybind11::module INTERFACE IMPORTED GLOBAL)
+    set(_pybind11_TARGET_CREATE TRUE)
 endif()
 
 ###############################################################################


### PR DESCRIPTION
This PR resolves the error that has been failing the Analysis workflow the last few nights. The failure was due to using a CMake config in the find module where possible, which could define an imported target that I was already defining. Now the find module only defines the target if it doesn't yet exist.

I have also removed the `paths-ignore` option in the CI workflow triggers. Ignore paths currently doesn't work with repos that have required checks setup for branch protection. More on that here:
https://github.community/t5/GitHub-Actions/Feature-request-conditional-required-checks/td-p/36938