### PR TITLE
Adsk Contrib - Various CLF writer improvements

### DIFF
--- a/src/OpenColorIO/fileformats/xmlutils/XMLWriterUtils.cpp
+++ b/src/OpenColorIO/fileformats/xmlutils/XMLWriterUtils.cpp
@@ -43,7 +43,7 @@ void XmlFormatter::writeStartTag(const std::string & tagName,
         m_stream << "\"";
     }
 
-    m_stream << ">" << std::endl;
+    m_stream << ">\n";
 }
 
 void XmlFormatter::writeStartTag(const std::string & tagName)
@@ -55,7 +55,7 @@ void XmlFormatter::writeStartTag(const std::string & tagName)
 void XmlFormatter::writeEndTag(const std::string & tagName)
 {
     writeIndent();
-    m_stream << "</" << tagName << ">" << std::endl;
+    m_stream << "</" << tagName << ">\n";
 }
 
 void XmlFormatter::writeContentTag(const std::string & tagName,
@@ -79,7 +79,7 @@ void XmlFormatter::writeContentTag(const std::string & tagName,
     }
     m_stream << ">";
     writeString(content);
-    m_stream << "</" << tagName << ">" << std::endl;
+    m_stream << "</" << tagName << ">\n";
 }
 
 // Write the content using escaped characters if needed.
@@ -87,7 +87,7 @@ void XmlFormatter::writeContent(const std::string & content)
 {
     writeIndent();
     writeString(content);
-    m_stream << std::endl;
+    m_stream << "\n";
 }
 
 void XmlFormatter::writeEmptyTag(const std::string & tagName,
@@ -105,7 +105,7 @@ void XmlFormatter::writeEmptyTag(const std::string & tagName,
     }
 
     // Note we close the tag, no end tag is needed.
-    m_stream << " />" << std::endl;
+    m_stream << " />\n";
 }
 
 std::ostream & XmlFormatter::getStream()

--- a/src/apps/ociomakeclf/main.cpp
+++ b/src/apps/ociomakeclf/main.cpp
@@ -11,6 +11,7 @@
 namespace OCIO = OCIO_NAMESPACE;
 
 #include "apputils/argparse.h"
+#include "apputils/measure.h"
 #include "utils/StringUtils.h"
 
 
@@ -78,7 +79,7 @@ void CreateOutputLutFile(const std::string & outLutFilepath, OCIO::ConstGroupTra
 
 int main(int argc, const char ** argv)
 {
-    bool help = false, verbose = false, listCSCColorSpaces = false;
+    bool help = false, verbose = false, measure = false, listCSCColorSpaces = false;
     std::string cscColorSpace;
 
     ArgParse ap;
@@ -92,6 +93,7 @@ int main(int argc, const char ** argv)
                "<SEPARATOR>", "Options:",
                "--help",      &help,               "Print help message",
                "--verbose",   &verbose,            "Display general information",
+               "--measure",   &measure,            "Measure (in ms) the CLF write",
                "--list",      &listCSCColorSpaces, "List of the supported CSC color spaces",
                "--csc %s",    &cscColorSpace,      "The color space that the input LUT expects and produces",
                nullptr);
@@ -251,13 +253,26 @@ int main(int argc, const char ** argv)
             grp->appendTransform(outBuiltin);
         }
 
-        if (verbose)
+        static constexpr char Msg[] = "Creating the CLF lut file";
+
+        if (verbose && !measure)
         {
-            std::cout << "Creating the CLF lut file." << std::endl;
+            std::cout << Msg << "." << std::endl;
         }
 
-        // Create the CLF file.
-        CreateOutputLutFile(outLutFilepath, grp);
+        if (measure)
+        {
+            Measure m(Msg);
+            m.resume();
+
+            // Create the CLF file.
+            CreateOutputLutFile(outLutFilepath, grp);
+        }
+        else
+        {
+            // Create the CLF file.
+            CreateOutputLutFile(outLutFilepath, grp);
+        }
     }
     catch (OCIO::Exception & exception)
     {

--- a/src/apps/ocioperf/main.cpp
+++ b/src/apps/ocioperf/main.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
-#include <chrono>
 
 #include <OpenColorIO/OpenColorIO.h>
 
@@ -12,6 +11,7 @@ namespace OIIO = OIIO_NAMESPACE;
 #endif
 
 #include "apputils/argparse.h"
+#include "apputils/measure.h"
 #include "OpenEXR/half.h"
 #include "oiiohelpers.h"
 #include "utils/StringUtils.h"
@@ -20,75 +20,6 @@ namespace OIIO = OIIO_NAMESPACE;
 namespace OCIO = OCIO_NAMESPACE;
 
 
-
-// Utility to measure time in ms.
-class Measure
-{
-public:
-    Measure() = delete;
-    Measure(const Measure &) = delete;
-
-    explicit Measure(const char * explanation, unsigned iterations)
-        :   m_explanations(explanation)
-        ,   m_iterations(iterations)
-        ,   m_started(false)
-        ,   m_duration(0)
-    {
-    }
-
-    ~Measure()
-    {
-        if(m_started)
-        {
-            pause();
-        }
-
-        std::cout << std::endl;
-        std::cout << m_explanations << std::endl;
-        std::cout << "  CPU processing took: "
-                  << (m_duration.count()/float(m_iterations))
-                  <<  " ms" << std::endl;
-    }
-
-    void resume()
-    {
-        if(m_started)
-        {
-            throw OCIO::Exception("Measure already started.");
-        }
-
-        m_started = true;
-        m_start = std::chrono::high_resolution_clock::now();
-    }
-
-    void pause()
-    {
-        std::chrono::high_resolution_clock::time_point end
-           = std::chrono::high_resolution_clock::now();
-
-        if(m_started)
-        {
-            std::chrono::duration<float, std::milli> duration = end - m_start;
-
-            m_duration += duration;
-        }
-        else
-        {
-            throw OCIO::Exception("Measure already stopped.");
-        }
-
-        m_started = false;
-    }
-
-private:
-    const std::string m_explanations;
-    const unsigned m_iterations;
-
-    bool m_started;
-    std::chrono::high_resolution_clock::time_point m_start;
-
-    std::chrono::duration<float, std::milli> m_duration;
-};
 
 // Load in memory an image from disk.
 void LoadImage(const std::string & filepath,

--- a/src/apputils/measure.h
+++ b/src/apputils/measure.h
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#ifndef INCLUDED_OCIO_MEASURE_H
+#define INCLUDED_OCIO_MEASURE_H
+
+
+#include <chrono>
+#include <string>
+#include <stdexcept>
+
+
+// Utility to measure time in ms.
+class Measure
+{
+public:
+    Measure() = delete;
+    Measure(const Measure &) = delete;
+
+    explicit Measure(const char * explanation)
+        :   m_explanations(explanation)
+    {
+    }
+
+    explicit Measure(const char * explanation, unsigned iterations)
+        :   m_explanations(explanation)
+        ,   m_iterations(iterations)
+    {
+    }
+
+    ~Measure()
+    {
+        if(m_started)
+        {
+            pause();
+        }
+        print();
+    }
+
+    void resume()
+    {
+        if(m_started)
+        {
+            throw std::runtime_error("Measure already started.");
+        }
+
+        m_started = true;
+        m_start = std::chrono::high_resolution_clock::now();
+    }
+
+    void pause()
+    {
+        std::chrono::high_resolution_clock::time_point end
+           = std::chrono::high_resolution_clock::now();
+
+        if(m_started)
+        {
+            const std::chrono::duration<float, std::milli> duration = end - m_start;
+
+            m_duration += duration;
+        }
+        else
+        {
+            throw std::runtime_error("Measure already stopped.");
+        }
+
+        m_started = false;
+    }
+    
+    void print() const noexcept
+    {
+        std::cout << "\n"
+                  << m_explanations << "\n"
+                  << "  Processing took: "
+                  << (m_duration.count() / float(m_iterations))
+                  <<  " ms" << std::endl;
+    }
+
+private:
+    const std::string m_explanations;
+    const unsigned m_iterations = 1;
+
+    bool m_started = false;
+    std::chrono::high_resolution_clock::time_point m_start;
+
+    std::chrono::duration<float, std::milli> m_duration { 0 };
+};
+
+
+#endif // INCLUDED_OCIO_MEASURE_H

--- a/tests/cpu/fileformats/FileFormatCTF_tests.cpp
+++ b/tests/cpu/fileformats/FileFormatCTF_tests.cpp
@@ -5405,10 +5405,10 @@ OCIO_ADD_TEST(CTFTransform, gamma5_ctf)
     const std::string expected{ R"(<?xml version="1.0" encoding="UTF-8"?>
 <ProcessList version="1.5" id="UID42">
     <Gamma inBitDepth="32f" outBitDepth="32f" style="monCurveFwd">
-        <GammaParams channel="R" gamma="2.22222" offset="0.099" />
-        <GammaParams channel="G" gamma="2.22222" offset="0.099" />
-        <GammaParams channel="B" gamma="2.22222" offset="0.099" />
-        <GammaParams channel="A" gamma="2.22222" offset="0.099" />
+        <GammaParams channel="R" gamma="2.22222222222222" offset="0.099" />
+        <GammaParams channel="G" gamma="2.22222222222222" offset="0.099" />
+        <GammaParams channel="B" gamma="2.22222222222222" offset="0.099" />
+        <GammaParams channel="A" gamma="2.22222222222222" offset="0.099" />
     </Gamma>
 </ProcessList>
 )" };
@@ -6067,7 +6067,7 @@ OCIO_ADD_TEST(CTFTransform, lut1d_10i_ctf)
         <Array dim="3 3">
    0    0    0
  511 4011.12 -24.103
-1023 1023 1023
+   1023    1023    1023
         </Array>
     </LUT1D>
 </ProcessList>
@@ -6395,7 +6395,7 @@ OCIO_ADD_TEST(CTFTransform, bitdepth_ctf)
         <Array dim="3 1">
    0
 511.5
-1023
+ 1023
         </Array>
     </LUT1D>
     <Exponent inBitDepth="10i" outBitDepth="16f" style="basicFwd">


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

The pull request contains several fixes to the CLF/CTF writer:
- The right precision for the double serialization was missing for some Ops (such as the Log one),
- The layout of the LUT values is improved to better align them on the fly,
- The writer performance is improved by at least 2 for the LUT serialization.

Note: The `ociomakeclf` app has now a new argument to measure the performance of the write step only. The app was used to validate the write performance improvement.