### PR TITLE
Rename Config::GetProcessor to GetProcessorFromConfigs

### DIFF
--- a/docs/api/c_config.rst
+++ b/docs/api/c_config.rst
@@ -664,7 +664,7 @@ variable to point at the root of that configuration.
 
          Create a configuration using a stream.
 
-      .. cpp:function:: ConstProcessorRcPtr GetProcessor(const ConstConfigRcPtr &srcConfig, const char *srcColorSpaceName, const ConstConfigRcPtr &dstConfig, const char *dstColorSpaceName)
+      .. cpp:function:: ConstProcessorRcPtr GetProcessorFromConfigs(const ConstConfigRcPtr &srcConfig, const char *srcColorSpaceName, const ConstConfigRcPtr &dstConfig, const char *dstColorSpaceName)
 
          Get a processor to convert between color spaces in two
          separate configs.
@@ -674,15 +674,15 @@ variable to point at the root of that configuration.
          cie_xyz_d65_interchange (when srcName is display-referred)
          defined. An exception is thrown if that is not the case.
 
-      .. cpp:function:: ConstProcessorRcPtr GetProcessor(const ConstContextRcPtr &srcContext, const ConstConfigRcPtr &srcConfig, const char *srcColorSpaceName, const ConstContextRcPtr &dstContext, const ConstConfigRcPtr &dstConfig, const char *dstColorSpaceName)
+      .. cpp:function:: ConstProcessorRcPtr GetProcessorFromConfigs(const ConstContextRcPtr &srcContext, const ConstConfigRcPtr &srcConfig, const char *srcColorSpaceName, const ConstContextRcPtr &dstContext, const ConstConfigRcPtr &dstConfig, const char *dstColorSpaceName)
 
-      .. cpp:function:: ConstProcessorRcPtr GetProcessor(const ConstConfigRcPtr &srcConfig, const char *srcColorSpaceName, const char *srcInterchangeName, const ConstConfigRcPtr &dstConfig, const char *dstColorSpaceName, const char *dstInterchangeName)
+      .. cpp:function:: ConstProcessorRcPtr GetProcessorFromConfigs(const ConstConfigRcPtr &srcConfig, const char *srcColorSpaceName, const char *srcInterchangeName, const ConstConfigRcPtr &dstConfig, const char *dstColorSpaceName, const char *dstInterchangeName)
 
          The srcInterchangeName and dstInterchangeName must refer to a
          pair of color spaces in the two configs that are the same. A
          role name may also be used.
 
-      .. cpp:function:: ConstProcessorRcPtr GetProcessor(const ConstContextRcPtr &srcContext, const ConstConfigRcPtr &srcConfig, const char *srcColorSpaceName, const char *srcInterchangeName, const ConstContextRcPtr &dstContext, const ConstConfigRcPtr &dstConfig, const char *dstColorSpaceName, const char *dstInterchangeName)
+      .. cpp:function:: ConstProcessorRcPtr GetProcessorFromConfigs(const ConstContextRcPtr &srcContext, const ConstConfigRcPtr &srcConfig, const char *srcColorSpaceName, const char *srcInterchangeName, const ConstContextRcPtr &dstContext, const ConstConfigRcPtr &dstConfig, const char *dstColorSpaceName, const char *dstInterchangeName)
 
 
    .. group-tab:: Python
@@ -709,17 +709,17 @@ variable to point at the root of that configuration.
 
       .. py:class:: EnvironmentVarNameIterator
 
-      .. py:function:: GetProcessor(*args,**kwargs)
+      .. py:function:: GetProcessorFromConfigs(*args,**kwargs)
 
       Overloaded function.
 
-         1. .. py:function:: GetProcessor(srcConfig: PyOpenColorIO.Config, srcColorSpaceName: str, dstConfig: PyOpenColorIO.Config, dstColorSpaceName: str) -> OpenColorIO_v2_0dev::Processor
+         1. .. py:function:: GetProcessorFromConfigs(srcConfig: PyOpenColorIO.Config, srcColorSpaceName: str, dstConfig: PyOpenColorIO.Config, dstColorSpaceName: str) -> OpenColorIO_v2_0dev::Processor
 
-         2. .. py:function:: GetProcessor(srcContext: OpenColorIO_v2_0dev::Context, srcConfig: PyOpenColorIO.Config, srcColorSpaceName: str, dstContext: OpenColorIO_v2_0dev::Context, dstConfig: PyOpenColorIO.Config, dstColorSpaceName: str) -> OpenColorIO_v2_0dev::Processor
+         2. .. py:function:: GetProcessorFromConfigs(srcContext: OpenColorIO_v2_0dev::Context, srcConfig: PyOpenColorIO.Config, srcColorSpaceName: str, dstContext: OpenColorIO_v2_0dev::Context, dstConfig: PyOpenColorIO.Config, dstColorSpaceName: str) -> OpenColorIO_v2_0dev::Processor
 
-         3. .. py:function:: GetProcessor(srcConfig: PyOpenColorIO.Config, srcColorSpaceName: str, srcInterchangeName: str, dstConfig: PyOpenColorIO.Config, dstColorSpaceName: str, dstInterchangeName: str) -> OpenColorIO_v2_0dev::Processor
+         3. .. py:function:: GetProcessorFromConfigs(srcConfig: PyOpenColorIO.Config, srcColorSpaceName: str, srcInterchangeName: str, dstConfig: PyOpenColorIO.Config, dstColorSpaceName: str, dstInterchangeName: str) -> OpenColorIO_v2_0dev::Processor
 
-         4. .. py:function:: GetProcessor(srcContext: OpenColorIO_v2_0dev::Context, srcConfig: PyOpenColorIO.Config, srcColorSpaceName: str, srcInterchangeName: str, dstContext: OpenColorIO_v2_0dev::Context, dstConfig: PyOpenColorIO.Config, dstColorSpaceName: str, dstInterchangeName: str) -> OpenColorIO_v2_0dev::Processor
+         4. .. py:function:: GetProcessorFromConfigs(srcContext: OpenColorIO_v2_0dev::Context, srcConfig: PyOpenColorIO.Config, srcColorSpaceName: str, srcInterchangeName: str, dstContext: OpenColorIO_v2_0dev::Context, dstConfig: PyOpenColorIO.Config, dstColorSpaceName: str, dstInterchangeName: str) -> OpenColorIO_v2_0dev::Processor
 
       .. py:class:: LookIterator
 

--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -876,36 +876,36 @@ public:
      * is scene-referred) or the role cie_xyz_d65_interchange (when srcName is
      * display-referred) defined.  An exception is thrown if that is not the case.
      */
-    static ConstProcessorRcPtr GetProcessor(const ConstConfigRcPtr & srcConfig,
-                                            const char * srcColorSpaceName,
-                                            const ConstConfigRcPtr & dstConfig,
-                                            const char * dstColorSpaceName);
-    static ConstProcessorRcPtr GetProcessor(const ConstContextRcPtr & srcContext, 
-                                            const ConstConfigRcPtr & srcConfig,
-                                            const char * srcColorSpaceName,
-                                            const ConstContextRcPtr & dstContext,
-                                            const ConstConfigRcPtr & dstConfig,
-                                            const char * dstColorSpaceName);
+    static ConstProcessorRcPtr GetProcessorFromConfigs(const ConstConfigRcPtr & srcConfig,
+                                                       const char * srcColorSpaceName,
+                                                       const ConstConfigRcPtr & dstConfig,
+                                                       const char * dstColorSpaceName);
+    static ConstProcessorRcPtr GetProcessorFromConfigs(const ConstContextRcPtr & srcContext, 
+                                                       const ConstConfigRcPtr & srcConfig,
+                                                       const char * srcColorSpaceName,
+                                                       const ConstContextRcPtr & dstContext,
+                                                       const ConstConfigRcPtr & dstConfig,
+                                                       const char * dstColorSpaceName);
 
     /**
      * The srcInterchangeName and dstInterchangeName must refer to a pair of
      * color spaces in the two configs that are the same.  A role name may also be used.
      */
-    static ConstProcessorRcPtr GetProcessor(const ConstConfigRcPtr & srcConfig,
-                                            const char * srcColorSpaceName,
-                                            const char * srcInterchangeName,
-                                            const ConstConfigRcPtr & dstConfig,
-                                            const char * dstColorSpaceName,
-                                            const char * dstInterchangeName);
+    static ConstProcessorRcPtr GetProcessorFromConfigs(const ConstConfigRcPtr & srcConfig,
+                                                       const char * srcColorSpaceName,
+                                                       const char * srcInterchangeName,
+                                                       const ConstConfigRcPtr & dstConfig,
+                                                       const char * dstColorSpaceName,
+                                                       const char * dstInterchangeName);
 
-    static ConstProcessorRcPtr GetProcessor(const ConstContextRcPtr & srcContext,
-                                            const ConstConfigRcPtr & srcConfig,
-                                            const char * srcColorSpaceName,
-                                            const char * srcInterchangeName,
-                                            const ConstContextRcPtr & dstContext,
-                                            const ConstConfigRcPtr & dstConfig,
-                                            const char * dstColorSpaceName,
-                                            const char * dstInterchangeName);
+    static ConstProcessorRcPtr GetProcessorFromConfigs(const ConstContextRcPtr & srcContext,
+                                                       const ConstConfigRcPtr & srcConfig,
+                                                       const char * srcColorSpaceName,
+                                                       const char * srcInterchangeName,
+                                                       const ConstContextRcPtr & dstContext,
+                                                       const ConstConfigRcPtr & dstConfig,
+                                                       const char * dstColorSpaceName,
+                                                       const char * dstInterchangeName);
 
     Config(const Config &) = delete;
     Config& operator= (const Config &) = delete;

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -2860,21 +2860,21 @@ ConstProcessorRcPtr Config::getProcessor(const ConstContextRcPtr & context,
     return processor;
 }
 
-ConstProcessorRcPtr Config::GetProcessor(const ConstConfigRcPtr & srcConfig,
-                                         const char * srcName,
-                                         const ConstConfigRcPtr & dstConfig,
-                                         const char * dstName)
+ConstProcessorRcPtr Config::GetProcessorFromConfigs(const ConstConfigRcPtr & srcConfig,
+                                                    const char * srcName,
+                                                    const ConstConfigRcPtr & dstConfig,
+                                                    const char * dstName)
 {
-    return GetProcessor(srcConfig->getCurrentContext(), srcConfig, srcName,
-                        dstConfig->getCurrentContext(), dstConfig, dstName);
+    return GetProcessorFromConfigs(srcConfig->getCurrentContext(), srcConfig, srcName,
+                                   dstConfig->getCurrentContext(), dstConfig, dstName);
 }
 
-ConstProcessorRcPtr Config::GetProcessor(const ConstContextRcPtr & srcContext,
-                                         const ConstConfigRcPtr & srcConfig,
-                                         const char * srcName,
-                                         const ConstContextRcPtr & dstContext,
-                                         const ConstConfigRcPtr & dstConfig,
-                                         const char * dstName)
+ConstProcessorRcPtr Config::GetProcessorFromConfigs(const ConstContextRcPtr & srcContext,
+                                                    const ConstConfigRcPtr & srcConfig,
+                                                    const char * srcName,
+                                                    const ConstContextRcPtr & dstContext,
+                                                    const ConstConfigRcPtr & dstConfig,
+                                                    const char * dstName)
 {
     ConstColorSpaceRcPtr srcColorSpace = srcConfig->getColorSpace(srcName);
     if (!srcColorSpace)
@@ -2920,29 +2920,29 @@ ConstProcessorRcPtr Config::GetProcessor(const ConstContextRcPtr & srcContext,
         throw Exception(os.str().c_str());
     }
 
-    return GetProcessor(srcContext, srcConfig, srcName, srcExName,
-                        dstContext, dstConfig, dstName, dstExName);
+    return GetProcessorFromConfigs(srcContext, srcConfig, srcName, srcExName,
+                                   dstContext, dstConfig, dstName, dstExName);
 }
 
-ConstProcessorRcPtr Config::GetProcessor(const ConstConfigRcPtr & srcConfig,
-                                         const char * srcName,
-                                         const char * srcInterchangeName,
-                                         const ConstConfigRcPtr & dstConfig,
-                                         const char * dstName,
-                                         const char * dstInterchangeName)
+ConstProcessorRcPtr Config::GetProcessorFromConfigs(const ConstConfigRcPtr & srcConfig,
+                                                    const char * srcName,
+                                                    const char * srcInterchangeName,
+                                                    const ConstConfigRcPtr & dstConfig,
+                                                    const char * dstName,
+                                                    const char * dstInterchangeName)
 {
-    return GetProcessor(srcConfig->getCurrentContext(), srcConfig, srcName, srcInterchangeName,
-                        dstConfig->getCurrentContext(), dstConfig, dstName, dstInterchangeName);
+    return GetProcessorFromConfigs(srcConfig->getCurrentContext(), srcConfig, srcName, srcInterchangeName,
+                                   dstConfig->getCurrentContext(), dstConfig, dstName, dstInterchangeName);
 }
 
-ConstProcessorRcPtr Config::GetProcessor(const ConstContextRcPtr & srcContext,
-                                         const ConstConfigRcPtr & srcConfig,
-                                         const char * srcName,
-                                         const char * srcInterchangeName,
-                                         const ConstContextRcPtr & dstContext,
-                                         const ConstConfigRcPtr & dstConfig,
-                                         const char * dstName,
-                                         const char * dstInterchangeName)
+ConstProcessorRcPtr Config::GetProcessorFromConfigs(const ConstContextRcPtr & srcContext,
+                                                    const ConstConfigRcPtr & srcConfig,
+                                                    const char * srcName,
+                                                    const char * srcInterchangeName,
+                                                    const ConstContextRcPtr & dstContext,
+                                                    const ConstConfigRcPtr & dstConfig,
+                                                    const char * dstName,
+                                                    const char * dstInterchangeName)
 {
     ConstColorSpaceRcPtr srcColorSpace = srcConfig->getColorSpace(srcName);
     if (!srcColorSpace)

--- a/src/bindings/python/PyConfig.cpp
+++ b/src/bindings/python/PyConfig.cpp
@@ -321,50 +321,50 @@ void bindPyConfig(py::module & m)
              &Config::getProcessor, 
              "context"_a, "transform"_a, "direction"_a)
 
-        .def_static("GetProcessor", [](const ConstConfigRcPtr & srcConfig,
-                                       const char * srcColorSpaceName,
-                                       const ConstConfigRcPtr & dstConfig,
-                                       const char * dstColorSpaceName)
+        .def_static("GetProcessorFromConfigs", [](const ConstConfigRcPtr & srcConfig,
+                                                  const char * srcColorSpaceName,
+                                                  const ConstConfigRcPtr & dstConfig,
+                                                  const char * dstColorSpaceName)
             {
-                return Config::GetProcessor(srcConfig, srcColorSpaceName,
-                                            dstConfig, dstColorSpaceName);
+                return Config::GetProcessorFromConfigs(srcConfig, srcColorSpaceName,
+                                                       dstConfig, dstColorSpaceName);
             },
                     "srcConfig"_a, "srcColorSpaceName"_a, "dstConfig"_a, "dstColorSpaceName"_a)
-        .def_static("GetProcessor", [](const ConstContextRcPtr & srcContext,
-                                       const ConstConfigRcPtr & srcConfig,
-                                       const char * srcColorSpaceName,
-                                       const ConstContextRcPtr & dstContext,
-                                       const ConstConfigRcPtr & dstConfig,
-                                       const char * dstColorSpaceName)
+        .def_static("GetProcessorFromConfigs", [](const ConstContextRcPtr & srcContext,
+                                                  const ConstConfigRcPtr & srcConfig,
+                                                  const char * srcColorSpaceName,
+                                                  const ConstContextRcPtr & dstContext,
+                                                  const ConstConfigRcPtr & dstConfig,
+                                                  const char * dstColorSpaceName)
             {
-                return Config::GetProcessor(srcContext, srcConfig, srcColorSpaceName,
-                                            dstContext, dstConfig, dstColorSpaceName);
+                return Config::GetProcessorFromConfigs(srcContext, srcConfig, srcColorSpaceName,
+                                                       dstContext, dstConfig, dstColorSpaceName);
             },
                     "srcContext"_a, "srcConfig"_a, "srcColorSpaceName"_a, 
                     "dstContext"_a, "dstConfig"_a, "dstColorSpaceName"_a)
-        .def_static("GetProcessor", [](const ConstConfigRcPtr & srcConfig,
-                                       const char * srcColorSpaceName,
-                                       const char * srcInterchangeName,
-                                       const ConstConfigRcPtr & dstConfig,
-                                       const char * dstColorSpaceName,
-                                       const char * dstInterchangeName)
+        .def_static("GetProcessorFromConfigs", [](const ConstConfigRcPtr & srcConfig,
+                                                  const char * srcColorSpaceName,
+                                                  const char * srcInterchangeName,
+                                                  const ConstConfigRcPtr & dstConfig,
+                                                  const char * dstColorSpaceName,
+                                                  const char * dstInterchangeName)
             {
-                return Config::GetProcessor(srcConfig, srcColorSpaceName, srcInterchangeName,
-                                            dstConfig, dstColorSpaceName, dstInterchangeName);
+                return Config::GetProcessorFromConfigs(srcConfig, srcColorSpaceName, srcInterchangeName,
+                                                       dstConfig, dstColorSpaceName, dstInterchangeName);
             }, 
                     "srcConfig"_a, "srcColorSpaceName"_a, "srcInterchangeName"_a, 
                     "dstConfig"_a, "dstColorSpaceName"_a, "dstInterchangeName"_a)
-        .def_static("GetProcessor", [](const ConstContextRcPtr & srcContext,
-                                       const ConstConfigRcPtr & srcConfig,
-                                       const char * srcColorSpaceName,
-                                       const char * srcInterchangeName,
-                                       const ConstContextRcPtr & dstContext,
-                                       const ConstConfigRcPtr & dstConfig,
-                                       const char * dstColorSpaceName,
-                                       const char * dstInterchangeName)
+        .def_static("GetProcessorFromConfigs", [](const ConstContextRcPtr & srcContext,
+                                                  const ConstConfigRcPtr & srcConfig,
+                                                  const char * srcColorSpaceName,
+                                                  const char * srcInterchangeName,
+                                                  const ConstContextRcPtr & dstContext,
+                                                  const ConstConfigRcPtr & dstConfig,
+                                                  const char * dstColorSpaceName,
+                                                  const char * dstInterchangeName)
             {
-                return Config::GetProcessor(srcContext, srcConfig, srcColorSpaceName, srcInterchangeName,
-                                            dstContext, dstConfig, dstColorSpaceName, dstInterchangeName);
+                return Config::GetProcessorFromConfigs(srcContext, srcConfig, srcColorSpaceName, srcInterchangeName,
+                                                       dstContext, dstConfig, dstColorSpaceName, dstInterchangeName);
             }, 
                     "srcContext"_a, "srcConfig"_a, "srcColorSpaceName"_a, "srcInterchangeName"_a, 
                     "dstContext"_a, "dstConfig"_a, "dstColorSpaceName"_a, "dstInterchangeName"_a);

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -3776,7 +3776,7 @@ display_colorspaces:
 
     OCIO::ConstProcessorRcPtr p;
     // NB: Although they have the same name, they are in different configs and are different ColorSpaces.
-    OCIO_CHECK_NO_THROW(p = OCIO::Config::GetProcessor(config1, "test1", config2, "test2"));
+    OCIO_CHECK_NO_THROW(p = OCIO::Config::GetProcessorFromConfigs(config1, "test1", config2, "test2"));
     OCIO_REQUIRE_ASSERT(p);
     auto group = p->createGroupTransform();
     OCIO_REQUIRE_EQUAL(group->getNumTransforms(), 4);
@@ -3794,28 +3794,28 @@ display_colorspaces:
     OCIO_CHECK_ASSERT(m3);
 
     // Or interchange spaces can be specified.
-    OCIO_CHECK_NO_THROW(p = OCIO::Config::GetProcessor(config1, "test1", "aces1", config2, "test2", "aces2"));
+    OCIO_CHECK_NO_THROW(p = OCIO::Config::GetProcessorFromConfigs(config1, "test1", "aces1", config2, "test2", "aces2"));
     OCIO_REQUIRE_ASSERT(p);
     OCIO_REQUIRE_ASSERT(p);
     group = p->createGroupTransform();
     OCIO_REQUIRE_EQUAL(group->getNumTransforms(), 4);
 
     // Or interchange space can be specified using role.
-    OCIO_CHECK_NO_THROW(p = OCIO::Config::GetProcessor(config1, "test1", "aces_interchange", config2, "test2", "aces2"));
+    OCIO_CHECK_NO_THROW(p = OCIO::Config::GetProcessorFromConfigs(config1, "test1", "aces_interchange", config2, "test2", "aces2"));
     OCIO_REQUIRE_ASSERT(p);
     OCIO_REQUIRE_ASSERT(p);
     group = p->createGroupTransform();
     OCIO_REQUIRE_EQUAL(group->getNumTransforms(), 4);
 
     // Or color space can be specified using role.
-    OCIO_CHECK_NO_THROW(p = OCIO::Config::GetProcessor(config1, "test1", "aces_interchange", config2, "test_role", "aces2"));
+    OCIO_CHECK_NO_THROW(p = OCIO::Config::GetProcessorFromConfigs(config1, "test1", "aces_interchange", config2, "test_role", "aces2"));
     OCIO_REQUIRE_ASSERT(p);
     OCIO_REQUIRE_ASSERT(p);
     group = p->createGroupTransform();
     OCIO_REQUIRE_EQUAL(group->getNumTransforms(), 4);
 
     // Display-referred interchange space.
-    OCIO_CHECK_NO_THROW(p = OCIO::Config::GetProcessor(config1, "display2", config2, "display4"));
+    OCIO_CHECK_NO_THROW(p = OCIO::Config::GetProcessorFromConfigs(config1, "display2", config2, "display4"));
     OCIO_REQUIRE_ASSERT(p);
     group = p->createGroupTransform();
     OCIO_REQUIRE_EQUAL(group->getNumTransforms(), 4);
@@ -3832,7 +3832,7 @@ display_colorspaces:
     auto l3 = OCIO_DYNAMIC_POINTER_CAST<OCIO::LogTransform>(t3);
     OCIO_CHECK_ASSERT(l3);
 
-    OCIO_CHECK_THROW_WHAT(OCIO::Config::GetProcessor(config1, "display2", config2, "test2"),
+    OCIO_CHECK_THROW_WHAT(OCIO::Config::GetProcessorFromConfigs(config1, "display2", config2, "test2"),
                           OCIO::Exception,
                           "There is no view transform between the main scene-referred space "
                           "and the display-referred space");
@@ -3859,11 +3859,11 @@ colorspaces:
     OCIO::ConstConfigRcPtr config3;
     OCIO_CHECK_NO_THROW(config3 = OCIO::Config::CreateFromStream(is));
 
-    OCIO_CHECK_THROW_WHAT(OCIO::Config::GetProcessor(config1, "test1", config3, "test"),
+    OCIO_CHECK_THROW_WHAT(OCIO::Config::GetProcessorFromConfigs(config1, "test1", config3, "test"),
                           OCIO::Exception,
                           "The role 'aces_interchange' is missing in the destination config");
 
-    OCIO_CHECK_THROW_WHAT(OCIO::Config::GetProcessor(config1, "display1", config3, "test"),
+    OCIO_CHECK_THROW_WHAT(OCIO::Config::GetProcessorFromConfigs(config1, "display1", config3, "test"),
                           OCIO::Exception,
                           "The role 'cie_xyz_d65_interchange' is missing in the destination config");
 }


### PR DESCRIPTION
This PR renames renames OCIO::Config::GetProcessor to OCIO::Config::GetProcessorFromConfigs (and likewise for the python bindings). (Closes  #1122 )
