### PR TITLE
Added custom callback for ComputeHash function

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -161,6 +161,14 @@ extern OCIOEXPORT void ResetToDefaultLoggingFunction();
 /// Log a message using the library logging function.
 extern OCIOEXPORT void LogMessage(LoggingLevel level, const char * message);
 
+/**
+ * \brief Set the Compute Hash Function to use; otherwise, use the default.
+ * 
+ * \param ComputeHashFunction
+ */
+extern OCIOEXPORT void SetComputeHashFunction(ComputeHashFunction hashFunction);
+extern OCIOEXPORT void ResetComputeHashFunction();
+
 //
 // Note that the following environment variable access methods are not thread safe.
 //

--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -249,6 +249,9 @@ enum LoggingLevel
     LOGGING_LEVEL_DEFAULT = LOGGING_LEVEL_INFO
 };
 
+/// Define Compute Hash function signature.
+using ComputeHashFunction = std::function<std::string(const std::string &)>;
+
 /**
  * OCIO does not mandate the image state of the main reference space and it is not
  * required to be scene-referred.  This enum is used in connection with the display color space

--- a/src/OpenColorIO/PathUtils.h
+++ b/src/OpenColorIO/PathUtils.h
@@ -11,6 +11,7 @@
 
 namespace OCIO_NAMESPACE
 {
+
 // This is not currently included in pystring, but we need it
 // So let's define it locally for now
 

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -5,254 +5,254 @@
 add_definitions("-DOCIO_SOURCE_DIR=${CMAKE_SOURCE_DIR}")
 
 function(add_ocio_test NAME SOURCES PRIVATE_INCLUDES)
-	set(TEST_BINARY "test_${NAME}_exec")
-	set(TEST_NAME "test_${NAME}")
-	add_executable(${TEST_BINARY} ${SOURCES})
-	target_compile_definitions(${TEST_BINARY}
-		PRIVATE
-			OpenColorIO_SKIP_IMPORTS
+    set(TEST_BINARY "test_${NAME}_exec")
+    set(TEST_NAME "test_${NAME}")
+    add_executable(${TEST_BINARY} ${SOURCES})
+    target_compile_definitions(${TEST_BINARY}
+        PRIVATE
+            OpenColorIO_SKIP_IMPORTS
 
-	)
-	target_link_libraries(${TEST_BINARY}
-		PUBLIC
-			public_api
-		PRIVATE
-			expat::expat
-			IlmBase::Half
-			pystring::pystring
-			sampleicc::sampleicc
-			unittest_data
-			utils::strings
-			yaml-cpp
-			testutils
-	)
+    )
+    target_link_libraries(${TEST_BINARY}
+        PUBLIC
+            public_api
+        PRIVATE
+            expat::expat
+            IlmBase::Half
+            pystring::pystring
+            sampleicc::sampleicc
+            unittest_data
+            utils::strings
+            yaml-cpp
+            testutils
+    )
 
-	if(APPLE)
-		# Frameworks needed to access the ICC monitor profile. 
-		target_link_libraries(${TEST_BINARY}
-			PRIVATE
-				"-framework Carbon"
-				"-framework IOKit"
-		)
-	endif(APPLE)
+    if(APPLE)
+        # Frameworks needed to access the ICC monitor profile. 
+        target_link_libraries(${TEST_BINARY}
+            PRIVATE
+                "-framework Carbon"
+                "-framework IOKit"
+        )
+    endif(APPLE)
 
-	if(PRIVATE_INCLUDES)
-		target_include_directories(${TEST_BINARY}
-			PRIVATE
-				"${CMAKE_SOURCE_DIR}/src/OpenColorIO"
-				"${CMAKE_SOURCE_DIR}/tests/cpu"
-		)
-	endif(PRIVATE_INCLUDES)
-	if(OCIO_USE_SSE)
-		target_compile_definitions(${TEST_BINARY}
-			PRIVATE
-				USE_SSE
-		)
-	endif(OCIO_USE_SSE)
-	if(OCIO_ADD_EXTRA_BUILTINS)
-		target_compile_definitions(${TEST_BINARY}
-			PRIVATE
-				ADD_EXTRA_BUILTINS
-		)
-	endif(OCIO_ADD_EXTRA_BUILTINS)
-	if(WIN32)
-		# A windows application linking to eXpat static libraries must
-		# have the global macro XML_STATIC defined
-		target_compile_definitions(${TEST_BINARY}
-			PRIVATE
-				XML_STATIC
-		)
-	endif(WIN32)
-	set_target_properties(${TEST_BINARY} PROPERTIES
-		COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
+    if(PRIVATE_INCLUDES)
+        target_include_directories(${TEST_BINARY}
+            PRIVATE
+                "${CMAKE_SOURCE_DIR}/src/OpenColorIO"
+                "${CMAKE_SOURCE_DIR}/tests/cpu"
+        )
+    endif(PRIVATE_INCLUDES)
+    if(OCIO_USE_SSE)
+        target_compile_definitions(${TEST_BINARY}
+            PRIVATE
+                USE_SSE
+        )
+    endif(OCIO_USE_SSE)
+    if(OCIO_ADD_EXTRA_BUILTINS)
+        target_compile_definitions(${TEST_BINARY}
+            PRIVATE
+                ADD_EXTRA_BUILTINS
+        )
+    endif(OCIO_ADD_EXTRA_BUILTINS)
+    if(WIN32)
+        # A windows application linking to eXpat static libraries must
+        # have the global macro XML_STATIC defined
+        target_compile_definitions(${TEST_BINARY}
+            PRIVATE
+                XML_STATIC
+        )
+    endif(WIN32)
+    set_target_properties(${TEST_BINARY} PROPERTIES
+        COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
 
-	add_test(${TEST_NAME} ${TEST_BINARY})
+    add_test(${TEST_NAME} ${TEST_BINARY})
 endfunction(add_ocio_test)
 
 # Eventually we will factor out each test into it's own executable
 # but for now, we will maintain the status quo and copy all from the
 # OpenColorIO target
 set(SOURCES
-	fileformats/cdl/CDLParser.cpp
-	fileformats/cdl/CDLReaderHelper.cpp
-	fileformats/ctf/CTFReaderHelper.cpp
-	fileformats/ctf/CTFReaderUtils.cpp
-	fileformats/FileFormatUtils.cpp
-	fileformats/xmlutils/XMLReaderHelper.cpp
-	fileformats/xmlutils/XMLWriterUtils.cpp
-	GPUProcessor.cpp
-	GpuShaderDesc.cpp
-	HashUtils.cpp
-	ImageDesc.cpp
-	ImagePacking.cpp
-	Look.cpp
-	md5/md5.cpp
-	OCIOYaml.cpp
-	ops/cdl/CDLOpCPU.cpp
-	ops/cdl/CDLOpGPU.cpp
-	ops/exposurecontrast/ExposureContrastOpGPU.cpp
-	ops/fixedfunction/FixedFunctionOpGPU.cpp
-	ops/gamma/GammaOpGPU.cpp
-	ops/gradingprimary/GradingPrimaryOpGPU.cpp
-	ops/gradingrgbcurve/GradingRGBCurveOpGPU.cpp
-	ops/gradingtone/GradingToneOpGPU.cpp
-	ops/log/LogOpGPU.cpp
-	ops/lut3d/Lut3DOpGPU.cpp
-	ops/matrix/MatrixOpGPU.cpp
-	ops/OpTools.cpp
-	ops/range/RangeOpGPU.cpp
-	ScanlineHelper.cpp
-	Transform.cpp
-	transforms/builtins/ACES.cpp
-	transforms/builtins/ColorMatrixHelpers.cpp
-	transforms/builtins/OpHelpers.cpp
-	SystemMonitor.cpp
+    fileformats/cdl/CDLParser.cpp
+    fileformats/cdl/CDLReaderHelper.cpp
+    fileformats/ctf/CTFReaderHelper.cpp
+    fileformats/ctf/CTFReaderUtils.cpp
+    fileformats/FileFormatUtils.cpp
+    fileformats/xmlutils/XMLReaderHelper.cpp
+    fileformats/xmlutils/XMLWriterUtils.cpp
+    GPUProcessor.cpp
+    GpuShaderDesc.cpp
+    HashUtils.cpp
+    ImageDesc.cpp
+    ImagePacking.cpp
+    Look.cpp
+    md5/md5.cpp
+    OCIOYaml.cpp
+    ops/cdl/CDLOpCPU.cpp
+    ops/cdl/CDLOpGPU.cpp
+    ops/exposurecontrast/ExposureContrastOpGPU.cpp
+    ops/fixedfunction/FixedFunctionOpGPU.cpp
+    ops/gamma/GammaOpGPU.cpp
+    ops/gradingprimary/GradingPrimaryOpGPU.cpp
+    ops/gradingrgbcurve/GradingRGBCurveOpGPU.cpp
+    ops/gradingtone/GradingToneOpGPU.cpp
+    ops/log/LogOpGPU.cpp
+    ops/lut3d/Lut3DOpGPU.cpp
+    ops/matrix/MatrixOpGPU.cpp
+    ops/OpTools.cpp
+    ops/range/RangeOpGPU.cpp
+    ScanlineHelper.cpp
+    Transform.cpp
+    transforms/builtins/ACES.cpp
+    transforms/builtins/ColorMatrixHelpers.cpp
+    transforms/builtins/OpHelpers.cpp
+    SystemMonitor.cpp
 )
 
 if(OCIO_ADD_EXTRA_BUILTINS)
-	set(SOURCES_BUILTINS
-		transforms/builtins/ArriCameras.cpp
-		transforms/builtins/CanonCameras.cpp
-		transforms/builtins/PanasonicCameras.cpp
-		transforms/builtins/RedCameras.cpp
-		transforms/builtins/SonyCameras.cpp
-	)
+    set(SOURCES_BUILTINS
+        transforms/builtins/ArriCameras.cpp
+        transforms/builtins/CanonCameras.cpp
+        transforms/builtins/PanasonicCameras.cpp
+        transforms/builtins/RedCameras.cpp
+        transforms/builtins/SonyCameras.cpp
+    )
 
-	list(INSERT SOURCES 0 ${SOURCES_BUILTINS})
+    list(INSERT SOURCES 0 ${SOURCES_BUILTINS})
 endif()
 
 set(TESTS
-	Baker_tests.cpp
-	BitDepthUtils_tests.cpp
-	Caching_tests.cpp
-	ColorSpace_tests.cpp
-	ColorSpaceSet_tests.cpp
-	Config_tests.cpp
-	Context_tests.cpp
-	ContextVariableUtils_tests.cpp
-	CPUProcessor_tests.cpp
-	Display_tests.cpp
-	DynamicProperty_tests.cpp
-	Exception_tests.cpp
-	fileformats/ctf/CTFTransform_tests.cpp
-	fileformats/ctf/IndexMapping_tests.cpp
-	fileformats/FileFormat3DL_tests.cpp
-	fileformats/FileFormatCC_tests.cpp
-	fileformats/FileFormatCCC_tests.cpp
-	fileformats/FileFormatCDL_tests.cpp
-	fileformats/FileFormatCSP_tests.cpp
-	fileformats/FileFormatCTF_tests.cpp
-	fileformats/FileFormatDiscreet1DL_tests.cpp
-	fileformats/FileFormatHDL_tests.cpp
-	fileformats/FileFormatICC_tests.cpp
-	fileformats/FileFormatIridasCube_tests.cpp
-	fileformats/FileFormatIridasItx_tests.cpp
-	fileformats/FileFormatIridasLook_tests.cpp
-	fileformats/FileFormatPandora_tests.cpp
-	fileformats/FileFormatResolveCube_tests.cpp
-	fileformats/FileFormatSpi1D_tests.cpp
-	fileformats/FileFormatSpi3D_tests.cpp
-	fileformats/FileFormatSpiMtx_tests.cpp
-	fileformats/FileFormatTruelight_tests.cpp
-	fileformats/FileFormatVF_tests.cpp
-	fileformats/FormatMetadata_tests.cpp
-	fileformats/xmlutils/XMLReaderUtils_tests.cpp
-	FileRules_tests.cpp
-	GpuShader_tests.cpp
-	GpuShaderUtils_tests.cpp
-	Logging_tests.cpp
-	LookParse_tests.cpp
-	MathUtils_tests.cpp
-	Op_tests.cpp
-	OpOptimizers_tests.cpp
-	ops/allocation/AllocationOp_tests.cpp
-	ops/cdl/CDLOpData_tests.cpp
-	ops/cdl/CDLOp_tests.cpp
-	ops/exponent/ExponentOp_tests.cpp
-	ops/exposurecontrast/ExposureContrastOpCPU_tests.cpp
-	ops/exposurecontrast/ExposureContrastOpData_tests.cpp
-	ops/exposurecontrast/ExposureContrastOp_tests.cpp
-	ops/fixedfunction/FixedFunctionOpCPU_tests.cpp
-	ops/fixedfunction/FixedFunctionOpData_tests.cpp
-	ops/fixedfunction/FixedFunctionOp_tests.cpp
-	ops/gamma/GammaOp_tests.cpp
-	ops/gamma/GammaOpCPU_tests.cpp
-	ops/gamma/GammaOpData_tests.cpp
-	ops/gamma/GammaOpUtils_tests.cpp
-	ops/gradingprimary/GradingPrimary_tests.cpp
-	ops/gradingprimary/GradingPrimaryOpCPU_tests.cpp
-	ops/gradingprimary/GradingPrimaryOpData_tests.cpp
-	ops/gradingprimary/GradingPrimaryOp_tests.cpp
-	ops/gradingrgbcurve/GradingBSplineCurve_tests.cpp
-	ops/gradingrgbcurve/GradingRGBCurve_tests.cpp
-	ops/gradingrgbcurve/GradingRGBCurveOpCPU_tests.cpp
-	ops/gradingrgbcurve/GradingRGBCurveOpData_tests.cpp
-	ops/gradingrgbcurve/GradingRGBCurveOp_tests.cpp
-	ops/gradingtone/GradingTone_tests.cpp
-	ops/gradingtone/GradingToneOpCPU_tests.cpp
-	ops/gradingtone/GradingToneOpData_tests.cpp
-	ops/gradingtone/GradingToneOp_tests.cpp
-	ops/log/LogOpCPU_tests.cpp
-	ops/log/LogOpData_tests.cpp
-	ops/log/LogOp_tests.cpp
-	ops/log/LogUtils_tests.cpp
-	ops/lut1d/Lut1DOp_tests.cpp
-	ops/lut1d/Lut1DOpCPU_tests.cpp
-	ops/lut1d/Lut1DOpData_tests.cpp
-	ops/lut1d/Lut1DOpGPU_tests.cpp
-	ops/lut3d/Lut3DOp_tests.cpp
-	ops/lut3d/Lut3DOpCPU_tests.cpp
-	ops/lut3d/Lut3DOpData_tests.cpp
-	ops/matrix/MatrixOpCPU_tests.cpp
-	ops/matrix/MatrixOpData_tests.cpp
-	ops/matrix/MatrixOp_tests.cpp
-	ops/noop/NoOps_tests.cpp
-	ops/range/RangeOpCPU_tests.cpp
-	ops/range/RangeOpData_tests.cpp
-	ops/range/RangeOp_tests.cpp
-	ops/reference/ReferenceOpData_tests.cpp
-	ParseUtils_tests.cpp
-	PathUtils_tests.cpp
-	Platform_tests.cpp
-	Processor_tests.cpp
-	SSE_tests.cpp
-	transforms/AllocationTransform_tests.cpp
-	transforms/builtins/BuiltinTransformRegistry_tests.cpp
-	transforms/BuiltinTransform_tests.cpp
-	transforms/CDLTransform_tests.cpp
-	transforms/ColorSpaceTransform_tests.cpp
-	transforms/DisplayViewTransform_tests.cpp
-	transforms/ExponentTransform_tests.cpp
-	transforms/ExponentWithLinearTransform_tests.cpp
-	transforms/ExposureContrastTransform_tests.cpp
-	transforms/FileTransform_tests.cpp
-	transforms/FixedFunctionTransform_tests.cpp
-	transforms/GradingPrimaryTransform_tests.cpp
-	transforms/GradingRGBCurveTransform_tests.cpp
-	transforms/GradingToneTransform_tests.cpp
-	transforms/GroupTransform_tests.cpp
-	transforms/LogAffineTransform_tests.cpp
-	transforms/LogCameraTransform_tests.cpp
-	transforms/LogTransform_tests.cpp
-	transforms/LookTransform_tests.cpp
-	transforms/Lut1DTransform_tests.cpp
-	transforms/Lut3DTransform_tests.cpp
-	transforms/MatrixTransform_tests.cpp
-	transforms/RangeTransform_tests.cpp
-	UnitTestLogUtils.cpp
-	UnitTestMain.cpp
-	UnitTestOptimFlags.cpp
-	UnitTestUtils.cpp
-	ViewingRules_tests.cpp
-	ViewTransform_tests.cpp
+    Baker_tests.cpp
+    BitDepthUtils_tests.cpp
+    Caching_tests.cpp
+    ColorSpace_tests.cpp
+    ColorSpaceSet_tests.cpp
+    Config_tests.cpp
+    Context_tests.cpp
+    ContextVariableUtils_tests.cpp
+    CPUProcessor_tests.cpp
+    Display_tests.cpp
+    DynamicProperty_tests.cpp
+    Exception_tests.cpp
+    fileformats/ctf/CTFTransform_tests.cpp
+    fileformats/ctf/IndexMapping_tests.cpp
+    fileformats/FileFormat3DL_tests.cpp
+    fileformats/FileFormatCC_tests.cpp
+    fileformats/FileFormatCCC_tests.cpp
+    fileformats/FileFormatCDL_tests.cpp
+    fileformats/FileFormatCSP_tests.cpp
+    fileformats/FileFormatCTF_tests.cpp
+    fileformats/FileFormatDiscreet1DL_tests.cpp
+    fileformats/FileFormatHDL_tests.cpp
+    fileformats/FileFormatICC_tests.cpp
+    fileformats/FileFormatIridasCube_tests.cpp
+    fileformats/FileFormatIridasItx_tests.cpp
+    fileformats/FileFormatIridasLook_tests.cpp
+    fileformats/FileFormatPandora_tests.cpp
+    fileformats/FileFormatResolveCube_tests.cpp
+    fileformats/FileFormatSpi1D_tests.cpp
+    fileformats/FileFormatSpi3D_tests.cpp
+    fileformats/FileFormatSpiMtx_tests.cpp
+    fileformats/FileFormatTruelight_tests.cpp
+    fileformats/FileFormatVF_tests.cpp
+    fileformats/FormatMetadata_tests.cpp
+    fileformats/xmlutils/XMLReaderUtils_tests.cpp
+    FileRules_tests.cpp
+    GpuShader_tests.cpp
+    GpuShaderUtils_tests.cpp
+    Logging_tests.cpp
+    LookParse_tests.cpp
+    MathUtils_tests.cpp
+    Op_tests.cpp
+    OpOptimizers_tests.cpp
+    ops/allocation/AllocationOp_tests.cpp
+    ops/cdl/CDLOpData_tests.cpp
+    ops/cdl/CDLOp_tests.cpp
+    ops/exponent/ExponentOp_tests.cpp
+    ops/exposurecontrast/ExposureContrastOpCPU_tests.cpp
+    ops/exposurecontrast/ExposureContrastOpData_tests.cpp
+    ops/exposurecontrast/ExposureContrastOp_tests.cpp
+    ops/fixedfunction/FixedFunctionOpCPU_tests.cpp
+    ops/fixedfunction/FixedFunctionOpData_tests.cpp
+    ops/fixedfunction/FixedFunctionOp_tests.cpp
+    ops/gamma/GammaOp_tests.cpp
+    ops/gamma/GammaOpCPU_tests.cpp
+    ops/gamma/GammaOpData_tests.cpp
+    ops/gamma/GammaOpUtils_tests.cpp
+    ops/gradingprimary/GradingPrimary_tests.cpp
+    ops/gradingprimary/GradingPrimaryOpCPU_tests.cpp
+    ops/gradingprimary/GradingPrimaryOpData_tests.cpp
+    ops/gradingprimary/GradingPrimaryOp_tests.cpp
+    ops/gradingrgbcurve/GradingBSplineCurve_tests.cpp
+    ops/gradingrgbcurve/GradingRGBCurve_tests.cpp
+    ops/gradingrgbcurve/GradingRGBCurveOpCPU_tests.cpp
+    ops/gradingrgbcurve/GradingRGBCurveOpData_tests.cpp
+    ops/gradingrgbcurve/GradingRGBCurveOp_tests.cpp
+    ops/gradingtone/GradingTone_tests.cpp
+    ops/gradingtone/GradingToneOpCPU_tests.cpp
+    ops/gradingtone/GradingToneOpData_tests.cpp
+    ops/gradingtone/GradingToneOp_tests.cpp
+    ops/log/LogOpCPU_tests.cpp
+    ops/log/LogOpData_tests.cpp
+    ops/log/LogOp_tests.cpp
+    ops/log/LogUtils_tests.cpp
+    ops/lut1d/Lut1DOp_tests.cpp
+    ops/lut1d/Lut1DOpCPU_tests.cpp
+    ops/lut1d/Lut1DOpData_tests.cpp
+    ops/lut1d/Lut1DOpGPU_tests.cpp
+    ops/lut3d/Lut3DOp_tests.cpp
+    ops/lut3d/Lut3DOpCPU_tests.cpp
+    ops/lut3d/Lut3DOpData_tests.cpp
+    ops/matrix/MatrixOpCPU_tests.cpp
+    ops/matrix/MatrixOpData_tests.cpp
+    ops/matrix/MatrixOp_tests.cpp
+    ops/noop/NoOps_tests.cpp
+    ops/range/RangeOpCPU_tests.cpp
+    ops/range/RangeOpData_tests.cpp
+    ops/range/RangeOp_tests.cpp
+    ops/reference/ReferenceOpData_tests.cpp
+    ParseUtils_tests.cpp
+    PathUtils_tests.cpp
+    Platform_tests.cpp
+    Processor_tests.cpp
+    SSE_tests.cpp
+    transforms/AllocationTransform_tests.cpp
+    transforms/builtins/BuiltinTransformRegistry_tests.cpp
+    transforms/BuiltinTransform_tests.cpp
+    transforms/CDLTransform_tests.cpp
+    transforms/ColorSpaceTransform_tests.cpp
+    transforms/DisplayViewTransform_tests.cpp
+    transforms/ExponentTransform_tests.cpp
+    transforms/ExponentWithLinearTransform_tests.cpp
+    transforms/ExposureContrastTransform_tests.cpp
+    transforms/FileTransform_tests.cpp
+    transforms/FixedFunctionTransform_tests.cpp
+    transforms/GradingPrimaryTransform_tests.cpp
+    transforms/GradingRGBCurveTransform_tests.cpp
+    transforms/GradingToneTransform_tests.cpp
+    transforms/GroupTransform_tests.cpp
+    transforms/LogAffineTransform_tests.cpp
+    transforms/LogCameraTransform_tests.cpp
+    transforms/LogTransform_tests.cpp
+    transforms/LookTransform_tests.cpp
+    transforms/Lut1DTransform_tests.cpp
+    transforms/Lut3DTransform_tests.cpp
+    transforms/MatrixTransform_tests.cpp
+    transforms/RangeTransform_tests.cpp
+    UnitTestLogUtils.cpp
+    UnitTestMain.cpp
+    UnitTestOptimFlags.cpp
+    UnitTestUtils.cpp
+    ViewingRules_tests.cpp
+    ViewTransform_tests.cpp
 )
 
 function(prepend var prefix)
-	set(new "")
-	foreach(f ${ARGN})
-		list(APPEND new "${prefix}${f}")
-	endforeach(f)
-	set(${var} "${new}" PARENT_SCOPE)
+    set(new "")
+    foreach(f ${ARGN})
+        list(APPEND new "${prefix}${f}")
+    endforeach(f)
+    set(${var} "${new}" PARENT_SCOPE)
 endfunction(prepend)
 
 prepend(SOURCES "${CMAKE_SOURCE_DIR}/src/OpenColorIO/" ${SOURCES})

--- a/tests/cpu/PathUtils_tests.cpp
+++ b/tests/cpu/PathUtils_tests.cpp
@@ -1,21 +1,88 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
-
 #include "PathUtils.cpp"
 
 #include "testutils/UnitTest.h"
 #include "UnitTestUtils.h"
+
+namespace OCIO_NAMESPACE
+{
+
+namespace
+{
+
+// A custom compute hash function for testing.
+std::string CustomComputeHash(const std::string & filename)
+{
+    std::ostringstream testHasher;
+    testHasher << std::hash<std::string>{}(filename + "this is custom hash");
+    return testHasher.str();
+}
+
+} //anon.
+
+// A class for testing the working of custom callback for compute hash.
+class ComputeHashGuard
+{
+
+public:
+
+    ComputeHashGuard();
+
+    ComputeHashGuard(ComputeHashGuard &) = delete;
+
+    ~ComputeHashGuard();
+
+};
+
+ComputeHashGuard::ComputeHashGuard()
+{
+    SetComputeHashFunction(CustomComputeHash);
+}
+
+ComputeHashGuard::~ComputeHashGuard()
+{
+    ResetComputeHashFunction();
+}
+
+}
 
 namespace OCIO = OCIO_NAMESPACE;
 
 
 OCIO_ADD_TEST(PathUtils, compute_hash)
 {
+
     const std::string file1 = OCIO::GetTestFilesDir() + "/lut1d_4.spi1d";
     const std::string file2 = OCIO::GetTestFilesDir() + "/lut1d_5.spi1d";
 
-    OCIO_CHECK_EQUAL(OCIO::ComputeHash(file1), OCIO::ComputeHash(file1));
+    OCIO_CHECK_EQUAL(OCIO::g_hashFunction(file1), OCIO::g_hashFunction(file1));
 
-    OCIO_CHECK_NE(OCIO::ComputeHash(file1), OCIO::ComputeHash(file2));
+    OCIO_CHECK_NE(OCIO::g_hashFunction(file1), OCIO::g_hashFunction(file2));
+
+    const std::string result1 = OCIO::g_hashFunction(file1);
+    const std::string result2 = OCIO::g_hashFunction(file2);
+    std::string result3, result4;
+
+    {
+
+        OCIO::ComputeHashGuard tester;
+
+        OCIO_CHECK_NE(OCIO::g_hashFunction(file1), result1);
+
+        OCIO_CHECK_NE(OCIO::g_hashFunction(file2), result2);
+
+        OCIO_CHECK_EQUAL(OCIO::g_hashFunction(file1), OCIO::g_hashFunction(file1));
+
+        result3 = OCIO::g_hashFunction(file1);
+
+        result4 = OCIO::g_hashFunction(file2);
+
+    }
+
+    OCIO_CHECK_NE(result3, OCIO::g_hashFunction(file1));
+
+    OCIO_CHECK_NE(result4, OCIO::g_hashFunction(file2));
+
 }


### PR DESCRIPTION
fixes #1150 

Description: Declared a global container to store ComputeHash function and provided an endpoint to the (relevant) client for generating a custom callback for the same.

(Still figuring out to make appropriate unit tests for this.)