### PR TITLE
Add id and description to CDLTransform YAML

### DIFF
--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -579,7 +579,7 @@ inline void load(const YAML::Node& node, CDLTransformRcPtr& t)
 
     CheckDuplicates(node);
 
-    std::string key;
+    std::string key, stringval;
     std::vector<double> floatvecval;
 
     for (Iterator iter = node.begin();
@@ -637,9 +637,8 @@ inline void load(const YAML::Node& node, CDLTransformRcPtr& t)
         }
         else if (key == "style")
         {
-            std::string style;
-            load(second, style);
-            t->setStyle(CDLStyleFromString(style.c_str()));
+            load(second, stringval);
+            t->setStyle(CDLStyleFromString(stringval.c_str()));
         }
         else if (key == "direction")
         {
@@ -647,11 +646,15 @@ inline void load(const YAML::Node& node, CDLTransformRcPtr& t)
             load(second, val);
             t->setDirection(val);
         }
-        else if (key == "name")
+        else if (key == "id")
         {
-            std::string name;
-            load(second, name);
-            t->getFormatMetadata().addAttribute(METADATA_NAME, name.c_str());
+            load(second, stringval);
+            t->setID(stringval.c_str());
+        }
+        else if (key == "description")
+        {
+            load(second, stringval);
+            t->setDescription(stringval.c_str());
         }
         else
         {
@@ -699,6 +702,18 @@ inline void save(YAML::Emitter& out, ConstCDLTransformRcPtr t)
     if (t->getStyle() != CDL_TRANSFORM_DEFAULT)
     {
         out << YAML::Key << "style" << YAML::Value << CDLStyleToString(t->getStyle());
+    }
+
+    if(t->getID() != NULL && strlen(t->getID()) > 0)
+    {
+        out << YAML::Key << "id";
+        out << YAML::Value << YAML::Literal << t->getID();
+    }
+
+    if(t->getDescription() != NULL && strlen(t->getDescription()) > 0)
+    {
+        out << YAML::Key << "description";
+        out << YAML::Value << YAML::Literal << t->getDescription();
     }
 
     EmitBaseTransformKeyValues(out, t);

--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -431,7 +431,7 @@ inline void save(YAML::Emitter& out, const View & view)
 // Common Transform
 
 inline void EmitBaseTransformKeyValues(YAML::Emitter & out,
-                                        const ConstTransformRcPtr & t)
+                                       const ConstTransformRcPtr & t)
 {
     if(t->getDirection() != TRANSFORM_DIR_FORWARD)
     {
@@ -655,6 +655,11 @@ inline void load(const YAML::Node& node, CDLTransformRcPtr& t)
         {
             load(second, stringval);
             t->setDescription(stringval.c_str());
+        }
+        else if (key == "name")
+        {
+            load(second, stringval);
+            t->getFormatMetadata().addAttribute(METADATA_NAME, stringval.c_str());
         }
         else
         {

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -4223,7 +4223,8 @@ OCIO_ADD_TEST(Config, cdl_serialization)
             "        - !<CDLTransform> {offset: [0.1, 0.2, 0.1]}\n"
             "        - !<CDLTransform> {power: [1.1, 1.2, 1.1]}\n"
             "        - !<CDLTransform> {sat: 0.1, direction: inverse}\n"
-            "        - !<CDLTransform> {slope: [2, 2, 3], offset: [0.2, 0.3, 0.1], power: [1.2, 1.1, 1], sat: 0.2, style: asc}\n";
+            "        - !<CDLTransform> {slope: [2, 2, 3], offset: [0.2, 0.3, 0.1], power: [1.2, 1.1, 1], sat: 0.2, style: asc}\n"
+            "        - !<CDLTransform> {id: \"foo\", description: \"this is a description\"}\n";
 
         const std::string str = PROFILE_V2_START + strEnd;
 
@@ -4247,7 +4248,8 @@ OCIO_ADD_TEST(Config, cdl_serialization)
             "        - !<CDLTransform> {slope: [1, 2, 1]}\n"
             "        - !<CDLTransform> {offset: [0.1, 0.2, 0.1]}\n"
             "        - !<CDLTransform> {power: [1.1, 1.2, 1.1]}\n"
-            "        - !<CDLTransform> {sat: 0.1}\n";
+            "        - !<CDLTransform> {sat: 0.1}\n"
+            "        - !<CDLTransform> {id: \"foo\", description: \"this is a description\"}\n";
 
         const std::string str = PROFILE_V1 + SIMPLE_PROFILE_A + SIMPLE_PROFILE_B + strEnd;
 

--- a/tests/cpu/transforms/DisplayViewTransform_tests.cpp
+++ b/tests/cpu/transforms/DisplayViewTransform_tests.cpp
@@ -393,11 +393,11 @@ OCIO_ADD_TEST(DisplayViewTransform, build_ops)
 
 namespace
 {
-void ValidateTransform(OCIO::ConstOpRcPtr & op, const std::string id,
+void ValidateTransform(OCIO::ConstOpRcPtr & op, const std::string name,
                        OCIO::TransformDirection dir, unsigned line)
 {
     OCIO_REQUIRE_EQUAL_FROM(op->data()->getFormatMetadata().getNumAttributes(), 1, line);
-    OCIO_CHECK_EQUAL_FROM(id, op->data()->getFormatMetadata().getAttributeValue(0), line);
+    OCIO_CHECK_EQUAL_FROM(name, op->data()->getFormatMetadata().getAttributeValue(0), line);
 
     auto cdl = OCIO_DYNAMIC_POINTER_CAST<const OCIO::CDLOpData>(op->data());
     OCIO_REQUIRE_ASSERT_FROM(cdl, line);
@@ -429,8 +429,8 @@ looks:
   - !<Look>
     name: look
     process_space: displayCSProcess
-    transform: !<CDLTransform> {id: "look forward", sat: 1.5}
-    inverse_transform: !<CDLTransform> {id: "look inverse", sat: 1.5}
+    transform: !<CDLTransform> {name: look forward, sat: 1.5}
+    inverse_transform: !<CDLTransform> {name: look inverse, sat: 1.5}
 
 view_transforms:
   - !<ViewTransform>
@@ -439,24 +439,24 @@ view_transforms:
 
   - !<ViewTransform>
     name: display_vt
-    to_display_reference: !<CDLTransform> {id: "display vt to ref", sat: 1.5}
-    from_display_reference: !<CDLTransform> {id: "display vt from ref", sat: 1.5}
+    to_display_reference: !<CDLTransform> {name: display vt to ref, sat: 1.5}
+    from_display_reference: !<CDLTransform> {name: display vt from ref, sat: 1.5}
 
 display_colorspaces:
   - !<ColorSpace>
     name: displayCSIn
-    to_display_reference: !<CDLTransform> {id: "in cs to ref", sat: 1.5}
-    from_display_reference: !<CDLTransform> {id: "in cs from ref", sat: 1.5}
+    to_display_reference: !<CDLTransform> {name: in cs to ref, sat: 1.5}
+    from_display_reference: !<CDLTransform> {name: in cs from ref, sat: 1.5}
 
   - !<ColorSpace>
     name: displayCSOut
-    to_display_reference: !<CDLTransform> {id: "out cs to ref", sat: 1.5}
-    from_display_reference: !<CDLTransform> {id: "out cs from ref", sat: 1.5}
+    to_display_reference: !<CDLTransform> {name: out cs to ref, sat: 1.5}
+    from_display_reference: !<CDLTransform> {name: out cs from ref, sat: 1.5}
 
   - !<ColorSpace>
     name: displayCSProcess
-    to_display_reference: !<CDLTransform> {id: "process cs to ref", sat: 1.5}
-    from_display_reference: !<CDLTransform> {id: "process cs from ref", sat: 1.5}
+    to_display_reference: !<CDLTransform> {name: process cs to ref, sat: 1.5}
+    from_display_reference: !<CDLTransform> {name: process cs from ref, sat: 1.5}
 
 colorspaces:
   - !<ColorSpace>

--- a/tests/cpu/transforms/DisplayViewTransform_tests.cpp
+++ b/tests/cpu/transforms/DisplayViewTransform_tests.cpp
@@ -393,11 +393,11 @@ OCIO_ADD_TEST(DisplayViewTransform, build_ops)
 
 namespace
 {
-void ValidateTransform(OCIO::ConstOpRcPtr & op, const std::string name,
+void ValidateTransform(OCIO::ConstOpRcPtr & op, const std::string id,
                        OCIO::TransformDirection dir, unsigned line)
 {
     OCIO_REQUIRE_EQUAL_FROM(op->data()->getFormatMetadata().getNumAttributes(), 1, line);
-    OCIO_CHECK_EQUAL_FROM(name, op->data()->getFormatMetadata().getAttributeValue(0), line);
+    OCIO_CHECK_EQUAL_FROM(id, op->data()->getFormatMetadata().getAttributeValue(0), line);
 
     auto cdl = OCIO_DYNAMIC_POINTER_CAST<const OCIO::CDLOpData>(op->data());
     OCIO_REQUIRE_ASSERT_FROM(cdl, line);
@@ -429,8 +429,8 @@ looks:
   - !<Look>
     name: look
     process_space: displayCSProcess
-    transform: !<CDLTransform> {name: look forward, sat: 1.5}
-    inverse_transform: !<CDLTransform> {name: look inverse, sat: 1.5}
+    transform: !<CDLTransform> {id: "look forward", sat: 1.5}
+    inverse_transform: !<CDLTransform> {id: "look inverse", sat: 1.5}
 
 view_transforms:
   - !<ViewTransform>
@@ -439,24 +439,24 @@ view_transforms:
 
   - !<ViewTransform>
     name: display_vt
-    to_display_reference: !<CDLTransform> {name: display vt to ref, sat: 1.5}
-    from_display_reference: !<CDLTransform> {name: display vt from ref, sat: 1.5}
+    to_display_reference: !<CDLTransform> {id: "display vt to ref", sat: 1.5}
+    from_display_reference: !<CDLTransform> {id: "display vt from ref", sat: 1.5}
 
 display_colorspaces:
   - !<ColorSpace>
     name: displayCSIn
-    to_display_reference: !<CDLTransform> {name: in cs to ref, sat: 1.5}
-    from_display_reference: !<CDLTransform> {name: in cs from ref, sat: 1.5}
+    to_display_reference: !<CDLTransform> {id: "in cs to ref", sat: 1.5}
+    from_display_reference: !<CDLTransform> {id: "in cs from ref", sat: 1.5}
 
   - !<ColorSpace>
     name: displayCSOut
-    to_display_reference: !<CDLTransform> {name: out cs to ref, sat: 1.5}
-    from_display_reference: !<CDLTransform> {name: out cs from ref, sat: 1.5}
+    to_display_reference: !<CDLTransform> {id: "out cs to ref", sat: 1.5}
+    from_display_reference: !<CDLTransform> {id: "out cs from ref", sat: 1.5}
 
   - !<ColorSpace>
     name: displayCSProcess
-    to_display_reference: !<CDLTransform> {name: process cs to ref, sat: 1.5}
-    from_display_reference: !<CDLTransform> {name: process cs from ref, sat: 1.5}
+    to_display_reference: !<CDLTransform> {id: "process cs to ref", sat: 1.5}
+    from_display_reference: !<CDLTransform> {id: "process cs from ref", sat: 1.5}
 
 colorspaces:
   - !<ColorSpace>


### PR DESCRIPTION
This fixes the issue @KelSolaar found with ID and description not being serialized to the config YAML. `name` was used in the config IO and tests, which passed tests since it became legitimate metadata, but ID and description were bypassed.

Signed-off-by: Michael Dolan <michdolan@gmail.com>