### PR TITLE
Fix ctest -R test_python for Python 3.8

### DIFF
--- a/tests/python/OpenColorIOTestSuite.py
+++ b/tests/python/OpenColorIOTestSuite.py
@@ -20,8 +20,12 @@ if os.name == 'nt':
         opencolorio_dir = os.path.join(opencolorio_dir, sys.argv[3])
         pyopencolorio_dir = os.path.join(pyopencolorio_dir, sys.argv[3])
 
-    os.environ['PATH'] = '{0};{1}'.format(
-        opencolorio_dir, os.getenv('PATH', ''))
+    # Python 3.8+ does no longer look for DLLs in PATH environment variable
+    if hasattr(os, 'add_dll_directory'):
+        os.add_dll_directory(opencolorio_dir)
+    else:
+        os.environ['PATH'] = '{0};{1}'.format(
+            opencolorio_dir, os.getenv('PATH', ''))
 elif sys.platform == 'darwin':
     # On OSX we must add the main library location to DYLD_LIBRARY_PATH
     os.environ['DYLD_LIBRARY_PATH'] = '{0}:{1}'.format(


### PR DESCRIPTION
It couldn't find OpenColorIO_2_0.dll, because PATH is longer used for discovery. Use the new os.add_dll_directory() insead:

> - DLL dependencies for extension modules and DLLs loaded with ctypes on Windows are now resolved more securely. Only the system paths, the directory containing the DLL or PYD file, and directories added with add_dll_directory() are searched for load-time dependencies. Specifically, PATH and the current working directory are no longer used, and modifications to these will no longer have any effect on normal DLL resolution. If your application relies on these mechanisms, you should check for add_dll_directory() and if it exists, use it to add your DLLs directory while loading your library. [...]

https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-the-python-api