### PR TITLE
Adds Natron description to compatible_software.rst

### DIFF
--- a/docs/guides/using_ocio/compatible_software.rst
+++ b/docs/guides/using_ocio/compatible_software.rst
@@ -251,6 +251,8 @@ Documentation:
 Natron
 ******
 
+Natron is an open source 2D compositor that ships with native support for OCIO. Standard configs are included however users can point to a custom config in the color management section of the user preferences.
+
 Website : `<https://natrongithub.github.io/>`__
 
 Documentation :


### PR DESCRIPTION
Signed-off-by: Henry Wilkinson <henry@wilkinson.graphics>

Natron didn't have a description and now it does!

