### PR TITLE
Adsk Contrib - Add 2021 VFX Reference Platform requirements

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -55,8 +55,7 @@ jobs:
       image: aswf/ci-ocio:${{ matrix.vfx-cy }}
     strategy:
       matrix:
-        # Builds 11 & 12 - pybind11 2.4.3 with clang 9 & C++17 fails but succeeds with clang 10.
-        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
         include:
           # -------------------------------------------------------------------
           # VFX CY2021

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -55,13 +55,40 @@ jobs:
       image: aswf/ci-ocio:${{ matrix.vfx-cy }}
     strategy:
       matrix:
-        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
         include:
+          # -------------------------------------------------------------------
+          # VFX CY2021
+          # -------------------------------------------------------------------
+          - build: 12
+            build-type: Debug
+            build-shared: 'ON'
+            build-docs: 'OFF'
+            build-gpu: 'OFF'
+            use-headless: 'OFF'
+            use-sse: 'OFF'
+            cxx-standard: 17
+            cxx-compiler: clang++
+            cc-compiler: clang
+            compiler-desc: Clang 9
+            vfx-cy: 2021
+          - build: 11
+            build-type: Release
+            build-shared: 'ON'
+            build-docs: 'OFF'
+            build-gpu: 'OFF'
+            use-headless: 'OFF'
+            use-sse: 'ON'
+            cxx-standard: 17
+            cxx-compiler: g++
+            cc-compiler: gcc
+            compiler-desc: GCC 9.3.1
+            vfx-cy: 2021
           # -------------------------------------------------------------------
           # GCC, VFX CY2020
           # -------------------------------------------------------------------
           # C++11, Python 3.7
-          - build: 1
+          - build: 10
             build-type: Release
             build-shared: 'ON'
             build-docs: 'ON'
@@ -74,7 +101,7 @@ jobs:
             compiler-desc: GCC 6.3.1
             vfx-cy: 2020
           # Debug
-          - build: 2
+          - build: 9
             build-type: Debug
             build-shared: 'ON'
             build-docs: 'OFF'
@@ -87,7 +114,7 @@ jobs:
             compiler-desc: GCC 6.3.1
             vfx-cy: 2020
           # C++14
-          - build: 3
+          - build: 8
             build-type: Release
             build-shared: 'ON'
             build-docs: 'OFF'
@@ -100,7 +127,7 @@ jobs:
             compiler-desc: GCC 6.3.1
             vfx-cy: 2020
           # Static, no SSE
-          - build: 4
+          - build: 7
             build-type: Release
             build-shared: 'OFF'
             build-docs: 'OFF'
@@ -116,7 +143,7 @@ jobs:
           # GCC, VFX CY2019
           # -------------------------------------------------------------------
           # Python 2.7
-          - build: 5
+          - build: 6
             build-type: Release
             build-shared: 'ON'
             # Doc build requires Python 3
@@ -133,7 +160,7 @@ jobs:
           # Clang, VFX CY2020
           # -------------------------------------------------------------------
           # C++11, Python 3.7
-          - build: 6
+          - build: 5
             build-type: Release
             build-shared: 'ON'
             build-docs: 'ON'
@@ -146,7 +173,7 @@ jobs:
             compiler-desc: Clang 7
             vfx-cy: 2020
           # Debug
-          - build: 7
+          - build: 4
             build-type: Debug
             build-shared: 'ON'
             build-docs: 'OFF'
@@ -159,7 +186,7 @@ jobs:
             compiler-desc: Clang 7
             vfx-cy: 2020
           # C++14
-          - build: 8
+          - build: 3
             build-type: Release
             build-shared: 'ON'
             build-docs: 'OFF'
@@ -172,7 +199,7 @@ jobs:
             compiler-desc: Clang 7
             vfx-cy: 2020
           # Static, no SSE
-          - build: 9
+          - build: 2
             build-type: Release
             build-shared: 'OFF'
             build-docs: 'OFF'
@@ -188,7 +215,7 @@ jobs:
           # Clang, VFX CY2019
           # -------------------------------------------------------------------
           # Python 2.7
-          - build: 10
+          - build: 1
             build-type: Release
             build-shared: 'ON'
             # Doc build requires Python 3
@@ -253,10 +280,21 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        build: [1, 2, 3, 4, 5]
+        build: [1, 2, 3, 4, 5, 6]
         include:
+          # C++17
+          - build: 6
+            build-type: Release
+            build-shared: 'ON'
+            build-docs: 'OFF'
+            build-gpu: 'OFF'
+            use-headless: 'OFF'
+            use-sse: 'ON'
+            cxx-standard: 17
+            python-version: 3.7
+          # Static, no SSE
           # C++11, Python 3.7
-          - build: 1
+          - build: 5
             build-type: Release
             build-shared: 'ON'
             build-docs: 'ON'
@@ -266,7 +304,7 @@ jobs:
             cxx-standard: 11
             python-version: 3.7
           # Debug
-          - build: 2
+          - build: 4
             build-type: Debug
             build-shared: 'ON'
             build-docs: 'OFF'
@@ -286,7 +324,7 @@ jobs:
             cxx-standard: 14
             python-version: 3.7
           # Static, no SSE
-          - build: 4
+          - build: 2
             build-type: Release
             build-shared: 'OFF'
             build-docs: 'OFF'
@@ -296,7 +334,7 @@ jobs:
             cxx-standard: 11
             python-version: 3.7
           # Python 2.7
-          - build: 5
+          - build: 1
             build-type: Release
             build-shared: 'ON'
             # Doc build requires Python 3
@@ -361,10 +399,20 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        build: [1, 2, 3, 4, 5]
+        build: [1, 2, 3, 4, 5, 6]
         include:
+          # C++17
+          - build: 6
+            build-type: Release
+            build-shared: 'ON'
+            build-docs: 'OFF'
+            build-gpu: 'OFF'
+            use-headless: 'OFF'
+            use-sse: 'ON'
+            cxx-standard: 17
+            python-version: 3.7
           # C++11, Python 3.7
-          - build: 1
+          - build: 5
             build-type: Release
             build-shared: 'ON'
             build-docs: 'ON'
@@ -374,7 +422,7 @@ jobs:
             cxx-standard: 11
             python-version: 3.7
           # Debug
-          - build: 2
+          - build: 4
             build-type: Debug
             build-shared: 'ON'
             build-docs: 'OFF'
@@ -394,7 +442,7 @@ jobs:
             cxx-standard: 14
             python-version: 3.7
           # Static, no SSE
-          - build: 4
+          - build: 2
             build-type: Release
             build-shared: 'OFF'
             build-docs: 'OFF'
@@ -404,7 +452,7 @@ jobs:
             cxx-standard: 11
             python-version: 3.7
           # Python 2.7
-          - build: 5
+          - build: 1
             build-type: Release
             build-shared: 'ON'
             # Doc build requires Python 3

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -55,7 +55,8 @@ jobs:
       image: aswf/ci-ocio:${{ matrix.vfx-cy }}
     strategy:
       matrix:
-        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        # Builds 11 & 12 - pybind11 2.4.3 with clang 9 & C++17 fails but succeeds with clang 10.
+        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         include:
           # -------------------------------------------------------------------
           # VFX CY2021

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,31 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 
+
+###############################################################################
+# CMake definition.
+
 cmake_minimum_required(VERSION 3.12)
+
+set(CMAKE_MODULE_PATH
+    ${CMAKE_MODULE_PATH}
+    ${CMAKE_SOURCE_DIR}/share/cmake/utils
+    ${CMAKE_SOURCE_DIR}/share/cmake/macros
+    ${CMAKE_SOURCE_DIR}/share/cmake/modules
+)
+
+set(CMAKE_WARN_DEPRECATED ON)
+
+
+if(APPLE)
+    # The value of this variable should be set prior to the first project() command invocation
+    # because it may influence configuration of the toolchain and flags.
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X deployment version")
+endif()
+
+
+###############################################################################
+# Project definition.
 
 project(OpenColorIO 
     VERSION 2.0.0
@@ -14,59 +38,44 @@ set(OpenColorIO_VERSION_RELEASE_TYPE "dev")
 
 enable_testing()
 
-set(CMAKE_MODULE_PATH
-    ${CMAKE_MODULE_PATH}
-    ${CMAKE_SOURCE_DIR}/share/cmake/macros
-    ${CMAKE_SOURCE_DIR}/share/cmake/modules
-)
-set(CMAKE_WARN_DEPRECATED ON)
-
-if(NOT CMAKE_BUILD_TYPE)
-	set(CMAKE_BUILD_TYPE Release)
-endif()
 
 ###############################################################################
-# C++ version configuration
+# Forbid in-source build.
 
-set(SUPPORTED_CXX_STANDARDS 11 14)
-string(REPLACE ";" ", " SUPPORTED_CXX_STANDARDS_STR "${SUPPORTED_CXX_STANDARDS}")
-
-if(CMAKE_CXX_STANDARD AND NOT CMAKE_CXX_STANDARD IN_LIST SUPPORTED_CXX_STANDARDS)
-    message(FATAL_ERROR " CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} is unsupported. Supported standards are: ${SUPPORTED_CXX_STANDARDS_STR}.")
-elseif(NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 11)
-endif()
-
-include(CheckCXXCompilerFlag)
-
-if(MSVC)
-	CHECK_CXX_COMPILER_FLAG("-std:c++11" COMPILER_SUPPORTS_CXX11)
-	CHECK_CXX_COMPILER_FLAG("-std:c++14" COMPILER_SUPPORTS_CXX14)
-else()
-	CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-	CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
-endif()
-
-if(NOT COMPILER_SUPPORTS_CXX11 AND ${CMAKE_CXX_STANDARD} EQUAL 11)
-	message(STATUS "The compiler ${CMAKE_CXX_COMPILER_ID} has no C++11 only support. Use C++14.")
-	set(CMAKE_CXX_STANDARD 14)
-endif()
-
-if(NOT COMPILER_SUPPORTS_CXX14 AND ${CMAKE_CXX_STANDARD} EQUAL 14)
-	message(ERROR "The compiler ${CMAKE_CXX_COMPILER_ID} has no C++14 only support.")
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+    message(FATAL_ERROR 
+            "In-source build not allowed. Please make a new sub-directory and run cmake from there.")
 endif()
 
 
-# Disable fallback to other C++ version if standard is not supported.
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# Disable any compiler specific C++ extensions.
-set(CMAKE_CXX_EXTENSIONS OFF)
+###############################################################################
+# Define compilation mode i.e. debug or release
+
+if(NOT CMAKE_BUILD_TYPE)
+    message(STATUS "Setting build type to 'Release' as none was specified.")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build." FORCE)
+endif()
+
+if(NOT CMAKE_CONFIGURATION_TYPES)
+    # Set the possible values of build type for cmake-gui or ccmake.
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+                 "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
 
 set(_BUILD_TYPE_DEBUG OFF)
 if(CMAKE_BUILD_TYPE MATCHES "[Dd][Ee][Bb][Uu][Gg]")
     set(_BUILD_TYPE_DEBUG ON)
 endif()
-set(BUILD_TYPE_DEBUG ${_BUILD_TYPE_DEBUG} CACHE BOOL "Case-insensitive CMAKE_BUILD_TYPE Debug equality flag.")
+
+set(BUILD_TYPE_DEBUG ${_BUILD_TYPE_DEBUG})
+
+
+###############################################################################
+# C++ version configuration
+
+include(Compilers)
+include(CppVersion)
+
 
 ###############################################################################
 # Components to build
@@ -84,80 +93,6 @@ option(OCIO_BUILD_JAVA "Specify whether to build java bindings" OFF)
 
 option(OCIO_WARNING_AS_ERROR "Set build error level for CI testing" OFF)
 
-###############################################################################
-# GPU configuration
-
-include(PackageUtils)
-
-if(OCIO_BUILD_GPU_TESTS OR OCIO_BUILD_APPS)
-    set(OCIO_GL_ENABLED ON)
-    set(OCIO_USE_GLVND OFF)
-    set(OCIO_EGL_HEADLESS OFF)
-
-    find_package(OpenGL COMPONENTS OpenGL)
-    if(NOT OpenGL_OpenGL_FOUND AND NOT OPENGL_GLU_FOUND)
-        package_root_message(OpenGL)
-        set(OCIO_GL_ENABLED OFF)
-    endif()
-
-    if(NOT APPLE)
-        # On some Linux platform, the glew-config.cmake is found first so make it explicit
-        # to fall back on the regular search if not found.
-        find_package(GLEW CONFIG QUIET)
-        if(NOT GLEW_FOUND)
-            find_package(GLEW)
-            if(NOT GLEW_FOUND)
-                package_root_message(GLEW)
-                set(OCIO_GL_ENABLED OFF)
-            endif()
-        else()
-            # Expected variables GLEW_LIBRARIES and GLEW_INCLUDE_DIRS are missing so create
-            # the mandatory one. Note that the cmake bug is now fixed (issue 19662).
-            if(NOT GLEW_LIBRARIES)
-                set(GLEW_LIBRARIES GLEW::GLEW)
-            endif()
-        endif()
-    endif()
-
-    find_package(GLUT)
-    if(NOT GLUT_FOUND)
-        package_root_message(GLUT)
-        set(OCIO_GL_ENABLED OFF)
-    endif()
-
-    if(NOT OCIO_GL_ENABLED)
-        message(WARNING "GPU rendering disabled")
-    else()
-        # OpenGL_egl_Library is defined iff GLVND is supported (CMake 10+).
-        if(OPENGL_egl_LIBRARY)
-            message(STATUS "GLVND supported")
-            set(OCIO_USE_GLVND ON)
-        else()
-            message(STATUS "GLVND not supported; legacy OpenGL libraries used")
-        endif()
-
-        if(OCIO_USE_HEADLESS)
-            if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-                if(NOT OCIO_USE_GLVND)
-                    message(STATUS "Can't find EGL without GLVND support; can't render headlessly")
-                    set(OCIO_USE_HEADLESS OFF)
-                else()
-                    find_package(OpenGL COMPONENTS EGL)
-                    if(NOT OpenGL_EGL_FOUND)
-                        message(WARNING "EGL component missing; can't render headlessly")
-                        set(OCIO_USE_HEADLESS OFF)
-                    else()
-                        add_compile_definitions(OCIO_HEADLESS_ENABLED)
-                        set(OCIO_EGL_HEADLESS ON)
-                        message(STATUS "EGL enabled")
-                    endif()
-                endif()
-            else()
-                message(WARNING "OS system is not Linux; can't render headlessly")
-            endif()
-        endif()
-    endif()
-endif()
 
 ###############################################################################
 # Optimization / internal linking preferences
@@ -165,54 +100,25 @@ endif()
 option(OCIO_USE_SSE "Specify whether to enable SSE CPU performance optimizations" ON)
 option(OCIO_INLINES_HIDDEN "Specify whether to build with -fvisibility-inlines-hidden" ${UNIX})
 
+
 ###############################################################################
 # Supplemental builtins
 
 # Add supplemental built-in transformations such as camera related one.
 option(OCIO_ADD_EXTRA_BUILTINS "Specify whether to add supplemental built-in transforms" ON)
 
+
 ###############################################################################
-# Platform & Compiler dependent compilation flags
+# GPU configuration
 
-set(PLATFORM_COMPILE_FLAGS "")
+include(CheckSupportGL)
 
-if(MSVC)
-	# Because our Exceptions derive from std::runtime_error we can safely disable warning 4275
-	# /we4062 Enables warning in switch when an enumeration value is not explicitly handled.
-	set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /EHsc /wd4275 /DWIN32 /we4062")
 
-else()
-    if(APPLE AND OCIO_GL_ENABLED)
-        # Mute the deprecated warning for some GLUT methods.
-        set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} -Wno-deprecated-declarations")
-    endif()
+###############################################################################
+# Define compilation and link flags
 
-	# -Wswitch-enum Enables warning in switch when an enumeration value is not explicitly handled.
-	set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} -Wall -Wswitch-enum")
+include(CompilerFlags)
 
-	# TODO: OCIO being under active development, unused functions are fine for now.
-	set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} -Wno-unused-function")
-
-	# TODO: A C++17 specific warning when compiling in C++11 !!
-	if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-		# Use of 'register' specifier must be removed for C++17 support.
-		set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} -Wno-deprecated-register")
-	endif()
-endif()
-
-if(OCIO_WARNING_AS_ERROR)
-	if(MSVC)
-		set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /WX")
-	else()
-		set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} -Werror")
-	endif()
-endif()
-
-include(CheckSSEFeatures)
-if(NOT HAVE_SSE2)
-	message(STATUS "Disabling SSE optimizations, as the target doesn't support them")
-	set(OCIO_USE_SSE OFF)
-endif(NOT HAVE_SSE2)
 
 ###############################################################################
 # External linking options
@@ -228,26 +134,33 @@ if(DEFINED OCIO_INSTALL_EXT_PACKAGES)
     # Case insensitive match
     string(TOUPPER "${OCIO_INSTALL_EXT_PACKAGES}" _OCIO_INSTALL_EXT_PACKAGES)
     if(NOT "${_OCIO_INSTALL_EXT_PACKAGES}" IN_LIST _EXT_OPTIONS)
-        message(FATAL_ERROR " OCIO_INSTALL_EXT_PACKAGES=${OCIO_INSTALL_EXT_PACKAGES} is unsupported. Supported values are: ${_EXT_OPTIONS_STR}.")
+        message(FATAL_ERROR 
+                "OCIO_INSTALL_EXT_PACKAGES=${OCIO_INSTALL_EXT_PACKAGES} is unsupported. Supported values are: ${_EXT_OPTIONS_STR}.")
     endif()
 endif()
 
 # Overwrite cache variable with normalized case
-set(OCIO_INSTALL_EXT_PACKAGES "${_OCIO_INSTALL_EXT_PACKAGES}" CACHE STRING "Set the condition for Installing external dependencies" FORCE)
+set(OCIO_INSTALL_EXT_PACKAGES "${_OCIO_INSTALL_EXT_PACKAGES}" CACHE STRING
+    "Set the condition for Installing external dependencies" FORCE)
+
 set_property(CACHE OCIO_INSTALL_EXT_PACKAGES PROPERTY STRINGS ${_EXT_OPTIONS})
+
 
 ###############################################################################
 # Versioning
 
 if(NOT SOVERSION)
-	set(SOVERSION "${OpenColorIO_VERSION_MAJOR}.${OpenColorIO_VERSION_MINOR}" CACHE STRING "Set the SO version in the SO name of the output library")
+	set(SOVERSION "${OpenColorIO_VERSION_MAJOR}.${OpenColorIO_VERSION_MINOR}" CACHE STRING 
+        "Set the SO version in the SO name of the output library")
 endif()
+
 
 ###############################################################################
 # Namespace
 
 if(NOT OCIO_NAMESPACE)
-	set(OCIO_NAMESPACE OpenColorIO CACHE STRING "Specify the master OCIO C++ namespace: Options include OpenColorIO OpenColorIO_<YOURFACILITY> etc.")
+	set(OCIO_NAMESPACE OpenColorIO CACHE STRING 
+        "Specify the master OCIO C++ namespace: Options include OpenColorIO OpenColorIO_<YOURFACILITY> etc.")
 endif()
 
 ###############################################################################
@@ -259,26 +172,31 @@ endif()
 set (OCIO_LIBNAME_SUFFIX "" CACHE STRING
      "Specify a suffix to all libraries that are built")
 
+
 ###############################################################################
 # Error checking
 
 if(OCIO_BUILD_SHARED AND OCIO_BUILD_STATIC)
-	message(FATAL_ERROR " Deprecated options OCIO_BUILD_SHARED and OCIO_BUILD_STATIC cannot both be used at once")
+	message(FATAL_ERROR 
+            "Deprecated options OCIO_BUILD_SHARED and OCIO_BUILD_STATIC cannot both be used at once")
 endif()
 
 if(OCIO_BUILD_SHARED)
-	message(DEPRECATION " Option OCIO_BUILD_SHARED is deprecated. Please use the cmake standard BUILD_SHARED_LIBS=ON (default ON)")
+	message(DEPRECATION 
+            "Option OCIO_BUILD_SHARED is deprecated. Please use the cmake standard BUILD_SHARED_LIBS=ON (default ON)")
 	if(NOT BUILD_SHARED_LIBS)
 		set(BUILD_SHARED_LIBS ON)
 	endif()
 endif()
 
 if(OCIO_BUILD_STATIC)
-	message(DEPRECATION " Option OCIO_BUILD_STATIC is deprecated. Please use the cmake standard BUILD_SHARED_LIBS=OFF (default ON)")
+	message(DEPRECATION 
+            "Option OCIO_BUILD_STATIC is deprecated. Please use the cmake standard BUILD_SHARED_LIBS=OFF (default ON)")
 	if(BUILD_SHARED_LIBS)
 		set(BUILD_SHARED_LIBS OFF)
 	endif()
 endif()
+
 
 ###############################################################################
 # Find or install external dependencies
@@ -288,13 +206,14 @@ endif()
 
 include(FindExtPackages)
 
+
 ###############################################################################
 # Progress to other sources
 
 add_subdirectory(ext)
-add_subdirectory(tests)
 add_subdirectory(include)
 add_subdirectory(src)
+add_subdirectory(tests)
 if(OCIO_BUILD_DOCS)
 	add_subdirectory(docs)
 endif()

--- a/share/cmake/modules/FindExtPackages.cmake
+++ b/share/cmake/modules/FindExtPackages.cmake
@@ -42,7 +42,7 @@ find_package(pystring 1.1.3 REQUIRED)
 
 if(OCIO_BUILD_APPS)
 
-    # NOTE: Depending of the compiler version lcms2 2.2 does not compile on C++17 so, if
+    # NOTE: Depending of the compiler version lcms2 2.2 does not compile with C++17 so, if
     # you change the lcms2 version update the code to compile lcms2 and dependencies
     # with C++17 or higher i.e. remove the cap of C++ version in Findlcms2.cmake and
     # src/apps/ociobakelut/CMakeLists.txt.
@@ -54,7 +54,7 @@ endif()
 
 if(OCIO_BUILD_PYTHON)
 
-    # NOTE: Depending of the compiler version pybind11 2.4.3 does not compile on C++17 so, if
+    # NOTE: Depending of the compiler version pybind11 2.4.3 does not compile with C++17 so, if
     # you change the pybind11 version update the code to compile pybind11 and dependencies
     # with C++17 or higher i.e. remove the cap of C++ version in FindPybind11.cmake and
     # src/bindings/python/CMakeLists.txt.

--- a/share/cmake/modules/FindExtPackages.cmake
+++ b/share/cmake/modules/FindExtPackages.cmake
@@ -41,12 +41,24 @@ find_package(Half 2.4.0 REQUIRED)
 find_package(pystring 1.1.3 REQUIRED)
 
 if(OCIO_BUILD_APPS)
+
+    # NOTE: Depending of the compiler version lcms2 2.2 does not compile on C++17 so, if
+    # you change the lcms2 version update the code to compile lcms2 and dependencies
+    # with C++17 or higher i.e. remove the cap of C++ version in Findlcms2.cmake and
+    # src/apps/ociobakelut/CMakeLists.txt.
+
     # lcms2
     # https://github.com/mm2/Little-CMS
     find_package(lcms2 2.2 REQUIRED)
 endif()
 
 if(OCIO_BUILD_PYTHON)
+
+    # NOTE: Depending of the compiler version pybind11 2.4.3 does not compile on C++17 so, if
+    # you change the pybind11 version update the code to compile pybind11 and dependencies
+    # with C++17 or higher i.e. remove the cap of C++ version in FindPybind11.cmake and
+    # src/bindings/python/CMakeLists.txt.
+
     # pybind11
     # https://github.com/pybind/pybind11
     find_package(pybind11 2.4.3 REQUIRED)

--- a/share/cmake/modules/FindExtPackages.cmake
+++ b/share/cmake/modules/FindExtPackages.cmake
@@ -15,8 +15,11 @@
 # when a package has previously been installed to ext/dist. Set these variables
 # to OFF during cmake configuration to enable package registry use.
 
-set(CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY ON CACHE BOOL "Disable CMake User Package Registry when finding packages")
-set(CMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY ON CACHE BOOL "Disable CMake System Package Registry when finding packages")
+set(CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY ON CACHE BOOL
+    "Disable CMake User Package Registry when finding packages")
+
+set(CMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY ON CACHE BOOL
+    "Disable CMake System Package Registry when finding packages")
 
 ###############################################################################
 ### Packages and versions ###

--- a/share/cmake/modules/Findlcms2.cmake
+++ b/share/cmake/modules/Findlcms2.cmake
@@ -118,8 +118,8 @@ if(NOT lcms2_FOUND)
 
         string(STRIP "${lcms2_C_FLAGS}" lcms2_C_FLAGS)
 
-        # NOTE: Depending of the compiler version lcm2 2.2 does not compile on C++17 so revert 
-        # to c++11 because the library is only used by a cmd line tools.
+        # NOTE: Depending of the compiler version lcm2 2.2 does not compile with C++17 so revert 
+        # to C++11 because the library is only used by a cmd line tool.
 
         set(lcms2_CXX_STANDARD ${CMAKE_CXX_STANDARD})
         if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 17)

--- a/share/cmake/modules/Findlcms2.cmake
+++ b/share/cmake/modules/Findlcms2.cmake
@@ -118,8 +118,13 @@ if(NOT lcms2_FOUND)
 
         string(STRIP "${lcms2_C_FLAGS}" lcms2_C_FLAGS)
 
-        # TODO: lcm2 2.2 does not compile on C++17 so revert to c++11
-        # because the library is only used by a cmd line tools.
+        # NOTE: Depending of the compiler version lcm2 2.2 does not compile on C++17 so revert 
+        # to c++11 because the library is only used by a cmd line tools.
+
+        set(lcms2_CXX_STANDARD ${CMAKE_CXX_STANDARD})
+        if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 17)
+            set(lcms2_CXX_STANDARD 11)
+        endif()
 
         set(lcms2_CMAKE_ARGS
             ${lcms2_CMAKE_ARGS}
@@ -127,7 +132,7 @@ if(NOT lcms2_FOUND)
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
             -DBUILD_SHARED_LIBS=OFF
             -DCMAKE_C_FLAGS=${lcms2_C_FLAGS}
-            -DCMAKE_CXX_STANDARD=11
+            -DCMAKE_CXX_STANDARD=${lcms2_CXX_STANDARD}
         )
         if(CMAKE_TOOLCHAIN_FILE)
             set(lcms2_CMAKE_ARGS

--- a/share/cmake/modules/Findlcms2.cmake
+++ b/share/cmake/modules/Findlcms2.cmake
@@ -118,13 +118,16 @@ if(NOT lcms2_FOUND)
 
         string(STRIP "${lcms2_C_FLAGS}" lcms2_C_FLAGS)
 
+        # TODO: lcm2 2.2 does not compile on C++17 so revert to c++11
+        # because the library is only used by a cmd line tools.
+
         set(lcms2_CMAKE_ARGS
             ${lcms2_CMAKE_ARGS}
             -DCMAKE_INSTALL_PREFIX=${_EXT_DIST_ROOT}
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
             -DBUILD_SHARED_LIBS=OFF
             -DCMAKE_C_FLAGS=${lcms2_C_FLAGS}
-            -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+            -DCMAKE_CXX_STANDARD=11
         )
         if(CMAKE_TOOLCHAIN_FILE)
             set(lcms2_CMAKE_ARGS

--- a/share/cmake/modules/Findpybind11.cmake
+++ b/share/cmake/modules/Findpybind11.cmake
@@ -150,8 +150,8 @@ if(NOT pybind11_FOUND)
         # Hack to let imported target be built from ExternalProject_Add
         file(MAKE_DIRECTORY ${pybind11_INCLUDE_DIR})
 
-        # NOTE: Depending of the compiler version pybind11 2.4.3 does not compile on C++17 so revert
-        # to c++11 because the library is only used by Python bindings.
+        # NOTE: Depending of the compiler version pybind11 2.4.3 does not compile with C++17 so revert
+        # to C++11 because the library is only used by the Python bindings.
 
         set(PYBIND11_CXX_STANDARD ${CMAKE_CXX_STANDARD})
         if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 17)

--- a/share/cmake/modules/Findpybind11.cmake
+++ b/share/cmake/modules/Findpybind11.cmake
@@ -150,11 +150,14 @@ if(NOT pybind11_FOUND)
         # Hack to let imported target be built from ExternalProject_Add
         file(MAKE_DIRECTORY ${pybind11_INCLUDE_DIR})
 
+        # TODO: pybind11 2.4.3 does not compile on C++17 so revert to c++11
+        # because the library is only used by Python bindings.
+
         set(pybind11_CMAKE_ARGS
             ${pybind11_CMAKE_ARGS}
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
             -DCMAKE_INSTALL_PREFIX=${_EXT_DIST_ROOT}
-            -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+            -DCMAKE_CXX_STANDARD=11
             -DPYBIND11_INSTALL=ON
             -DPYBIND11_TEST=OFF
         )

--- a/share/cmake/modules/Findpybind11.cmake
+++ b/share/cmake/modules/Findpybind11.cmake
@@ -150,14 +150,19 @@ if(NOT pybind11_FOUND)
         # Hack to let imported target be built from ExternalProject_Add
         file(MAKE_DIRECTORY ${pybind11_INCLUDE_DIR})
 
-        # TODO: pybind11 2.4.3 does not compile on C++17 so revert to c++11
-        # because the library is only used by Python bindings.
+        # NOTE: Depending of the compiler version pybind11 2.4.3 does not compile on C++17 so revert
+        # to c++11 because the library is only used by Python bindings.
+
+        set(PYBIND11_CXX_STANDARD ${CMAKE_CXX_STANDARD})
+        if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 17)
+            set(PYBIND11_CXX_STANDARD 11)
+        endif()
 
         set(pybind11_CMAKE_ARGS
             ${pybind11_CMAKE_ARGS}
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
             -DCMAKE_INSTALL_PREFIX=${_EXT_DIST_ROOT}
-            -DCMAKE_CXX_STANDARD=11
+            -DCMAKE_CXX_STANDARD=${PYBIND11_CXX_STANDARD}
             -DPYBIND11_INSTALL=ON
             -DPYBIND11_TEST=OFF
         )

--- a/share/cmake/utils/CheckSupportGL.cmake
+++ b/share/cmake/utils/CheckSupportGL.cmake
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+
+###############################################################################
+# Define variables around the GL support.
+
+include(PackageUtils)
+
+if(OCIO_BUILD_GPU_TESTS OR OCIO_BUILD_APPS)
+    set(OCIO_GL_ENABLED ON)
+    set(OCIO_USE_GLVND OFF)
+    set(OCIO_EGL_HEADLESS OFF)
+
+    find_package(OpenGL COMPONENTS OpenGL)
+    if(NOT OpenGL_OpenGL_FOUND AND NOT OPENGL_GLU_FOUND)
+        package_root_message(OpenGL)
+        set(OCIO_GL_ENABLED OFF)
+    endif()
+
+    if(NOT APPLE)
+        # On some Linux platform, the glew-config.cmake is found first so make it explicit
+        # to fall back on the regular search if not found.
+        find_package(GLEW CONFIG QUIET)
+        if(NOT GLEW_FOUND)
+            find_package(GLEW)
+            if(NOT GLEW_FOUND)
+                package_root_message(GLEW)
+                set(OCIO_GL_ENABLED OFF)
+            endif()
+        else()
+            # Expected variables GLEW_LIBRARIES and GLEW_INCLUDE_DIRS are missing so create
+            # the mandatory one. Note that the cmake bug is now fixed (issue 19662).
+            if(NOT GLEW_LIBRARIES)
+                set(GLEW_LIBRARIES GLEW::GLEW)
+            endif()
+        endif()
+    endif()
+
+    find_package(GLUT)
+    if(NOT GLUT_FOUND)
+        package_root_message(GLUT)
+        set(OCIO_GL_ENABLED OFF)
+    endif()
+
+    if(NOT OCIO_GL_ENABLED)
+        message(WARNING "GPU rendering disabled")
+    else()
+        # OpenGL_egl_Library is defined iff GLVND is supported (CMake 10+).
+        if(OPENGL_egl_LIBRARY)
+            message(STATUS "GLVND supported")
+            set(OCIO_USE_GLVND ON)
+        else()
+            message(STATUS "GLVND not supported; legacy OpenGL libraries used")
+        endif()
+
+        if(OCIO_USE_HEADLESS)
+            if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+                if(NOT OCIO_USE_GLVND)
+                    message(STATUS "Can't find EGL without GLVND support; can't render headlessly")
+                    set(OCIO_USE_HEADLESS OFF)
+                else()
+                    find_package(OpenGL COMPONENTS EGL)
+                    if(NOT OpenGL_EGL_FOUND)
+                        message(WARNING "EGL component missing; can't render headlessly")
+                        set(OCIO_USE_HEADLESS OFF)
+                    else()
+                        add_compile_definitions(OCIO_HEADLESS_ENABLED)
+                        set(OCIO_EGL_HEADLESS ON)
+                        message(STATUS "EGL enabled")
+                    endif()
+                endif()
+            else()
+                message(WARNING "OS system is not Linux; can't render headlessly")
+            endif()
+        endif()
+    endif()
+endif()
+
+
+# An advanced variable will not be displayed in any of the cmake GUIs
+
+mark_as_advanced(OCIO_GL_ENABLED)
+mark_as_advanced(OCIO_USE_GLVND)
+mark_as_advanced(OCIO_EGL_HEADLESS)

--- a/share/cmake/utils/CheckSupportSSE2.cmake
+++ b/share/cmake/utils/CheckSupportSSE2.cmake
@@ -3,13 +3,13 @@
 
 include(CheckCXXSourceCompiles)
 
-if (NOT CMAKE_SIZE_OF_VOID_P EQUAL 8)
-    if (MSVC)
+if(NOT CMAKE_SIZE_OF_VOID_P EQUAL 8)
+    if(USE_MSVC)
         set(CMAKE_REQUIRED_FLAGS "/arch:SSE2")
-    else ()
+    elseif(USE_GCC OR USE_CLANG)
         set(CMAKE_REQUIRED_FLAGS "-msse2")
-    endif ()
-endif (NOT CMAKE_SIZE_OF_VOID_P EQUAL 8)
+    endif()
+endif()
 
 check_cxx_source_compiles ("
     #include <emmintrin.h>
@@ -24,4 +24,4 @@ check_cxx_source_compiles ("
     }"
     HAVE_SSE2)
 
-MARK_AS_ADVANCED (HAVE_SSE2)
+mark_as_advanced(HAVE_SSE2)

--- a/share/cmake/utils/CompilerFlags.cmake
+++ b/share/cmake/utils/CompilerFlags.cmake
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+
+###############################################################################
+# Define the global compilation and link flags.
+
+set(PLATFORM_COMPILE_FLAGS "")
+
+if(USE_MSVC)
+
+    set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /DUSE_MSVC")
+
+    # /wd4275 Exceptions derive from std::runtime_error but STL classes are not exportable.
+    # /we4062 Enables warning in switch when an enumeration value is not explicitly handled.
+    set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /EHsc /wd4275 /DWIN32 /we4062")
+
+    if(OCIO_WARNING_AS_ERROR)
+        set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /WX")
+    endif()
+
+elseif(USE_CLANG)
+
+    set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} -DUSE_CLANG")
+
+    # Use of 'register' specifier must be removed for C++17 support.
+    set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} -Wno-deprecated-register")
+
+elseif(USE_GCC)
+
+    set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} -DUSE_GCC")
+
+endif()
+
+
+if(USE_GCC OR USE_CLANG)
+
+    # -Wswitch-enum Enables warning in switch when an enumeration value is not explicitly handled.
+    set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} -Wall -Wswitch-enum")
+
+    # TODO: OCIO being under active development, unused functions are fine for now.
+    set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} -Wno-unused-function")
+
+    if(OCIO_WARNING_AS_ERROR)
+        set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} -Werror")
+    endif()
+
+    if(OCIO_INLINES_HIDDEN)
+        set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} -fvisibility-inlines-hidden")
+    endif()
+
+    if(APPLE)
+        # Mute the deprecated warning for some GLUT methods.
+        set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} -Wno-deprecated-declarations")
+    endif()
+
+endif()
+
+# An advanced variable will not be displayed in any of the cmake GUIs
+
+mark_as_advanced(PLATFORM_COMPILE_FLAGS)
+
+
+###############################################################################
+# Define if SSE2 can be used.
+
+include(CheckSupportSSE2)
+
+if(NOT HAVE_SSE2)
+    message(STATUS "Disabling SSE optimizations, as the target doesn't support them")
+    set(OCIO_USE_SSE OFF)
+endif(NOT HAVE_SSE2)

--- a/share/cmake/utils/CompilerFlags.cmake
+++ b/share/cmake/utils/CompilerFlags.cmake
@@ -15,6 +15,13 @@ if(USE_MSVC)
     # /we4062 Enables warning in switch when an enumeration value is not explicitly handled.
     set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /EHsc /wd4275 /DWIN32 /we4062")
 
+    if(${CMAKE_CXX_STANDARD} EQUAL 17)
+        # Inheriting from std::iterator is deprecated starting with C++17 and Yaml 0.6.3 does that.
+        set(PLATFORM_COMPILE_FLAGS 
+            "${PLATFORM_COMPILE_FLAGS} /D_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING"
+        )
+    endif()
+
     if(OCIO_WARNING_AS_ERROR)
         set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /WX")
     endif()

--- a/share/cmake/utils/CompilerFlags.cmake
+++ b/share/cmake/utils/CompilerFlags.cmake
@@ -15,7 +15,7 @@ if(USE_MSVC)
     # /we4062 Enables warning in switch when an enumeration value is not explicitly handled.
     set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /EHsc /wd4275 /DWIN32 /we4062")
 
-    if(${CMAKE_CXX_STANDARD} EQUAL 17)
+    if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 17)
         # Inheriting from std::iterator is deprecated starting with C++17 and Yaml 0.6.3 does that.
         set(PLATFORM_COMPILE_FLAGS 
             "${PLATFORM_COMPILE_FLAGS} /D_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING"

--- a/share/cmake/utils/Compilers.cmake
+++ b/share/cmake/utils/Compilers.cmake
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+
+###############################################################################
+# Define which compiler is used.
+
+set(USE_MSVC  OFF)
+set(USE_CLANG OFF)
+set(USE_GCC   OFF)
+
+if(MSVC)
+    set(USE_MSVC ON)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+    set(USE_CLANG ON)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(USE_GCC ON)
+else()
+    message(FATAL_ERROR "No compiler support for '${CMAKE_CXX_COMPILER_ID}' compiler.")
+endif()
+
+
+# An advanced variable will not be displayed in any of the cmake GUIs
+
+mark_as_advanced(USE_MSVC)
+mark_as_advanced(USE_CLANG)
+mark_as_advanced(USE_GCC)

--- a/share/cmake/utils/CppVersion.cmake
+++ b/share/cmake/utils/CppVersion.cmake
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+
+###############################################################################
+# C++ version configuration
+
+set(SUPPORTED_CXX_STANDARDS 11 14 17)
+string(REPLACE ";" ", " SUPPORTED_CXX_STANDARDS_STR "${SUPPORTED_CXX_STANDARDS}")
+
+if(CMAKE_CXX_STANDARD AND NOT CMAKE_CXX_STANDARD IN_LIST SUPPORTED_CXX_STANDARDS)
+    message(FATAL_ERROR 
+            "CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} is unsupported. Supported standards are: ${SUPPORTED_CXX_STANDARDS_STR}.")
+elseif(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard to compile against")
+endif()
+
+include(CheckCXXCompilerFlag)
+
+if(USE_MSVC)
+    CHECK_CXX_COMPILER_FLAG("-std:c++11" COMPILER_SUPPORTS_CXX11)
+    CHECK_CXX_COMPILER_FLAG("-std:c++14" COMPILER_SUPPORTS_CXX14)
+    CHECK_CXX_COMPILER_FLAG("-std:c++17" COMPILER_SUPPORTS_CXX17)
+else()
+    CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+    CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
+    CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
+endif()
+
+if(NOT COMPILER_SUPPORTS_CXX11 AND ${CMAKE_CXX_STANDARD} EQUAL 11)
+    message(STATUS "The compiler ${CMAKE_CXX_COMPILER_ID} has no C++11 only support. Use C++14.")
+    set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(NOT COMPILER_SUPPORTS_CXX14 AND ${CMAKE_CXX_STANDARD} EQUAL 14)
+    message(STATUS "The compiler ${CMAKE_CXX_COMPILER_ID} has no C++14 only support. Use C++17.")
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(NOT COMPILER_SUPPORTS_CXX17 AND ${CMAKE_CXX_STANDARD} EQUAL 17)
+    message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER_ID} has no C++17 support.")
+endif()
+
+
+# Disable fallback to other C++ version if standard is not supported.
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Disable any compiler specific C++ extensions.
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/src/OpenColorIO/PathUtils.h
+++ b/src/OpenColorIO/PathUtils.h
@@ -9,6 +9,7 @@
 
 #include <map>
 
+
 namespace OCIO_NAMESPACE
 {
 // This is not currently included in pystring, but we need it
@@ -21,10 +22,9 @@ std::string AbsPath(const std::string & path);
 // keys as expected.
 // ie. '$TEST_$TESTING_$TE' will expand in this order '2 1 3'
 template <class T>
-struct EnvMapKey : std::binary_function <T, T, bool>
+struct EnvMapKey
 {
-    bool
-    operator() (const T &x, const T &y) const
+    bool operator() (const T & x, const T & y) const
     {
         // If the lengths are unequal, sort by length
         if(x.length() != y.length())

--- a/src/OpenColorIO/transforms/FileTransform.cpp
+++ b/src/OpenColorIO/transforms/FileTransform.cpp
@@ -757,17 +757,17 @@ void BuildFileTransformOps(OpRcPtrVec & ops,
     std::string filepath = context->resolveFileLocation(src.c_str());
 
     // Verify the recursion is valid, FileNoOp is added for each file.
-    for (ConstOpRcPtr&& op : ops)
+    for (const OpRcPtr & op : ops)
     {
-        ConstOpDataRcPtr data = op->data();
+        ConstOpRcPtr const_op(op);
+        ConstOpDataRcPtr data = const_op->data();
         auto fileData = DynamicPtrCast<const FileNoOpData>(data);
         if (fileData)
         {
             // Error if file is still being loaded and is the same as the
             // one about to be loaded.
             if (!fileData->getComplete() &&
-                Platform::Strcasecmp(fileData->getPath().c_str(),
-                                        filepath.c_str()) == 0)
+                Platform::Strcasecmp(fileData->getPath().c_str(), filepath.c_str()) == 0)
             {
                 std::ostringstream os;
                 os << "Reference to: " << filepath;

--- a/src/apps/ociobakelut/CMakeLists.txt
+++ b/src/apps/ociobakelut/CMakeLists.txt
@@ -19,13 +19,17 @@ if(MSVC)
     set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /wd4996")
 endif()
 
-# TODO: lcm2 2.2 does not compile on C++17 so revert to c++11
+# NOTE: Depending of the compiler version lcm2 2.2 does not compile on C++17 so revert to c++11
+
+set(APP_CXX_STANDARD ${CMAKE_CXX_STANDARD})
+if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 17)
+    set(APP_CXX_STANDARD 11)
+endif()
 
 set_target_properties(ociobakelut
     PROPERTIES 
         COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}"
-        C_STANDARD 11
-        CXX_STANDARD 11
+        CXX_STANDARD ${APP_CXX_STANDARD}
 )
 
 target_link_libraries(ociobakelut 

--- a/src/apps/ociobakelut/CMakeLists.txt
+++ b/src/apps/ociobakelut/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(ociobakelut ${SOURCES})
 if(NOT BUILD_SHARED_LIBS)
     target_compile_definitions(ociobakelut
         PRIVATE
-        OpenColorIO_SKIP_IMPORTS
+            OpenColorIO_SKIP_IMPORTS
     )
 endif()
 
@@ -19,8 +19,14 @@ if(MSVC)
     set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /wd4996")
 endif()
 
-set_target_properties(ociobakelut PROPERTIES 
-    COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
+# TODO: lcm2 2.2 does not compile on C++17 so revert to c++11
+
+set_target_properties(ociobakelut
+    PROPERTIES 
+        COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}"
+        C_STANDARD 11
+        CXX_STANDARD 11
+)
 
 target_link_libraries(ociobakelut 
     PRIVATE 

--- a/src/apps/ociobakelut/CMakeLists.txt
+++ b/src/apps/ociobakelut/CMakeLists.txt
@@ -19,7 +19,7 @@ if(MSVC)
     set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /wd4996")
 endif()
 
-# NOTE: Depending of the compiler version lcm2 2.2 does not compile on C++17 so revert to c++11
+# NOTE: Depending of the compiler version lcm2 2.2 does not compile with C++17 so revert to c++11
 
 set(APP_CXX_STANDARD ${CMAKE_CXX_STANDARD})
 if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 17)

--- a/src/apps/ociomakeclf/main.cpp
+++ b/src/apps/ociomakeclf/main.cpp
@@ -57,7 +57,7 @@ void CreateOutputLutFile(const std::string & outLutFilepath, OCIO::ConstGroupTra
         {
             optProcessor->write("Academy/ASC Common LUT Format", outfs);
         }
-        catch (OCIO::Exception)
+        catch (const OCIO::Exception &)
         {
             outfs.close();
             remove(outLutFilepath.c_str());

--- a/src/apputils/CMakeLists.txt
+++ b/src/apputils/CMakeLists.txt
@@ -7,4 +7,9 @@ set(SOURCES
 )
 
 add_library(apputils STATIC ${SOURCES})
+
 target_include_directories(apputils PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+set_target_properties(apputils PROPERTIES 
+    COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}"
+)

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -81,8 +81,18 @@ if(WIN32)
 	)
 endif()
 
-set_target_properties(PyOpenColorIO PROPERTIES
-	COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
+# NOTE: Depending of the compiler version pybind11 2.4.3 does not compile on C++17 so revert to c++11
+
+set(APP_CXX_STANDARD ${CMAKE_CXX_STANDARD})
+if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 17)
+    set(APP_CXX_STANDARD 11)
+endif()
+
+set_target_properties(PyOpenColorIO
+	PROPERTIES
+		COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}"
+        CXX_STANDARD ${APP_CXX_STANDARD}
+)
 
 if(NOT BUILD_SHARED_LIBS)
 	target_compile_definitions(PyOpenColorIO

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -81,17 +81,17 @@ if(WIN32)
 	)
 endif()
 
-# NOTE: Depending of the compiler version pybind11 2.4.3 does not compile on C++17 so revert to c++11
+# NOTE: Depending of the compiler version pybind11 2.4.3 does not compile with C++17 so revert to c++11
 
 set(APP_CXX_STANDARD ${CMAKE_CXX_STANDARD})
 if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 17)
-    set(APP_CXX_STANDARD 11)
+	set(APP_CXX_STANDARD 11)
 endif()
 
 set_target_properties(PyOpenColorIO
 	PROPERTIES
 		COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}"
-        CXX_STANDARD ${APP_CXX_STANDARD}
+		CXX_STANDARD ${APP_CXX_STANDARD}
 )
 
 if(NOT BUILD_SHARED_LIBS)

--- a/src/libutils/oglapphelpers/CMakeLists.txt
+++ b/src/libutils/oglapphelpers/CMakeLists.txt
@@ -27,7 +27,8 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 set_target_properties(oglapphelpers PROPERTIES 
-    COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
+    COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}"
+)
 
 target_include_directories(oglapphelpers
     PUBLIC

--- a/src/libutils/oiiohelpers/CMakeLists.txt
+++ b/src/libutils/oiiohelpers/CMakeLists.txt
@@ -17,7 +17,8 @@ if(NOT BUILD_SHARED_LIBS)
 endif()
 
 set_target_properties(oiiohelpers PROPERTIES
-    COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
+    COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}"
+)
 
 target_include_directories(oiiohelpers
     PUBLIC


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

Following the Open Source Day, I realized that the OCIO build system was missing the C++17 support so I've added it. I also refactored the root CMakeLists.txt to limit its size and increase its readability.

Note: I also put some attention to limit the number of publicly available cmake variables (using `ccmake` or `cmake-gui` for Windows).