### PR TITLE
Python unit test module LookTest update

### DIFF
--- a/src/bindings/python/PyLook.cpp
+++ b/src/bindings/python/PyLook.cpp
@@ -17,7 +17,7 @@ void bindPyLook(py::module & m)
                          const std::string & processSpace,
                          const TransformRcPtr & transform,
                          const TransformRcPtr & inverseTransform,
-                         const std::string & description) 
+                         const std::string & description)
             {
                 LookRcPtr p = Look::Create();
                 if (!name.empty())         { p->setName(name.c_str()); }
@@ -26,24 +26,23 @@ void bindPyLook(py::module & m)
                 if (inverseTransform)      { p->setInverseTransform(inverseTransform); }
                 if (!description.empty())  { p->setDescription(description.c_str()); }
                 return p;
-            }), 
+            }),
              "name"_a = DEFAULT->getName(),
              "processSpace"_a = DEFAULT->getProcessSpace(),
              "transform"_a = DEFAULT->getTransform(),
              "inverseTransform"_a = DEFAULT->getInverseTransform(),
-             "description"_a = DEFAULT->getDescription())  
+             "description"_a = DEFAULT->getDescription())
 
         .def("getName", &Look::getName)
-        .def("setName", &Look::setName, "name"_a)
+        .def("setName", &Look::setName, "name"_a.none(false))
         .def("getProcessSpace", &Look::getProcessSpace)
-        .def("setProcessSpace", &Look::setProcessSpace, "processSpace"_a)
+        .def("setProcessSpace", &Look::setProcessSpace, "processSpace"_a.none(false))
         .def("getTransform", &Look::getTransform)
         .def("setTransform", &Look::setTransform, "transform"_a)
         .def("getInverseTransform", &Look::getInverseTransform)
         .def("setInverseTransform", &Look::setInverseTransform, "transform"_a)
         .def("getDescription", &Look::getDescription)
-        .def("setDescription", &Look::setDescription, "description"_a);
-
+        .def("setDescription", &Look::setDescription, "description"_a.none(false));
     defStr(cls);
 }
 

--- a/src/bindings/python/PyLook.cpp
+++ b/src/bindings/python/PyLook.cpp
@@ -43,6 +43,7 @@ void bindPyLook(py::module & m)
         .def("setInverseTransform", &Look::setInverseTransform, "transform"_a)
         .def("getDescription", &Look::getDescription)
         .def("setDescription", &Look::setDescription, "description"_a.none(false));
+
     defStr(cls);
 }
 

--- a/tests/python/LookTest.py
+++ b/tests/python/LookTest.py
@@ -33,6 +33,7 @@ class LookTest(unittest.TestCase):
         # Wrong type tests.
         with self.assertRaises(TypeError):
             self.look.setName(None)
+            self.look.setName(1)
 
     def test_process(self):
         """
@@ -49,6 +50,7 @@ class LookTest(unittest.TestCase):
         # Wrong type tests.
         with self.assertRaises(TypeError):
             self.look.setProcessSpace(None)
+            self.look.setProcessSpace(1)
 
     def test_description(self):
         """
@@ -65,6 +67,7 @@ class LookTest(unittest.TestCase):
         # Wrong type tests.
         with self.assertRaises(TypeError):
             self.look.setDescription(None)
+            self.look.setDescription(1)
 
     def test_transform(self):
         """
@@ -84,6 +87,7 @@ class LookTest(unittest.TestCase):
         # Wrong type tests.
         with self.assertRaises(TypeError):
             self.look.setTransform(OCIO.ALLOCATION_UNIFORM)
+            self.look.setTransform(1)
 
     def test_inverse_transform(self):
         """
@@ -103,6 +107,7 @@ class LookTest(unittest.TestCase):
         # Wrong type tests.
         with self.assertRaises(TypeError):
             self.look.setInverseTransform(OCIO.ALLOCATION_UNIFORM)
+            self.look.setInverseTransform(1)
 
     def test_constructor_with_keyword(self):
         """
@@ -178,3 +183,4 @@ class LookTest(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             look = OCIO.Look(None)
+            look = OCIO.Look(1)

--- a/tests/python/LookTest.py
+++ b/tests/python/LookTest.py
@@ -1,28 +1,180 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 
-import unittest, os, sys
+import unittest
+import os
+import sys
+
 import PyOpenColorIO as OCIO
+from UnitTestUtils import TEST_NAMES, TEST_DESCS
+
 
 class LookTest(unittest.TestCase):
-    
-    def test_interface(self):
-        lk = OCIO.Look()
-        lk.setName("coollook")
-        self.assertEqual("coollook", lk.getName())
-        lk.setProcessSpace("somespace")
-        self.assertEqual("somespace", lk.getProcessSpace())
-        lk.setDescription("this is a test")
-        self.assertEqual("this is a test", lk.getDescription())
-        et = OCIO.ExponentTransform()
-        et.setValue([0.1, 0.2, 0.3, 0.4])
-        lk.setTransform(et)
-        oet = lk.getTransform()
-        vals = oet.getValue()
-        self.assertAlmostEqual(0.2, vals[1], delta=1e-8)
-        iet = OCIO.ExponentTransform()
-        iet.setValue([-0.1, -0.2, -0.3, -0.4])
-        lk.setInverseTransform(iet)
-        ioet = lk.getInverseTransform()
-        vals2 = ioet.getValue()
-        self.assertAlmostEqual(-0.2, vals2[1], delta=1e-8)
+    TEST_PROCESS_SPACES = ['raw', 'lnh', 'vd8', 'a.b.c.', '1-2-3-']
+
+    def setUp(self):
+        self.look = OCIO.Look()
+
+    def tearDown(self):
+        self.look = None
+
+    def test_name(self):
+        """
+        Test the setName() and getName() methods.
+        """
+
+        # Default initialized name value is ""
+        self.assertEqual(self.look.getName(), '')
+
+        for name in TEST_NAMES:
+            self.look.setName(name)
+            self.assertEqual(name, self.look.getName())
+
+        # Wrong type tests.
+        with self.assertRaises(TypeError):
+            self.look.setName(None)
+
+    def test_process(self):
+        """
+        Test the setProcessSpace() and getProcessName() methods.
+        """
+
+        # Default initialized process space value is ""
+        self.assertEqual(self.look.getProcessSpace(), '')
+
+        for process_space in self.TEST_PROCESS_SPACES:
+            self.look.setProcessSpace(process_space)
+            self.assertEqual(process_space, self.look.getProcessSpace())
+
+        # Wrong type tests.
+        with self.assertRaises(TypeError):
+            self.look.setProcessSpace(None)
+
+    def test_description(self):
+        """
+        Test the setDescription() and getDescription() methods.
+        """
+
+        # Default initialized description value is ""
+        self.assertEqual(self.look.getDescription(), '')
+
+        for desc in TEST_DESCS:
+            self.look.setDescription(desc)
+            self.assertEqual(desc, self.look.getDescription())
+
+        # Wrong type tests.
+        with self.assertRaises(TypeError):
+            self.look.setDescription(None)
+
+    def test_transform(self):
+        """
+        Test the setTransform() and getTransform() methods.
+        """
+
+        # Default initialized transform value is None
+        self.assertIsNone(self.look.getTransform())
+
+        exp_tr = OCIO.ExponentTransform()
+        exp_values = [0.1, 0.2, 0.3, 0.4]
+        exp_tr.setValue(exp_values)
+        self.look.setTransform(exp_tr)
+        oet = self.look.getTransform()
+        self.assertListEqual(oet.getValue(), exp_values)
+
+        # Wrong type tests.
+        with self.assertRaises(TypeError):
+            self.look.setTransform(OCIO.ALLOCATION_UNIFORM)
+
+    def test_inverse_transform(self):
+        """
+        Test the setInverseTransform() and getInverseTransform() methods.
+        """
+
+        # Default initialized inverse transform value is None
+        self.assertIsNone(self.look.getInverseTransform())
+
+        exp_tr = OCIO.ExponentTransform()
+        exp_values = [-0.1, -0.2, -0.3, -0.4]
+        exp_tr.setValue(exp_values)
+        self.look.setInverseTransform(exp_tr)
+        inv_oet = self.look.getInverseTransform()
+        self.assertListEqual(inv_oet.getValue(), exp_values)
+
+        # Wrong type tests.
+        with self.assertRaises(TypeError):
+            self.look.setInverseTransform(OCIO.ALLOCATION_UNIFORM)
+
+    def test_constructor_with_keyword(self):
+        """
+        Test Look constructor with keywords and validate its values.
+        """
+
+        # With keywords in their proper order.
+        exp_tr = OCIO.ExponentTransform()
+        inv_exp_tr = OCIO.ExponentTransform()
+        look = OCIO.Look(name='coollook',
+                         processSpace='somespace',
+                         transform=exp_tr,
+                         inverseTransform=inv_exp_tr,
+                         description='this is a test')
+
+        self.assertEqual(look.getName(), 'coollook')
+        self.assertEqual(look.getProcessSpace(), 'somespace')
+        self.assertIsInstance(look.getTransform(), type(exp_tr))
+        self.assertIsInstance(look.getInverseTransform(), type(inv_exp_tr))
+        self.assertEqual(look.getDescription(), 'this is a test')
+
+        # With keyword not in their proper order.
+        exp_tr2 = OCIO.ExponentTransform()
+        inv_exp_tr2 = OCIO.ExponentTransform()
+        look2 = OCIO.Look(inverseTransform=inv_exp_tr,
+                          description='this is a test',
+                          name='coollook',
+                          processSpace='somespace',
+                          transform=exp_tr)
+
+        self.assertEqual(look2.getName(), 'coollook')
+        self.assertEqual(look2.getProcessSpace(), 'somespace')
+        self.assertIsInstance(look2.getTransform(), type(exp_tr2))
+        self.assertIsInstance(look2.getInverseTransform(), type(inv_exp_tr2))
+        self.assertEqual(look2.getDescription(), 'this is a test')
+
+    def test_constructor_without_keyword(self):
+        """
+        Test Look constructor without keywords and validate its values.
+        """
+
+        exp_tr = OCIO.ExponentTransform()
+        inv_exp_tr = OCIO.ExponentTransform()
+        look = OCIO.Look('coollook',
+                         'somespace',
+                         exp_tr,
+                         inv_exp_tr,
+                         'this is a test')
+
+        self.assertEqual(look.getName(), 'coollook')
+        self.assertEqual(look.getProcessSpace(), 'somespace')
+        self.assertIsInstance(look.getTransform(), type(exp_tr))
+        self.assertIsInstance(look.getInverseTransform(), type(inv_exp_tr))
+        self.assertEqual(look.getDescription(), 'this is a test')
+
+    def test_constructor_without_parameter(self):
+        """
+        Test Look default constructor and validate its values.
+        """
+
+        look = OCIO.Look()
+
+        self.assertEqual(look.getName(), '')
+        self.assertEqual(look.getProcessSpace(), '')
+        self.assertIsNone(look.getTransform())
+        self.assertIsNone(look.getInverseTransform())
+        self.assertEqual(look.getDescription(), '')
+
+    def test_constructor_wrong_parameter_type(self):
+        """
+        Test Look constructor with a wrong parameter type.
+        """
+
+        with self.assertRaises(TypeError):
+            look = OCIO.Look(None)

--- a/tests/python/LookTest.py
+++ b/tests/python/LookTest.py
@@ -31,9 +31,9 @@ class LookTest(unittest.TestCase):
             self.assertEqual(name, self.look.getName())
 
         # Wrong type tests.
-        with self.assertRaises(TypeError):
-            self.look.setName(None)
-            self.look.setName(1)
+        for invalid in (None, 1):
+            with self.assertRaises(TypeError):
+                self.look.setName(invalid)
 
     def test_process(self):
         """
@@ -48,9 +48,9 @@ class LookTest(unittest.TestCase):
             self.assertEqual(process_space, self.look.getProcessSpace())
 
         # Wrong type tests.
-        with self.assertRaises(TypeError):
-            self.look.setProcessSpace(None)
-            self.look.setProcessSpace(1)
+        for invalid in (None, 1):
+            with self.assertRaises(TypeError):
+                self.look.setProcessSpace(invalid)
 
     def test_description(self):
         """
@@ -65,9 +65,9 @@ class LookTest(unittest.TestCase):
             self.assertEqual(desc, self.look.getDescription())
 
         # Wrong type tests.
-        with self.assertRaises(TypeError):
-            self.look.setDescription(None)
-            self.look.setDescription(1)
+        for invalid in (None, 1):
+            with self.assertRaises(TypeError):
+                self.look.setDescription(invalid)
 
     def test_transform(self):
         """
@@ -85,9 +85,9 @@ class LookTest(unittest.TestCase):
         self.assertListEqual(oet.getValue(), exp_values)
 
         # Wrong type tests.
-        with self.assertRaises(TypeError):
-            self.look.setTransform(OCIO.ALLOCATION_UNIFORM)
-            self.look.setTransform(1)
+        for invalid in (OCIO.ALLOCATION_UNIFORM, 1):
+            with self.assertRaises(TypeError):
+                self.look.setTransform(invalid)
 
     def test_inverse_transform(self):
         """
@@ -105,9 +105,9 @@ class LookTest(unittest.TestCase):
         self.assertListEqual(inv_oet.getValue(), exp_values)
 
         # Wrong type tests.
-        with self.assertRaises(TypeError):
-            self.look.setInverseTransform(OCIO.ALLOCATION_UNIFORM)
-            self.look.setInverseTransform(1)
+        for invalid in (OCIO.ALLOCATION_UNIFORM, 1):
+            with self.assertRaises(TypeError):
+                self.look.setInverseTransform(invalid)
 
     def test_constructor_with_keyword(self):
         """
@@ -181,6 +181,6 @@ class LookTest(unittest.TestCase):
         Test Look constructor with a wrong parameter type.
         """
 
-        with self.assertRaises(TypeError):
-            look = OCIO.Look(None)
-            look = OCIO.Look(1)
+        for invalid in (None, 1):
+            with self.assertRaises(TypeError):
+                look = OCIO.Look(invalid)

--- a/tests/python/LookTest.py
+++ b/tests/python/LookTest.py
@@ -11,6 +11,7 @@ from UnitTestUtils import TEST_NAMES, TEST_DESCS
 
 class LookTest(unittest.TestCase):
     TEST_PROCESS_SPACES = ['raw', 'lnh', 'vd8', 'a.b.c.', '1-2-3-']
+    TEST_EXP_VALUES = [0.1, 0.2, 0.3, 0.4]
 
     def setUp(self):
         self.look = OCIO.Look()
@@ -35,7 +36,7 @@ class LookTest(unittest.TestCase):
             with self.assertRaises(TypeError):
                 self.look.setName(invalid)
 
-    def test_process(self):
+    def test_process_space(self):
         """
         Test the setProcessSpace() and getProcessName() methods.
         """
@@ -78,11 +79,10 @@ class LookTest(unittest.TestCase):
         self.assertIsNone(self.look.getTransform())
 
         exp_tr = OCIO.ExponentTransform()
-        exp_values = [0.1, 0.2, 0.3, 0.4]
-        exp_tr.setValue(exp_values)
+        exp_tr.setValue(self.TEST_EXP_VALUES)
         self.look.setTransform(exp_tr)
-        oet = self.look.getTransform()
-        self.assertListEqual(oet.getValue(), exp_values)
+        out_exp_tr = self.look.getTransform()
+        self.assertListEqual(out_exp_tr.getValue(), self.TEST_EXP_VALUES)
 
         # Wrong type tests.
         for invalid in (OCIO.ALLOCATION_UNIFORM, 1):
@@ -98,18 +98,18 @@ class LookTest(unittest.TestCase):
         self.assertIsNone(self.look.getInverseTransform())
 
         exp_tr = OCIO.ExponentTransform()
-        exp_values = [-0.1, -0.2, -0.3, -0.4]
-        exp_tr.setValue(exp_values)
+        inv_exp_values = [1.0 / v for v in self.TEST_EXP_VALUES]
+        exp_tr.setValue(inv_exp_values)
         self.look.setInverseTransform(exp_tr)
         inv_oet = self.look.getInverseTransform()
-        self.assertListEqual(inv_oet.getValue(), exp_values)
+        self.assertListEqual(inv_oet.getValue(), inv_exp_values)
 
         # Wrong type tests.
         for invalid in (OCIO.ALLOCATION_UNIFORM, 1):
             with self.assertRaises(TypeError):
                 self.look.setInverseTransform(invalid)
 
-    def test_constructor_with_keyword(self):
+    def test_constructor_with_positional(self):
         """
         Test Look constructor with keywords and validate its values.
         """
@@ -144,7 +144,7 @@ class LookTest(unittest.TestCase):
         self.assertIsInstance(look2.getInverseTransform(), type(inv_exp_tr2))
         self.assertEqual(look2.getDescription(), 'this is a test')
 
-    def test_constructor_without_keyword(self):
+    def test_constructor_without_positional(self):
         """
         Test Look constructor without keywords and validate its values.
         """
@@ -162,19 +162,6 @@ class LookTest(unittest.TestCase):
         self.assertIsInstance(look.getTransform(), type(exp_tr))
         self.assertIsInstance(look.getInverseTransform(), type(inv_exp_tr))
         self.assertEqual(look.getDescription(), 'this is a test')
-
-    def test_constructor_without_parameter(self):
-        """
-        Test Look default constructor and validate its values.
-        """
-
-        look = OCIO.Look()
-
-        self.assertEqual(look.getName(), '')
-        self.assertEqual(look.getProcessSpace(), '')
-        self.assertIsNone(look.getTransform())
-        self.assertIsNone(look.getInverseTransform())
-        self.assertEqual(look.getDescription(), '')
 
     def test_constructor_wrong_parameter_type(self):
         """

--- a/tests/python/LookTest.py
+++ b/tests/python/LookTest.py
@@ -109,7 +109,7 @@ class LookTest(unittest.TestCase):
             with self.assertRaises(TypeError):
                 self.look.setInverseTransform(invalid)
 
-    def test_constructor_with_positional(self):
+    def test_constructor_with_keyword(self):
         """
         Test Look constructor with keywords and validate its values.
         """
@@ -144,7 +144,7 @@ class LookTest(unittest.TestCase):
         self.assertIsInstance(look2.getInverseTransform(), type(inv_exp_tr2))
         self.assertEqual(look2.getDescription(), 'this is a test')
 
-    def test_constructor_without_positional(self):
+    def test_constructor_with_positional(self):
         """
         Test Look constructor without keywords and validate its values.
         """

--- a/tests/python/OpenColorIOTestSuite.py
+++ b/tests/python/OpenColorIOTestSuite.py
@@ -32,11 +32,11 @@ import PyOpenColorIO as OCIO
 
 import ColorSpaceTest
 import CDLTransformTest
+import LookTest
 #from MainTest import *
 #from ConstantsTest import *
 #from ConfigTest import *
 #from ContextTest import *
-#from LookTest import *
 #from GpuShaderDescTest import *
 #from Baker import *
 #from TransformsTest import *
@@ -55,12 +55,12 @@ def suite():
 
     suite.addTest(loader.loadTestsFromModule(ColorSpaceTest))
     suite.addTest(loader.loadTestsFromModule(CDLTransformTest))
+    suite.addTest(loader.loadTestsFromModule(LookTest))
     #suite.addTest(MainTest("test_interface"))
     #suite.addTest(ConstantsTest("test_interface"))
     #suite.addTest(ConfigTest("test_interface"))
     #suite.addTest(ConfigTest("test_is_editable"))
     #suite.addTest(ContextTest("test_interface"))
-    #suite.addTest(LookTest("test_interface"))
     #suite.addTest(RangeTransformTest("test_interface"))
     #suite.addTest(RangeTransformTest("test_equality"))
     #suite.addTest(RangeTransformTest("test_validation"))


### PR DESCRIPTION
Result of the LookTest module update:
`
test_constructor_with_keyword (LookTest.LookTest) ... ok
test_constructor_without_keyword (LookTest.LookTest) ... ok
test_constructor_without_parameter (LookTest.LookTest) ... ok
test_constructor_wrong_parameter_type (LookTest.LookTest) ... ok
test_description (LookTest.LookTest) ... Segmentation fault: 11
`

The wrong type tests in `setName()`, `setProcessSpace()`, and `setDescription()` will trigger a segmentation fault. That seems like a really harsh rejection and perhaps it would be nice to have it throw exceptions instead of a crash? The rest of the test are fine and should pass without issues.