### PR TITLE
Document OpenColorIO Development Process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,6 @@ explains our contribution process and procedures, so please review it first:
 * [Getting Started](#Getting-Started)
 * [Repository Structure](#Repository-Structure)
 * [Development and Pull Requests](#Development-and-Pull-Requests)
-* [Required Approvals](#Required-Approvals)
 * [Coding Standards](#Coding-Standards)
 * [Test Policy](#Test-Policy)
 * [Versioning Policy](#Versioning-Policy)
@@ -180,6 +179,12 @@ Contributions should be submitted as Github pull requests. See
 [Creating a pull request](https://help.github.com/articles/creating-a-pull-request/)
 if you're unfamiliar with this concept.
 
+Please review [PROCESS.md](PROCESS.md) for important procedures related to 
+making changes to OpenColorIO. Small bug fixes and documentation changes can be
+more informal, but modifications to core OpenColorIO functionality MUST follow
+the 
+[Core Library Changes](https://github.com/AcademySoftwareFoundation/OpenColorIO/blob/master/PROCESS.md#Core-Library-Changes) process.
+
 The development cycle for a code change should follow this protocol:
 
 1. Create a topic branch in your local repository, following the naming format
@@ -204,65 +209,14 @@ for merging after all builds have succeeded.
 who may discuss, offer constructive feedback, request changes, or approve
 the work.
 
-7. Upon receiving the required number of Committer approvals (as outlined
-in [Required Approvals](#required-approvals)), a Committer other than the PR
-contributor may squash and merge changes into the master branch.
+7. Upon receiving the required number of Committer approvals (as outlined in 
+[Required Approvals](https://github.com/AcademySoftwareFoundation/OpenColorIO/blob/master/PROCESS.md#Required-Approvals)), 
+a Committer other than the PR contributor may squash and merge changes into the 
+master branch.
 
 See also (from the OCIO Developer Guide):
 * [Getting started](http://opencolorio.org/developers/getting_started.html)
 * [Submitting Changes](http://opencolorio.org/developers/submitting_changes.html)
-
-## Required Approvals
-
-Modifications of the contents of the OpenColorIO repository are made on a
-collaborative basis. Anyone with a GitHub account may propose a modification via
-pull request and it will be considered by the project Committers.
-
-Pull requests must meet a minimum number of Committer approvals prior to being
-merged. Rather than having a hard rule for all PRs, the requirement is based on
-the complexity and risk of the proposed changes, factoring in the length of
-time the PR has been open to discussion. The following guidelines outline the
-project's established approval rules for merging:
-
-* Core design decisions, large new features, or anything that might be perceived
-as changing the overall direction of the project should be discussed at length
-in the mail list before any PR is submitted, in order to: solicit feedback, try
-to get as much consensus as possible, and alert all the stakeholders to be on
-the lookout for the eventual PR when it appears.
-
-* Small changes (bug fixes, docs, tests, cleanups) can be approved and merged by
-a single Committer.
-
-* Big changes that can alter behavior, add major features, or present a high
-degree of risk should be signed off by TWO Committers, ideally one of whom
-should be the "owner" for that section of the codebase (if a specific owner
-has been designated). If the person submitting the PR is him/herself the "owner"
-of that section of the codebase, then only one additional Committer approval is
-sufficient. But in either case, a 48 hour minimum is helpful to give everybody a
-chance to see it, unless it's a critical emergency fix (which would probably put
-it in the previous "small fix" category, rather than a "big feature").
-
-* Escape valve: big changes can nonetheless be merged by a single Committer if
-the PR has been open for over two weeks without any unaddressed objections from
-other Committers. At some point, we have to assume that the people who know and
-care are monitoring the PRs and that an extended period without objections is
-really assent.
-
-Approval must be from Committers who are not authors of the change. If one or
-more Committers oppose a proposed change, then the change cannot be accepted
-unless:
-
-* Discussions and/or additional changes result in no Committers objecting to the
-change. Previously-objecting Committers do not necessarily have to sign-off on
-the change, but they should not be opposed to it.
-
-* The change is escalated to the TSC and the TSC votes to approve the change.
-This should only happen if disagreements between Committers cannot be resolved
-through discussion.
-
-Committers may opt to elevate significant or controversial modifications to the
-TSC by assigning the `tsc-review` label to a pull request or issue. The TSC
-should serve as the final arbiter where required.
 
 ## Coding Standards
 

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -96,10 +96,9 @@ project's established approval rules for merging:
   feature, a Committer that is affiliated with the author may approve it. At 
   some point, we have to assume that the people who know and care are 
   monitoring the PRs and that an extended period without objections is really 
-  assent. Notice must be given in the pull request 48 hours before merging 
-  (as early as the 12th day of an open PR) with the intent to merge. This 
-  gives a windows for reviewers to comment or request additional time for 
-  review.
+  assent. Notice must be given in the pull request between 2 and 4 days in 
+  advance of the intended merge date. This gives a windows for reviewers to 
+  comment or request additional time for review.
 
 If one or more Committers oppose a proposed change, then the change cannot be 
 accepted unless:

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -23,20 +23,21 @@ Commitee) and the wider OCIO community and stakeholders.
 library changes since they have cascading effects across the project.
 
 1. All core changes begin with community discussion, which can involve informal 
-   conversation in Slack or on 
+   conversation in [Slack](http://slack.opencolorio.org/) or on 
    [ocio-dev](https://lists.aswf.io/g/ocio-dev), but are ultimately brought to a 
    TSC meeting where concensus can be reached around the proposal's relevance 
    and approach. TSC meetings are public and meeting notes are posted to the 
    [OCIO repo](https://github.com/AcademySoftwareFoundation/OpenColorIO/tree/master/ASWF/meetings/tsc) 
    within days of a meeting for a permanent record of decisions.
-2. Following TSC resolution, an issue is created in GitHub to present a design 
-   proposal. A period of further community discussion is encouraged around the
-   proposed changes, captured in issue comments. Ongoing concerns may continue 
-   to be brought to the TSC prior to and during development.
-3. Feature proposal issues are then be added to the 
+2. Following acceptance of the proposal by the TSC, an issue is created in 
+   GitHub to present a design proposal. A period of further community 
+   discussion is encouraged around the proposed changes, captured in issue 
+   comments. Ongoing concerns may continue to be raised in this issue, and 
+   brought to the TSC prior to and during development.
+3. Feature proposal issues are added to the 
    [Roadmap](https://github.com/AcademySoftwareFoundation/OpenColorIO/projects/3) 
-   project in GitHub for tracking development progress of all accepted 
-   proposals.
+   project in GitHub by a committer for tracking the status of all accepted 
+   proposals in one place.
 4. During development, work in progress may optionally be shared for feedback 
    and early review via a 
    [draft pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
@@ -56,6 +57,14 @@ library changes since they have cascading effects across the project.
    feature, a committer that is affiliated with the author may approve it. See 
    [Required Approvals](#Required-Approvals) for a detailed breakdown of OCIO 
    pull request approval policy.
+
+**NOTE**: Software design is often an iterative process with development. While 
+a design proposal is required, it is understood that development of the 
+proposed feature may begin prior to opening a design proposal issue in GitHub. It 
+is however highly encouraged to propose the design early in the interest of 
+respecting the contributor's time and effort. This avoids getting too far into 
+development without community involvement, which may lead to redesign and 
+extensive rework before changes can be approved.
 
 ## Required Approvals
 

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -14,18 +14,19 @@ submitting changes.
 ## Core Library Changes
 
 This procedure outlines the OpenColorIO project's process for design, 
-development, and review of changes to the core library. The intent is for 
-discussion and decisions around such changes to be made in public and have 
-transparent outcomes, seeking the guidance of both the TSC (Technical Steering 
-Commitee) and the wider OCIO community and stakeholders.
+development, and review of changes to the core library, large new features, or 
+anything that might be perceived as changing the overall direction of the 
+project. The intent is for discussion and decisions around such changes to be 
+made in public and have transparent outcomes, seeking the guidance of both the 
+TSC (Technical Steering Commitee) and the wider OCIO community and stakeholders.
 
-**NOTE:** Changes to OpenColorIO process or governance are considered core 
-library changes since they have cascading effects across the project.
+**NOTE:** Changes to OpenColorIO process or governance have cascading effects 
+across the project so are treated as core changes.
 
 1. All core changes begin with community discussion, which can involve informal 
    conversation in [Slack](http://slack.opencolorio.org/) or on 
    [ocio-dev](https://lists.aswf.io/g/ocio-dev), but are ultimately brought to a 
-   TSC meeting where concensus can be reached around the proposal's relevance 
+   TSC meeting where consensus can be reached around the proposal's relevance 
    and approach. TSC meetings are public and meeting notes are posted to the 
    [OCIO repo](https://github.com/AcademySoftwareFoundation/OpenColorIO/tree/master/ASWF/meetings/tsc) 
    within days of a meeting for a permanent record of decisions.
@@ -35,7 +36,7 @@ library changes since they have cascading effects across the project.
    comments. Ongoing concerns may continue to be raised in this issue, and 
    brought to the TSC prior to and during development.
 3. Feature proposal issues are added to the 
-   [Roadmap](https://github.com/AcademySoftwareFoundation/OpenColorIO/projects/3) 
+   [Feature Development](https://github.com/AcademySoftwareFoundation/OpenColorIO/projects/3) 
    project in GitHub by a committer for tracking the status of all accepted 
    proposals in one place.
 4. During development, work in progress may optionally be shared for feedback 
@@ -46,17 +47,11 @@ library changes since they have cascading effects across the project.
    [linked to the associated issue]((https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for review.
    Linking the issue and PR will result in the issue being closed automatically 
    upon the PR being merged, and facilitate tracking of the proposed feature in
-   the 
-   [Roadmap](https://github.com/AcademySoftwareFoundation/OpenColorIO/projects/3). 
+   [Feature Development](https://github.com/AcademySoftwareFoundation/OpenColorIO/projects/3). 
    See [CONTRIBUTING.md](CONTRIBUTING.md) for an overview of commit signing 
    requirements and a guide on submitting a pull request.
-6. The pull request is merged only after obtaining 2 approvals from committers 
-   listed in [COMMITTERS.md](COMMITTERS.md) that are not affiliated with the 
-   author or their company. If approval does not happen within two weeks and 
-   there are no raised objections or unresolved discussions happening about the 
-   feature, a committer that is affiliated with the author may approve it. See 
-   [Required Approvals](#Required-Approvals) for a detailed breakdown of OCIO 
-   pull request approval policy.
+6. The pull request is merged after being approved as documented in the 
+   [Required Approvals](#Required-Approvals) section below.
 
 **NOTE**: Software design is often an iterative process with development. While 
 a design proposal is required, it is understood that development of the 
@@ -78,41 +73,36 @@ the complexity and risk of the proposed changes, factoring in the length of
 time the PR has been open to discussion. The following guidelines outline the
 project's established approval rules for merging:
 
-* Core design decisions, large new features, or anything that might be perceived
-as changing the overall direction of the project should be discussed at length
-in the mail list before any PR is submitted, in order to: solicit feedback, try
-to get as much consensus as possible, and alert all the stakeholders to be on
-the lookout for the eventual PR when it appears.
+* All changes must receive a minimum of two approvals from Committers 
+  listed in [COMMITTERS.md](COMMITTERS.md) that are not affiliated with the 
+  author or their company prior to being merged. GitHub branch protections 
+  are enabled to enforce minimum committer count and Committer status. A 
+  Committer approval is denoted in a PR with a green check mark. A gray check 
+  mark beside an approval means the approver does not count toward the minimum
+  approval count, but such approvals are welcome and encouraged from the 
+  community.
 
-* Small changes (bug fixes, docs, tests, cleanups) can be approved and merged by
-a single Committer.
+* Ideally one of two approvers of a pull request should be the "owner" for that 
+  section of the codebase (if a specific owner has been designated). If the 
+  person submitting the PR is him/herself the "owner" of that section of the 
+  codebase, then only one additional Committer approval is required in addition 
+  to the submitter. But in either case, a 48 hour minimum is required to give 
+  everybody a chance to see it, unless it's a critical emergency fix.
 
-* Big changes that can alter behavior, add major features, or present a high
-degree of risk should be signed off by TWO Committers, ideally one of whom
-should be the "owner" for that section of the codebase (if a specific owner
-has been designated). If the person submitting the PR is him/herself the "owner"
-of that section of the codebase, then only one additional Committer approval is
-sufficient. But in either case, a 48 hour minimum is helpful to give everybody a
-chance to see it, unless it's a critical emergency fix (which would probably put
-it in the previous "small fix" category, rather than a "big feature").
+* If approval does not happen within two weeks of opening a pull request and 
+  there are no raised objections or unresolved discussions happening about the 
+  feature, a Committer that is affiliated with the author may approve it. At 
+  some point, we have to assume that the people who know and care are 
+  monitoring the PRs and that an extended period without objections is really 
+  assent.
 
-* Escape valve: big changes can nonetheless be merged by a single Committer if
-the PR has been open for over two weeks without any unaddressed objections from
-other Committers. At some point, we have to assume that the people who know and
-care are monitoring the PRs and that an extended period without objections is
-really assent.
+* Discussions and/or additional changes should result in no Committers 
+  objecting to the change. Previously-objecting Committers do not necessarily 
+  have to sign-off on the change, but they should not be opposed to it.
 
-Approval must be from Committers who are not authors of the change. If one or
-more Committers oppose a proposed change, then the change cannot be accepted
-unless:
-
-* Discussions and/or additional changes result in no Committers objecting to the
-change. Previously-objecting Committers do not necessarily have to sign-off on
-the change, but they should not be opposed to it.
-
-* The change is escalated to the TSC and the TSC votes to approve the change.
-This should only happen if disagreements between Committers cannot be resolved
-through discussion.
+* Changes may be escalated to the TSC for a vote to approve a PR. This should 
+  only happen if disagreements between Committers cannot be resolved through 
+  discussion.
 
 Committers may opt to elevate significant or controversial modifications to the
 TSC by assigning the `tsc-review` label to a pull request or issue. The TSC

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -1,0 +1,103 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the OpenColorIO Project. -->
+
+# OpenColorIO Project Processes
+
+This document outlines important development and administrative processes and 
+procedures adhered to by the OpenColorIO project. It should be reviewed in 
+conjuntion with [CONTRIBUTING.md](CONTRIBUTING.md) prior to proposing or 
+submitting changes.
+
+* [Core Library Changes](#Core-Library-Changes)
+* [Required Approvals](#Required-Approvals)
+
+## Core Library Changes
+
+This procedure outlines the OpenColorIO project's process for design, 
+development, and review of changes to the core library. The intent is for 
+discussion and decisions around such changes to be made in public and have 
+transparent outcomes, seeking the guidance of both the TSC (Technical Steering 
+Commitee) and the wider OCIO community and stakeholders.
+
+**NOTE:** Changes to OpenColorIO process or governance are considered core 
+library changes since they have cascading effects across the project.
+
+1. All core changes begin with community discussion, which can involve informal 
+   conversation in Slack or on 
+   [ocio-dev](https://lists.aswf.io/g/ocio-dev), but are ultimately brought to a 
+   TSC meeting where concensus can be reached around the proposal's relevance 
+   and approach. TSC meetings are public and meeting notes are posted to the 
+   [OCIO repo](https://github.com/AcademySoftwareFoundation/OpenColorIO/tree/master/ASWF/meetings/tsc) 
+   within days of a meeting for a permanent record of decisions.
+2. Following TSC resolution, an issue is created in GitHub to present a design 
+   proposal. A period of further community discussion is encouraged around the
+   proposed changes, captured in issue comments. Ongoing concerns may continue 
+   to be brought to the TSC prior to and during development.
+3. During development, work in progress may optionally be shared for feedback 
+   and early review via a 
+   [draft pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
+4. Upon completion of feature development, a pull request is created for review 
+   and 
+   [linked to the associated issue]((https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for review.
+   Linking the issue and PR will result in the issue being closed automatically 
+   upon the PR being merged. See [CONTRIBUTING.md](CONTRIBUTING.md) for an overview
+   of commit signing requirements and a guide on submitting a pull request.
+5. The pull request is merged only after obtaining 2 approvals from committers 
+   listed in [COMMITTERS.md](COMMITTERS.md) that are not affiliated with the 
+   author or their company. If approval does not happen within two weeks and 
+   there are no raised objections or unresolved discussions happening about the 
+   feature, a committer that is affiliated with the author may approve it. See 
+   [Required Approvals](#Required-Approvals) for a detailed breakdown of OCIO 
+   pull request approval policy.
+
+## Required Approvals
+
+Modifications of the contents of the OpenColorIO repository are made on a
+collaborative basis. Anyone with a GitHub account may propose a modification via
+pull request and it will be considered by the project Committers.
+
+Pull requests must meet a minimum number of Committer approvals prior to being
+merged. Rather than having a hard rule for all PRs, the requirement is based on
+the complexity and risk of the proposed changes, factoring in the length of
+time the PR has been open to discussion. The following guidelines outline the
+project's established approval rules for merging:
+
+* Core design decisions, large new features, or anything that might be perceived
+as changing the overall direction of the project should be discussed at length
+in the mail list before any PR is submitted, in order to: solicit feedback, try
+to get as much consensus as possible, and alert all the stakeholders to be on
+the lookout for the eventual PR when it appears.
+
+* Small changes (bug fixes, docs, tests, cleanups) can be approved and merged by
+a single Committer.
+
+* Big changes that can alter behavior, add major features, or present a high
+degree of risk should be signed off by TWO Committers, ideally one of whom
+should be the "owner" for that section of the codebase (if a specific owner
+has been designated). If the person submitting the PR is him/herself the "owner"
+of that section of the codebase, then only one additional Committer approval is
+sufficient. But in either case, a 48 hour minimum is helpful to give everybody a
+chance to see it, unless it's a critical emergency fix (which would probably put
+it in the previous "small fix" category, rather than a "big feature").
+
+* Escape valve: big changes can nonetheless be merged by a single Committer if
+the PR has been open for over two weeks without any unaddressed objections from
+other Committers. At some point, we have to assume that the people who know and
+care are monitoring the PRs and that an extended period without objections is
+really assent.
+
+Approval must be from Committers who are not authors of the change. If one or
+more Committers oppose a proposed change, then the change cannot be accepted
+unless:
+
+* Discussions and/or additional changes result in no Committers objecting to the
+change. Previously-objecting Committers do not necessarily have to sign-off on
+the change, but they should not be opposed to it.
+
+* The change is escalated to the TSC and the TSC votes to approve the change.
+This should only happen if disagreements between Committers cannot be resolved
+through discussion.
+
+Committers may opt to elevate significant or controversial modifications to the
+TSC by assigning the `tsc-review` label to a pull request or issue. The TSC
+should serve as the final arbiter where required.

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -33,16 +33,23 @@ library changes since they have cascading effects across the project.
    proposal. A period of further community discussion is encouraged around the
    proposed changes, captured in issue comments. Ongoing concerns may continue 
    to be brought to the TSC prior to and during development.
-3. During development, work in progress may optionally be shared for feedback 
+3. Feature proposal issues are then be added to the 
+   [Roadmap](https://github.com/AcademySoftwareFoundation/OpenColorIO/projects/3) 
+   project in GitHub for tracking development progress of all accepted 
+   proposals.
+4. During development, work in progress may optionally be shared for feedback 
    and early review via a 
    [draft pull request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
-4. Upon completion of feature development, a pull request is created for review 
+5. Upon completion of feature development, a pull request is created for review 
    and 
    [linked to the associated issue]((https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) for review.
    Linking the issue and PR will result in the issue being closed automatically 
-   upon the PR being merged. See [CONTRIBUTING.md](CONTRIBUTING.md) for an overview
-   of commit signing requirements and a guide on submitting a pull request.
-5. The pull request is merged only after obtaining 2 approvals from committers 
+   upon the PR being merged, and facilitate tracking of the proposed feature in
+   the 
+   [Roadmap](https://github.com/AcademySoftwareFoundation/OpenColorIO/projects/3). 
+   See [CONTRIBUTING.md](CONTRIBUTING.md) for an overview of commit signing 
+   requirements and a guide on submitting a pull request.
+6. The pull request is merged only after obtaining 2 approvals from committers 
    listed in [COMMITTERS.md](COMMITTERS.md) that are not affiliated with the 
    author or their company. If approval does not happen within two weeks and 
    there are no raised objections or unresolved discussions happening about the 

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -5,7 +5,7 @@
 
 This document outlines important development and administrative processes and 
 procedures adhered to by the OpenColorIO project. It should be reviewed in 
-conjuntion with [CONTRIBUTING.md](CONTRIBUTING.md) prior to proposing or 
+conjunction with [CONTRIBUTING.md](CONTRIBUTING.md) prior to proposing or 
 submitting changes.
 
 * [Core Library Changes](#Core-Library-Changes)
@@ -73,36 +73,44 @@ the complexity and risk of the proposed changes, factoring in the length of
 time the PR has been open to discussion. The following guidelines outline the
 project's established approval rules for merging:
 
-* All changes must receive a minimum of two approvals from Committers 
-  listed in [COMMITTERS.md](COMMITTERS.md) that are not affiliated with the 
-  author or their company prior to being merged. GitHub branch protections 
-  are enabled to enforce minimum committer count and Committer status. A 
-  Committer approval is denoted in a PR with a green check mark. A gray check 
-  mark beside an approval means the approver does not count toward the minimum
-  approval count, but such approvals are welcome and encouraged from the 
-  community.
+* All changes must receive a minimum of two approvals from Committers listed in 
+  [COMMITTERS.md](COMMITTERS.md) prior to being merged. GitHub branch 
+  protections are enabled to enforce minimum committer count and Committer 
+  status. A Committer approval is denoted in a PR with a green check mark. A 
+  gray check mark beside an approval means the approver does not count toward 
+  the minimum approval count, but such approvals are welcome and encouraged 
+  from the community.
 
-* Ideally one of two approvers of a pull request should be the "owner" for that 
-  section of the codebase (if a specific owner has been designated). If the 
-  person submitting the PR is him/herself the "owner" of that section of the 
-  codebase, then only one additional Committer approval is required in addition 
-  to the submitter. But in either case, a 48 hour minimum is required to give 
-  everybody a chance to see it, unless it's a critical emergency fix.
+* Small changes (bug fixes, docs, tests, cleanups) may be approved by any two 
+  Committers (other than the author).
+
+* Large or significant changes must receive both approvals from Committers that 
+  are not affiliated with the author or their company.
+
+* All pull requests, except critical emergency fixes, must be posted for a 48 
+  hour minimum prior to merging, even with the required approvals. This gives 
+  everybody a chance to see it across time zones and schedules.
 
 * If approval does not happen within two weeks of opening a pull request and 
   there are no raised objections or unresolved discussions happening about the 
   feature, a Committer that is affiliated with the author may approve it. At 
   some point, we have to assume that the people who know and care are 
   monitoring the PRs and that an extended period without objections is really 
-  assent.
+  assent. Notice must be given in the pull request 48 hours before merging 
+  (as early as the 12th day of an open PR) with the intent to merge. This 
+  gives a windows for reviewers to comment or request additional time for 
+  review.
 
-* Discussions and/or additional changes should result in no Committers 
-  objecting to the change. Previously-objecting Committers do not necessarily 
-  have to sign-off on the change, but they should not be opposed to it.
+If one or more Committers oppose a proposed change, then the change cannot be 
+accepted unless:
 
-* Changes may be escalated to the TSC for a vote to approve a PR. This should 
-  only happen if disagreements between Committers cannot be resolved through 
-  discussion.
+* Discussions and/or additional changes result in no Committers objecting to 
+  the change. Previously-objecting Committers do not necessarily have to 
+  sign-off on the change, but they should not be opposed to it.
+
+* The change is escalated to the TSC and the TSC votes to approve the change. 
+  This should only happen if disagreements between Committers cannot be 
+  resolved through discussion.
 
 Committers may opt to elevate significant or controversial modifications to the
 TSC by assigning the `tsc-review` label to a pull request or issue. The TSC


### PR DESCRIPTION
Following discussion on transparency and openness of new feature development, and related TSC discussion, I've added a PROCESS.md document to outline a feature proposal process. The process is based on current practices adhered to by the project with two changes:

1. Push up proposal discussion and issue creation in the timeline where possible. In short, it's up to the contributor when a design is proposed, but accepting the risk of potential redesign requested by the community.
2. Adding accepted proposals to a new Roadmap GH Project for progress tracking and transparency.

All of this is up for discussion of course. All comments/suggestions are welcome and appreciated.

Resolves #1124 

Signed-off-by: Michael Dolan <michdolan@gmail.com>