### PR TITLE
Refactor PyBuiltinTransform

### DIFF
--- a/src/bindings/python/PyBuiltinTransform.cpp
+++ b/src/bindings/python/PyBuiltinTransform.cpp
@@ -8,10 +8,22 @@ namespace OCIO_NAMESPACE
 
 void bindPyBuiltinTransform(py::module & m)
 {
+    BuiltinTransformRcPtr DEFAULT = BuiltinTransform::Create();
+
     py::class_<BuiltinTransform, 
                BuiltinTransformRcPtr /* holder */, 
                Transform /* base */>(m, "BuiltinTransform")
         .def(py::init(&BuiltinTransform::Create))
+        .def(py::init([](const std::string & style, TransformDirection dir) 
+            {
+                BuiltinTransformRcPtr p = BuiltinTransform::Create();
+                if (!style.empty()) { p->setStyle(style.c_str()); }
+                p->setDirection(dir);
+                p->validate();
+                return p;
+            }), 
+             "style"_a = DEFAULT->getStyle(),
+             "dir"_a = DEFAULT->getDirection())
 
         .def("setStyle",       &BuiltinTransform::setStyle, "style"_a)
         .def("getStyle",       &BuiltinTransform::getStyle)

--- a/src/bindings/python/PyBuiltinTransformRegistry.cpp
+++ b/src/bindings/python/PyBuiltinTransformRegistry.cpp
@@ -7,39 +7,115 @@
 namespace OCIO_NAMESPACE
 {
 
+namespace 
+{
+
+// Wrapper to preserve the BuiltinTransformRegistry singleton.
+class PyBuiltinTransformRegistry
+{
+public:
+    PyBuiltinTransformRegistry() = default;
+    ~PyBuiltinTransformRegistry() = default;
+
+    size_t getNumBuiltins() const noexcept
+    {
+        return BuiltinTransformRegistry::Get()->getNumBuiltins();
+    }
+
+    const char * getBuiltinStyle(size_t idx) const
+    {
+        return BuiltinTransformRegistry::Get()->getBuiltinStyle(idx);
+    }
+
+    const char * getBuiltinDescription(size_t idx) const
+    {
+        return BuiltinTransformRegistry::Get()->getBuiltinDescription(idx);
+    }
+};
+
+enum BuiltinTransformRegistryIterator
+{
+    IT_BUILTIN_STYLE = 0,
+    IT_BUILTIN
+};
+
+using BuiltinStyleIterator = PyIterator<PyBuiltinTransformRegistry, IT_BUILTIN_STYLE>;
+using BuiltinIterator = PyIterator<PyBuiltinTransformRegistry, IT_BUILTIN>;
+
+} // namespace
+
 void bindPyBuiltinTransformRegistry(py::module & m)
 {
-    // Wrapper to preserve the BuiltinTransformRegistry singleton.
-    class Wrapper
-    {
-    public:
-        Wrapper() = default;
-        Wrapper(const Wrapper &) = delete;
-        Wrapper & operator=(const Wrapper &) = delete;
-        ~Wrapper() = default;
-
-        size_t getNumBuiltins() const noexcept
-        {
-        	return BuiltinTransformRegistry::Get()->getNumBuiltins();
-        }
-
-        const char * getBuiltinStyle(size_t idx) const
-        {
-        	return BuiltinTransformRegistry::Get()->getBuiltinStyle(idx);
-        }
-
-        const char * getBuiltinDescription(size_t idx) const
-        {
-        	return BuiltinTransformRegistry::Get()->getBuiltinDescription(idx);
-        }
-    };
-
-    py::class_<Wrapper>(m, "BuiltinTransformRegistry")
+    auto cls = py::class_<PyBuiltinTransformRegistry>(m, "BuiltinTransformRegistry")
         .def(py::init<>())
 
-        .def("getNumBuiltins",        &Wrapper::getNumBuiltins)
-        .def("getBuiltinStyle",       &Wrapper::getBuiltinStyle)
-        .def("getBuiltinDescription", &Wrapper::getBuiltinDescription);
+        .def("__iter__", [](PyBuiltinTransformRegistry & self)
+            { 
+                return BuiltinStyleIterator(self); 
+            })
+        .def("__len__", [](PyBuiltinTransformRegistry & self) { return self.getNumBuiltins(); })
+        .def("__getitem__", [](PyBuiltinTransformRegistry & self, const std::string & style) 
+            { 
+                for (size_t i = 0; i < self.getNumBuiltins(); i++)
+                {
+                    const char * thisStyle = self.getBuiltinStyle(i);
+                    if (StringUtils::Compare(std::string(thisStyle), style))
+                    {
+                        return self.getBuiltinDescription(i);
+                    }
+                }
+                
+                std::ostringstream os;
+                os << "'" << style << "'";
+                throw py::key_error(os.str().c_str());
+            })
+        .def("__contains__", [](PyBuiltinTransformRegistry & self, const std::string & style) 
+            { 
+                for (size_t i = 0; i < self.getNumBuiltins(); i++)
+                {
+                    const char * thisStyle = self.getBuiltinStyle(i);
+                    if (StringUtils::Compare(std::string(thisStyle), style))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            })
+
+        .def("getBuiltins", [](PyBuiltinTransformRegistry & self) 
+            {
+                return BuiltinIterator(self);
+            });
+
+    py::class_<BuiltinStyleIterator>(cls, "BuiltinStyleIterator")
+        .def("__len__", [](BuiltinStyleIterator & it) { return it.m_obj.getNumBuiltins(); })
+        .def("__getitem__", [](BuiltinStyleIterator & it, int i) 
+            { 
+                // BuiltinTransformRegistry provides index check with exception
+                return it.m_obj.getBuiltinStyle(i);
+            })
+        .def("__iter__", [](BuiltinStyleIterator & it) -> BuiltinStyleIterator & { return it; })
+        .def("__next__", [](BuiltinStyleIterator & it)
+            {
+                int i = it.nextIndex(it.m_obj.getNumBuiltins());
+                return it.m_obj.getBuiltinStyle(i);
+            });
+
+    py::class_<BuiltinIterator>(cls, "BuiltinIterator")
+        .def("__len__", [](BuiltinIterator & it) { return it.m_obj.getNumBuiltins(); })
+        .def("__getitem__", [](BuiltinIterator & it, int i) 
+            { 
+                // BuiltinTransformRegistry provides index check with exception
+                return py::make_tuple(it.m_obj.getBuiltinStyle(i), 
+                                      it.m_obj.getBuiltinDescription(i));
+            })
+        .def("__iter__", [](BuiltinIterator & it) -> BuiltinIterator & { return it; })
+        .def("__next__", [](BuiltinIterator & it)
+            {
+                int i = it.nextIndex(it.m_obj.getNumBuiltins());
+                return py::make_tuple(it.m_obj.getBuiltinStyle(i), 
+                                      it.m_obj.getBuiltinDescription(i));
+            });
 }
 
 } // namespace OCIO_NAMESPACE


### PR DESCRIPTION
```
# Added convenience constructor to BuiltinTransform
>>> t = ocio.BuiltinTransform('ACES-AP0_to_CIE-XYZ-D65_BFD')
>>> t.getStyle()
'ACES-AP0_to_CIE-XYZ-D65_BFD'

# Refactored BuiltinTransformRegistry to behave like a dict
>>> import PyOpenColorIO as ocio
>>> reg = ocio.BuiltinTransformRegistry()
>>> list(reg)
['IDENTITY', 'ACES-AP0_to_CIE-XYZ-D65_BFD', 'ACES-AP1_to_CIE-XYZ-D65_BFD', 'ACES-AP1_to_LINEAR-REC709_BFD', 'ACEScct-LOG_to_LIN', 'ACEScct_to_ACES2065-1', 'ACEScc_to_ACES2065-1', 'ACEScg_to_ACES2065-1', 'ACESproxy10i_to_ACES2065-1', 'ADX10_to_ACES2065-1', 'ADX16_to_ACES2065-1', 'ARRI_ALEXA-LOGC-EI800-AWG_to_ACES2065-1', 'CANON_CLOG2-CGAMUT_to_ACES2065-1', 'CANON_CLOG3-CGAMUT_to_ACES2065-1', 'PANASONIC_VLOG-VGAMUT_to_ACES2065-1', 'RED_REDLOGFILM-RWG_to_ACES2065-1', 'RED_LOG3G10-RWG_to_ACES2065-1', 'SONY_SLOG3-SGAMUT3_to_ACES2065-1', 'SONY_SLOG3-SGAMUT3.CINE_to_ACES2065-1']
>>> len(reg)
19
>>> 'IDENTITY' in reg
True
>>> reg['ACES-AP1_to_CIE-XYZ-D65_BFD']
'Convert ACES AP1 primaries to CIE XYZ with a D65 white point with Bradford adaptation'
>>> list(reg.getBuiltins())
[('IDENTITY', ''), ('ACES-AP0_to_CIE-XYZ-D65_BFD', 'Convert ACES AP0 primaries to CIE XYZ with a D65 white point with Bradford adaptation'), ('ACES-AP1_to_CIE-XYZ-D65_BFD', 'Convert ACES AP1 primaries to CIE XYZ with a D65 white point with Bradford adaptation'), ('ACES-AP1_to_LINEAR-REC709_BFD', 'Convert ACES AP1 primaries to linear Rec.709 primaries with Bradford adaptation'), ('ACEScct-LOG_to_LIN', 'Apply the log-to-lin curve used in ACEScct'), ('ACEScct_to_ACES2065-1', 'Convert ACEScct to ACES2065-1'), ('ACEScc_to_ACES2065-1', 'Convert ACEScc to ACES2065-1'), ('ACEScg_to_ACES2065-1', 'Convert ACEScg to ACES2065-1'), ('ACESproxy10i_to_ACES2065-1', 'Convert ACESproxy 10i to ACES2065-1'), ('ADX10_to_ACES2065-1', 'Convert ADX10 to ACES2065-1'), ('ADX16_to_ACES2065-1', 'Convert ADX16 to ACES2065-1'), ('ARRI_ALEXA-LOGC-EI800-AWG_to_ACES2065-1', 'Convert ARRI ALEXA LogC (EI800) ALEXA Wide Gamut to ACES2065-1'), ('CANON_CLOG2-CGAMUT_to_ACES2065-1', 'Convert Canon Log 2 Cinema Gamut to ACES2065-1'), ('CANON_CLOG3-CGAMUT_to_ACES2065-1', 'Convert Canon Log 3 Cinema Gamut to ACES2065-1'), ('PANASONIC_VLOG-VGAMUT_to_ACES2065-1', 'Convert Panasonic Varicam V-Log V-Gamut to ACES2065-1'), ('RED_REDLOGFILM-RWG_to_ACES2065-1', 'Convert RED LogFilm RED Wide Gamut to ACES2065-1'), ('RED_LOG3G10-RWG_to_ACES2065-1', 'Convert RED Log3G10 RED Wide Gamut to ACES2065-1'), ('SONY_SLOG3-SGAMUT3_to_ACES2065-1', 'Convert Sony S-Log3 S-Gamut3 to ACES2065-1'), ('SONY_SLOG3-SGAMUT3.CINE_to_ACES2065-1', 'Convert Sony S-Log3 S-Gamut3.Cine to ACES2065-1')]
```

Signed-off-by: Michael Dolan <michdolan@gmail.com>