### PR TITLE
Adsk Contrib - Improve GLEW detection

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -205,8 +205,6 @@ jobs:
       CXX: ${{ matrix.cxx-compiler }}
       CC: ${{ matrix.cc-compiler }}
     steps:
-      - name: Setup container
-        if: matrix.vfx-cy == 2020
       - name: Checkout
         uses: actions/checkout@v2
       - name: Create build directories

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -205,10 +205,7 @@ jobs:
       CXX: ${{ matrix.cxx-compiler }}
       CC: ${{ matrix.cc-compiler }}
     steps:
-      # TODO: Remove this workaround following resolution of:
-      #       https://github.com/AcademySoftwareFoundation/aswf-docker/issues/43
       - name: Setup container
-        run: sudo rm -rf /usr/local/lib64/cmake/glew
         if: matrix.vfx-cy == 2020
       - name: Checkout
         uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,13 +101,24 @@ if(OCIO_BUILD_GPU_TESTS OR OCIO_BUILD_APPS)
     endif()
 
     if(NOT APPLE)
-        find_package(GLEW)
+        # On some Linux platform, the glew-config.cmake is found first so make it explicit
+        # to fall back on the regular search if not found.
+	find_package(GLEW CONFIG QUIET)
         if(NOT GLEW_FOUND)
-            package_root_message(GLEW)
-            set(OCIO_GL_ENABLED OFF)
+            find_package(GLEW)
+            if(NOT GLEW_FOUND)
+                package_root_message(GLEW)
+                set(OCIO_GL_ENABLED OFF)
+            endif()
+        else()
+            # Expected variables GLEW_LIBRARIES and GLEW_INCLUDE_DIRS are missing so create
+            # the mandatory one. Note that the cmake bug is now fixed (issue 19662).
+            if(NOT GLEW_LIBRARIES)
+                set(GLEW_LIBRARIES GLEW::GLEW)
+            endif()
         endif()
-	endif()
-	
+    endif()
+
     find_package(GLUT)
     if(NOT GLUT_FOUND)
         package_root_message(GLUT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ if(OCIO_BUILD_GPU_TESTS OR OCIO_BUILD_APPS)
     if(NOT APPLE)
         # On some Linux platform, the glew-config.cmake is found first so make it explicit
         # to fall back on the regular search if not found.
-	find_package(GLEW CONFIG QUIET)
+        find_package(GLEW CONFIG QUIET)
         if(NOT GLEW_FOUND)
             find_package(GLEW)
             if(NOT GLEW_FOUND)

--- a/src/apps/ociobakelut/main.cpp
+++ b/src/apps/ociobakelut/main.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
@@ -14,10 +15,10 @@ namespace OCIO = OCIO_NAMESPACE;
 #include "apputils/argparse.h"
 #include "ocioicc.h"
 
+
 static std::string outputfile;
 
-static int
-parse_end_args(int argc, const char *argv[])
+static int parse_end_args(int argc, const char *argv[])
 {
     if(argc>0)
     {
@@ -27,8 +28,7 @@ parse_end_args(int argc, const char *argv[])
     return 0;
 }
 
-OCIO::GroupTransformRcPtr
-parse_luts(int argc, const char *argv[]);
+OCIO::GroupTransformRcPtr parse_luts(int argc, const char *argv[]);
 
 int main (int argc, const char* argv[])
 {
@@ -392,8 +392,7 @@ int main (int argc, const char* argv[])
 // then atof() will likely try to convert "--invlut" to its double equivalent,
 // resulting in an invalid (or at least undesired) scale value.
 
-OCIO::GroupTransformRcPtr
-parse_luts(int argc, const char *argv[])
+OCIO::GroupTransformRcPtr parse_luts(int argc, const char *argv[])
 {
     OCIO::GroupTransformRcPtr groupTransform = OCIO::GroupTransform::Create();
     const char *lastCCCId = NULL; // Ugly to use this but using GroupTransform::getTransform()


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul Patrick.Hodoul@autodesk.com

The GPU CI build investigations raise a GLEW library detection problem coming from a cmake bug. The pull request manages the cmake bug to always correctly detect the GLEWlibrary.

Refer to AcademySoftwareFoundation/aswf-docker#43 for details.
Refer to https://gitlab.kitware.com/cmake/cmake/-/issues/19662 for cmake details.

To correctly test the fix, you have to install a ASWF docker image. And I used: aswf/ci-ocio:2021.