### PR TITLE
Adds Natron description in compatible_software.rst

### DIFF
--- a/docs/guides/using_ocio/compatible_software.rst
+++ b/docs/guides/using_ocio/compatible_software.rst
@@ -251,6 +251,8 @@ Documentation:
 Natron
 ******
 
+Natron is an open source 2D compositor that ships with native support for OCIO. Standard configs are included however users can also point to custom configs in the color management section of the user preferences.
+
 Website : `<https://natrongithub.github.io/>`__
 
 Documentation :


### PR DESCRIPTION
Signed-off-by: Henry Wilkinson <henry@wilkinson.graphics>

Natron didn't have a description in the documentation before, now it does!

This is a very minor documentation change and I didn't follow the branch naming structure as outlined [here](https://github.com/AcademySoftwareFoundation/OpenColorIO/blob/master/CONTRIBUTING.md#development-and-pull-requests)... sorry.  Should I ever make more involved PRs to OCIO and not just change things in the GitHub web editor I will definitely follow that.