### PR TITLE
Adsk Contrib - Default the family separator to '/' to comply with existing v1 ACES configs

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -272,7 +272,7 @@ public:
     void setMinorVersion(unsigned int minor);
 
     /// Allows an older config to be serialized as the current version.
-    void upgradeToLatestVersion();
+    void upgradeToLatestVersion() noexcept;
 
     /**
      * \brief Performs a thorough validation for the most common user errors.
@@ -283,14 +283,20 @@ public:
      */
     void validate() const;
 
-    /// If not empty or null a single character to separate the family string in levels.
-    char getFamilySeparator() const;
     /**
-     * \brief
+     * \brief Get the family separator
      * 
-     * Succeeds if the characters is null or a valid character
-     * from the ASCII table i.e. from value 32 (i.e. space) to 126 (i.e. '~');
-     * otherwise, it throws an exception.
+     * A single character used to separate the family string into tokens for use in hierarchical
+     * menus.  Defaults to '/'.
+     */
+    char getFamilySeparator() const;
+    /// Reset the family separator to default i.e. '/' .
+    void resetFamilySeparatorToDefault() noexcept;
+    /**
+     * \brief Set the family separator
+     *
+     * Succeeds if the characters is null or a valid character from the ASCII table i.e. from
+     * value 32 (i.e. space) to 126 (i.e. '~'); otherwise, it throws an exception.
      */
     void setFamilySeparator(char separator);
 

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -266,7 +266,8 @@ public:
     unsigned int m_minorVersion;
     StringMap m_env;
     ContextRcPtr m_context;
-    char m_familySeparator = 0;
+    static constexpr char DefaultFamilySeparator = '/';
+    char m_familySeparator = DefaultFamilySeparator;
     std::string m_description;
 
     // The final list of inactive color spaces is built from several inputs.
@@ -522,7 +523,7 @@ public:
     static ConstConfigRcPtr Read(std::istream & istream, const char * filename);
 
     // Upgrade from v1 to v2.
-    void upgradeFromVersion1ToVersion2()
+    void upgradeFromVersion1ToVersion2() noexcept
     {
         // V2 adds file_rules and these require a default rule. We try to initialize the default
         // rule using the default role. If the default role doesn't exist, we look for a Raw
@@ -1169,7 +1170,7 @@ void Config::setMinorVersion(unsigned int version)
      m_impl->m_minorVersion = version;
 }
 
-void Config::upgradeToLatestVersion()
+void Config::upgradeToLatestVersion() noexcept
 {
     const auto wasVersion = m_impl->m_majorVersion;
     if (wasVersion != LastSupportedMajorVersion)
@@ -1786,6 +1787,11 @@ char Config::getFamilySeparator() const
     return getImpl()->m_familySeparator;
 }
 
+void Config::resetFamilySeparatorToDefault() noexcept
+{
+    getImpl()->m_familySeparator = Impl::DefaultFamilySeparator;
+}
+
 void Config::setFamilySeparator(char separator)
 {
     const int val = (int)separator;
@@ -1799,9 +1805,6 @@ void Config::setFamilySeparator(char separator)
     }
 
     getImpl()->m_familySeparator = separator;
-
-    AutoMutex lock(getImpl()->m_cacheidMutex);
-    getImpl()->resetCacheIDs();
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -1813,10 +1816,7 @@ const char * Config::getDescription() const
 
 void Config::setDescription(const char * description)
 {
-    getImpl()->m_description = description ? description : "";
-
-    AutoMutex lock(getImpl()->m_cacheidMutex);
-    getImpl()->resetCacheIDs();
+    getImpl()->m_description = (description ? description : "");
 }
 
 // RESOURCES //////////////////////////////////////////////////////////////
@@ -4133,11 +4133,25 @@ void Config::Impl::checkVersionConsistency() const
         checkVersionConsistency(transform);
     }
 
-    // Check for the FileRules.
+    // Check for the family separator.
+
+    if (m_majorVersion < 2 && m_familySeparator != '/')
+    {
+        throw Exception("Only version 2 (or higher) can have a family separator.");
+    }
+
+    // Check for the file rules.
 
     if (m_majorVersion < 2 && m_fileRules->getNumEntries() > 1)
     {
-        throw Exception("Only version 2 (or higher) can have FileRules.");
+        throw Exception("Only version 2 (or higher) can have file rules.");
+    }
+
+    // Check for inactive color spaces.
+
+    if (m_majorVersion < 2 && !m_inactiveColorSpaceNamesConf.empty())
+    {
+        throw Exception("Only version 2 (or higher) can have inactive color spaces.");
     }
 
     // Check for ViewingRules.

--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -4160,18 +4160,22 @@ inline void load(const YAML::Node& node, ConfigRcPtr & config, const char* filen
         }
         else if (key=="family_separator")
         {
-            load(second, stringval);
-            if (!stringval.empty())
+            // Check that the key is not present in a v1 config (checkVersionConsistency is not
+            // able to detect this).
+            if (config->getMajorVersion() < 2)
             {
-                if(stringval.size()!=1)
-                {
-                    std::ostringstream os;
-                    os << "'family_separator' value must be a single character.";
-                    os << " Found '" << stringval << "'.";
-                    throwValueError(node.Tag(), first, os.str());
-                }
-                config->setFamilySeparator(stringval[0]);
+                throwError(first, "Config v1 can't have 'family_separator'.");
             }
+
+            load(second, stringval);
+            if(stringval.size()!=1)
+            {
+                std::ostringstream os;
+                os << "'family_separator' value must be a single character.";
+                os << " Found '" << stringval << "'.";
+                throwValueError(node.Tag(), first, os.str());
+            }
+            config->setFamilySeparator(stringval[0]);
         }
         else if(key == "description")
         {
@@ -4208,6 +4212,8 @@ inline void load(const YAML::Node& node, ConfigRcPtr & config, const char* filen
         }
         else if (key == "file_rules")
         {
+            // Check that the key is not present in a v1 config (checkVersionConsistency is not
+            // able to detect this).
             if (config->getMajorVersion() < 2)
             {
                 throwError(first, "Config v1 can't use 'file_rules'");
@@ -4246,11 +4252,6 @@ inline void load(const YAML::Node& node, ConfigRcPtr & config, const char* filen
         }
         else if (key == "viewing_rules")
         {
-            if (config->getMajorVersion() < 2)
-            {
-                throwError(first, "Config v1 can't use 'viewing_rules'.");
-            }
-
             if (second.Type() != YAML::NodeType::Sequence)
             {
                 throwError(second, "The 'viewing_rules' field needs to be a (- !<Rule>) list.");
@@ -4633,10 +4634,13 @@ inline void save(YAML::Emitter & out, const Config & config)
     }
     out << YAML::Key << "strictparsing" << YAML::Value << config.isStrictParsingEnabled();
 
-    const char familySeparator = config.getFamilySeparator();
-    if (familySeparator)
+    if (configMajorVersion >= 2)
     {
-        out << YAML::Key << "family_separator" << YAML::Value << familySeparator;
+        const char familySeparator = config.getFamilySeparator();
+        if (familySeparator != '/')
+        {
+            out << YAML::Key << "family_separator" << YAML::Value << familySeparator;
+        }
     }
 
     std::vector<double> luma(3, 0.f);

--- a/tests/apphelpers/ColorSpaceHelpers_tests.cpp
+++ b/tests/apphelpers/ColorSpaceHelpers_tests.cpp
@@ -116,16 +116,16 @@ OCIO_ADD_TEST(ColorSpaceInfo, change_values)
     OCIO_CHECK_NO_THROW(cs->setFamily("Acme     /   Camera"));
     OCIO_CHECK_EQUAL(cs->getFamily(), std::string("Acme     /   Camera"));
 
+    OCIO::ConfigRcPtr cfg = config->createEditableCopy();
+
     // No family separator.
 
-    OCIO_CHECK_EQUAL(config->getFamilySeparator(), 0x0);
+    OCIO_CHECK_NO_THROW(cfg->setFamilySeparator(0)); // i.e. that's the null character
 
-    OCIO_CHECK_NO_THROW(csInfo = OCIO::ColorSpaceInfo::Create(config, cs));
+    OCIO_CHECK_NO_THROW(csInfo = OCIO::ColorSpaceInfo::Create(cfg, cs));
     OCIO_REQUIRE_EQUAL(csInfo->getHierarchyLevels()->getNumString(), 1);
     OCIO_CHECK_EQUAL(csInfo->getHierarchyLevels()->getString(0), std::string(cs->getFamily()));
 
-
-    OCIO::ConfigRcPtr cfg = config->createEditableCopy();
 
     // '/' is the new family separator.
 
@@ -145,13 +145,15 @@ OCIO_ADD_TEST(ColorSpaceInfo, change_values)
     OCIO_REQUIRE_EQUAL(csInfo->getHierarchyLevels()->getNumString(), 1);
     OCIO_CHECK_EQUAL(csInfo->getHierarchyLevels()->getString(0), std::string(cs->getFamily()));
 
-    // '' is the new family separator.
+    // Reset to the v2 default family separator i.e. default to '/'.
 
-    OCIO_CHECK_NO_THROW(cfg->setFamilySeparator(0x0));
+    OCIO_CHECK_NO_THROW(cfg->resetFamilySeparatorToDefault());
 
     OCIO_CHECK_NO_THROW(csInfo = OCIO::ColorSpaceInfo::Create(cfg, cs));
-    OCIO_REQUIRE_EQUAL(csInfo->getHierarchyLevels()->getNumString(), 1);
-    OCIO_CHECK_EQUAL(csInfo->getHierarchyLevels()->getString(0), std::string(cs->getFamily()));
+    OCIO_REQUIRE_EQUAL(csInfo->getHierarchyLevels()->getNumString(), 2);
+    OCIO_CHECK_EQUAL(csInfo->getHierarchyLevels()->getString(0), std::string("Acme"));
+    OCIO_CHECK_EQUAL(csInfo->getHierarchyLevels()->getString(1), std::string("Camera"));
+    OCIO_CHECK_EQUAL(csInfo->getFamily(), std::string(cs->getFamily()));
 
     // Change the description.
 


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

The pull request changes the family separator behaviour (added in v2) to always default to '/' (instead of empty for v1 and '/' for v2) so it can effortlessly support existing v1 ACES configs.

When loading config from any version or creating a config instance, the family separator defaults to '/' (or it takes the value from v2 configs if the key is present) but only v2 config supports writing the family separator (It writes it only if different from the default value). The pull request also includes an updated unit test to clearly demonstrate the new behaviour, and the differences between v1 and v2.