### PR TITLE
Enforce LF line endings for .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,6 @@ tests/data/files/image_png.clf binary
 # Exclude binary formats.
 tests/data/files/*.icc binary
 tests/data/files/*.icm binary
+
+# Avoid Windows line breaks in shell scripts (bound to fail)
+*.sh text eol=lf


### PR DESCRIPTION
If you checkout the repo on Windows with Git's autocrlf enabled, then you will end up with CRLF line breaks. Shell scripts don't go well with CR (^M) characters however. They break scripts and give you misleading error messages such as `: command not found` or `: No such file or director`.