### PR TITLE
Fix SPI1D and SPI3D LUT parsing failing depending on locale

### DIFF
--- a/src/OpenColorIO/fileformats/FileFormatSpi1D.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatSpi1D.cpp
@@ -107,12 +107,19 @@ CachedFileRcPtr LocalFileFormat::read(
             ++currentLine;
             headerLine = std::string(lineBuffer);
 
-            if(StringUtils::StartsWith(headerLine, "Version"))
+            StringUtils::StringVec chunks = StringUtils::SplitByWhiteSpaces(StringUtils::Trim(headerLine));
+
+            if(!chunks.size())
+            {
+                continue;
+            }
+
+            if(chunks[0] == "Version")
             {
                 // " " in format means any number of spaces (white space,
                 // new line, tab) including 0 of them.
                 // "Version1" is valid.
-                if (sscanf(lineBuffer, "Version %d", &version) != 1)
+                if (chunks.size() != 2 || !StringToInt(&version, chunks[1].c_str()))
                 {
                     ThrowErrorMessage("Invalid 'Version' Tag", currentLine, headerLine);
                 }
@@ -121,23 +128,24 @@ CachedFileRcPtr LocalFileFormat::read(
                     ThrowErrorMessage("Only format version 1 supported", currentLine, headerLine);
                 }
             }
-            else if(StringUtils::StartsWith(headerLine, "From"))
+            else if(chunks[0] == "From")
             {
-                if (sscanf(lineBuffer, "From %f %f", &from_min, &from_max) != 2)
+                if (chunks.size() != 3 || !StringToFloat(&from_min, chunks[1].c_str())
+                    || !StringToFloat(&from_max, chunks[2].c_str()))
                 {
                     ThrowErrorMessage("Invalid 'From' Tag", currentLine, headerLine);
                 }
             }
-            else if(StringUtils::StartsWith(headerLine, "Components"))
+            else if(chunks[0] == "Components")
             {
-                if (sscanf(lineBuffer, "Components %d", &components) != 1)
+                if (chunks.size() != 2 || !StringToInt(&components, chunks[1].c_str()))
                 {
                     ThrowErrorMessage("Invalid 'Components' Tag", currentLine, headerLine);
                 }
             }
-            else if(StringUtils::StartsWith(headerLine, "Length"))
+            else if(chunks[0] == "Length")
             {
-                if (sscanf(lineBuffer, "Length %d", &lut_size) != 1)
+                if (chunks.size() != 2 || !StringToInt(&lut_size, chunks[1].c_str()))
                 {
                     ThrowErrorMessage("Invalid 'Length' Tag", currentLine, headerLine);
                 }

--- a/tests/cpu/fileformats/FileFormatSpi3D_tests.cpp
+++ b/tests/cpu/fileformats/FileFormatSpi3D_tests.cpp
@@ -86,6 +86,23 @@ OCIO_ADD_TEST(FileFormatSpi3D, read_failure)
         OCIO_CHECK_NO_THROW(ReadSpi3d(SAMPLE_NO_ERROR));
     }
     {
+        // Multiple spaces between entries are accepted
+        const std::string SAMPLE_NO_ERROR =
+            "SPILUT \t1.0\n"
+            "3    3\n"
+            "2  2\t2\n"
+            "0   0   0\t0.0 0.0 0.0\n"
+            "0 0 1 0.0 0.0 0.9\n"
+            "0 1 0 0.0 0.7 0.0\n"
+            "0 1 1 0.0 0.8 0.8\n"
+            "1 0 0 0.7 0.0 0.1\n"
+            "1 0 1 0.7 0.6 0.1\n"
+            "1 1 0 0.6 0.7 0.1\n"
+            "1 1 1 0.6 0.7 0.7\n";
+
+        OCIO_CHECK_NO_THROW(ReadSpi3d(SAMPLE_NO_ERROR));
+    }
+    {
         // Wrong first line
         const std::string SAMPLE_ERROR =
             "SPI LUT 1.0\n"
@@ -168,6 +185,60 @@ OCIO_ADD_TEST(FileFormatSpi3D, read_failure)
             "3 3\n"
             "2 2 2\n"
             "0 0 0 0.0 0.0 0.0\n"
+            "0 0 1 0.0 0.0 0.9\n"
+            "0 1 0 0.0 0.7 0.0\n"
+            "0 1 1 0.0 0.8 0.8\n"
+            "1 0 1 0.7 0.6 0.1\n"
+            "1 1 0 0.6 0.7 0.1\n"
+            "1 1 1 0.6 0.7 0.7\n";
+
+        OCIO_CHECK_THROW_WHAT(ReadSpi3d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Not enough entries found");
+    }
+    {
+        // Float instead of integer for index
+        const std::string SAMPLE_ERROR =
+            "SPILUT 1.0\n"
+            "3 3\n"
+            "2 2 2\n"
+            "0.0 0 0 0.0 0.0 0.0\n"
+            "0 0 1 0.0 0.0 0.9\n"
+            "0 1 0 0.0 0.7 0.0\n"
+            "0 1 1 0.0 0.8 0.8\n"
+            "1 0 1 0.7 0.6 0.1\n"
+            "1 1 0 0.6 0.7 0.1\n"
+            "1 1 1 0.6 0.7 0.7\n";
+
+        OCIO_CHECK_THROW_WHAT(ReadSpi3d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Not enough entries found");
+    }
+    {
+        // No newline between first and second entries
+        const std::string SAMPLE_ERROR =
+            "SPILUT 1.0\n"
+            "3 3\n"
+            "2 2 2\n"
+            "0 0 0 0.0 0.0 0.0"
+            "0 0 1 0.0 0.0 0.9\n"
+            "0 1 0 0.0 0.7 0.0\n"
+            "0 1 1 0.0 0.8 0.8\n"
+            "1 0 1 0.7 0.6 0.1\n"
+            "1 1 0 0.6 0.7 0.1\n"
+            "1 1 1 0.6 0.7 0.7\n";
+
+        OCIO_CHECK_THROW_WHAT(ReadSpi3d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Not enough entries found");
+    }
+    {
+        // First entry is incomplete
+        const std::string SAMPLE_ERROR =
+            "SPILUT 1.0\n"
+            "3 3\n"
+            "2 2 2\n"
+            "0 0 0 0.0 0.0\n"
             "0 0 1 0.0 0.0 0.9\n"
             "0 1 0 0.0 0.7 0.0\n"
             "0 1 1 0.0 0.8 0.8\n"


### PR DESCRIPTION
Ain't pretty but I wanted to keep the amount of changes minimal. Unit tests pass and they look like they're fairly valid for checking if the parsing works.

This leaves only a few more spots in the codebase that use sscanf (and thus break depending on locale):

```
OpenColorIO/src> ag sscanf
OpenColorIO/Platform.h
29:#define sscanf sscanf_s

OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
412:        const int nummatched = sscanf(InString, "%*s %d %d %s", &numtables, &length, dstDepthS, 16);
414:        const int nummatched = sscanf(InString, "%*s %d %d %s", &numtables, &length, dstDepthS);
436:            sscanf(dstDepthS, "%d%c", &dstDepth, &floatC, 1);
438:            sscanf(dstDepthS, "%d%c", &dstDepth, &floatC);

OpenColorIO/fileformats/ctf/CTFReaderHelper.cpp
598:        // (e.g. "10.5@") but it does not cause the sscanf to fail.
757:        if (0 == sscanf(versionValue, "%d", &fver))

OpenColorIO/fileformats/ctf/CTFTransform.cpp
78:    sscanf(versionString.c_str(), "%d.%d.%d",
```
%d should be pretty safe, not sure about %s (probably not).

Fixes some instances of #297 occurring.