### PR TITLE
Adsk Contrib - Remove unknown direction enums

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -233,9 +233,9 @@ public:
     //
 
     /**
-     * \brief Create an empty config.
+     * \brief Create an empty config of the current version.
      *
-     * Latest version is used. An empty config might be missing elements to ve valid.
+     * Note that an empty config will not pass validation since required elements will be missing.
      */
     static ConfigRcPtr Create();
     /**
@@ -1521,7 +1521,7 @@ public:
      * If a transform in the specified direction has been specified,
      * return it. Otherwise return a null ConstTransformRcPtr
      */
-    ConstTransformRcPtr getTransform(ColorSpaceDirection dir) const;
+    ConstTransformRcPtr getTransform(ColorSpaceDirection dir) const noexcept;
     /**
      * Specify the transform for the appropriate direction.
      * Setting the transform to null will clear it.
@@ -1817,7 +1817,7 @@ public:
      * If a transform in the specified direction has been specified, return it.
      * Otherwise return a null ConstTransformRcPtr
      */
-    ConstTransformRcPtr getTransform(ViewTransformDirection dir) const;
+    ConstTransformRcPtr getTransform(ViewTransformDirection dir) const noexcept;
 
     /**
      * Specify the transform for the appropriate direction. Setting the transform

--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -285,22 +285,19 @@ enum ViewType
 
 enum ColorSpaceDirection
 {
-    COLORSPACE_DIR_UNKNOWN = 0,
-    COLORSPACE_DIR_TO_REFERENCE,
+    COLORSPACE_DIR_TO_REFERENCE = 0,
     COLORSPACE_DIR_FROM_REFERENCE
 };
 
 enum ViewTransformDirection
 {
-    VIEWTRANSFORM_DIR_UNKNOWN = 0,
-    VIEWTRANSFORM_DIR_TO_REFERENCE,
+    VIEWTRANSFORM_DIR_TO_REFERENCE = 0,
     VIEWTRANSFORM_DIR_FROM_REFERENCE
 };
 
 enum TransformDirection
 {
-    TRANSFORM_DIR_UNKNOWN = 0,
-    TRANSFORM_DIR_FORWARD,
+    TRANSFORM_DIR_FORWARD = 0,
     TRANSFORM_DIR_INVERSE
 };
 
@@ -641,6 +638,7 @@ extern OCIOEXPORT const char * LoggingLevelToString(LoggingLevel level);
 extern OCIOEXPORT LoggingLevel LoggingLevelFromString(const char * s);
 
 extern OCIOEXPORT const char * TransformDirectionToString(TransformDirection dir);
+/// Will throw if string is not recognized.
 extern OCIOEXPORT TransformDirection TransformDirectionFromString(const char * s);
 
 extern OCIOEXPORT TransformDirection GetInverseTransformDirection(TransformDirection dir);
@@ -648,6 +646,7 @@ extern OCIOEXPORT TransformDirection CombineTransformDirections(TransformDirecti
                                                                 TransformDirection d2);
 
 extern OCIOEXPORT const char * ColorSpaceDirectionToString(ColorSpaceDirection dir);
+/// Will throw if string is not recognized.
 extern OCIOEXPORT ColorSpaceDirection ColorSpaceDirectionFromString(const char * s);
 
 extern OCIOEXPORT const char * BitDepthToString(BitDepth bitDepth);

--- a/src/OpenColorIO/ColorSpace.cpp
+++ b/src/OpenColorIO/ColorSpace.cpp
@@ -261,14 +261,16 @@ void ColorSpace::setAllocationVars(int numvars, const float * vars)
     }
 }
 
-ConstTransformRcPtr ColorSpace::getTransform(ColorSpaceDirection dir) const
+ConstTransformRcPtr ColorSpace::getTransform(ColorSpaceDirection dir) const noexcept
 {
-    if(dir == COLORSPACE_DIR_TO_REFERENCE)
+    switch (dir)
+    {
+    case COLORSPACE_DIR_TO_REFERENCE:
         return getImpl()->m_toRefTransform;
-    else if(dir == COLORSPACE_DIR_FROM_REFERENCE)
+    case COLORSPACE_DIR_FROM_REFERENCE:
         return getImpl()->m_fromRefTransform;
-
-    throw Exception("Unspecified ColorSpaceDirection");
+    }
+    return ConstTransformRcPtr();
 }
 
 void ColorSpace::setTransform(const ConstTransformRcPtr & transform,
@@ -277,12 +279,15 @@ void ColorSpace::setTransform(const ConstTransformRcPtr & transform,
     TransformRcPtr transformCopy;
     if(transform) transformCopy = transform->createEditableCopy();
 
-    if(dir == COLORSPACE_DIR_TO_REFERENCE)
+    switch (dir)
+    {
+    case COLORSPACE_DIR_TO_REFERENCE:
         getImpl()->m_toRefTransform = transformCopy;
-    else if(dir == COLORSPACE_DIR_FROM_REFERENCE)
+        break;
+    case COLORSPACE_DIR_FROM_REFERENCE:
         getImpl()->m_fromRefTransform = transformCopy;
-    else
-        throw Exception("Unspecified ColorSpaceDirection");
+        break;
+    }
 }
 
 std::ostream & operator<< (std::ostream & os, const ColorSpace & cs)
@@ -346,19 +351,22 @@ std::ostream & operator<< (std::ostream & os, const ColorSpace & cs)
     {
         os << ", encoding=" << str;
     }
-    os << ">";
-
+    str = cs.getDescription();
+    if (!str.empty())
+    {
+        os << ", description=" << str;
+    }
     if(cs.getTransform(COLORSPACE_DIR_TO_REFERENCE))
     {
-        os << "\n    " << cs.getName() << " --> Reference";
-        os << "\n\t" << *cs.getTransform(COLORSPACE_DIR_TO_REFERENCE);
+        os << ",\n    " << cs.getName() << " --> Reference";
+        os << "\n        " << *cs.getTransform(COLORSPACE_DIR_TO_REFERENCE);
     }
-
     if(cs.getTransform(COLORSPACE_DIR_FROM_REFERENCE))
     {
-        os << "\n    Reference --> " << cs.getName();
-        os << "\n\t" << *cs.getTransform(COLORSPACE_DIR_FROM_REFERENCE);
+        os << ",\n    Reference --> " << cs.getName();
+        os << "\n        " << *cs.getTransform(COLORSPACE_DIR_FROM_REFERENCE);
     }
+    os << ">";
     return os;
 }
 } // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -3600,11 +3600,6 @@ ConstProcessorRcPtr Config::getProcessor(const ConstContextRcPtr & context,
         throw Exception("Config::GetProcessor failed. Transform is null.");
     }
 
-    if (direction == TRANSFORM_DIR_UNKNOWN)
-    {
-        throw Exception("Config::GetProcessor failed. Direction is unspecified.");
-    }
-
     ContextRcPtr usedContext = Context::Create();
     usedContext->setSearchPath(context->getSearchPath());
     usedContext->setWorkingDir(context->getWorkingDir());

--- a/src/OpenColorIO/Context.cpp
+++ b/src/OpenColorIO/Context.cpp
@@ -530,7 +530,7 @@ std::ostream& operator<< (std::ostream& os, const Context& context)
     for(int i=0; i<context.getNumStringVars(); ++i)
     {
         const char * key = context.getStringVarNameByIndex(i);
-        os << "\n\t" << key << ": " << context.getStringVar(key);
+        os << "\n    " << key << ": " << context.getStringVar(key);
     }
     os << ">";
     return os;

--- a/src/OpenColorIO/DynamicProperty.cpp
+++ b/src/OpenColorIO/DynamicProperty.cpp
@@ -173,7 +173,7 @@ void DynamicPropertyGradingPrimaryImpl::setStyle(GradingStyle style)
     m_preRenderValues.update(m_style, m_direction, m_value);
 }
 
-void DynamicPropertyGradingPrimaryImpl::setDirection(TransformDirection dir)
+void DynamicPropertyGradingPrimaryImpl::setDirection(TransformDirection dir) noexcept
 {
     m_direction = dir;
     m_preRenderValues.update(m_style, m_direction, m_value);

--- a/src/OpenColorIO/DynamicProperty.h
+++ b/src/OpenColorIO/DynamicProperty.h
@@ -108,7 +108,7 @@ public:
     void setValue(const GradingPrimary & value) override;
 
     void setStyle(GradingStyle style);
-    void setDirection(TransformDirection dir);
+    void setDirection(TransformDirection dir) noexcept;
     const GradingPrimaryPreRender & getComputedValue() const { return m_preRenderValues; }
 
     const Float3 & getBrightness() const { return m_preRenderValues.getBrightness(); }

--- a/src/OpenColorIO/Look.cpp
+++ b/src/OpenColorIO/Look.cpp
@@ -137,7 +137,9 @@ bool CollectContextVariables(const Config & config,
 {
     bool foundContextVars = false;
 
-    if(direction== TRANSFORM_DIR_FORWARD)
+    switch (direction)
+    {
+    case TRANSFORM_DIR_FORWARD:
     {
         ConstTransformRcPtr tr = look.getTransform();
         if (tr)
@@ -155,8 +157,9 @@ bool CollectContextVariables(const Config & config,
                 foundContextVars = true;
             }
         }
+        break;
     }
-    else
+    case TRANSFORM_DIR_INVERSE:
     {
         ConstTransformRcPtr tr = look.getInverseTransform();
         if (tr)
@@ -174,6 +177,8 @@ bool CollectContextVariables(const Config & config,
                 foundContextVars = true;
             }
         }
+        break;
+    }
     }
 
     const char * ps = look.getProcessSpace();
@@ -205,16 +210,22 @@ std::ostream& operator<< (std::ostream& os, const Look& look)
     os << " name=" << look.getName();
     os << ", processSpace=" << look.getProcessSpace();
 
+    std::string desc{ look.getDescription() };
+    if (!desc.empty())
+    {
+        os << ", description=" << desc;
+    }
+
     if(look.getTransform())
     {
         os << ",\n    transform=";
-        os << "\n\t" << *look.getTransform();
+        os << "\n        " << *look.getTransform();
     }
 
     if(look.getInverseTransform())
     {
         os << ",\n    inverseTransform=";
-        os << "\n\t" << *look.getInverseTransform();
+        os << "\n        " << *look.getInverseTransform();
     }
 
     os << ">";

--- a/src/OpenColorIO/LookParse.cpp
+++ b/src/OpenColorIO/LookParse.cpp
@@ -37,17 +37,14 @@ void LookParseResult::Token::parse(const std::string & str)
 
 void LookParseResult::Token::serialize(std::ostream & os) const
 {
-    if(dir==TRANSFORM_DIR_FORWARD)
+    switch (dir)
     {
+    case TRANSFORM_DIR_FORWARD:
         os << name;
-    }
-    else if(dir==TRANSFORM_DIR_INVERSE)
-    {
+        break;
+    case TRANSFORM_DIR_INVERSE:
         os << "-" << name;
-    }
-    else
-    {
-        os << "?" << name;
+        break;
     }
 }
 

--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -433,11 +433,15 @@ inline void save(YAML::Emitter& out, const View & view)
 inline void EmitBaseTransformKeyValues(YAML::Emitter & out,
                                         const ConstTransformRcPtr & t)
 {
-    if(t->getDirection() != TRANSFORM_DIR_FORWARD)
+    switch (t->getDirection())
     {
+    case TRANSFORM_DIR_FORWARD:
+        break;
+    case TRANSFORM_DIR_INVERSE:
         out << YAML::Key << "direction";
         out << YAML::Value << YAML::Flow;
         save(out, t->getDirection());
+        break;
     }
 }
 
@@ -547,7 +551,7 @@ inline void load(const YAML::Node & node, BuiltinTransformRcPtr & t)
         }
         else if (key == "direction")
         {
-            TransformDirection dir = TRANSFORM_DIR_UNKNOWN;
+            TransformDirection dir = TRANSFORM_DIR_FORWARD;
             load(second, dir);
             t->setDirection(dir);
         }

--- a/src/OpenColorIO/Op.cpp
+++ b/src/OpenColorIO/Op.cpp
@@ -473,11 +473,6 @@ void CreateOpVecFromOpData(OpRcPtrVec & ops,
                            const ConstOpDataRcPtr & opData,
                            TransformDirection dir)
 {
-    if (dir == TRANSFORM_DIR_UNKNOWN)
-    {
-        throw Exception("Cannot create Op with unspecified transform direction.");
-    }
-
     switch (opData->getType())
     {
     case OpData::CDLType:

--- a/src/OpenColorIO/ParseUtils.cpp
+++ b/src/OpenColorIO/ParseUtils.cpp
@@ -131,8 +131,8 @@ LoggingLevel LoggingLevelFromString(const char * s)
 const char * TransformDirectionToString(TransformDirection dir)
 {
     if(dir == TRANSFORM_DIR_FORWARD) return "forward";
-    else if(dir == TRANSFORM_DIR_INVERSE) return "inverse";
-    return "unknown";
+    // TRANSFORM_DIR_INVERSE
+    return "inverse";
 }
 
 TransformDirection TransformDirectionFromString(const char * s)
@@ -140,16 +140,13 @@ TransformDirection TransformDirectionFromString(const char * s)
     const std::string str = StringUtils::Lower(s);
     if(str == "forward") return TRANSFORM_DIR_FORWARD;
     else if(str == "inverse") return TRANSFORM_DIR_INVERSE;
-    return TRANSFORM_DIR_UNKNOWN;
+    std::ostringstream oss;
+    oss << "Unrecognized transform direction '" << std::string(s ? s : "") << "'.";
+    throw Exception(oss.str().c_str());
 }
 
-TransformDirection CombineTransformDirections(TransformDirection d1,
-                                                TransformDirection d2)
+TransformDirection CombineTransformDirections(TransformDirection d1, TransformDirection d2)
 {
-    // Any unknowns always combine to be unknown.
-    if(d1 == TRANSFORM_DIR_UNKNOWN || d2 == TRANSFORM_DIR_UNKNOWN)
-        return TRANSFORM_DIR_UNKNOWN;
-
     if(d1 == TRANSFORM_DIR_FORWARD && d2 == TRANSFORM_DIR_FORWARD)
         return TRANSFORM_DIR_FORWARD;
 
@@ -162,15 +159,15 @@ TransformDirection CombineTransformDirections(TransformDirection d1,
 TransformDirection GetInverseTransformDirection(TransformDirection dir)
 {
     if(dir == TRANSFORM_DIR_FORWARD) return TRANSFORM_DIR_INVERSE;
-    else if(dir == TRANSFORM_DIR_INVERSE) return TRANSFORM_DIR_FORWARD;
-    return TRANSFORM_DIR_UNKNOWN;
+    // TRANSFORM_DIR_INVERSE
+    return TRANSFORM_DIR_FORWARD;
 }
 
 const char * ColorSpaceDirectionToString(ColorSpaceDirection dir)
 {
     if(dir == COLORSPACE_DIR_TO_REFERENCE) return "to_reference";
-    else if(dir == COLORSPACE_DIR_FROM_REFERENCE) return "from_reference";
-    return "unknown";
+    // COLORSPACE_DIR_FROM_REFERENCE
+    return "from_reference";
 }
 
 ColorSpaceDirection ColorSpaceDirectionFromString(const char * s)
@@ -178,7 +175,9 @@ ColorSpaceDirection ColorSpaceDirectionFromString(const char * s)
     const std::string str = StringUtils::Lower(s);
     if(str == "to_reference") return COLORSPACE_DIR_TO_REFERENCE;
     else if(str == "from_reference") return COLORSPACE_DIR_FROM_REFERENCE;
-    return COLORSPACE_DIR_UNKNOWN;
+    std::ostringstream oss;
+    oss << "Unrecognized color space direction '" << std::string(s ? s : "") << "'.";
+    throw Exception(oss.str().c_str());
 }
 
 const char * BitDepthToString(BitDepth bitDepth)

--- a/src/OpenColorIO/ViewTransform.cpp
+++ b/src/OpenColorIO/ViewTransform.cpp
@@ -149,18 +149,16 @@ ReferenceSpaceType ViewTransform::getReferenceSpaceType() const noexcept
     return getImpl()->m_referenceSpaceType;
 }
 
-ConstTransformRcPtr ViewTransform::getTransform(ViewTransformDirection dir) const
+ConstTransformRcPtr ViewTransform::getTransform(ViewTransformDirection dir) const noexcept
 {
-    if (dir == VIEWTRANSFORM_DIR_TO_REFERENCE)
+    switch (dir)
     {
+    case VIEWTRANSFORM_DIR_TO_REFERENCE:
         return getImpl()->m_toRefTransform;
-    }
-    else if (dir == VIEWTRANSFORM_DIR_FROM_REFERENCE)
-    {
+    case VIEWTRANSFORM_DIR_FROM_REFERENCE:
         return getImpl()->m_fromRefTransform;
     }
-
-    throw Exception("View transform: Unspecified ViewTransformDirection.");
+    return ConstTransformRcPtr();
 }
 
 void ViewTransform::setTransform(const ConstTransformRcPtr & transform, ViewTransformDirection dir)
@@ -171,17 +169,14 @@ void ViewTransform::setTransform(const ConstTransformRcPtr & transform, ViewTran
         transformCopy = transform->createEditableCopy();
     }
 
-    if (dir == VIEWTRANSFORM_DIR_TO_REFERENCE)
+    switch (dir)
     {
-        getImpl()->m_toRefTransform = transformCopy;
-    }
-    else if (dir == VIEWTRANSFORM_DIR_FROM_REFERENCE)
-    {
-        getImpl()->m_fromRefTransform = transformCopy;
-    }
-    else
-    {
-        throw Exception("View transform: Unspecified ViewTransformDirection.");
+    case VIEWTRANSFORM_DIR_TO_REFERENCE:
+        getImpl()->m_toRefTransform = transformCopy; 
+        break;
+    case VIEWTRANSFORM_DIR_FROM_REFERENCE:
+        getImpl()->m_fromRefTransform = transformCopy; 
+        break;
     }
 }
 
@@ -210,19 +205,22 @@ std::ostream & operator<< (std::ostream & os, const ViewTransform & vt)
     os << "name=" << vt.getName() << ", ";
     os << "family=" << vt.getFamily() << ", ";
     os << "referenceSpaceType=" << ReferenceSpaceTypeToString(vt.getReferenceSpaceType());
-    os << ">";
-
+    const std::string desc{ vt.getDescription() };
+    if (!desc.empty())
+    {
+        os << ", description=" << desc;
+    }
     if (vt.getTransform(VIEWTRANSFORM_DIR_TO_REFERENCE))
     {
-        os << "\n    " << vt.getName() << " --> Reference";
-        os << "\n\t" << *vt.getTransform(VIEWTRANSFORM_DIR_TO_REFERENCE);
+        os << ",\n    " << vt.getName() << " --> Reference";
+        os << "\n        " << *vt.getTransform(VIEWTRANSFORM_DIR_TO_REFERENCE);
     }
-
     if (vt.getTransform(VIEWTRANSFORM_DIR_FROM_REFERENCE))
     {
-        os << "\n    Reference --> " << vt.getName();
-        os << "\n\t" << *vt.getTransform(VIEWTRANSFORM_DIR_FROM_REFERENCE);
+        os << ",\n    Reference --> " << vt.getName();
+        os << "\n        " << *vt.getTransform(VIEWTRANSFORM_DIR_FROM_REFERENCE);
     }
+    os << ">";
     return os;
 }
 

--- a/src/OpenColorIO/fileformats/FileFormat3DL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormat3DL.cpp
@@ -536,8 +536,7 @@ void LocalFileFormat::bake(const Baker & baker,
         transform->setLooks(looks.c_str());
         transform->setSrc(baker.getInputSpace());
         transform->setDst(baker.getTargetSpace());
-        inputToTarget = config->getProcessor(transform,
-            TRANSFORM_DIR_FORWARD);
+        inputToTarget = config->getProcessor(transform, TRANSFORM_DIR_FORWARD);
     }
     else
     {
@@ -629,27 +628,28 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
         LogWarningInterpolationNotUsed(fileInterp, fileTransform);
     }
 
-    if(newDir == TRANSFORM_DIR_FORWARD)
+    switch (newDir)
     {
-        if(lut1D)
+    case TRANSFORM_DIR_FORWARD:
+        if (lut1D)
         {
             CreateLut1DOp(ops, lut1D, newDir);
         }
-        if(lut3D)
+        if (lut3D)
         {
             CreateLut3DOp(ops, lut3D, newDir);
         }
-    }
-    else if(newDir == TRANSFORM_DIR_INVERSE)
-    {
-        if(lut3D)
+        break;
+    case TRANSFORM_DIR_INVERSE:
+        if (lut3D)
         {
             CreateLut3DOp(ops, lut3D, newDir);
         }
-        if(lut1D)
+        if (lut1D)
         {
             CreateLut1DOp(ops, lut1D, newDir);
         }
+        break;
     }
 }
 }

--- a/src/OpenColorIO/fileformats/FileFormatCSP.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCSP.cpp
@@ -829,8 +829,7 @@ void LocalFileFormat::bake(const Baker & baker,
             transform->setLooks(looks.c_str());
             transform->setSrc(baker.getInputSpace());
             transform->setDst(baker.getTargetSpace());
-            inputToTarget = config->getProcessor(transform, 
-                                                    TRANSFORM_DIR_FORWARD);
+            inputToTarget = config->getProcessor(transform, TRANSFORM_DIR_FORWARD);
         }
         else
         {
@@ -932,9 +931,11 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
         LogWarningInterpolationNotUsed(fileInterp, fileTransform);
     }
 
-    if(newDir == TRANSFORM_DIR_FORWARD)
+    switch (newDir)
     {
-        if(prelut)
+    case TRANSFORM_DIR_FORWARD:
+    {
+        if (prelut)
         {
             CreateMinMaxOp(ops,
                            cachedFile->prelut_from_min,
@@ -950,8 +951,9 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
         {
             CreateLut3DOp(ops, lut3D, newDir);
         }
+        break;
     }
-    else if(newDir == TRANSFORM_DIR_INVERSE)
+    case TRANSFORM_DIR_INVERSE:
     {
         if (lut1D)
         {
@@ -961,7 +963,7 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
         {
             CreateLut3DOp(ops, lut3D, newDir);
         }
-        if(prelut)
+        if (prelut)
         {
             CreateLut1DOp(ops, prelut, newDir);
             CreateMinMaxOp(ops,
@@ -969,6 +971,8 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
                            cachedFile->prelut_from_max,
                            newDir);
         }
+        break;
+    }
     }
 }
 }

--- a/src/OpenColorIO/fileformats/FileFormatCTF.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCTF.cpp
@@ -1273,7 +1273,9 @@ void LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
 
     const auto fileInterpolation = fileTransform.getInterpolation();
 
-    if (newDir == TRANSFORM_DIR_FORWARD)
+    switch (newDir)
+    {
+    case TRANSFORM_DIR_FORWARD:
     {
         for (auto opData : opDataVec)
         {
@@ -1281,8 +1283,9 @@ void LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
             HandleLUT(opData, fileInterpolation);
             BuildOp(ops, config, context, opData, newDir);
         }
+        break;
     }
-    else
+    case TRANSFORM_DIR_INVERSE:
     {
         for (int idx = (int)opDataVec.size() - 1; idx >= 0; --idx)
         {
@@ -1290,6 +1293,8 @@ void LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
             HandleLUT(opData, fileInterpolation);
             BuildOp(ops, config, context, opData, newDir);
         }
+        break;
+    }
     }
 }
 
@@ -1362,13 +1367,11 @@ void LocalFileFormat::bake(const Baker & baker,
         transform->setLooks(looks.c_str());
         transform->setSrc(inputSpace.c_str());
         transform->setDst(targetSpace.c_str());
-        inputToTargetProc = config->getProcessor(transform,
-                                                 TRANSFORM_DIR_FORWARD);
+        inputToTargetProc = config->getProcessor(transform, TRANSFORM_DIR_FORWARD);
     }
     else
     {
-        inputToTargetProc = config->getProcessor(inputSpace.c_str(),
-                                                 targetSpace.c_str());
+        inputToTargetProc = config->getProcessor(inputSpace.c_str(), targetSpace.c_str());
     }
 
     int required_lut = -1;
@@ -1491,13 +1494,11 @@ void LocalFileFormat::bake(const Baker & baker,
                 transform->setLooks(looks.c_str());
                 transform->setSrc(shaperSpace.c_str());
                 transform->setDst(targetSpace.c_str());
-                cubeProc = config->getProcessor(transform,
-                                                TRANSFORM_DIR_FORWARD);
+                cubeProc = config->getProcessor(transform, TRANSFORM_DIR_FORWARD);
             }
             else
             {
-                cubeProc = config->getProcessor(shaperSpace.c_str(),
-                    targetSpace.c_str());
+                cubeProc = config->getProcessor(shaperSpace.c_str(), targetSpace.c_str());
             }
         }
         else

--- a/src/OpenColorIO/fileformats/FileFormatHDL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatHDL.cpp
@@ -644,8 +644,7 @@ void LocalFileFormat::bake(const Baker & baker,
         transform->setLooks(looks.c_str());
         transform->setSrc(inputSpace.c_str());
         transform->setDst(targetSpace.c_str());
-        inputToTargetProc = config->getProcessor(transform,
-            TRANSFORM_DIR_FORWARD);
+        inputToTargetProc = config->getProcessor(transform, TRANSFORM_DIR_FORWARD);
     }
     else
     {
@@ -771,13 +770,11 @@ void LocalFileFormat::bake(const Baker & baker,
                 transform->setLooks(looks.c_str());
                 transform->setSrc(shaperSpace.c_str());
                 transform->setDst(targetSpace.c_str());
-                cubeProc = config->getProcessor(transform,
-                    TRANSFORM_DIR_FORWARD);
+                cubeProc = config->getProcessor(transform, TRANSFORM_DIR_FORWARD);
             }
             else
             {
-                cubeProc = config->getProcessor(shaperSpace.c_str(),
-                                                targetSpace.c_str());
+                cubeProc = config->getProcessor(shaperSpace.c_str(), targetSpace.c_str());
             }
         }
         else
@@ -924,18 +921,20 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
         LogWarningInterpolationNotUsed(fileInterp, fileTransform);
     }
 
-    if(newDir == TRANSFORM_DIR_FORWARD)
+    switch (newDir)
     {
-        if(cachedFile->hdltype == "c")
+    case TRANSFORM_DIR_FORWARD:
+    {
+        if (cachedFile->hdltype == "c")
         {
             CreateMinMaxOp(ops, cachedFile->from_min, cachedFile->from_max, newDir);
             CreateLut1DOp(ops, lut1D, newDir);
         }
-        else if(cachedFile->hdltype == "3d")
+        else if (cachedFile->hdltype == "3d")
         {
             CreateLut3DOp(ops, lut3D, newDir);
         }
-        else if(cachedFile->hdltype == "3d+1d")
+        else if (cachedFile->hdltype == "3d+1d")
         {
             CreateMinMaxOp(ops, cachedFile->from_min, cachedFile->from_max, newDir);
             CreateLut1DOp(ops, lut1D, newDir);
@@ -945,19 +944,20 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
         {
             throw Exception("Unhandled hdltype while creating forward ops");
         }
+        break;
     }
-    else if(newDir == TRANSFORM_DIR_INVERSE)
+    case TRANSFORM_DIR_INVERSE:
     {
-        if(cachedFile->hdltype == "c")
+        if (cachedFile->hdltype == "c")
         {
             CreateLut1DOp(ops, lut1D, newDir);
             CreateMinMaxOp(ops, cachedFile->from_min, cachedFile->from_max, newDir);
         }
-        else if(cachedFile->hdltype == "3d")
+        else if (cachedFile->hdltype == "3d")
         {
             CreateLut3DOp(ops, lut3D, newDir);
         }
-        else if(cachedFile->hdltype == "3d+1d")
+        else if (cachedFile->hdltype == "3d+1d")
         {
             CreateLut3DOp(ops, lut3D, newDir);
             CreateLut1DOp(ops, lut1D, newDir);
@@ -967,6 +967,8 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
         {
             throw Exception("Unhandled hdltype while creating reverse ops");
         }
+        break;
+    }
     }
 }
 }

--- a/src/OpenColorIO/fileformats/FileFormatICC.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatICC.cpp
@@ -469,7 +469,9 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
     // display device code values to the CIE XYZ based version 
     // of the ICC profile connection space (PCS).
     // So we will adopt this convention as the "forward" direction.
-    if (newDir == TRANSFORM_DIR_FORWARD)
+    switch (newDir)
+    {
+    case TRANSFORM_DIR_FORWARD:
     {
         if (lut)
         {
@@ -482,18 +484,19 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
             const GammaOpData::Params blueParams  = { cachedFile->mGammaRGB[2] };
             const GammaOpData::Params alphaParams = { cachedFile->mGammaRGB[3] };
             auto gamma = std::make_shared<GammaOpData>(GammaOpData::BASIC_FWD, 
-                                                        redParams,
-                                                        greenParams,
-                                                        blueParams,
-                                                        alphaParams);
+                                                       redParams,
+                                                       greenParams,
+                                                       blueParams,
+                                                       alphaParams);
             CreateGammaOp(ops, gamma, TRANSFORM_DIR_FORWARD);
         }
 
         CreateMatrixOp(ops, cachedFile->mMatrix44, TRANSFORM_DIR_FORWARD);
 
         CreateMatrixOp(ops, D50_to_D65_m44, TRANSFORM_DIR_FORWARD);
+        break;
     }
-    else if (newDir == TRANSFORM_DIR_INVERSE)
+    case TRANSFORM_DIR_INVERSE:
     {
         CreateMatrixOp(ops, D50_to_D65_m44, TRANSFORM_DIR_INVERSE);
 
@@ -514,13 +517,15 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
             const GammaOpData::Params blueParams  = { cachedFile->mGammaRGB[2] };
             const GammaOpData::Params alphaParams = { cachedFile->mGammaRGB[3] };
             auto gamma = std::make_shared<GammaOpData>(GammaOpData::BASIC_REV,
-                                                        redParams,
-                                                        greenParams,
-                                                        blueParams,
-                                                        alphaParams);
+                                                       redParams,
+                                                       greenParams,
+                                                       blueParams,
+                                                       alphaParams);
 
             CreateGammaOp(ops, gamma, TRANSFORM_DIR_FORWARD);
         }
+        break;
+    }
     }
 }
 

--- a/src/OpenColorIO/fileformats/FileFormatIridasCube.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasCube.cpp
@@ -460,7 +460,9 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
     const double dmin[]{ cachedFile->domain_min[0], cachedFile->domain_min[1], cachedFile->domain_min[2] };
     const double dmax[]{ cachedFile->domain_max[0], cachedFile->domain_max[1], cachedFile->domain_max[2] };
 
-    if(newDir == TRANSFORM_DIR_FORWARD)
+    switch (newDir)
+    {
+    case TRANSFORM_DIR_FORWARD:
     {
         CreateMinMaxOp(ops, dmin, dmax, newDir);
         if(lut1D)
@@ -471,8 +473,9 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
         {
             CreateLut3DOp(ops, lut3D, newDir);
         }
+        break;
     }
-    else if(newDir == TRANSFORM_DIR_INVERSE)
+    case TRANSFORM_DIR_INVERSE:
     {
         if(lut3D)
         {
@@ -483,6 +486,8 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
             CreateLut1DOp(ops, lut1D, newDir);
         }
         CreateMinMaxOp(ops, dmin, dmax, newDir);
+        break;
+    }
     }
 }
 }

--- a/src/OpenColorIO/fileformats/FileFormatIridasItx.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasItx.cpp
@@ -262,13 +262,11 @@ void LocalFileFormat::bake(const Baker & baker,
         transform->setLooks(looks.c_str());
         transform->setSrc(baker.getInputSpace());
         transform->setDst(baker.getTargetSpace());
-        inputToTarget = config->getProcessor(transform,
-            TRANSFORM_DIR_FORWARD);
+        inputToTarget = config->getProcessor(transform, TRANSFORM_DIR_FORWARD);
     }
     else
     {
-        inputToTarget = config->getProcessor(baker.getInputSpace(),
-            baker.getTargetSpace());
+        inputToTarget = config->getProcessor(baker.getInputSpace(), baker.getTargetSpace());
     }
     ConstCPUProcessorRcPtr cpu = inputToTarget->getOptimizedCPUProcessor(OPTIMIZATION_LOSSLESS);
     cpu->apply(cubeImg);

--- a/src/OpenColorIO/fileformats/FileFormatResolveCube.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatResolveCube.cpp
@@ -557,14 +557,11 @@ void LocalFileFormat::bake(const Baker & baker,
         transform->setLooks(looks.c_str());
         transform->setSrc(inputSpace.c_str());
         transform->setDst(targetSpace.c_str());
-        inputToTargetProc = config->getProcessor(transform,
-            TRANSFORM_DIR_FORWARD);
+        inputToTargetProc = config->getProcessor(transform, TRANSFORM_DIR_FORWARD);
     }
     else
     {
-        inputToTargetProc = config->getProcessor(
-            inputSpace.c_str(),
-            targetSpace.c_str());
+        inputToTargetProc = config->getProcessor(inputSpace.c_str(), targetSpace.c_str());
     }
 
     int required_lut = -1;
@@ -686,13 +683,11 @@ void LocalFileFormat::bake(const Baker & baker,
                 transform->setLooks(looks.c_str());
                 transform->setSrc(shaperSpace.c_str());
                 transform->setDst(targetSpace.c_str());
-                cubeProc = config->getProcessor(transform,
-                    TRANSFORM_DIR_FORWARD);
+                cubeProc = config->getProcessor(transform, TRANSFORM_DIR_FORWARD);
             }
             else
             {
-                cubeProc = config->getProcessor(shaperSpace.c_str(),
-                                                targetSpace.c_str());
+                cubeProc = config->getProcessor(shaperSpace.c_str(), targetSpace.c_str());
             }
         }
         else
@@ -825,43 +820,36 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
         LogWarningInterpolationNotUsed(fileInterp, fileTransform);
     }
 
-    if(newDir == TRANSFORM_DIR_FORWARD)
+    switch (newDir)
     {
-        if(lut1D)
+    case TRANSFORM_DIR_FORWARD:
+    {
+        if (lut1D)
         {
-            CreateMinMaxOp(ops,
-                            cachedFile->range1d_min,
-                            cachedFile->range1d_max,
-                            newDir);
+            CreateMinMaxOp(ops, cachedFile->range1d_min, cachedFile->range1d_max, newDir);
             CreateLut1DOp(ops, lut1D, newDir);
         }
-        if(lut3D)
+        if (lut3D)
         {
-            CreateMinMaxOp(ops,
-                            cachedFile->range3d_min,
-                            cachedFile->range3d_max,
-                            newDir);
+            CreateMinMaxOp(ops, cachedFile->range3d_min, cachedFile->range3d_max, newDir);
             CreateLut3DOp(ops, lut3D, newDir);
         }
+        break;
     }
-    else if(newDir == TRANSFORM_DIR_INVERSE)
+    case TRANSFORM_DIR_INVERSE:
     {
-        if(lut3D)
+        if (lut3D)
         {
             CreateLut3DOp(ops, lut3D, newDir);
-            CreateMinMaxOp(ops,
-                            cachedFile->range3d_min,
-                            cachedFile->range3d_max,
-                            newDir);
+            CreateMinMaxOp(ops, cachedFile->range3d_min, cachedFile->range3d_max, newDir);
         }
-        if(lut1D)
+        if (lut1D)
         {
             CreateLut1DOp(ops, lut1D, newDir);
-            CreateMinMaxOp(ops,
-                            cachedFile->range1d_min,
-                            cachedFile->range1d_max,
-                            newDir);
+            CreateMinMaxOp(ops, cachedFile->range1d_min, cachedFile->range1d_max, newDir);
         }
+        break;
+    }
     }
 }
 }

--- a/src/OpenColorIO/fileformats/FileFormatSpi1D.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatSpi1D.cpp
@@ -293,15 +293,16 @@ void LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
         LogWarningInterpolationNotUsed(fileInterp, fileTransform);
     }
 
-    if (newDir == TRANSFORM_DIR_FORWARD)
+    switch (newDir)
     {
+    case TRANSFORM_DIR_FORWARD:
         CreateMinMaxOp(ops, min, max, TRANSFORM_DIR_FORWARD);
         CreateLut1DOp(ops, lut, TRANSFORM_DIR_FORWARD);
-    }
-    else
-    {
+        break;
+    case TRANSFORM_DIR_INVERSE:
         CreateLut1DOp(ops, lut, TRANSFORM_DIR_INVERSE);
         CreateMinMaxOp(ops, min, max, TRANSFORM_DIR_INVERSE);
+        break;
     }
 }
 

--- a/src/OpenColorIO/fileformats/FileFormatTruelight.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatTruelight.cpp
@@ -366,8 +366,9 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
         LogWarningInterpolationNotUsed(fileInterp, fileTransform);
     }
 
-    if (newDir == TRANSFORM_DIR_FORWARD)
+    switch (newDir)
     {
+    case TRANSFORM_DIR_FORWARD:
         if (lut1D)
         {
             CreateLut1DOp(ops, lut1D, newDir);
@@ -377,9 +378,8 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
         {
             CreateLut3DOp(ops, lut3D, newDir);
         }
-    }
-    else if (newDir == TRANSFORM_DIR_INVERSE)
-    {
+        break;
+    case TRANSFORM_DIR_INVERSE:
         if (lut3D)
         {
             CreateLut3DOp(ops, lut3D, newDir);
@@ -389,6 +389,7 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
         {
             CreateLut1DOp(ops, lut1D, newDir);
         }
+        break;
     }
 }
 }

--- a/src/OpenColorIO/fileformats/FileFormatVF.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatVF.cpp
@@ -285,8 +285,9 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
         }
     }
 
-    if (newDir == TRANSFORM_DIR_FORWARD)
+    switch (newDir)
     {
+    case TRANSFORM_DIR_FORWARD:
         if (cachedFile->useMatrix)
         {
             CreateMatrixOp(ops, cachedFile->m44, newDir);
@@ -296,9 +297,8 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
         {
             CreateLut3DOp(ops, lut3D, newDir);
         }
-    }
-    else if (newDir == TRANSFORM_DIR_INVERSE)
-    {
+        break;
+    case TRANSFORM_DIR_INVERSE:
         if (lut3D)
         {
             CreateLut3DOp(ops, lut3D, newDir);
@@ -308,6 +308,7 @@ LocalFileFormat::buildFileOps(OpRcPtrVec & ops,
         {
             CreateMatrixOp(ops, cachedFile->m44, newDir);
         }
+        break;
     }
 }
 }

--- a/src/OpenColorIO/fileformats/ctf/CTFTransform.cpp
+++ b/src/OpenColorIO/fileformats/ctf/CTFTransform.cpp
@@ -290,30 +290,31 @@ CTFVersion GetOpMinimumVersion(const ConstOpDataRcPtr & op)
     case OpData::Lut1DType:
     {
         auto lut = OCIO_DYNAMIC_POINTER_CAST<const Lut1DOpData>(op);
-        if (lut->getDirection() == TRANSFORM_DIR_FORWARD)
+        switch (lut->getDirection())
         {
-            minVersion = (lut->getHueAdjust() != HUE_NONE) ?
-                CTF_PROCESS_LIST_VERSION_1_4 :
-                CTF_PROCESS_LIST_VERSION_1_3;
-        }
-        else
-        {
+        case TRANSFORM_DIR_FORWARD:
+            minVersion = (lut->getHueAdjust() != HUE_NONE) ? CTF_PROCESS_LIST_VERSION_1_4 :
+                                                             CTF_PROCESS_LIST_VERSION_1_3;
+            break;
+        case TRANSFORM_DIR_INVERSE:
             minVersion = (lut->getHueAdjust() != HUE_NONE || lut->isInputHalfDomain()) ?
-                CTF_PROCESS_LIST_VERSION_1_6 :
-                CTF_PROCESS_LIST_VERSION_1_3;
+                         CTF_PROCESS_LIST_VERSION_1_6 :
+                         CTF_PROCESS_LIST_VERSION_1_3;
+            break;
         }
         break;
     }
     case OpData::Lut3DType:
     {
         auto lut = OCIO_DYNAMIC_POINTER_CAST<const Lut3DOpData>(op);
-        if (lut->getDirection() == TRANSFORM_DIR_FORWARD)
+        switch (lut->getDirection())
         {
+        case TRANSFORM_DIR_FORWARD:
             minVersion = CTF_PROCESS_LIST_VERSION_1_3;
-        }
-        else
-        {
+            break;
+        case TRANSFORM_DIR_INVERSE:
             minVersion = CTF_PROCESS_LIST_VERSION_1_6;
+            break;
         }
         break;
     }

--- a/src/OpenColorIO/ops/allocation/AllocationOp.cpp
+++ b/src/OpenColorIO/ops/allocation/AllocationOp.cpp
@@ -70,27 +70,16 @@ void CreateAllocationOps(OpRcPtrVec & ops,
             }
         }
 
-        if(dir == TRANSFORM_DIR_FORWARD)
+        switch (dir)
         {
+        case TRANSFORM_DIR_FORWARD:
             CreateLogOp(ops, base, logSlope, logOffset, linSlope, linOffset, dir);
-
-            CreateFitOp(ops,
-                        oldmin, oldmax,
-                        newmin, newmax,
-                        dir);
-        }
-        else if(dir == TRANSFORM_DIR_INVERSE)
-        {
-            CreateFitOp(ops,
-                        oldmin, oldmax,
-                        newmin, newmax,
-                        dir);
-
+            CreateFitOp(ops, oldmin, oldmax, newmin, newmax, dir);
+            break;
+        case TRANSFORM_DIR_INVERSE:
+            CreateFitOp(ops, oldmin, oldmax, newmin, newmax, dir);
             CreateLogOp(ops, base, logSlope, logOffset, linSlope, linOffset, dir);
-        }
-        else
-        {
-            throw Exception("Cannot BuildAllocationOp, unspecified transform direction.");
+            break;
         }
     }
     else

--- a/src/OpenColorIO/ops/cdl/CDLOp.cpp
+++ b/src/OpenColorIO/ops/cdl/CDLOp.cpp
@@ -246,7 +246,9 @@ void BuildCDLOp(OpRcPtrVec & ops,
 
         double sat = cdlTransform.getSat();
 
-        if (combinedDir == TRANSFORM_DIR_FORWARD)
+        switch (combinedDir)
+        {
+        case TRANSFORM_DIR_FORWARD:
         {
             // 1) Scale + Offset
             CreateScaleOffsetOp(ops, slope4, offset4, TRANSFORM_DIR_FORWARD);
@@ -258,8 +260,9 @@ void BuildCDLOp(OpRcPtrVec & ops,
             // 3) Saturation (NB: Does not clamp at 0 and 1
             //    as per ASC v1.2 spec)
             CreateSaturationOp(ops, sat, lumaCoef3, TRANSFORM_DIR_FORWARD);
+            break;
         }
-        else if (combinedDir == TRANSFORM_DIR_INVERSE)
+        case TRANSFORM_DIR_INVERSE:
         {
             // 3) Saturation (NB: Does not clamp at 0 and 1
             //    as per ASC v1.2 spec)
@@ -271,6 +274,8 @@ void BuildCDLOp(OpRcPtrVec & ops,
 
             // 1) Scale + Offset
             CreateScaleOffsetOp(ops, slope4, offset4, TRANSFORM_DIR_INVERSE);
+            break;
+        }
         }
     }
     else

--- a/src/OpenColorIO/ops/cdl/CDLOpData.cpp
+++ b/src/OpenColorIO/ops/cdl/CDLOpData.cpp
@@ -176,7 +176,7 @@ void CDLOpData::setStyle(CDLOpData::Style style)
     m_style = style;
 }
 
-TransformDirection CDLOpData::getDirection() const
+TransformDirection CDLOpData::getDirection() const noexcept
 {
     switch (m_style)
     {
@@ -190,17 +190,12 @@ TransformDirection CDLOpData::getDirection() const
     return TRANSFORM_DIR_FORWARD;
 }
 
-void CDLOpData::setDirection(TransformDirection dir)
+void CDLOpData::setDirection(TransformDirection dir) noexcept
 {
-    if (dir != TRANSFORM_DIR_UNKNOWN)
+    if (getDirection() != dir)
     {
-        const auto curDir = getDirection();
-        if (curDir != dir)
-        {
-            invert();
-        }
+        invert();
     }
-
 }
 
 void CDLOpData::setSlopeParams(const ChannelParams & slopeParams)
@@ -475,7 +470,7 @@ bool CDLOpData::isInverse(ConstCDLOpDataRcPtr & r) const
     return *r == *inverse();
 }
 
-void CDLOpData::invert()
+void CDLOpData::invert() noexcept
 {
     switch (m_style)
     {

--- a/src/OpenColorIO/ops/cdl/CDLOpData.h
+++ b/src/OpenColorIO/ops/cdl/CDLOpData.h
@@ -131,8 +131,8 @@ public:
     inline Style getStyle() const { return m_style; }
     void setStyle(Style cdlStyle);
 
-    TransformDirection getDirection() const;
-    void setDirection(TransformDirection dir);
+    TransformDirection getDirection() const noexcept;
+    void setDirection(TransformDirection dir) noexcept;
 
     const ChannelParams & getSlopeParams() const { return m_slopeParams; }
     void setSlopeParams(const ChannelParams& slopeParams);
@@ -174,7 +174,7 @@ protected:
     // Note: Return a boolean status based on the enum stored in the "style" variable.
     bool isClamping() const;
 
-    void invert();
+    void invert() noexcept;
 
 private:
     Style         m_style;         // CDL style

--- a/src/OpenColorIO/ops/exponent/ExponentOp.cpp
+++ b/src/OpenColorIO/ops/exponent/ExponentOp.cpp
@@ -289,11 +289,14 @@ void CreateExponentOp(OpRcPtrVec & ops,
                       ExponentOpDataRcPtr & expData,
                       TransformDirection direction)
 {
-    if (direction == TRANSFORM_DIR_UNKNOWN)
+    switch (direction)
     {
-        throw Exception("Cannot create ExponentOp with unspecified transform direction.");
+    case TRANSFORM_DIR_FORWARD:
+    {
+        ops.push_back(std::make_shared<ExponentOp>(expData));
+        break;
     }
-    else if (direction == TRANSFORM_DIR_INVERSE)
+    case TRANSFORM_DIR_INVERSE:
     {
         double values[4];
         for (int i = 0; i<4; ++i)
@@ -309,10 +312,8 @@ void CreateExponentOp(OpRcPtrVec & ops,
         }
         ExponentOpDataRcPtr expInv = std::make_shared<ExponentOpData>(values);
         ops.push_back(std::make_shared<ExponentOp>(expInv));
+        break;
     }
-    else
-    {
-        ops.push_back(std::make_shared<ExponentOp>(expData));
     }
 }
 

--- a/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOp.cpp
+++ b/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOp.cpp
@@ -176,19 +176,19 @@ void CreateExposureContrastOp(OpRcPtrVec & ops,
                               ExposureContrastOpDataRcPtr & data,
                               TransformDirection direction)
 {
-    if (direction == TRANSFORM_DIR_FORWARD)
+    switch (direction)
+    {
+    case TRANSFORM_DIR_FORWARD:
     {
         ops.push_back(std::make_shared<ExposureContrastOp>(data));
+        break;
     }
-    else if (direction == TRANSFORM_DIR_INVERSE)
+    case TRANSFORM_DIR_INVERSE:
     {
         ExposureContrastOpDataRcPtr dataInv = data->inverse();
         ops.push_back(std::make_shared<ExposureContrastOp>(dataInv));
+        break;
     }
-    else
-    {
-        throw Exception("Cannot apply ExposureContrast op, "
-                        "unspecified transform direction.");
     }
 }
 

--- a/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpData.cpp
+++ b/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpData.cpp
@@ -103,12 +103,6 @@ const char * ExposureContrastOpData::ConvertStyleToString(ExposureContrastOpData
 ExposureContrastOpData::Style ExposureContrastOpData::ConvertStyle(ExposureContrastStyle style,
                                                                    TransformDirection dir)
 {
-    if (dir == TRANSFORM_DIR_UNKNOWN)
-    {
-        throw Exception(
-            "Cannot create ExposureContrastOp with unspecified transform direction.");
-    }
-
     const bool isForward = dir == TRANSFORM_DIR_FORWARD;
 
     switch (style)
@@ -221,7 +215,7 @@ bool ExposureContrastOpData::isInverse(ConstExposureContrastOpDataRcPtr & r) con
     return *r == *inverse();
 }
 
-void ExposureContrastOpData::invert()
+void ExposureContrastOpData::invert() noexcept
 {
     Style invStyle = STYLE_LINEAR;
     switch (getStyle())
@@ -434,7 +428,7 @@ ExposureContrastOpData & ExposureContrastOpData::operator=(const ExposureContras
 }
 
 // Convert internal OpData style into Transform direction.
-TransformDirection ExposureContrastOpData::getDirection() const
+TransformDirection ExposureContrastOpData::getDirection() const noexcept
 {
     switch (m_style)
     {
@@ -451,15 +445,11 @@ TransformDirection ExposureContrastOpData::getDirection() const
     return TRANSFORM_DIR_FORWARD;
 }
 
-void ExposureContrastOpData::setDirection(TransformDirection dir)
+void ExposureContrastOpData::setDirection(TransformDirection dir) noexcept
 {
-    if (dir != TRANSFORM_DIR_UNKNOWN)
+    if (getDirection() != dir)
     {
-        const auto curDir = getDirection();
-        if (curDir != dir)
-        {
-            invert();
-        }
+        invert();
     }
 }
 

--- a/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpData.h
+++ b/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpData.h
@@ -171,11 +171,11 @@ public:
 
     ExposureContrastOpData & operator=(const ExposureContrastOpData & rhs);
 
-    Style getStyle() const { return m_style; }
-    void setStyle(Style style) { m_style = style; }
+    Style getStyle() const noexcept { return m_style; }
+    void setStyle(Style style) noexcept { m_style = style; }
 
-    TransformDirection getDirection() const;
-    void setDirection(TransformDirection dir);
+    TransformDirection getDirection() const noexcept;
+    void setDirection(TransformDirection dir) noexcept;
 
     double getExposure() const { return m_exposure->getValue(); }
     void setExposure(double exposure) { m_exposure->setValue(exposure); }
@@ -212,7 +212,7 @@ public:
     static constexpr double LOGMIDGRAY_DEFAULT = 0.435;
 
 private:
-    void invert();
+    void invert() noexcept;
 
     Style  m_style = STYLE_LINEAR;
     DynamicPropertyDoubleImplRcPtr m_exposure;

--- a/src/OpenColorIO/ops/fixedfunction/FixedFunctionOpData.cpp
+++ b/src/OpenColorIO/ops/fixedfunction/FixedFunctionOpData.cpp
@@ -393,7 +393,7 @@ bool FixedFunctionOpData::isInverse(ConstFixedFunctionOpDataRcPtr & r) const
     return *r == *inverse();
 }
 
-void FixedFunctionOpData::invert()
+void FixedFunctionOpData::invert() noexcept
 {
     // NB: The following assumes the op has already been validated.
 
@@ -518,7 +518,7 @@ FixedFunctionOpDataRcPtr FixedFunctionOpData::inverse() const
 }
 
 // Convert internal OpData style into Transform direction.
-TransformDirection FixedFunctionOpData::getDirection() const
+TransformDirection FixedFunctionOpData::getDirection() const noexcept
 {
     switch (m_style)
     {
@@ -549,15 +549,11 @@ TransformDirection FixedFunctionOpData::getDirection() const
     return TRANSFORM_DIR_FORWARD;
 }
 
-void FixedFunctionOpData::setDirection(TransformDirection dir)
+void FixedFunctionOpData::setDirection(TransformDirection dir) noexcept
 {
-    if (dir != TRANSFORM_DIR_UNKNOWN)
+    if (getDirection() != dir)
     {
-        const auto curDir = getDirection();
-        if (curDir != dir)
-        {
-            invert();
-        }
+        invert();
     }
 }
 

--- a/src/OpenColorIO/ops/fixedfunction/FixedFunctionOpData.h
+++ b/src/OpenColorIO/ops/fixedfunction/FixedFunctionOpData.h
@@ -77,11 +77,11 @@ public:
 
     std::string getCacheID() const override;
 
-    Style getStyle() const { return m_style; }
-    void setStyle(Style style) { m_style = style; }
+    Style getStyle() const  noexcept { return m_style; }
+    void setStyle(Style style)  noexcept { m_style = style; }
 
-    TransformDirection getDirection() const;
-    void setDirection(TransformDirection dir);
+    TransformDirection getDirection() const noexcept;
+    void setDirection(TransformDirection dir) noexcept;
 
     void setParams(const Params & params) { m_params = params; }
     const Params & getParams() const { return m_params; }
@@ -89,7 +89,7 @@ public:
     bool operator==(const OpData & other) const override;
 
 protected:
-    void invert();
+    void invert() noexcept;
 
 private:
     Style m_style;

--- a/src/OpenColorIO/ops/gamma/GammaOpData.cpp
+++ b/src/OpenColorIO/ops/gamma/GammaOpData.cpp
@@ -177,11 +177,6 @@ NegativeStyle GammaOpData::ConvertStyle(Style style)
 
 GammaOpData::Style GammaOpData::ConvertStyleBasic(NegativeStyle negStyle, TransformDirection dir)
 {
-    if (dir == TRANSFORM_DIR_UNKNOWN)
-    {
-        throw Exception("Cannot create GammaOp with unspecified transform direction.");
-    }
-
     const bool isForward = dir == TRANSFORM_DIR_FORWARD;
 
     switch (negStyle)
@@ -215,11 +210,6 @@ GammaOpData::Style GammaOpData::ConvertStyleBasic(NegativeStyle negStyle, Transf
 
 GammaOpData::Style GammaOpData::ConvertStyleMonCurve(NegativeStyle negStyle, TransformDirection dir)
 {
-    if (dir == TRANSFORM_DIR_UNKNOWN)
-    {
-        throw Exception("Cannot create GammaOp with unspecified transform direction.");
-    }
-
     const bool isForward = dir == TRANSFORM_DIR_FORWARD;
 
     switch (negStyle)
@@ -334,7 +324,7 @@ bool GammaOpData::isInverse(const GammaOpData & B) const
     return false;
 }
 
-void GammaOpData::setStyle(const Style & style)
+void GammaOpData::setStyle(const Style & style) noexcept
 {
     // NB: Must call validate after using this method.
     m_style = style;
@@ -820,7 +810,7 @@ std::string GammaOpData::getCacheID() const
     return cacheIDStream.str();
 }
 
-TransformDirection GammaOpData::getDirection() const
+TransformDirection GammaOpData::getDirection() const noexcept
 {
     switch (m_style)
     {
@@ -842,19 +832,15 @@ TransformDirection GammaOpData::getDirection() const
     return TRANSFORM_DIR_FORWARD;
 }
 
-void GammaOpData::setDirection(TransformDirection dir)
+void GammaOpData::setDirection(TransformDirection dir) noexcept
 {
-    if (dir != TRANSFORM_DIR_UNKNOWN)
+    if (getDirection() != dir)
     {
-        const auto curDir = getDirection();
-        if (curDir != dir)
-        {
-            invert();
-        }
+        invert();
     }
 }
 
-void GammaOpData::invert()
+void GammaOpData::invert() noexcept
 {
     Style invStyle = BASIC_FWD;
     switch (getStyle())

--- a/src/OpenColorIO/ops/gamma/GammaOpData.h
+++ b/src/OpenColorIO/ops/gamma/GammaOpData.h
@@ -90,7 +90,7 @@ public:
 
     GammaOpDataRcPtr clone() const;
 
-    inline Style getStyle() const { return m_style; }
+    inline Style getStyle() const noexcept { return m_style; }
 
     Type getType() const override { return GammaType; }
 
@@ -104,7 +104,7 @@ public:
     inline Params & getBlueParams()  { return m_blueParams;  }
     inline Params & getAlphaParams() { return m_alphaParams; }
 
-    void setStyle(const Style & style);
+    void setStyle(const Style & style) noexcept;
 
     void setRedParams  (const Params & parameter);
     void setGreenParams(const Params & parameter);
@@ -145,8 +145,8 @@ public:
 
     std::string getCacheID() const override;
 
-    TransformDirection getDirection() const;
-    void setDirection(TransformDirection dir);
+    TransformDirection getDirection() const noexcept;
+    void setDirection(TransformDirection dir) noexcept;
 
     static bool isIdentityParameters(const Params & parameters, Style style);
     static Params getIdentityParameters(Style style);
@@ -155,7 +155,7 @@ protected:
     bool isClamping() const;
 
 private:
-    void invert();
+    void invert() noexcept;
 
     Style m_style;
     Params m_redParams;

--- a/src/OpenColorIO/ops/gradingprimary/GradingPrimary.cpp
+++ b/src/OpenColorIO/ops/gradingprimary/GradingPrimary.cpp
@@ -101,7 +101,9 @@ void GradingPrimary::validate(GradingStyle style) const
     }
 }
 
-void GradingPrimaryPreRender::update(GradingStyle style, TransformDirection dir, const GradingPrimary & v)
+void GradingPrimaryPreRender::update(GradingStyle style,
+                                     TransformDirection dir,
+                                     const GradingPrimary & v) noexcept
 {
     m_localBypass = v.m_clampBlack == GradingPrimary::NoClampBlack() &&
                     v.m_clampWhite == GradingPrimary::NoClampWhite();
@@ -113,7 +115,9 @@ void GradingPrimaryPreRender::update(GradingStyle style, TransformDirection dir,
         const GradingRGBM & b = v.m_brightness;
         const GradingRGBM & c = v.m_contrast;
         const GradingRGBM & g = v.m_gamma;
-        if (dir == TRANSFORM_DIR_FORWARD)
+        switch (dir)
+        {
+        case TRANSFORM_DIR_FORWARD:
         {
             m_brightness[0] = static_cast<float>((b.m_master + b.m_red)   * 6.25 / 1023.);
             m_brightness[1] = static_cast<float>((b.m_master + b.m_green) * 6.25 / 1023.);
@@ -124,8 +128,9 @@ void GradingPrimaryPreRender::update(GradingStyle style, TransformDirection dir,
             m_gamma[0] = static_cast<float>(1. / (g.m_master * g.m_red));
             m_gamma[1] = static_cast<float>(1. / (g.m_master * g.m_green));
             m_gamma[2] = static_cast<float>(1. / (g.m_master * g.m_blue));
+            break;
         }
-        else
+        case TRANSFORM_DIR_INVERSE:
         {
             m_brightness[0] = -static_cast<float>((b.m_master + b.m_red)   * 6.25 / 1023.);
             m_brightness[1] = -static_cast<float>((b.m_master + b.m_green) * 6.25 / 1023.);
@@ -139,6 +144,8 @@ void GradingPrimaryPreRender::update(GradingStyle style, TransformDirection dir,
             m_gamma[0] = static_cast<float>(g.m_master * g.m_red);
             m_gamma[1] = static_cast<float>(g.m_master * g.m_green);
             m_gamma[2] = static_cast<float>(g.m_master * g.m_blue);
+            break;
+        }
         }
         m_isPowerIdentity = m_gamma[0] == 1.0f && m_gamma[1] == 1.0f && m_gamma[2] == 1.0f;
         m_pivot = 0.5 + v.m_pivot * 0.5;
@@ -152,7 +159,9 @@ void GradingPrimaryPreRender::update(GradingStyle style, TransformDirection dir,
         const GradingRGBM & o = v.m_offset;
         const GradingRGBM & e = v.m_exposure;
         const GradingRGBM & c = v.m_contrast;
-        if (dir == TRANSFORM_DIR_FORWARD)
+        switch (dir)
+        {
+        case TRANSFORM_DIR_FORWARD:
         {
             m_offset[0] = static_cast<float>(o.m_master + o.m_red);
             m_offset[1] = static_cast<float>(o.m_master + o.m_green);
@@ -163,8 +172,9 @@ void GradingPrimaryPreRender::update(GradingStyle style, TransformDirection dir,
             m_contrast[0] = static_cast<float>(c.m_master * c.m_red);
             m_contrast[1] = static_cast<float>(c.m_master * c.m_green);
             m_contrast[2] = static_cast<float>(c.m_master * c.m_blue);
+            break;
         }
-        else
+        case TRANSFORM_DIR_INVERSE:
         {
             m_offset[0] = -static_cast<float>(o.m_master + o.m_red);
             m_offset[1] = -static_cast<float>(o.m_master + o.m_green);
@@ -176,6 +186,8 @@ void GradingPrimaryPreRender::update(GradingStyle style, TransformDirection dir,
             m_contrast[0] = static_cast<float>(1. / (c.m_master * c.m_red));
             m_contrast[1] = static_cast<float>(1. / (c.m_master * c.m_green));
             m_contrast[2] = static_cast<float>(1. / (c.m_master * c.m_blue));
+            break;
+        }
         }
         m_isPowerIdentity = m_contrast[0] == 1.0f || m_contrast[1] == 1.0f ||
                             m_contrast[2] == 1.0f;
@@ -196,14 +208,16 @@ void GradingPrimaryPreRender::update(GradingStyle style, TransformDirection dir,
         gain1 = gain1 == 0. ? 1. : gain1;
         gain2 = gain2 == 0. ? 1. : gain2;
         const GradingRGBM & g = v.m_gamma;
-        if (dir == TRANSFORM_DIR_FORWARD)
+        switch (dir)
         {
-            m_offset[0] = static_cast<float>(o.m_master + o.m_red   + l.m_master + l.m_red);
+        case TRANSFORM_DIR_FORWARD:
+        {
+            m_offset[0] = static_cast<float>(o.m_master + o.m_red + l.m_master + l.m_red);
             m_offset[1] = static_cast<float>(o.m_master + o.m_green + l.m_master + l.m_green);
-            m_offset[2] = static_cast<float>(o.m_master + o.m_blue  + l.m_master + l.m_blue);
-            const double slopeDen0 = v.m_pivotWhite / gain0 + l.m_master + l.m_red   - v.m_pivotBlack;
+            m_offset[2] = static_cast<float>(o.m_master + o.m_blue + l.m_master + l.m_blue);
+            const double slopeDen0 = v.m_pivotWhite / gain0 + l.m_master + l.m_red - v.m_pivotBlack;
             const double slopeDen1 = v.m_pivotWhite / gain1 + l.m_master + l.m_green - v.m_pivotBlack;
-            const double slopeDen2 = v.m_pivotWhite / gain2 + l.m_master + l.m_blue  - v.m_pivotBlack;
+            const double slopeDen2 = v.m_pivotWhite / gain2 + l.m_master + l.m_blue - v.m_pivotBlack;
             m_slope[0] = static_cast<float>((v.m_pivotWhite - v.m_pivotBlack) /
                                             (slopeDen0 == 0. ? 1. : slopeDen0));
             m_slope[1] = static_cast<float>((v.m_pivotWhite - v.m_pivotBlack) /
@@ -213,8 +227,9 @@ void GradingPrimaryPreRender::update(GradingStyle style, TransformDirection dir,
             m_gamma[0] = static_cast<float>(1. / (g.m_master * g.m_red));
             m_gamma[1] = static_cast<float>(1. / (g.m_master * g.m_green));
             m_gamma[2] = static_cast<float>(1. / (g.m_master * g.m_blue));
+            break;
         }
-        else
+        case TRANSFORM_DIR_INVERSE:
         {
             m_offset[0] = -static_cast<float>(o.m_master + o.m_red + l.m_master + l.m_red);
             m_offset[1] = -static_cast<float>(o.m_master + o.m_green + l.m_master + l.m_green);
@@ -231,8 +246,9 @@ void GradingPrimaryPreRender::update(GradingStyle style, TransformDirection dir,
             m_gamma[0] = static_cast<float>(g.m_master * g.m_red);
             m_gamma[1] = static_cast<float>(g.m_master * g.m_green);
             m_gamma[2] = static_cast<float>(g.m_master * g.m_blue);
+            break;
         }
-
+        }
         m_isPowerIdentity = m_gamma[0] == 1.0f || m_gamma[1] == 1.0f || m_gamma[2] == 1.0f;
         m_localBypass = m_localBypass && m_isPowerIdentity &&
                         m_slope[0] == 1.f && m_slope[2] == 1.f && m_slope[2] == 1.f &&

--- a/src/OpenColorIO/ops/gradingprimary/GradingPrimary.h
+++ b/src/OpenColorIO/ops/gradingprimary/GradingPrimary.h
@@ -21,7 +21,7 @@ struct GradingPrimaryPreRender
     GradingPrimaryPreRender() = default;
     ~GradingPrimaryPreRender() = default;
 
-    void update(GradingStyle style, TransformDirection dir, const GradingPrimary & v);
+    void update(GradingStyle style, TransformDirection dir, const GradingPrimary & v) noexcept;
 
     // Do not apply the op if all params are identity.
     bool m_localBypass{ false };

--- a/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOpCPU.cpp
+++ b/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOpCPU.cpp
@@ -1348,7 +1348,7 @@ ConstOpCPURcPtr GetGradingPrimaryCPURenderer(ConstGradingPrimaryOpDataRcPtr & pr
         }
     }
 
-    throw Exception("Unsupported GradingPrimary direction.");
+    throw Exception("Illegal GradingPrimary direction.");
 }
 
 } // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOpData.cpp
+++ b/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOpData.cpp
@@ -220,7 +220,7 @@ void GradingPrimaryOpData::setDirection(TransformDirection dir) noexcept
     if (dir != m_direction)
     {
         m_direction = dir;
-        m_value->setDirection(dir);
+        m_value->setDirection(m_direction);
     }
 }
 

--- a/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOpGPU.cpp
+++ b/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOpGPU.cpp
@@ -526,6 +526,7 @@ void GetGradingPrimaryGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
     switch (style)
     {
     case GRADING_LOG:
+    {
         AddGPLogProperties(shaderCreator, st, gpData, properties);
         if (dyn)
         {
@@ -534,13 +535,14 @@ void GetGradingPrimaryGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
             st.indent();
         }
 
-        if (dir == TRANSFORM_DIR_FORWARD)
+        switch (dir)
         {
+        case TRANSFORM_DIR_FORWARD:
             AddGPLogForwardShader(st, properties);
-        }
-        else
-        {
+            break;
+        case TRANSFORM_DIR_INVERSE:
             AddGPLogInverseShader(st, properties);
+            break;
         }
 
         if (dyn)
@@ -549,7 +551,9 @@ void GetGradingPrimaryGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
             st.newLine() << "}";
         }
         break;
+    }
     case GRADING_LIN:
+    {
         AddGPLinProperties(shaderCreator, st, gpData, properties);
         if (dyn)
         {
@@ -558,13 +562,14 @@ void GetGradingPrimaryGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
             st.indent();
         }
 
-        if (dir == TRANSFORM_DIR_FORWARD)
+        switch (dir)
         {
+        case TRANSFORM_DIR_FORWARD:
             AddGPLinForwardShader(st, properties);
-        }
-        else
-        {
+            break;
+        case TRANSFORM_DIR_INVERSE:
             AddGPLinInverseShader(st, properties);
+            break;
         }
 
         if (dyn)
@@ -573,7 +578,9 @@ void GetGradingPrimaryGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
             st.newLine() << "}";
         }
         break;
+    }
     case GRADING_VIDEO:
+    {
         AddGPVideoProperties(shaderCreator, st, gpData, properties);
         if (dyn)
         {
@@ -582,13 +589,14 @@ void GetGradingPrimaryGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
             st.indent();
         }
 
-        if (dir == TRANSFORM_DIR_FORWARD)
+        switch (dir)
         {
+        case TRANSFORM_DIR_FORWARD:
             AddGPVideoForwardShader(st, properties);
-        }
-        else
-        {
+            break;
+        case TRANSFORM_DIR_INVERSE:
             AddGPVideoInverseShader(st, properties);
+            break;
         }
 
         if (dyn)
@@ -597,6 +605,7 @@ void GetGradingPrimaryGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
             st.newLine() << "}";
         }
         break;
+    }
     }
     st.dedent();
     st.newLine() << "}";

--- a/src/OpenColorIO/ops/gradingrgbcurve/GradingRGBCurveOpCPU.cpp
+++ b/src/OpenColorIO/ops/gradingrgbcurve/GradingRGBCurveOpCPU.cpp
@@ -310,7 +310,9 @@ ConstOpCPURcPtr GetGradingRGBCurveCPURenderer(ConstGradingRGBCurveOpDataRcPtr & 
 {
     const bool linToLog = (prim->getStyle() == GRADING_LIN) && !prim->getBypassLinToLog();
 
-    if (prim->getDirection() == TRANSFORM_DIR_FORWARD)
+    switch (prim->getDirection())
+    {
+    case TRANSFORM_DIR_FORWARD:
     {
         if (linToLog)
         {
@@ -320,8 +322,9 @@ ConstOpCPURcPtr GetGradingRGBCurveCPURenderer(ConstGradingRGBCurveOpDataRcPtr & 
         {
             return std::make_shared<GradingRGBCurveFwdOpCPU>(prim);
         }
+        break;
     }
-    else if (prim->getDirection() == TRANSFORM_DIR_INVERSE)
+    case TRANSFORM_DIR_INVERSE:
     {
         if (linToLog)
         {
@@ -331,9 +334,11 @@ ConstOpCPURcPtr GetGradingRGBCurveCPURenderer(ConstGradingRGBCurveOpDataRcPtr & 
         {
             return std::make_shared<GradingRGBCurveRevOpCPU>(prim);
         }
+        break;
+    }
     }
 
-    throw Exception("Unsupported direction.");
+    throw Exception("Illegal GradingRGBCurve direction.");
 }
 
 } // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/gradingrgbcurve/GradingRGBCurveOpGPU.cpp
+++ b/src/OpenColorIO/ops/gradingrgbcurve/GradingRGBCurveOpGPU.cpp
@@ -346,13 +346,14 @@ void GetGradingRGBCurveGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
     }
 
     const bool doLinToLog = (style == GRADING_LIN) && !gcData->getBypassLinToLog();
-    if (dir == TRANSFORM_DIR_FORWARD)
+    switch (dir)
     {
+    case TRANSFORM_DIR_FORWARD:
         AddGCForwardShader(st, properties, dyn, doLinToLog);
-    }
-    else
-    {
+        break;
+    case TRANSFORM_DIR_INVERSE:
         AddGCInverseShader(st, properties, dyn, doLinToLog);
+        break;
     }
 
     st.dedent();

--- a/src/OpenColorIO/ops/gradingtone/GradingToneOpCPU.cpp
+++ b/src/OpenColorIO/ops/gradingtone/GradingToneOpCPU.cpp
@@ -789,16 +789,15 @@ void GradingToneLinearRevOpCPU::apply(const void * inImg, void * outImg, long nu
 
 ConstOpCPURcPtr GetGradingToneCPURenderer(ConstGradingToneOpDataRcPtr & tone)
 {
-    if (tone->getDirection() == TRANSFORM_DIR_FORWARD)
+    switch (tone->getDirection())
     {
+    case TRANSFORM_DIR_FORWARD:
         if (tone->getStyle() == GRADING_LIN)
         {
             return std::make_shared<GradingToneLinearFwdOpCPU>(tone);
         }
         return std::make_shared<GradingToneFwdOpCPU>(tone);
-    }
-    else if (tone->getDirection() == TRANSFORM_DIR_INVERSE)
-    {
+    case TRANSFORM_DIR_INVERSE:
         if (tone->getStyle() == GRADING_LIN)
         {
             return std::make_shared<GradingToneLinearRevOpCPU>(tone);
@@ -806,7 +805,7 @@ ConstOpCPURcPtr GetGradingToneCPURenderer(ConstGradingToneOpDataRcPtr & tone)
         return std::make_shared<GradingToneRevOpCPU>(tone);
     }
 
-    throw Exception("Unsupported GradingTone direction.");
+    throw Exception("Illegal GradingTone direction.");
 }
 
 } // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/gradingtone/GradingToneOpGPU.cpp
+++ b/src/OpenColorIO/ops/gradingtone/GradingToneOpGPU.cpp
@@ -996,13 +996,14 @@ void GetGradingToneGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
         st.indent();
     }
 
-    if (dir == TRANSFORM_DIR_FORWARD)
+    switch (dir)
     {
+    case TRANSFORM_DIR_FORWARD:
         AddGTForwardShader(st, properties, style);
-    }
-    else
-    {
+        break;
+    case TRANSFORM_DIR_INVERSE:
         AddGTInverseShader(st, properties, style);
+        break;
     }
 
     if (dyn)

--- a/src/OpenColorIO/ops/log/LogOp.cpp
+++ b/src/OpenColorIO/ops/log/LogOp.cpp
@@ -143,11 +143,6 @@ void CreateLogOp(OpRcPtrVec & ops,
                  LogOpDataRcPtr & logData,
                  TransformDirection direction)
 {
-    if (direction == TRANSFORM_DIR_UNKNOWN)
-    {
-        throw Exception("Cannot create Log op, unspecified transform direction.");
-    }
-
     auto log = logData;
     if (direction == TRANSFORM_DIR_INVERSE)
     {

--- a/src/OpenColorIO/ops/log/LogOpCPU.cpp
+++ b/src/OpenColorIO/ops/log/LogOpCPU.cpp
@@ -230,83 +230,88 @@ ConstOpCPURcPtr GetLogRenderer(ConstLogOpDataRcPtr & log, bool fastExp)
     const TransformDirection dir = log->getDirection();
     if (log->isLog2())
     {
-        if (dir == TRANSFORM_DIR_FORWARD)
+        switch (dir)
         {
+        case TRANSFORM_DIR_FORWARD:
 #ifdef USE_SSE
             if (fastExp) return std::make_shared<LogRendererSSE>(log, 1.0f);
             else
 #endif
                 return std::make_shared<LogRenderer>(log, 1.0f);
-        }
-        else
-        {
+            break;
+        case TRANSFORM_DIR_INVERSE:
 #ifdef USE_SSE
             if (fastExp) return std::make_shared<AntiLogRendererSSE>(log, 1.0f);
             else
 #endif
                 return std::make_shared<AntiLogRenderer>(log, 1.0f);
+            break;
         }
     }
     else if (log->isLog10())
     {
-        if (dir == TRANSFORM_DIR_FORWARD)
+        switch (dir)
         {
+        case TRANSFORM_DIR_FORWARD:
 #ifdef USE_SSE
             if (fastExp) return std::make_shared<LogRendererSSE>(log, LOG10_2);
             else
 #endif
                 return std::make_shared<LogRenderer>(log, LOG10_2);
-        }
-        else
-        {
+            break;
+        case TRANSFORM_DIR_INVERSE:
 #ifdef USE_SSE
             if (fastExp) return std::make_shared<AntiLogRendererSSE>(log, LOG2_10);
             else
 #endif
                 return std::make_shared<AntiLogRenderer>(log, LOG2_10);
+            break;
         }
     }
     else
     {
         if (log->isCamera())
         {
-            if (dir == TRANSFORM_DIR_FORWARD)
+            switch (dir)
             {
+            case TRANSFORM_DIR_FORWARD:
 #ifdef USE_SSE
                 if (fastExp) return std::make_shared<CameraLin2LogRendererSSE>(log);
                 else
 #endif
                     return std::make_shared<CameraLin2LogRenderer>(log);
-            }
-            else
-            {
+                break;
+            case TRANSFORM_DIR_INVERSE:
 #ifdef USE_SSE
                 if (fastExp) return std::make_shared<CameraLog2LinRendererSSE>(log);
                 else
 #endif
                     return std::make_shared<CameraLog2LinRenderer>(log);
+                break;
             }
         }
         else
         {
-            if (dir == TRANSFORM_DIR_FORWARD)
+            switch (dir)
             {
+            case TRANSFORM_DIR_FORWARD:
 #ifdef USE_SSE
                 if (fastExp) return std::make_shared<Lin2LogRendererSSE>(log);
                 else
 #endif
                     return std::make_shared<Lin2LogRenderer>(log);
-            }
-            else
-            {
+                break;
+            case TRANSFORM_DIR_INVERSE:
 #ifdef USE_SSE
                 if (fastExp) return std::make_shared<Log2LinRendererSSE>(log);
                 else
 #endif
                     return std::make_shared<Log2LinRenderer>(log);
+                break;
             }
         }
     }
+    throw Exception("Illegal Log direction.");
 }
 
 LogOpCPU::LogOpCPU(ConstLogOpDataRcPtr & log)

--- a/src/OpenColorIO/ops/log/LogOpData.cpp
+++ b/src/OpenColorIO/ops/log/LogOpData.cpp
@@ -42,28 +42,21 @@ void ValidateParams(const LogOpData::Params & params, TransformDirection directi
         throw Exception("Log: expecting at most 6 parameters.");
     }
 
-    if (direction != TRANSFORM_DIR_UNKNOWN)
+    if (IsScalarEqualToZero(params[LIN_SIDE_SLOPE]))
     {
-        if (IsScalarEqualToZero(params[LIN_SIDE_SLOPE]))
-        {
-            std::ostringstream oss;
-            oss << "Log: Invalid linear slope value '";
-            oss << params[LIN_SIDE_SLOPE];
-            oss << "', linear slope cannot be 0.";
-            throw Exception(oss.str().c_str());
-        }
-        if (IsScalarEqualToZero(params[LOG_SIDE_SLOPE]))
-        {
-            std::ostringstream oss;
-            oss << "Log: Invalid log slope value '";
-            oss << params[LOG_SIDE_SLOPE];
-            oss << "', log slope cannot be 0.";
-            throw Exception(oss.str().c_str());
-        }
+        std::ostringstream oss;
+        oss << "Log: Invalid linear slope value '";
+        oss << params[LIN_SIDE_SLOPE];
+        oss << "', linear slope cannot be 0.";
+        throw Exception(oss.str().c_str());
     }
-    else
+    if (IsScalarEqualToZero(params[LOG_SIDE_SLOPE]))
     {
-        throw Exception("Log: Invalid direction.");
+        std::ostringstream oss;
+        oss << "Log: Invalid log slope value '";
+        oss << params[LOG_SIDE_SLOPE];
+        oss << "', log slope cannot be 0.";
+        throw Exception(oss.str().c_str());
     }
 }
 }
@@ -73,11 +66,6 @@ LogOpData::LogOpData(double base, TransformDirection direction)
     , m_base(base)
     , m_direction(direction)
 {
-    if (m_direction == TRANSFORM_DIR_UNKNOWN)
-    {
-        throw Exception("Cannot create Log op, unspecified transform direction.");
-    }
-
     setParameters(DefaultValues::logSlope, DefaultValues::logOffset,
                   DefaultValues::linSlope, DefaultValues::linOffset);
 }
@@ -92,10 +80,6 @@ LogOpData::LogOpData(double base,
     , m_base(base)
     , m_direction(direction)
 {
-    if (m_direction == TRANSFORM_DIR_UNKNOWN)
-    {
-        throw Exception("Cannot create Log op, unspecified transform direction.");
-    }
     setParameters(logSlope, logOffset, linSlope, linOffset);
 }
 
@@ -111,10 +95,6 @@ LogOpData::LogOpData(double base,
     , m_base(base)
     , m_direction(dir)
 {
-    if (m_direction == TRANSFORM_DIR_UNKNOWN)
-    {
-        throw Exception("Cannot create Log op, unspecified transform direction.");
-    }
     const auto sr = redParams.size();
     const auto sg = greenParams.size();
     const auto sb = blueParams.size();
@@ -262,29 +242,31 @@ OpDataRcPtr LogOpData::getIdentityReplacement() const
     OpDataRcPtr resOp;
     if (isLog2() || isLog10())
     {
-        if (m_direction == TRANSFORM_DIR_FORWARD)
+        switch (m_direction)
         {
+        case TRANSFORM_DIR_FORWARD:
             // The first op logarithm is not defined for negative values.
-            resOp = std::make_shared<RangeOpData>(
-                0.,
-                // Don't clamp high end.
-                RangeOpData::EmptyValue(),
-                0.,
-                RangeOpData::EmptyValue());
-        }
-        else
-        {
+            resOp = std::make_shared<RangeOpData>(0.,
+                                                  // Don't clamp high end.
+                                                  RangeOpData::EmptyValue(),
+                                                  0.,
+                                                  RangeOpData::EmptyValue());
+            break;
+        case TRANSFORM_DIR_INVERSE:
             // In principle, the power function is defined over the entire domain.
             // However, in practice the input to the following logarithm is clamped
             // to a very small positive number and this imposes a limit.
             // E.g., log10(FLOAT_MIN) = -37.93, but this is so small that it makes
             // more sense to consider it an exact inverse.
             resOp = std::make_shared<MatrixOpData>();
+            break;
         }
     }
     else if (!isCamera())
     {
-        if (m_direction == TRANSFORM_DIR_FORWARD)  // LinToLog -> LogToLin
+        switch (m_direction)
+        {
+        case TRANSFORM_DIR_FORWARD: // LinToLog -> LogToLin
         {
             // Minimum value allowed is -linOffset/linSlope so that linSlope*x+linOffset > 0.
             const double minValue = -m_redParams[LIN_SIDE_OFFSET] / m_redParams[LIN_SIDE_SLOPE];
@@ -293,11 +275,13 @@ OpDataRcPtr LogOpData::getIdentityReplacement() const
                                                   RangeOpData::EmptyValue(),
                                                   minValue,
                                                   RangeOpData::EmptyValue());
-
+            break;
         }
-        else  // LogToLin -> LinToLog
+        case TRANSFORM_DIR_INVERSE: // LogToLin -> LinToLog
         {
             resOp = std::make_shared<MatrixOpData>();
+            break;
+        }
         }
     }
     else

--- a/src/OpenColorIO/ops/log/LogOpGPU.cpp
+++ b/src/OpenColorIO/ops/log/LogOpGPU.cpp
@@ -298,48 +298,52 @@ void GetLogGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator, ConstLogOpDat
     const TransformDirection dir = logData->getDirection();
     if (logData->isLog2())
     {
-        if (dir == TRANSFORM_DIR_FORWARD)
+        switch (dir)
         {
+        case TRANSFORM_DIR_FORWARD:
             AddLogShader(shaderCreator, logData, 2.0f);
-        }
-        else
-        {
+            break;
+        case TRANSFORM_DIR_INVERSE:
             AddAntiLogShader(shaderCreator, logData, 2.0f);
+            break;
         }
     }
     else if (logData->isLog10())
     {
-        if (dir == TRANSFORM_DIR_FORWARD)
+        switch (dir)
         {
+        case TRANSFORM_DIR_FORWARD:
             AddLogShader(shaderCreator, logData, 10.0f);
-        }
-        else
-        {
+            break;
+        case TRANSFORM_DIR_INVERSE:
             AddAntiLogShader(shaderCreator, logData, 10.0f);
+            break;
         }
     }
     else
     {
         if (logData->isCamera())
         {
-            if (dir == TRANSFORM_DIR_FORWARD)
+            switch (dir)
             {
+            case TRANSFORM_DIR_FORWARD:
                 AddCameraLinToLogShader(shaderCreator, logData);
-            }
-            else
-            {
+                break;
+            case TRANSFORM_DIR_INVERSE:
                 AddCameraLogToLinShader(shaderCreator, logData);
+                break;
             }
         }
         else
         {
-            if (dir == TRANSFORM_DIR_FORWARD)
+            switch (dir)
             {
+            case TRANSFORM_DIR_FORWARD:
                 AddLinToLogShader(shaderCreator, logData);
-            }
-            else
-            {
+                break;
+            case TRANSFORM_DIR_INVERSE:
                 AddLogToLinShader(shaderCreator, logData);
+                break;
             }
         }
     }

--- a/src/OpenColorIO/ops/lut1d/Lut1DOp.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOp.cpp
@@ -183,11 +183,7 @@ void CreateLut1DOp(OpRcPtrVec & ops,
     // If so, return a mtx instead.
 
     Lut1DOpDataRcPtr lutData = lut;
-    if (direction == TRANSFORM_DIR_UNKNOWN)
-    {
-        throw Exception("Cannot apply Lut1DOp op, unspecified transform direction.");
-    }
-    else if (direction == TRANSFORM_DIR_INVERSE)
+    if (direction == TRANSFORM_DIR_INVERSE)
     {
         lutData = lut->inverse();
     }

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpCPU.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpCPU.cpp
@@ -1630,11 +1630,14 @@ OpCPURcPtr GetForwardLut1DRenderer(ConstLut1DOpDataRcPtr & lut)
 template<BitDepth inBD, BitDepth outBD>
 ConstOpCPURcPtr GetLut1DRenderer_OutBitDepth(ConstLut1DOpDataRcPtr & lut)
 {
-    if (lut->getDirection() == TRANSFORM_DIR_FORWARD)
+    switch (lut->getDirection())
+    {
+    case TRANSFORM_DIR_FORWARD:
     {
         return GetForwardLut1DRenderer<inBD, outBD>(lut);
+        break;
     }
-    else
+    case TRANSFORM_DIR_INVERSE:
     {
         if (lut->isInputHalfDomain())
         {
@@ -1658,7 +1661,10 @@ ConstOpCPURcPtr GetLut1DRenderer_OutBitDepth(ConstLut1DOpDataRcPtr & lut)
                 return std::make_shared< InvLut1DRendererHueAdjust<inBD, outBD> >(lut);
             }
         }
+        break;
     }
+    }
+    throw Exception("Illegal LUT1D direction.");
 }
 
 template<BitDepth inBD>

--- a/src/OpenColorIO/ops/lut3d/Lut3DOp.cpp
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOp.cpp
@@ -305,11 +305,7 @@ void CreateLut3DOp(OpRcPtrVec & ops, Lut3DOpDataRcPtr & lut, TransformDirection 
 {
     Lut3DOpDataRcPtr lutData = lut;
 
-    if (direction == TRANSFORM_DIR_UNKNOWN)
-    {
-        throw Exception("Cannot apply Lut3DOp op, unspecified transform direction.");
-    }
-    else if (direction == TRANSFORM_DIR_INVERSE)
+    if (direction == TRANSFORM_DIR_INVERSE)
     {
         lutData = lut->inverse();
     }

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpCPU.cpp
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpCPU.cpp
@@ -1911,14 +1911,16 @@ ConstOpCPURcPtr GetForwardLut3DRenderer(ConstLut3DOpDataRcPtr & lut)
 
 ConstOpCPURcPtr GetLut3DRenderer(ConstLut3DOpDataRcPtr & lut)
 {
-    if (lut->getDirection() == TRANSFORM_DIR_FORWARD)
+    switch (lut->getDirection())
     {
+    case TRANSFORM_DIR_FORWARD:
         return GetForwardLut3DRenderer(lut);
-    }
-    else
-    {
+        break;
+    case TRANSFORM_DIR_INVERSE:
         return std::make_shared<InvLut3DRenderer>(lut);
+        break;
     }
+    throw Exception("Illegal LUT3D direction.");
 }
 
 } // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/matrix/MatrixOpData.cpp
+++ b/src/OpenColorIO/ops/matrix/MatrixOpData.cpp
@@ -794,13 +794,9 @@ bool MatrixOpData::operator==(const OpData & other) const
             m_array     == mop->m_array);
 }
 
-void MatrixOpData::setDirection(TransformDirection dir)
+void MatrixOpData::setDirection(TransformDirection dir) noexcept
 {
     m_direction = dir;
-    if (m_direction == TRANSFORM_DIR_UNKNOWN)
-    {
-        throw Exception("MatrixOpData: unspecified transform direction.");
-    }
 }
 
 MatrixOpDataRcPtr MatrixOpData::getAsForward() const

--- a/src/OpenColorIO/ops/matrix/MatrixOpData.h
+++ b/src/OpenColorIO/ops/matrix/MatrixOpData.h
@@ -216,8 +216,8 @@ public:
 
     bool operator==(const OpData & other) const override;
 
-    TransformDirection getDirection() const { return m_direction; }
-    void setDirection(TransformDirection dir);
+    TransformDirection getDirection() const noexcept { return m_direction; }
+    void setDirection(TransformDirection dir) noexcept;
 
     MatrixOpDataRcPtr getAsForward() const;
 

--- a/src/OpenColorIO/ops/noop/NoOps.cpp
+++ b/src/OpenColorIO/ops/noop/NoOps.cpp
@@ -235,10 +235,8 @@ void PartitionGPUOps(OpRcPtrVec & gpuPreOps,
         // (For example in the case of getProcessor(FileTransform)
         if(GetGpuAllocation(allocation, ops[gpuLut3DOpStartIndex]))
         {
-            CreateAllocationOps(gpuPreOps, allocation,
-                TRANSFORM_DIR_FORWARD);
-            CreateAllocationOps(gpuLatticeOps, allocation,
-                TRANSFORM_DIR_INVERSE);
+            CreateAllocationOps(gpuPreOps, allocation, TRANSFORM_DIR_FORWARD);
+            CreateAllocationOps(gpuLatticeOps, allocation, TRANSFORM_DIR_INVERSE);
         }
 
         // Handle cpu lattice processing

--- a/src/OpenColorIO/ops/range/RangeOpData.cpp
+++ b/src/OpenColorIO/ops/range/RangeOpData.cpp
@@ -547,13 +547,9 @@ bool RangeOpData::operator==(const OpData & other) const
     return true;
 }
 
-void RangeOpData::setDirection(TransformDirection dir)
+void RangeOpData::setDirection(TransformDirection dir) noexcept
 {
     m_direction = dir;
-    if (m_direction == TRANSFORM_DIR_UNKNOWN)
-    {
-        throw Exception("RangeOpData: unspecified transform direction.");
-    }
 }
 
 RangeOpDataRcPtr RangeOpData::getAsForward() const

--- a/src/OpenColorIO/ops/range/RangeOpData.h
+++ b/src/OpenColorIO/ops/range/RangeOpData.h
@@ -144,8 +144,8 @@ public:
 
     RangeOpDataRcPtr getAsForward() const;
 
-    TransformDirection getDirection() const { return m_direction; }
-    void setDirection(TransformDirection dir);
+    TransformDirection getDirection() const noexcept { return m_direction; }
+    void setDirection(TransformDirection dir) noexcept;
 
     BitDepth getFileInputBitDepth() const { return m_fileInBitDepth; }
     void setFileInputBitDepth(BitDepth in) { m_fileInBitDepth = in; }

--- a/src/OpenColorIO/transforms/AllocationTransform.cpp
+++ b/src/OpenColorIO/transforms/AllocationTransform.cpp
@@ -77,14 +77,23 @@ TransformDirection AllocationTransform::getDirection() const  noexcept
     return getImpl()->m_dir;
 }
 
-void AllocationTransform::setDirection(TransformDirection dir)  noexcept
+void AllocationTransform::setDirection(TransformDirection dir) noexcept
 {
     getImpl()->m_dir = dir;
 }
 
 void AllocationTransform::validate() const
 {
-    Transform::validate();
+    try
+    {
+        Transform::validate();
+    }
+    catch (Exception & ex)
+    {
+        std::string errMsg("AllocationTransform validation failed: ");
+        errMsg += ex.what();
+        throw Exception(errMsg.c_str());
+    }
 
     if (getImpl()->m_allocation == ALLOCATION_UNIFORM)
     {

--- a/src/OpenColorIO/transforms/ColorSpaceTransform.cpp
+++ b/src/OpenColorIO/transforms/ColorSpaceTransform.cpp
@@ -81,7 +81,16 @@ void ColorSpaceTransform::setDirection(TransformDirection dir) noexcept
 
 void ColorSpaceTransform::validate() const
 {
-    Transform::validate();
+    try
+    {
+        Transform::validate();
+    }
+    catch (Exception & ex)
+    {
+        std::string errMsg("ColorSpaceTransform validation failed: ");
+        errMsg += ex.what();
+        throw Exception(errMsg.c_str());
+    }
 
     if (getImpl()->m_src.empty())
     {
@@ -165,31 +174,36 @@ void BuildColorSpaceOps(OpRcPtrVec & ops,
 
     ConstColorSpaceRcPtr src, dst;
 
-    if(combinedDir == TRANSFORM_DIR_FORWARD)
+    switch (combinedDir)
     {
-        src = config.getColorSpace( context->resolveStringVar( colorSpaceTransform.getSrc() ) );
+    case TRANSFORM_DIR_FORWARD:
+    {
+        src = config.getColorSpace(context->resolveStringVar(colorSpaceTransform.getSrc()));
         if (!src)
         {
             ThrowMissingCS(SRC_CS, colorSpaceTransform.getSrc());
         }
-        dst = config.getColorSpace( context->resolveStringVar( colorSpaceTransform.getDst() ) );
+        dst = config.getColorSpace(context->resolveStringVar(colorSpaceTransform.getDst()));
         if (!dst)
         {
             ThrowMissingCS(DST_CS, colorSpaceTransform.getDst());
         }
+        break;
     }
-    else if(combinedDir == TRANSFORM_DIR_INVERSE)
+    case TRANSFORM_DIR_INVERSE:
     {
-        dst = config.getColorSpace( context->resolveStringVar( colorSpaceTransform.getSrc() ) );
+        dst = config.getColorSpace(context->resolveStringVar(colorSpaceTransform.getSrc()));
         if (!dst)
         {
             ThrowMissingCS(SRC_CS, colorSpaceTransform.getSrc());
         }
-        src = config.getColorSpace( context->resolveStringVar( colorSpaceTransform.getDst() ) );
+        src = config.getColorSpace(context->resolveStringVar(colorSpaceTransform.getDst()));
         if (!src)
         {
             ThrowMissingCS(DST_CS, colorSpaceTransform.getDst());
         }
+        break;
+    }
     }
 
     BuildColorSpaceOps(ops, config, context, src, dst, colorSpaceTransform.getDataBypass());

--- a/src/OpenColorIO/transforms/DisplayViewTransform.cpp
+++ b/src/OpenColorIO/transforms/DisplayViewTransform.cpp
@@ -73,7 +73,16 @@ void DisplayViewTransform::setDirection(TransformDirection dir) noexcept
 
 void DisplayViewTransform::validate() const
 {
-    Transform::validate();
+    try
+    {
+        Transform::validate();
+    }
+    catch (Exception & ex)
+    {
+        std::string errMsg("DisplayViewTransform validation failed: ");
+        errMsg += ex.what();
+        throw Exception(errMsg.c_str());
+    }
 
     if (getImpl()->m_src.empty())
     {
@@ -330,7 +339,9 @@ void BuildDisplayOps(OpRcPtrVec & ops,
     // Now that all the inputs are found and validated, the following code builds the list of ops
     // for the forward or the inverse direction.
 
-    if (combinedDir == TRANSFORM_DIR_FORWARD)
+    switch (combinedDir)
+    {
+    case TRANSFORM_DIR_FORWARD:
     {
         // Start from src color space.
         ConstColorSpaceRcPtr currentCS = srcColorSpace;
@@ -359,8 +370,9 @@ void BuildDisplayOps(OpRcPtrVec & ops,
             BuildColorSpaceOps(ops, config, context, currentCS, displayColorSpace,
                                 dataBypass);
         }
+        break;
     }
-    else // TRANSFORM_DIR_INVERSE
+    case TRANSFORM_DIR_INVERSE:
     {
         // The source color space of the view transform might need to be computed. In forward,
         // looks (if present) are applied and will change the current color space that is used
@@ -402,6 +414,8 @@ void BuildDisplayOps(OpRcPtrVec & ops,
             BuildColorSpaceOps(ops, config, context,
                                vtSourceCS, srcColorSpace, dataBypass);
         }
+        break;
+    }
     }
 }
 

--- a/src/OpenColorIO/transforms/FileTransform.cpp
+++ b/src/OpenColorIO/transforms/FileTransform.cpp
@@ -81,7 +81,16 @@ void FileTransform::setDirection(TransformDirection dir) noexcept
 
 void FileTransform::validate() const
 {
-    Transform::validate();
+    try
+    {
+        Transform::validate();
+    }
+    catch (Exception & ex)
+    {
+        std::string errMsg("FileTransform validation failed: ");
+        errMsg += ex.what();
+        throw Exception(errMsg.c_str());
+    }
 
     if (getImpl()->m_src.empty())
     {
@@ -158,12 +167,19 @@ const char * FileTransform::getFormatExtensionByIndex(int index)
 std::ostream& operator<< (std::ostream& os, const FileTransform& t)
 {
     os << "<FileTransform ";
-    os << "direction=";
-    os << TransformDirectionToString(t.getDirection()) << ", ";
-    os << "interpolation=" << InterpolationToString(t.getInterpolation());
-    os << ", src=" << t.getSrc() << ", ";
-    os << "cccid=" << t.getCCCId();
-    os << "cdl_style=" << CDLStyleToString(t.getCDLStyle());
+    os << "direction=" << TransformDirectionToString(t.getDirection());
+    os << ", interpolation=" << InterpolationToString(t.getInterpolation());
+    os << ", src=" << t.getSrc();
+    const std::string cccid{ t.getCCCId() };
+    if (!cccid.empty())
+    {
+        os << ", cccid=" << cccid;
+    }
+    const auto style = t.getCDLStyle();
+    if (style != CDL_TRANSFORM_DEFAULT)
+    {
+        os << ", cdl_style=" << CDLStyleToString(style);
+    }
     os << ">";
 
     return os;
@@ -575,7 +591,7 @@ void LoadFileUncached(FileFormat * & returnFormat,
                 filestream.close();
             }
 
-            primaryErrorText += "\t'";
+            primaryErrorText += "    '";
             primaryErrorText += tryFormat->getName();
             primaryErrorText += "' failed with: ";
             primaryErrorText += e.what();

--- a/src/OpenColorIO/transforms/builtins/BuiltinTransformRegistry.cpp
+++ b/src/OpenColorIO/transforms/builtins/BuiltinTransformRegistry.cpp
@@ -136,25 +136,25 @@ void CreateBuiltinTransformOps(OpRcPtrVec & ops, size_t nameIndex, TransformDire
         throw Exception("Invalid built-in transform name.");
     }
 
-    if (direction == TRANSFORM_DIR_UNKNOWN)
-    {
-        throw Exception("Unsupported direction.");
-    }
-
     const BuiltinTransformRegistryImpl * registry
         = dynamic_cast<const BuiltinTransformRegistryImpl *>(BuiltinTransformRegistry::Get().get());
 
-    if (direction == TRANSFORM_DIR_FORWARD)
+    switch (direction)
+    {
+    case TRANSFORM_DIR_FORWARD:
     {
         registry->createOps(nameIndex, ops);
+        break;
     }
-    else
+    case TRANSFORM_DIR_INVERSE:
     {
         OpRcPtrVec tmp;
         registry->createOps(nameIndex, tmp);
 
         OpRcPtrVec t = tmp.invert();
         ops.insert(ops.end(), t.begin(), t.end());
+        break;
+    }
     }
 }
 

--- a/src/bindings/python/PyTypes.cpp
+++ b/src/bindings/python/PyTypes.cpp
@@ -35,19 +35,16 @@ void bindPyTypes(py::module & m)
         .export_values();
 
     py::enum_<ColorSpaceDirection>(m, "ColorSpaceDirection")
-        .value("COLORSPACE_DIR_UNKNOWN", COLORSPACE_DIR_UNKNOWN)
         .value("COLORSPACE_DIR_TO_REFERENCE", COLORSPACE_DIR_TO_REFERENCE)
         .value("COLORSPACE_DIR_FROM_REFERENCE", COLORSPACE_DIR_FROM_REFERENCE)
         .export_values();
 
     py::enum_<ViewTransformDirection>(m, "ViewTransformDirection")
-        .value("VIEWTRANSFORM_DIR_UNKNOWN", VIEWTRANSFORM_DIR_UNKNOWN)
         .value("VIEWTRANSFORM_DIR_TO_REFERENCE", VIEWTRANSFORM_DIR_TO_REFERENCE)
         .value("VIEWTRANSFORM_DIR_FROM_REFERENCE", VIEWTRANSFORM_DIR_FROM_REFERENCE)
         .export_values();
 
     py::enum_<TransformDirection>(m, "TransformDirection")
-        .value("TRANSFORM_DIR_UNKNOWN", TRANSFORM_DIR_UNKNOWN)
         .value("TRANSFORM_DIR_FORWARD", TRANSFORM_DIR_FORWARD)
         .value("TRANSFORM_DIR_INVERSE", TRANSFORM_DIR_INVERSE)
         .export_values();

--- a/tests/cpu/ColorSpace_tests.cpp
+++ b/tests/cpu/ColorSpace_tests.cpp
@@ -61,7 +61,7 @@ OCIO_ADD_TEST(ColorSpace, basic)
 
     std::ostringstream oss;
     oss << *cs;
-    OCIO_CHECK_EQUAL(oss.str().size(), 168);
+    OCIO_CHECK_EQUAL(oss.str().size(), 193);
 }
 
 OCIO_ADD_TEST(ColorSpace, category)

--- a/tests/cpu/ParseUtils_tests.cpp
+++ b/tests/cpu/ParseUtils_tests.cpp
@@ -92,7 +92,7 @@ OCIO_ADD_TEST(ParseUtils, transform_direction)
     resStr = OCIO::TransformDirectionToString(OCIO::TRANSFORM_DIR_INVERSE);
     OCIO_CHECK_EQUAL("inverse", resStr);
 
-    OCIO::TransformDirection resDir;
+    OCIO::TransformDirection resDir = OCIO::TRANSFORM_DIR_INVERSE;
     OCIO_CHECK_NO_THROW(resDir = OCIO::TransformDirectionFromString("forward"));
     OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
     OCIO_CHECK_NO_THROW(resDir = OCIO::TransformDirectionFromString("inverse"));
@@ -141,7 +141,7 @@ OCIO_ADD_TEST(ParseUtils, color_space)
     resStr = OCIO::ColorSpaceDirectionToString(OCIO::COLORSPACE_DIR_FROM_REFERENCE);
     OCIO_CHECK_EQUAL("from_reference", resStr);
 
-    OCIO::ColorSpaceDirection resCSD;
+    OCIO::ColorSpaceDirection resCSD = OCIO::COLORSPACE_DIR_FROM_REFERENCE;
     OCIO_CHECK_NO_THROW(resCSD = OCIO::ColorSpaceDirectionFromString("to_reference"));
     OCIO_CHECK_EQUAL(OCIO::COLORSPACE_DIR_TO_REFERENCE, resCSD);
     OCIO_CHECK_NO_THROW(resCSD = OCIO::ColorSpaceDirectionFromString("from_reference"));

--- a/tests/cpu/ParseUtils_tests.cpp
+++ b/tests/cpu/ParseUtils_tests.cpp
@@ -91,38 +91,29 @@ OCIO_ADD_TEST(ParseUtils, transform_direction)
     OCIO_CHECK_EQUAL("forward", resStr);
     resStr = OCIO::TransformDirectionToString(OCIO::TRANSFORM_DIR_INVERSE);
     OCIO_CHECK_EQUAL("inverse", resStr);
-    resStr = OCIO::TransformDirectionToString(OCIO::TRANSFORM_DIR_UNKNOWN);
-    OCIO_CHECK_EQUAL("unknown", resStr);
 
     OCIO::TransformDirection resDir;
-    resDir = OCIO::TransformDirectionFromString("forward");
+    OCIO_CHECK_NO_THROW(resDir = OCIO::TransformDirectionFromString("forward"));
     OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
-    resDir = OCIO::TransformDirectionFromString("inverse");
+    OCIO_CHECK_NO_THROW(resDir = OCIO::TransformDirectionFromString("inverse"));
     OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_INVERSE, resDir);
-    resDir = OCIO::TransformDirectionFromString("Forward");
+    OCIO_CHECK_NO_THROW(resDir = OCIO::TransformDirectionFromString("Forward"));
     OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
-    resDir = OCIO::TransformDirectionFromString("Inverse");
+    OCIO_CHECK_NO_THROW(resDir = OCIO::TransformDirectionFromString("Inverse"));
     OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_INVERSE, resDir);
-    resDir = OCIO::TransformDirectionFromString("FORWARD");
+    OCIO_CHECK_NO_THROW(resDir = OCIO::TransformDirectionFromString("FORWARD"));
     OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
-    resDir = OCIO::TransformDirectionFromString("INVERSE");
+    OCIO_CHECK_NO_THROW(resDir = OCIO::TransformDirectionFromString("INVERSE"));
     OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_INVERSE, resDir);
-    resDir = OCIO::TransformDirectionFromString("unknown");
-    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
-    resDir = OCIO::TransformDirectionFromString("");
-    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
-    resDir = OCIO::TransformDirectionFromString("anything");
-    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
+    OCIO_CHECK_THROW_WHAT(resDir = OCIO::TransformDirectionFromString("unknown"), OCIO::Exception,
+                          "Unrecognized transform direction 'unknown'");
+    OCIO_CHECK_THROW_WHAT(resDir = OCIO::TransformDirectionFromString(""), OCIO::Exception,
+                          "Unrecognized transform direction ''");
+    OCIO_CHECK_THROW_WHAT(resDir = OCIO::TransformDirectionFromString("anything"), OCIO::Exception,
+                          "Unrecognized transform direction 'anything'");
+    OCIO_CHECK_THROW_WHAT(resDir = OCIO::TransformDirectionFromString(nullptr), OCIO::Exception,
+                          "Unrecognized transform direction ''");
 
-    resDir = OCIO::CombineTransformDirections(OCIO::TRANSFORM_DIR_UNKNOWN,
-                                              OCIO::TRANSFORM_DIR_FORWARD);
-    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
-    resDir = OCIO::CombineTransformDirections(OCIO::TRANSFORM_DIR_INVERSE,
-                                              OCIO::TRANSFORM_DIR_UNKNOWN);
-    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
-    resDir = OCIO::CombineTransformDirections(OCIO::TRANSFORM_DIR_UNKNOWN,
-                                              OCIO::TRANSFORM_DIR_UNKNOWN);
-    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
     resDir = OCIO::CombineTransformDirections(OCIO::TRANSFORM_DIR_INVERSE,
                                               OCIO::TRANSFORM_DIR_INVERSE);
     OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
@@ -136,8 +127,6 @@ OCIO_ADD_TEST(ParseUtils, transform_direction)
                                               OCIO::TRANSFORM_DIR_INVERSE);
     OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_INVERSE, resDir);
 
-    resDir = OCIO::GetInverseTransformDirection(OCIO::TRANSFORM_DIR_UNKNOWN);
-    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
     resDir = OCIO::GetInverseTransformDirection(OCIO::TRANSFORM_DIR_INVERSE);
     OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
     resDir = OCIO::GetInverseTransformDirection(OCIO::TRANSFORM_DIR_FORWARD);
@@ -151,18 +140,16 @@ OCIO_ADD_TEST(ParseUtils, color_space)
     OCIO_CHECK_EQUAL("to_reference", resStr);
     resStr = OCIO::ColorSpaceDirectionToString(OCIO::COLORSPACE_DIR_FROM_REFERENCE);
     OCIO_CHECK_EQUAL("from_reference", resStr);
-    resStr = OCIO::ColorSpaceDirectionToString(OCIO::COLORSPACE_DIR_UNKNOWN);
-    OCIO_CHECK_EQUAL("unknown", resStr);
 
     OCIO::ColorSpaceDirection resCSD;
-    resCSD = OCIO::ColorSpaceDirectionFromString("to_reference");
+    OCIO_CHECK_NO_THROW(resCSD = OCIO::ColorSpaceDirectionFromString("to_reference"));
     OCIO_CHECK_EQUAL(OCIO::COLORSPACE_DIR_TO_REFERENCE, resCSD);
-    resCSD = OCIO::ColorSpaceDirectionFromString("from_reference");
+    OCIO_CHECK_NO_THROW(resCSD = OCIO::ColorSpaceDirectionFromString("from_reference"));
     OCIO_CHECK_EQUAL(OCIO::COLORSPACE_DIR_FROM_REFERENCE, resCSD);
-    resCSD = OCIO::ColorSpaceDirectionFromString("unkwon");
-    OCIO_CHECK_EQUAL(OCIO::COLORSPACE_DIR_UNKNOWN, resCSD);
-    resCSD = OCIO::ColorSpaceDirectionFromString("");
-    OCIO_CHECK_EQUAL(OCIO::COLORSPACE_DIR_UNKNOWN, resCSD);
+    OCIO_CHECK_THROW_WHAT(OCIO::ColorSpaceDirectionFromString("unkwon"), OCIO::Exception,
+                          "Unrecognized color space direction 'unkwon'");
+    OCIO_CHECK_THROW_WHAT(OCIO::ColorSpaceDirectionFromString(""), OCIO::Exception,
+                          "Unrecognized color space direction ''");
 }
 
 OCIO_ADD_TEST(ParseUtils, bitdepth)

--- a/tests/cpu/ops/allocation/AllocationOp_tests.cpp
+++ b/tests/cpu/ops/allocation/AllocationOp_tests.cpp
@@ -23,10 +23,6 @@ OCIO_ADD_TEST(AllocationOps, create)
         OCIO::CreateAllocationOps(ops, allocData, OCIO::TRANSFORM_DIR_INVERSE),
                                   OCIO::Exception, "Unsupported Allocation Type");
     OCIO_CHECK_EQUAL(ops.size(), 0);
-    OCIO_CHECK_THROW_WHAT(
-        OCIO::CreateAllocationOps(ops, allocData, OCIO::TRANSFORM_DIR_UNKNOWN),
-                                  OCIO::Exception, "Unsupported Allocation Type");
-    OCIO_CHECK_EQUAL(ops.size(), 0);
 
     allocData.allocation = OCIO::ALLOCATION_UNIFORM;
     // No allocation data leads to identity, identity transform will be created.
@@ -42,10 +38,6 @@ OCIO_ADD_TEST(AllocationOps, create)
     allocData.vars.push_back(0.0f);
     allocData.vars.push_back(10.0f);
     ops.clear();
-    OCIO_CHECK_THROW_WHAT(
-        OCIO::CreateAllocationOps(ops, allocData, OCIO::TRANSFORM_DIR_UNKNOWN),
-                                  OCIO::Exception, "unspecified transform direction");
-    OCIO_CHECK_EQUAL(ops.size(), 0);
     OCIO_CHECK_NO_THROW(
         OCIO::CreateAllocationOps(ops, allocData, OCIO::TRANSFORM_DIR_FORWARD));
     OCIO_CHECK_EQUAL(ops.size(), 1);
@@ -120,10 +112,6 @@ OCIO_ADD_TEST(AllocationOps, create)
     OCIO_CHECK_EQUAL(defaultLogOp->isInverse(op1), true);
 
     ops.clear();
-    OCIO_CHECK_THROW_WHAT(
-        OCIO::CreateAllocationOps(ops, allocData, OCIO::TRANSFORM_DIR_UNKNOWN),
-                                  OCIO::Exception, "unspecified transform direction");
-    OCIO_CHECK_EQUAL(ops.size(), 0);
 
     // adding data to target identity, Log op and identity are created
     allocData.vars.push_back(0.0f);
@@ -147,10 +135,6 @@ OCIO_ADD_TEST(AllocationOps, create)
     op0 = ops[0];
     OCIO_CHECK_EQUAL(defaultLogOp->isSameType(op0), true);
     ops.clear();
-    OCIO_CHECK_THROW_WHAT(
-        OCIO::CreateAllocationOps(ops, allocData, OCIO::TRANSFORM_DIR_UNKNOWN),
-                                  OCIO::Exception, "unspecified transform direction");
-    OCIO_CHECK_EQUAL(ops.size(), 0);
 
     // change log intercept
     allocData.vars.push_back(10.0f);
@@ -173,5 +157,4 @@ OCIO_ADD_TEST(AllocationOps, create)
     {
         OCIO_CHECK_CLOSE(dstLogShift[idx], tmp[idx], error);
     }
-
 }

--- a/tests/cpu/ops/exponent/ExponentOp_tests.cpp
+++ b/tests/cpu/ops/exponent/ExponentOp_tests.cpp
@@ -224,9 +224,6 @@ OCIO_ADD_TEST(ExponentOp, throw_create)
     const double exp1[4] = { 0.0, 1.3, 1.4, 1.5 };
 
     OCIO::OpRcPtrVec ops;
-    OCIO_CHECK_THROW_WHAT(
-        OCIO::CreateExponentOp(ops, exp1, OCIO::TRANSFORM_DIR_UNKNOWN),
-        OCIO::Exception, "unspecified transform direction");
 
     OCIO_CHECK_THROW_WHAT(
         OCIO::CreateExponentOp(ops, exp1, OCIO::TRANSFORM_DIR_INVERSE),

--- a/tests/cpu/ops/log/LogOp_tests.cpp
+++ b/tests/cpu/ops/log/LogOp_tests.cpp
@@ -234,21 +234,6 @@ OCIO_ADD_TEST(LogOp, cache_id)
     OCIO_CHECK_NE(opCacheID0, opCacheID1);
 }
 
-OCIO_ADD_TEST(LogOp, throw_direction)
-{
-    const double base = 10.0;
-    const double logSlope[3] = { 0.18, 0.18, 0.18 };
-    const double linSlope[3] = { 2.0, 2.0, 2.0 };
-    const double linOffset[3] = { 0.1, 0.1, 0.1 };
-    const double logOffset[3] = { 1.0, 1.0, 1.0 };
-
-    OCIO::OpRcPtrVec ops;
-    OCIO_CHECK_THROW_WHAT(OCIO::CreateLogOp(ops, base, logSlope, logOffset,
-                                            linSlope, linOffset,
-                                            OCIO::TRANSFORM_DIR_UNKNOWN),
-                          OCIO::Exception, "unspecified transform direction");
-}
-
 OCIO_ADD_TEST(LogOp, create_transform)
 {
     OCIO::TransformDirection direction = OCIO::TRANSFORM_DIR_FORWARD;

--- a/tests/cpu/ops/lut3d/Lut3DOp_tests.cpp
+++ b/tests/cpu/ops/lut3d/Lut3DOp_tests.cpp
@@ -147,12 +147,6 @@ OCIO_ADD_TEST(Lut3DOpData, create_op)
     // Inverse is fine.
     OCIO_CHECK_NO_THROW(ops.validate());
     OCIO_CHECK_NO_THROW(ops.finalize(OCIO::OPTIMIZATION_NONE));
-    ops.clear();
-
-    // Only valid direction.
-    OCIO_CHECK_THROW_WHAT(CreateLut3DOp(ops, lut, OCIO::TRANSFORM_DIR_UNKNOWN),
-                          OCIO::Exception,
-                          "unspecified transform direction");
 }
 
 OCIO_ADD_TEST(Lut3DOp, cache_id)

--- a/tests/cpu/ops/matrix/MatrixOp_tests.cpp
+++ b/tests/cpu/ops/matrix/MatrixOp_tests.cpp
@@ -617,24 +617,6 @@ OCIO_ADD_TEST(MatrixOffsetOp, combining)
 OCIO_ADD_TEST(MatrixOffsetOp, throw_create)
 {
     OCIO::OpRcPtrVec ops;
-    const double scale[] = { 1.1, 1.3, 0.3, 1.0 };
-    OCIO_CHECK_THROW_WHAT(
-        OCIO::CreateScaleOp(ops, scale, OCIO::TRANSFORM_DIR_UNKNOWN),
-        OCIO::Exception, "unspecified transform direction");
-
-    const double offset[] = { 1.1, -1.3, 0.3, 0.0 };
-    OCIO_CHECK_THROW_WHAT(
-        OCIO::CreateOffsetOp(ops, offset, OCIO::TRANSFORM_DIR_UNKNOWN),
-        OCIO::Exception, "unspecified transform direction");
-
-    const double matrix[16] = { 1.1, 0.2, 0.3, 0.4,
-                                0.5, 1.6, 0.7, 0.8,
-                                0.2, 0.1, 1.1, 0.2,
-                                0.3, 0.4, 0.5, 1.6 };
-
-    OCIO_CHECK_THROW_WHAT(
-        OCIO::CreateMatrixOp(ops, matrix, OCIO::TRANSFORM_DIR_UNKNOWN),
-        OCIO::Exception, "unspecified transform direction");
 
     // FitOp can't be created when old min and max are equal.
     const double oldmin4[4] = { 1.0, 0.0, 0.0,  0.0 };

--- a/tests/cpu/transforms/ColorSpaceTransform_tests.cpp
+++ b/tests/cpu/transforms/ColorSpaceTransform_tests.cpp
@@ -50,9 +50,6 @@ OCIO_ADD_TEST(ColorSpaceTransform, basic)
     OCIO_CHECK_THROW_WHAT(cst->validate(), OCIO::Exception,
                           "ColorSpaceTransform: empty destination color space name");
     cst->setDst(dst.c_str());
-
-    cst->setDirection(OCIO::TRANSFORM_DIR_UNKNOWN);
-    OCIO_CHECK_THROW_WHAT(cst->validate(), OCIO::Exception, "invalid direction");
 }
 
 OCIO_ADD_TEST(ColorSpaceTransform, build_colorspace_ops)

--- a/tests/cpu/transforms/DisplayViewTransform_tests.cpp
+++ b/tests/cpu/transforms/DisplayViewTransform_tests.cpp
@@ -46,8 +46,6 @@ OCIO_ADD_TEST(DisplayViewTransform, basic)
 
     OCIO_CHECK_NO_THROW(dt->validate());
 
-    dt->setDirection(OCIO::TRANSFORM_DIR_UNKNOWN);
-    OCIO_CHECK_THROW_WHAT(dt->validate(), OCIO::Exception, "invalid direction");
     dt->setDirection(OCIO::TRANSFORM_DIR_INVERSE);
     OCIO_CHECK_EQUAL(dt->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
 

--- a/tests/cpu/transforms/GradingPrimaryTransform_tests.cpp
+++ b/tests/cpu/transforms/GradingPrimaryTransform_tests.cpp
@@ -393,7 +393,8 @@ OCIO_ADD_TEST(GradingPrimaryTransform, serialization)
         std::ostringstream oss;
         oss << *grp;
 
-        std::string GROUP_STR("<GroupTransform direction=forward, transforms=\n\t");
+        std::string GROUP_STR("<GroupTransform direction=forward, transforms=\n");
+        GROUP_STR += "        ";
         GROUP_STR += PRIMARY_STR;
         GROUP_STR += ">";
 

--- a/tests/cpu/transforms/GradingRGBCurveTransform_tests.cpp
+++ b/tests/cpu/transforms/GradingRGBCurveTransform_tests.cpp
@@ -284,7 +284,8 @@ OCIO_ADD_TEST(GradingRGBCurveTransform, serialization)
         std::ostringstream oss;
         oss << *grp;
 
-        std::string GROUP_STR("<GroupTransform direction=forward, transforms=\n\t");
+        std::string GROUP_STR("<GroupTransform direction=forward, transforms=\n");
+        GROUP_STR += "        ";
         GROUP_STR += CURVE_STR;
         GROUP_STR += ">";
 

--- a/tests/cpu/transforms/GradingToneTransform_tests.cpp
+++ b/tests/cpu/transforms/GradingToneTransform_tests.cpp
@@ -84,7 +84,8 @@ OCIO_ADD_TEST(GradingToneTransform, serialization)
         std::ostringstream oss;
         oss << *grp;
 
-        std::string GROUP_STR("<GroupTransform direction=forward, transforms=\n\t");
+        std::string GROUP_STR("<GroupTransform direction=forward, transforms=\n");
+        GROUP_STR += "        ";
         GROUP_STR += TONE_STR;
         GROUP_STR += ">";
 

--- a/tests/python/AllocationTransformTest.py
+++ b/tests/python/AllocationTransformTest.py
@@ -50,10 +50,8 @@ class AllocationTransformTest(unittest.TestCase):
                          OCIO.TRANSFORM_DIR_FORWARD)
 
         for direction in OCIO.TransformDirection.__members__.values():
-            # Setting the unknown direction preserves the current direction.
-            if direction != OCIO.TRANSFORM_DIR_UNKNOWN:
-                self.allo_tr.setDirection(direction)
-                self.assertEqual(self.allo_tr.getDirection(), direction)
+            self.allo_tr.setDirection(direction)
+            self.assertEqual(self.allo_tr.getDirection(), direction)
 
         # Wrong type tests.
         for invalid in (None, 1):

--- a/tests/python/BuiltinTransformTest.py
+++ b/tests/python/BuiltinTransformTest.py
@@ -59,16 +59,9 @@ class BuiltinTransformTest(unittest.TestCase):
     def test_direction(self):
         # All transform directions are supported
         for direction in OCIO.TransformDirection.__members__.values():
-            self.builtin_tr.setDirection(direction)
+            # Does not raise
+            self.assertIsNone(self.builtin_tr.setDirection(direction))
             self.assertEqual(self.builtin_tr.getDirection(), direction)
-
-            if direction != OCIO.TRANSFORM_DIR_UNKNOWN:
-                # Does not raise
-                self.assertIsNone(self.builtin_tr.validate())
-            else:
-                # TRANSFORM_DIR_UNKNOWN raises OCIO Exception
-                with self.assertRaises(OCIO.Exception):
-                    self.builtin_tr.validate()
 
     def test_constructor_keyword(self):
         # Keyword args in order

--- a/tests/python/CDLTransformTest.py
+++ b/tests/python/CDLTransformTest.py
@@ -160,10 +160,8 @@ class CDLTransformTest(unittest.TestCase):
         self.assertEqual(self.cdl_tr.getDirection(), OCIO.TRANSFORM_DIR_FORWARD)
 
         for direction in OCIO.TransformDirection.__members__.values():
-            # Setting the unknown direction preserves the current direction.
-            if direction != OCIO.TRANSFORM_DIR_UNKNOWN:
-                self.cdl_tr.setDirection(direction)
-                self.assertEqual(self.cdl_tr.getDirection(), direction)
+            self.cdl_tr.setDirection(direction)
+            self.assertEqual(self.cdl_tr.getDirection(), direction)
 
     def test_style(self):
         """
@@ -299,11 +297,6 @@ class CDLTransformTest(unittest.TestCase):
         """
 
         self.cdl_tr.setDirection(OCIO.TRANSFORM_DIR_FORWARD)
-        self.assertIsNone(self.cdl_tr.validate())
-
-        # As the CDL Transform does not support the unknown direction,
-        # it preserves the original direction.
-        self.cdl_tr.setDirection(OCIO.TRANSFORM_DIR_UNKNOWN)
         self.assertIsNone(self.cdl_tr.validate())
 
     def test_equality(self):

--- a/tests/python/ColorSpaceTest.py
+++ b/tests/python/ColorSpaceTest.py
@@ -302,18 +302,7 @@ class ColorSpaceTest(unittest.TestCase):
 
         # Known constants tests
         for i, direction in enumerate(OCIO.ColorSpaceDirection.__members__.values()):
-            if direction == OCIO.COLORSPACE_DIR_UNKNOWN:
-                with self.assertRaises(OCIO.Exception):
-                    self.colorspace.setTransform(self.log_tr, direction)
-            else:
-                self.colorspace.setTransform(self.log_tr, direction)
-
-            if direction == OCIO.COLORSPACE_DIR_UNKNOWN:
-                with self.assertRaises(OCIO.Exception):
-                    log_transform = self.colorspace.getTransform(
-                        direction)
-            else:
-                log_transform = self.colorspace.getTransform(direction)
-                self.assertIsInstance(log_transform, OCIO.LogTransform)
-                self.assertEquals(self.log_tr.getBase(),
-                                  log_transform.getBase())
+            self.colorspace.setTransform(self.log_tr, direction)
+            log_transform = self.colorspace.getTransform(direction)
+            self.assertIsInstance(log_transform, OCIO.LogTransform)
+            self.assertEquals(self.log_tr.getBase(), log_transform.getBase())

--- a/tests/python/ColorSpaceTransformTest.py
+++ b/tests/python/ColorSpaceTransformTest.py
@@ -68,10 +68,8 @@ class ColorSpaceTransformTest(unittest.TestCase):
                          OCIO.TRANSFORM_DIR_FORWARD)
 
         for direction in OCIO.TransformDirection.__members__.values():
-            # Setting the unknown direction preserves the current direction.
-            if direction != OCIO.TRANSFORM_DIR_UNKNOWN:
-                self.cs_tr.setDirection(direction)
-                self.assertEqual(self.cs_tr.getDirection(), direction)
+            self.cs_tr.setDirection(direction)
+            self.assertEqual(self.cs_tr.getDirection(), direction)
 
         # Wrong type tests.
         for invalid in (None, 1):

--- a/tests/python/ConstantsTest.py
+++ b/tests/python/ConstantsTest.py
@@ -16,18 +16,14 @@ class ConstantsTest(unittest.TestCase):
         self.assertEqual(OCIO.LOGGING_LEVEL_UNKNOWN, "unknown")
 
         # TransformDirection
-        self.assertEqual(OCIO.TRANSFORM_DIR_UNKNOWN, "unknown")
         self.assertEqual(OCIO.TRANSFORM_DIR_FORWARD, "forward")
         self.assertEqual(OCIO.TRANSFORM_DIR_INVERSE, "inverse")
-        self.assertEqual(OCIO.GetInverseTransformDirection(OCIO.TRANSFORM_DIR_UNKNOWN),
-            OCIO.TRANSFORM_DIR_UNKNOWN)
         self.assertEqual(OCIO.GetInverseTransformDirection(OCIO.TRANSFORM_DIR_FORWARD),
             OCIO.TRANSFORM_DIR_INVERSE)
         self.assertEqual(OCIO.GetInverseTransformDirection(OCIO.TRANSFORM_DIR_INVERSE),
             OCIO.TRANSFORM_DIR_FORWARD)
 
         # ColorSpaceDirection
-        self.assertEqual(OCIO.COLORSPACE_DIR_UNKNOWN, "unknown")
         self.assertEqual(OCIO.COLORSPACE_DIR_TO_REFERENCE, "to_reference")
         self.assertEqual(OCIO.COLORSPACE_DIR_FROM_REFERENCE, "from_reference")
 

--- a/tests/python/DisplayViewTransformTest.py
+++ b/tests/python/DisplayViewTransformTest.py
@@ -104,10 +104,8 @@ class DisplayViewTransformTest(unittest.TestCase):
         self.assertEqual(OCIO.TRANSFORM_DIR_FORWARD, self.dv_tr.getDirection())
 
         for direction in OCIO.TransformDirection.__members__.values():
-            # Setting the unknown direction preserves the current direction.
-            if direction != OCIO.TRANSFORM_DIR_UNKNOWN:
-                self.dv_tr.setDirection(direction)
-                self.assertEqual(direction, self.dv_tr.getDirection())
+            self.dv_tr.setDirection(direction)
+            self.assertEqual(direction, self.dv_tr.getDirection())
 
     def test_validate_src(self):
         """
@@ -167,11 +165,7 @@ class DisplayViewTransformTest(unittest.TestCase):
 
         for direction in OCIO.TransformDirection.__members__.values():
             self.dv_tr.setDirection(direction)
-            if direction != OCIO.TRANSFORM_DIR_UNKNOWN:
-                self.assertIsNone(self.dv_tr.validate())
-            else:
-                with self.assertRaises(OCIO.Exception):
-                   self.dv_tr.validate()
+            self.assertIsNone(self.dv_tr.validate())
 
     def test_constructor_with_keyword(self):
         """

--- a/tests/python/ExponentTransformTest.py
+++ b/tests/python/ExponentTransformTest.py
@@ -34,10 +34,8 @@ class ExponentTransformTest(unittest.TestCase):
                          OCIO.TRANSFORM_DIR_FORWARD)
 
         for direction in OCIO.TransformDirection.__members__.values():
-            # Setting the unknown direction preserves the current direction.
-            if direction != OCIO.TRANSFORM_DIR_UNKNOWN:
-                self.exp_tr.setDirection(direction)
-                self.assertEqual(self.exp_tr.getDirection(), direction)
+            self.exp_tr.setDirection(direction)
+            self.assertEqual(self.exp_tr.getDirection(), direction)
 
         # Wrong type tests.
         for invalid in (None, 1, 'test'):

--- a/tests/python/ExponentWithLinearTransformTest.py
+++ b/tests/python/ExponentWithLinearTransformTest.py
@@ -35,10 +35,8 @@ class ExponentWithLinearTransformTest(unittest.TestCase):
                          OCIO.TRANSFORM_DIR_FORWARD)
 
         for direction in OCIO.TransformDirection.__members__.values():
-            # Setting the unknown direction preserves the current direction.
-            if direction != OCIO.TRANSFORM_DIR_UNKNOWN:
-                self.exp_tr.setDirection(direction)
-                self.assertEqual(self.exp_tr.getDirection(), direction)
+            self.exp_tr.setDirection(direction)
+            self.assertEqual(self.exp_tr.getDirection(), direction)
 
         # Wrong type tests.
         for invalid in (None, 1, 'test'):

--- a/tests/python/ExposureContrastTransformTest.py
+++ b/tests/python/ExposureContrastTransformTest.py
@@ -197,11 +197,6 @@ class ExposureContrastTransformTest(unittest.TestCase):
         self.exp_tr.setDirection(OCIO.TRANSFORM_DIR_FORWARD)
         self.assertIsNone(self.exp_tr.validate())
 
-        # As the Exposure Contrast Transform does not support the unknown
-        # direction, it preserves the original direction.
-        self.exp_tr.setDirection(OCIO.TRANSFORM_DIR_UNKNOWN)
-        self.assertIsNone(self.exp_tr.validate())
-
     def test_constructor_with_keywords(self):
         """
         Test ExposureContrastTransform constructor with keywords and validate its values.

--- a/tests/python/FileTransformTest.py
+++ b/tests/python/FileTransformTest.py
@@ -95,10 +95,8 @@ class FileTransformTest(unittest.TestCase):
                          OCIO.TRANSFORM_DIR_FORWARD)
 
         for direction in OCIO.TransformDirection.__members__.values():
-            # Setting the unknown direction preserves the current direction.
-            if direction != OCIO.TRANSFORM_DIR_UNKNOWN:
-                self.file_tr.setDirection(direction)
-                self.assertEqual(self.file_tr.getDirection(), direction)
+            self.file_tr.setDirection(direction)
+            self.assertEqual(self.file_tr.getDirection(), direction)
 
         # Wrong type tests.
         for invalid in (None, 1):

--- a/tests/python/FixedFunctionTransformTest.py
+++ b/tests/python/FixedFunctionTransformTest.py
@@ -33,10 +33,8 @@ class FixedFunctionTransformTest(unittest.TestCase):
                          OCIO.TRANSFORM_DIR_FORWARD)
 
         for direction in OCIO.TransformDirection.__members__.values():
-            # Setting the unknown direction preserves the current direction.
-            if direction != OCIO.TRANSFORM_DIR_UNKNOWN:
-                self.fixed_func_tr.setDirection(direction)
-                self.assertEqual(self.fixed_func_tr.getDirection(), direction)
+            self.fixed_func_tr.setDirection(direction)
+            self.assertEqual(self.fixed_func_tr.getDirection(), direction)
 
         # Wrong type tests.
         for invalid in (None, 1, 'test'):

--- a/tests/python/GroupTransformTest.py
+++ b/tests/python/GroupTransformTest.py
@@ -81,10 +81,8 @@ class GroupTransformTest(unittest.TestCase):
                          OCIO.TRANSFORM_DIR_FORWARD)
 
         for direction in OCIO.TransformDirection.__members__.values():
-            # Setting the unknown direction preserves the current direction.
-            if direction != OCIO.TRANSFORM_DIR_UNKNOWN:
-                self.group_tr.setDirection(direction)
-                self.assertEqual(self.group_tr.getDirection(), direction)
+            self.group_tr.setDirection(direction)
+            self.assertEqual(self.group_tr.getDirection(), direction)
 
         # Wrong type tests.
         for invalid in (None, 1, 'test'):

--- a/tests/python/LogTransformTest.py
+++ b/tests/python/LogTransformTest.py
@@ -49,10 +49,8 @@ class LogTransformTest(unittest.TestCase):
                          OCIO.TRANSFORM_DIR_FORWARD)
 
         for direction in OCIO.TransformDirection.__members__.values():
-            # Setting the unknown direction preserves the current direction.
-            if direction != OCIO.TRANSFORM_DIR_UNKNOWN:
-                self.log_tr.setDirection(direction)
-                self.assertEqual(self.log_tr.getDirection(), direction)
+            self.log_tr.setDirection(direction)
+            self.assertEqual(self.log_tr.getDirection(), direction)
 
         # Wrong type tests.
         for invalid in (None, 1, 'test'):

--- a/tests/python/TransformsTest.py
+++ b/tests/python/TransformsTest.py
@@ -41,8 +41,6 @@ class TransformsTest(unittest.TestCase):
 
         ### Base Transform method tests ###
         self.assertEqual(OCIO.TRANSFORM_DIR_FORWARD, at.getDirection())
-        at.setDirection(OCIO.TRANSFORM_DIR_UNKNOWN)
-        self.assertEqual(OCIO.TRANSFORM_DIR_UNKNOWN, at.getDirection())
 
         ### CDLTransform ###
         cdl = OCIO.CDLTransform()


### PR DESCRIPTION
Implementation for issue #1175
Also adjust operator<< for objects that can have 2 transforms so that they use the same format.

Signed-off-by: Bernard Lefebvre <bernard.lefebvre@autodesk.com>