### PR TITLE
Adsk Contrib - Improve the FileRules behaviour for some limit cases

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -1158,13 +1158,14 @@ public:
     /**
      * \brief Insert a rule at a given ruleIndex.
      * 
-     * Rule currently at ruleIndex
-     * will be pushed to index: ruleIndex + 1.
+     * Rule currently at ruleIndex will be pushed to index: ruleIndex + 1.
      * Name must be unique.
      * - "Default" is a reserved name for the default rule. The default rule is automatically
      * added and can't be removed. (see \ref FileRules::setDefaultRuleColorSpace ).
      * - "ColorSpaceNamePathSearch" is also a reserved name
      * (see \ref FileRules::insertPathSearchRule ).
+     *
+     * Will throw if pattern, extension or regex is a null or empty string.
      *
      * Will throw if ruleIndex is not less than \ref FileRules::getNumEntries .
      */

--- a/src/OpenColorIO/FileRules.cpp
+++ b/src/OpenColorIO/FileRules.cpp
@@ -239,18 +239,23 @@ std::string BuildRegularExpression(const char * filePathPattern, const char * fi
     return SanitizeRegularExpression(str);
 }
 
-void ValidateRegularExpression(const char * exp)
+void ValidateRegularExpression(const char * regex)
 {
+    if (!regex || !*regex)
+    {
+        throw Exception("File rules: regex is empty.");
+    }
+
     try
     {
         // Throws an exception if the expression is ill-formed.
-        const std::regex reg(exp);
+        const std::regex reg(regex);
     }
     catch (std::regex_error & ex)
     {
         std::ostringstream oss;
         oss << "File rules: invalid regular expression '" 
-            << exp
+            << regex
             << "': '"
             << ex.what() 
             << "'.";
@@ -336,6 +341,10 @@ public:
         }
         else
         {
+            if (!pattern || !*pattern)
+            {
+                throw Exception("File rules: The file name pattern is empty.");
+            }
             ValidateRegularExpression(pattern, m_extension.c_str());
             m_pattern = pattern;
             m_regex = "";
@@ -364,6 +373,10 @@ public:
         }
         else
         {
+            if (!extension || !*extension)
+            {
+                throw Exception("File rules: The file extension pattern is empty.");
+            }
             ValidateRegularExpression(m_pattern.c_str(), extension);
             m_extension = extension;
             m_regex = "";

--- a/tests/cpu/FileRules_tests.cpp
+++ b/tests/cpu/FileRules_tests.cpp
@@ -125,9 +125,9 @@ OCIO_ADD_TEST(FileRules, config_insert_rule)
 
     // Pattern and extension can't be null.
     OCIO_CHECK_THROW_WHAT(fileRules->insertRule(0, "rule", "raw", nullptr, "a"),
-                          OCIO::Exception, "file pattern is empty");
+                          OCIO::Exception, "file name pattern is empty");
     OCIO_CHECK_THROW_WHAT(fileRules->insertRule(0, "rule", "raw", "*", nullptr),
-                          OCIO::Exception, "file extension is empty");
+                          OCIO::Exception, "file extension pattern is empty");
 
     // Invalid glob pattern.
     OCIO_CHECK_THROW_WHAT(fileRules->insertRule(0, "rule", "raw", "[", "a"),
@@ -369,8 +369,8 @@ OCIO_ADD_TEST(FileRules, pattern_error)
     OCIO_CHECK_NO_THROW(rules->insertRule(0, "new rule", "raw", "*", "a"));
     OCIO_REQUIRE_EQUAL(rules->getNumEntries(), 3);
 
-    OCIO_CHECK_THROW_WHAT(rules->setPattern(0, nullptr), OCIO::Exception, "file pattern is empty");
-    OCIO_CHECK_NO_THROW(rules->setPattern(0, ""));
+    OCIO_CHECK_THROW_WHAT(rules->setPattern(0, nullptr), OCIO::Exception, "file name pattern is empty");
+    OCIO_CHECK_THROW_WHAT(rules->setPattern(0, ""),      OCIO::Exception, "file name pattern is empty");
 
     OCIO_CHECK_THROW_WHAT(rules->setPattern(0, "[]"), OCIO::Exception,
                           "invalid regular expression");
@@ -386,6 +386,28 @@ OCIO_ADD_TEST(FileRules, pattern_error)
                           "invalid regular expression");
 }
 
+OCIO_ADD_TEST(FileRules, with_defaults)
+{
+    // Validate some default behaviours.
+
+    auto config = OCIO::Config::CreateRaw()->createEditableCopy();
+    auto rules = config->getFileRules()->createEditableCopy();
+    OCIO_REQUIRE_EQUAL(rules->getNumEntries(), 2);
+
+    // Null or empty pattern and/or extension throw.
+
+    OCIO_CHECK_THROW(rules->insertRule(0, "new rule2", "raw", nullptr, "a"), OCIO::Exception);
+    OCIO_CHECK_THROW(rules->insertRule(0, "new rule2", "raw", "", "a"), OCIO::Exception);
+
+    OCIO_CHECK_THROW(rules->insertRule(0, "new rule3", "raw", "a", nullptr), OCIO::Exception);
+    OCIO_CHECK_THROW(rules->insertRule(0, "new rule3", "raw", "a", ""), OCIO::Exception);
+
+    // Null or empty regex throws.
+
+    OCIO_CHECK_THROW(rules->insertRule(0, "new rule2", "raw", ""), OCIO::Exception);
+    OCIO_CHECK_THROW(rules->insertRule(0, "new rule2", "raw", nullptr), OCIO::Exception);
+}
+
 OCIO_ADD_TEST(FileRules, extension_error)
 {
     auto configRaw = OCIO::Config::CreateRaw();
@@ -396,8 +418,9 @@ OCIO_ADD_TEST(FileRules, extension_error)
     OCIO_REQUIRE_EQUAL(rules->getNumEntries(), 3);
 
     OCIO_CHECK_THROW_WHAT(rules->setExtension(0, nullptr), OCIO::Exception,
-                          "file extension is empty");
-    OCIO_CHECK_NO_THROW(rules->setExtension(0, ""));
+                          "file extension pattern is empty");
+    OCIO_CHECK_THROW_WHAT(rules->setExtension(0, ""), OCIO::Exception,
+                          "file extension pattern is empty");
 }
 
 OCIO_ADD_TEST(FileRules, multiple_rules)
@@ -838,7 +861,7 @@ OCIO_ADD_TEST(FileRules, rules_test)
     OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is)->createEditableCopy());
     auto rules = config->getFileRules()->createEditableCopy();
     rules->insertRule(0, OCIO::FileRuleUtils::ParseName, nullptr, nullptr);
-    rules->insertRule(1, "dpx file", "raw", "", "dpx");
+    rules->insertRule(1, "dpx file", "raw", "*", "dpx");
     config->setFileRules(rules);
 
     size_t rulePos = 0;


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

The `file rules` behaviour for some limit cases was not enough documented, and not consistent between the two types of file rules. The pull request fixes these two aspects. When creating or updating a file rule, a null or empty string for file name pattern, file extension pattern or regular expression now fail (by throwing an exception), and the public header is updated accordingly.