### PR TITLE
Fix doc CI for macOS and Windows

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -57,7 +57,8 @@ jobs:
           # -------------------------------------------------------------------
           # Python 2.7
           - build: 3
-            build-docs: 'ON'
+            # Doc build requires Python 3
+            build-docs: 'OFF'
             cxx-standard: 11
             cxx-compiler: g++
             cc-compiler: gcc
@@ -87,6 +88,7 @@ jobs:
           # -------------------------------------------------------------------
           # Python 2.7
           - build: 6
+            # Doc build requires Python 3
             build-docs: 'OFF'
             cxx-standard: 11
             cxx-compiler: clang++
@@ -113,7 +115,13 @@ jobs:
           share/ci/scripts/linux/install_pybind11.sh latest
           share/ci/scripts/linux/install_openexr.sh latest
           share/ci/scripts/linux/install_oiio.sh latest
+      - name: Install latest documentation ext package versions
+        run: |
           share/ci/scripts/linux/install_sphinx.sh latest
+          share/ci/scripts/linux/install_testresources.sh latest
+          share/ci/scripts/linux/install_recommonmark.sh latest
+          share/ci/scripts/linux/install_sphinx-press-theme.sh latest
+        if: matrix.build-docs == 'ON'
       - name: Create build directories
         run: |
           mkdir _install

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -119,7 +119,8 @@ jobs:
           - build: 5
             build-type: Release
             build-shared: 'ON'
-            build-docs: 'ON'
+            # Doc build requires Python 3
+            build-docs: 'OFF'
             build-gpu: 'OFF'
             use-headless: 'OFF'
             use-sse: 'ON'
@@ -190,7 +191,8 @@ jobs:
           - build: 10
             build-type: Release
             build-shared: 'ON'
-            build-docs: 'ON'
+            # Doc build requires Python 3
+            build-docs: 'OFF'
             build-gpu: 'OFF'
             use-headless: 'OFF'
             use-sse: 'ON'
@@ -302,7 +304,8 @@ jobs:
           - build: 5
             build-type: Release
             build-shared: 'ON'
-            build-docs: 'ON'
+            # Doc build requires Python 3
+            build-docs: 'OFF'
             build-gpu: 'OFF'
             use-headless: 'OFF'
             use-sse: 'ON'
@@ -409,7 +412,8 @@ jobs:
           - build: 5
             build-type: Release
             build-shared: 'ON'
-            build-docs: 'ON'
+            # Doc build requires Python 3
+            build-docs: 'OFF'
             build-gpu: 'OFF'
             use-headless: 'OFF'
             use-sse: 'ON'

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -4,7 +4,7 @@
 ###############################################################################
 ### Python ###
 find_package(Python REQUIRED COMPONENTS Interpreter)
-if((${Python_VERSION_MAJOR} GREATER_EQUAL 3) AND (NOT WIN32))
+if(${Python_VERSION_MAJOR} GREATER_EQUAL 3)
     if(NOT OCIO_BUILD_PYTHON)
         message(FATAL_ERROR "Doc generation requires that the python bindings be built")
     endif()
@@ -65,6 +65,10 @@ if((${Python_VERSION_MAJOR} GREATER_EQUAL 3) AND (NOT WIN32))
 
     ###############################################################################
     ### Copy templates to build area ###
+
+    message(STATUS "Create sphinx conf.py from conf.py.in")
+    configure_file(${CMAKE_SOURCE_DIR}/docs/conf.py.in
+        ${CMAKE_BINARY_DIR}/docs/conf.py @ONLY)
 
     file(GLOB_RECURSE DOC_SOURCES "${CMAKE_SOURCE_DIR}/docs/*")
     list(APPEND DOC_SOURCES

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -9,7 +9,11 @@ import sys, os
 
 # -- Add PyOpenColorIO to sys.path ---------------------------------------------
 
-sys.path.insert(0, "@CMAKE_BINARY_DIR@/src/pyglue")
+sys.path.insert(0, "@CMAKE_BINARY_DIR@/src/bindings/python")
+
+# -- Add installed ext packages to sys.path ------------------------------------
+
+sys.path.insert(1, "@CMAKE_BINARY_DIR@/ext/dist/lib@LIB_SUFFIX@/site-packages")
 
 # -- General configuration -----------------------------------------------------
 

--- a/share/ci/scripts/linux/install_recommonmark.sh
+++ b/share/ci/scripts/linux/install_recommonmark.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+set -ex
+
+if [[ "$(python -c 'import sys; print(sys.version_info[0])')" == "2" ]]; then
+    # Python 2
+    RECOMMONMARK_VERSION="$1"
+else
+    # Python 3
+    RECOMMONMARK_VERSION="${2:-${1}}"
+fi
+
+if [ "$RECOMMONMARK_VERSION" == "latest" ]; then
+    sudo pip install recommonmark
+else
+    sudo pip install recommonmark==${RECOMMONMARK_VERSION}
+fi

--- a/share/ci/scripts/linux/install_sphinx-press-theme.sh
+++ b/share/ci/scripts/linux/install_sphinx-press-theme.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+set -ex
+
+if [[ "$(python -c 'import sys; print(sys.version_info[0])')" == "2" ]]; then
+    # Python 2
+    SPHINX_PRESS_THEME_VERSION="$1"
+else
+    # Python 3
+    SPHINX_PRESS_THEME_VERSION="${2:-${1}}"
+fi
+
+if [ "$SPHINX_PRESS_THEME_VERSION" == "latest" ]; then
+    sudo pip install sphinx-press-theme
+else
+    sudo pip install sphinx-press-theme==${SPHINX_PRESS_THEME_VERSION}
+fi

--- a/share/ci/scripts/linux/install_sphinx-tabs.sh
+++ b/share/ci/scripts/linux/install_sphinx-tabs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+set -ex
+
+if [[ "$(python -c 'import sys; print(sys.version_info[0])')" == "2" ]]; then
+    # Python 2
+    SPHINX_TABS_VERSION="$1"
+else
+    # Python 3
+    SPHINX_TABS_VERSION="${2:-${1}}"
+fi
+
+if [ "$SPHINX_TABS_VERSION" == "latest" ]; then
+    sudo pip install sphinx-tabs
+else
+    sudo pip install sphinx-tabs==${SPHINX_TABS_VERSION}
+fi

--- a/share/ci/scripts/linux/install_testresources.sh
+++ b/share/ci/scripts/linux/install_testresources.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+set -ex
+
+if [[ "$(python -c 'import sys; print(sys.version_info[0])')" == "2" ]]; then
+    # Python 2
+    TESTRESOURCES_VERSION="$1"
+else
+    # Python 3
+    TESTRESOURCES_VERSION="${2:-${1}}"
+fi
+
+if [ "$TESTRESOURCES_VERSION" == "latest" ]; then
+    sudo pip install testresources
+else
+    sudo pip install testresources==${TESTRESOURCES_VERSION}
+fi

--- a/share/cmake/macros/FindPythonPackage.cmake
+++ b/share/cmake/macros/FindPythonPackage.cmake
@@ -100,15 +100,12 @@ macro(find_python_package package version)
             # Package install location
             if(WIN32)
                 set(_SITE_PKGS_DIR "${_EXT_DIST_ROOT}/lib${LIB_SUFFIX}/site-packages")
-                # On Windows platform, pip is in the Scripts sub-directory.
-                set(_PYTHON_PIP "${PYTHON_ROOT}/Scripts/pip.exe")
                 # --prefix value needs OS-native path separator
                 string(REPLACE "/" "\\" _PIP_PREFIX ${_EXT_DIST_ROOT})
             else()
                 set(_Python_VARIANT "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
                 set(_SITE_PKGS_DIR
                     "${_EXT_DIST_ROOT}/lib${LIB_SUFFIX}/python${_Python_VARIANT}/site-packages")
-                set(_Python_PIP "pip")
                 set(_PIP_PREFIX "${_EXT_DIST_ROOT}")
             endif()
 
@@ -117,7 +114,8 @@ macro(find_python_package package version)
                 TARGET
                     ${package}
                 COMMAND
-                    ${_Python_PIP} install --disable-pip-version-check
+                    "${Python_EXECUTABLE}" -m pip install  
+                                           --disable-pip-version-check
                                            --prefix="${_PIP_PREFIX}"
                                            -I ${package}==${version}
                 WORKING_DIRECTORY

--- a/share/cmake/macros/FindPythonPackage.cmake
+++ b/share/cmake/macros/FindPythonPackage.cmake
@@ -114,7 +114,7 @@ macro(find_python_package package version)
                 TARGET
                     ${package}
                 COMMAND
-                    "${Python_EXECUTABLE}" -m pip install  
+                    "${Python_EXECUTABLE}" -m pip -v install  
                                            --disable-pip-version-check
                                            --prefix="${_PIP_PREFIX}"
                                            -I ${package}==${version}

--- a/share/cmake/macros/FindPythonPackage.cmake
+++ b/share/cmake/macros/FindPythonPackage.cmake
@@ -4,7 +4,7 @@
 # Locate or install a Python package in PyPi
 #
 # Variables defined by this module:
-#   <PACKAGE>_FOUND
+#   <package>_FOUND
 #
 # Targets defined by this module:
 #   <package> - custom pip target, if package can be installed
@@ -21,8 +21,9 @@
 find_package(Python QUIET COMPONENTS Interpreter)
 
 macro(find_python_package package version)
-    string(TOUPPER ${package} _PKG_UPPER)
-    string(TOLOWER ${package} _PKG_LOWER)
+    # Some Python packages have "-" in the PyPi name, but are replaced with "_" 
+    # in the actual package name.
+    string(REPLACE "-" "_" _PKG_IMPORT ${package})
 
     # Parse options
     foreach(_ARG ${ARGN})
@@ -35,14 +36,13 @@ macro(find_python_package package version)
         set(_PREV_ARG ${_ARG})
     endforeach()
     
-
     if(NOT TARGET ${package})
         add_custom_target(${package})
         if(_PKG_REQUIRES)
             add_dependencies(${package} ${_PKG_REQUIRES})
             unset(_PKG_REQUIRES)
         endif()
-        set(_${_PKG_UPPER}_TARGET_CREATE TRUE)
+        set(_${package}_TARGET_CREATE TRUE)
     endif()
 
     set(_PKG_INSTALL TRUE)
@@ -54,21 +54,21 @@ macro(find_python_package package version)
         # Try importing Python package
         execute_process(
             COMMAND
-                "${Python_EXECUTABLE}" -c "import ${_PKG_LOWER}"
+                "${Python_EXECUTABLE}" -c "import ${_PKG_IMPORT}"
             RESULT_VARIABLE
                 _PKG_IMPORT_RESULT
             OUTPUT_QUIET ERROR_QUIET
         )
 
         if(_PKG_IMPORT_RESULT EQUAL 0)
-            set(${_PKG_UPPER}_FOUND TRUE)
+            set(${package}_FOUND TRUE)
             set(_PKG_INSTALL FALSE)
 
             # Get the package's location
             execute_process(
                 COMMAND
                     "${Python_EXECUTABLE}" -c 
-                    "import ${_PKG_LOWER}, os; print(os.path.dirname(${_PKG_LOWER}.__file__))"
+                    "import ${_PKG_IMPORT}, os; print(os.path.dirname(${_PKG_IMPORT}.__file__))"
                 OUTPUT_VARIABLE
                     _PKG_DIR
                 ERROR_QUIET
@@ -77,8 +77,8 @@ macro(find_python_package package version)
             message(STATUS "Found ${package}: ${_PKG_DIR}")
 
         else()
-            set(${_PKG_UPPER}_FOUND FALSE)
-            set(_FIND_ERR "Could NOT find ${package}: import ${_PKG_LOWER} failed")
+            set(${package}_FOUND FALSE)
+            set(_FIND_ERR "Could NOT find ${package}: import ${_PKG_IMPORT} failed")
             if(OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
                 set(_PKG_INSTALL FALSE)
                 if(_PKG_REQUIRED)
@@ -94,19 +94,22 @@ macro(find_python_package package version)
 
     if(_PKG_INSTALL)
         set(_EXT_DIST_ROOT "${CMAKE_BINARY_DIR}/ext/dist")
-        set(${_PKG_UPPER}_FOUND TRUE)
+        set(${package}_FOUND TRUE)
 
-        if(_${_PKG_UPPER}_TARGET_CREATE)
+        if(_${package}_TARGET_CREATE)
             # Package install location
             if(WIN32)
                 set(_SITE_PKGS_DIR "${_EXT_DIST_ROOT}/lib${LIB_SUFFIX}/site-packages")
                 # On Windows platform, pip is in the Scripts sub-directory.
                 set(_PYTHON_PIP "${PYTHON_ROOT}/Scripts/pip.exe")
+                # --prefix value needs OS-native path separator
+                string(REPLACE "/" "\\" _PIP_PREFIX ${_EXT_DIST_ROOT})
             else()
                 set(_Python_VARIANT "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
                 set(_SITE_PKGS_DIR
                     "${_EXT_DIST_ROOT}/lib${LIB_SUFFIX}/python${_Python_VARIANT}/site-packages")
                 set(_Python_PIP "pip")
+                set(_PIP_PREFIX "${_EXT_DIST_ROOT}")
             endif()
 
             # Configure install target
@@ -115,7 +118,7 @@ macro(find_python_package package version)
                     ${package}
                 COMMAND
                     ${_Python_PIP} install --disable-pip-version-check
-                                           --prefix=${_EXT_DIST_ROOT}
+                                           --prefix="${_PIP_PREFIX}"
                                            -I ${package}==${version}
                 WORKING_DIRECTORY
                     "${CMAKE_BINARY_DIR}"

--- a/share/cmake/macros/FindPythonPackage.cmake
+++ b/share/cmake/macros/FindPythonPackage.cmake
@@ -114,7 +114,7 @@ macro(find_python_package package version)
                 TARGET
                     ${package}
                 COMMAND
-                    "${Python_EXECUTABLE}" -m pip -v install  
+                    "${Python_EXECUTABLE}" -m pip install  
                                            --disable-pip-version-check
                                            --prefix="${_PIP_PREFIX}"
                                            -I ${package}==${version}

--- a/share/cmake/modules/FindSphinx.cmake
+++ b/share/cmake/modules/FindSphinx.cmake
@@ -67,13 +67,10 @@ if(NOT Sphinx_FOUND)
     set(Sphinx_FOUND TRUE)
     if(WIN32)
         set(Sphinx_EXECUTABLE "${_EXT_DIST_ROOT}/Scripts/sphinx-build")
-        # On Windows platform, pip is in the Scripts sub-directory.
-        set(_Python_PIP "${_Python_SCRIPTS_DIR}/pip.exe")
         # --prefix value needs OS-native path separator
         string(REPLACE "/" "\\" _PIP_PREFIX ${_EXT_DIST_ROOT})
     else()
         set(Sphinx_EXECUTABLE "${_EXT_DIST_ROOT}/bin/sphinx-build")
-        set(_Python_PIP "pip")
         set(_PIP_PREFIX "${_EXT_DIST_ROOT}")
     endif()
 
@@ -83,7 +80,8 @@ if(NOT Sphinx_FOUND)
             TARGET
                 Sphinx
             COMMAND
-                ${_Python_PIP} install --disable-pip-version-check
+                "${Python_EXECUTABLE}" -m pip install 
+                                       --disable-pip-version-check
                                        --prefix="${_PIP_PREFIX}"
                                        -I Sphinx==${Sphinx_FIND_VERSION}
             WORKING_DIRECTORY

--- a/share/cmake/modules/FindSphinx.cmake
+++ b/share/cmake/modules/FindSphinx.cmake
@@ -80,7 +80,7 @@ if(NOT Sphinx_FOUND)
             TARGET
                 Sphinx
             COMMAND
-                "${Python_EXECUTABLE}" -m pip install 
+                "${Python_EXECUTABLE}" -m pip -v install 
                                        --disable-pip-version-check
                                        --prefix="${_PIP_PREFIX}"
                                        -I Sphinx==${Sphinx_FIND_VERSION}

--- a/share/cmake/modules/FindSphinx.cmake
+++ b/share/cmake/modules/FindSphinx.cmake
@@ -69,9 +69,12 @@ if(NOT Sphinx_FOUND)
         set(Sphinx_EXECUTABLE "${_EXT_DIST_ROOT}/Scripts/sphinx-build")
         # On Windows platform, pip is in the Scripts sub-directory.
         set(_Python_PIP "${_Python_SCRIPTS_DIR}/pip.exe")
+        # --prefix value needs OS-native path separator
+        string(REPLACE "/" "\\" _PIP_PREFIX ${_EXT_DIST_ROOT})
     else()
         set(Sphinx_EXECUTABLE "${_EXT_DIST_ROOT}/bin/sphinx-build")
         set(_Python_PIP "pip")
+        set(_PIP_PREFIX "${_EXT_DIST_ROOT}")
     endif()
 
     # Configure install target
@@ -81,7 +84,7 @@ if(NOT Sphinx_FOUND)
                 Sphinx
             COMMAND
                 ${_Python_PIP} install --disable-pip-version-check
-                                       --install-option="--prefix=${_EXT_DIST_ROOT}"
+                                       --prefix="${_PIP_PREFIX}"
                                        -I Sphinx==${Sphinx_FIND_VERSION}
             WORKING_DIRECTORY
                 "${CMAKE_BINARY_DIR}"

--- a/share/cmake/modules/FindSphinx.cmake
+++ b/share/cmake/modules/FindSphinx.cmake
@@ -80,7 +80,7 @@ if(NOT Sphinx_FOUND)
             TARGET
                 Sphinx
             COMMAND
-                "${Python_EXECUTABLE}" -m pip -v install 
+                "${Python_EXECUTABLE}" -m pip install 
                                        --disable-pip-version-check
                                        --prefix="${_PIP_PREFIX}"
                                        -I Sphinx==${Sphinx_FIND_VERSION}


### PR DESCRIPTION
The issue ended up being use of deprecated pip/setup argument (in `FindSphinx.cmake`) and the Windows and macOS VMs recently bumping to the pip version (20.2) which removed the deprecated feature. On Windows there was a second issue which is that the pip command executed by CMake needed parameter paths to use the native Windows path separator (`\\` instead of `/`). With those resolved, the docs build on all platforms with the most recent pip release. The docs are still disabled for Python 2 however due to incompatibility of the `sphinx-press-theme` package. I disabled the doc build on all Python 2 CI builds to make this expected behavior. These fixes _should_ alleviate local Sphinx build issues as well. This PR also fixes the nightly "latest" build which needed the required python packages installed explicitly.

Signed-off-by: Michael Dolan <michdolan@gmail.com>