### PR TITLE
Adsk Contrib - Add operator<< for FormatMetadata

### DIFF
--- a/include/OpenColorIO/OpenColorTransforms.h
+++ b/include/OpenColorIO/OpenColorTransforms.h
@@ -59,25 +59,36 @@ public:
     virtual void addAttribute(const char * name, const char * value) = 0;
 
     virtual int getNumChildrenElements() const = 0;
+    /**
+     * Access a child element.
+     *
+     * \note
+     *    Adding siblings might cause a reallocation of the container and thus might make the
+     *    reference unusable.
+     *    Index i has to be positive and less than getNumChildrenElements() or the function will
+     *    throw.
+     */
     virtual const FormatMetadata & getChildElement(int i) const = 0;
     virtual FormatMetadata & getChildElement(int i) = 0;
 
     /**
-     * Add a child element with a given name and value. Name has to be
+     * Add a child element after the last child with a given name and value. Name has to be
      * non-empty. Value may be empty, particularly if this element will have children.
-     * Return a reference to the added element.
+     * Use getChildElement(getNumChildrenElements()-1) to access the added element.
      */
-    virtual FormatMetadata & addChildElement(const char * name, const char * value) = 0;
+    virtual void addChildElement(const char * name, const char * value) = 0;
 
     virtual void clear() = 0;
     virtual FormatMetadata & operator=(const FormatMetadata & rhs) = 0;
 
     FormatMetadata(const FormatMetadata & rhs) = delete;
-    virtual ~FormatMetadata();
+    virtual ~FormatMetadata() = default;
 
 protected:
-    FormatMetadata();
+    FormatMetadata() = default;
 };
+
+extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const FormatMetadata &);
 
 
 /// Base class for all the transform classes

--- a/src/OpenColorIO/fileformats/FormatMetadata.cpp
+++ b/src/OpenColorIO/fileformats/FormatMetadata.cpp
@@ -22,12 +22,32 @@ const char * METADATA_OUTPUT_DESCRIPTOR = "OutputDescriptor";
 const char * METADATA_NAME = "name";
 const char * METADATA_ID = "id";
 
-FormatMetadata::FormatMetadata()
-{
-}
 
-FormatMetadata::~FormatMetadata()
+std::ostream & operator<< (std::ostream & os, const FormatMetadata & fd)
 {
+    const std::string name{ fd.getName() };
+    os << "<" << name;
+    const int numAtt = fd.getNumAttributes();
+    if (numAtt)
+    {
+        for (int i = 0; i < numAtt; ++i)
+        {
+            os << " " << fd.getAttributeName(i) << "=\"" << fd.getAttributeValue(i) << "\"";
+        }
+    }
+    os << ">";
+    const std::string val{ fd.getValue() };
+    if (!val.empty())
+    {
+        os << val;
+    }
+    const int numElt = fd.getNumChildrenElements();
+    for (int i = 0; i < numElt; ++i)
+    {
+        os << fd.getChildElement(i);
+    }
+    os << "</" << name << ">";
+    return os;
 }
 
 FormatMetadataImpl::FormatMetadataImpl()
@@ -72,12 +92,20 @@ void FormatMetadataImpl::setName(const std::string & name)
     {
         throw Exception("FormatMetadata has to have a non-empty name.");
     }
+    if (name == METADATA_ROOT)
+    {
+        throw Exception("FormatMetadata 'ROOT' can't be renamed.");
 
+    }
     m_name = name;
 }
 
 void FormatMetadataImpl::setValue(const std::string & value)
 {
+    if (m_name == METADATA_ROOT)
+    {
+        throw Exception("FormatMetadata 'ROOT' can't have a value.");
+    }
     m_value = value;
 }
 
@@ -314,10 +342,9 @@ const FormatMetadata & FormatMetadataImpl::getChildElement(int i) const
     throw Exception("Invalid index for metadata object.");
 }
 
-FormatMetadata & FormatMetadataImpl::addChildElement(const char * name, const char * value)
+void FormatMetadataImpl::addChildElement(const char * name, const char * value)
 {
     m_elements.emplace_back(name, value);
-    return m_elements.back();
 }
 
 void FormatMetadataImpl::clear()

--- a/src/OpenColorIO/fileformats/FormatMetadata.h
+++ b/src/OpenColorIO/fileformats/FormatMetadata.h
@@ -88,7 +88,7 @@ public:
     int getNumChildrenElements() const override;
     FormatMetadata & getChildElement(int i) override;
     const FormatMetadata & getChildElement(int i) const override;
-    FormatMetadata & addChildElement(const char * name, const char * value) override;
+    void addChildElement(const char * name, const char * value) override;
 
     // Reset the contents of a metadata element. The value,
     // list of attributes and sub-elements are cleared.

--- a/src/bindings/python/PyFormatMetadata.cpp
+++ b/src/bindings/python/PyFormatMetadata.cpp
@@ -50,7 +50,7 @@ void bindPyFormatMetadata(py::module & m)
                 throw py::key_error(os.str());
             },
              "name"_a)
-        .def("__setitem__", &FormatMetadata::addAttribute, "name"_a, "value"_a)
+        .def("__setitem__", &FormatMetadata::addAttribute, "name"_a.none(false), "value"_a.none(false))
         .def("__contains__", [](const FormatMetadata & self, const std::string & name) -> bool
             {
                 for (int i = 0; i < self.getNumAttributes(); i++)
@@ -72,16 +72,16 @@ void bindPyFormatMetadata(py::module & m)
             })
 
         .def("getName", &FormatMetadata::getName)
-        .def("setName", &FormatMetadata::setName, "name"_a)
+        .def("setName", &FormatMetadata::setName, "name"_a.none(false))
         .def("getValue", &FormatMetadata::getValue)
-        .def("setValue", &FormatMetadata::setValue, "value"_a)
+        .def("setValue", &FormatMetadata::setValue, "value"_a.none(false))
         .def("getAttributes", [](const FormatMetadata & self) { return AttributeIterator(self); })
         .def("getChildElements", [](const FormatMetadata & self)
             {
                 return ConstChildElementIterator(self);
             })
         .def("getChildElements", [](FormatMetadata & self) { return ChildElementIterator(self); })
-        .def("addChildElement", &FormatMetadata::addChildElement, "name"_a, "value"_a)
+        .def("addChildElement", &FormatMetadata::addChildElement, "name"_a.none(false), "value"_a.none(false))
         .def("clear", &FormatMetadata::clear);
 
     py::class_<AttributeNameIterator>(cls, "AttributeNameIterator")

--- a/src/bindings/python/PyFormatMetadata.cpp
+++ b/src/bindings/python/PyFormatMetadata.cpp
@@ -81,11 +81,7 @@ void bindPyFormatMetadata(py::module & m)
                 return ConstChildElementIterator(self);
             })
         .def("getChildElements", [](FormatMetadata & self) { return ChildElementIterator(self); })
-        .def("addChildElement",
-            [](FormatMetadata & self, const std::string & name, const std::string & value) -> void
-            {
-                self.addChildElement(name.c_str(), value.c_str());
-            }, "name"_a, "value"_a)
+        .def("addChildElement", &FormatMetadata::addChildElement, "name"_a, "value"_a)
         .def("clear", &FormatMetadata::clear);
 
     py::class_<AttributeNameIterator>(cls, "AttributeNameIterator")

--- a/src/bindings/python/PyFormatMetadata.cpp
+++ b/src/bindings/python/PyFormatMetadata.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <sstream>
+
 #include "PyOpenColorIO.h"
 #include "PyUtils.h"
 
@@ -62,6 +64,12 @@ void bindPyFormatMetadata(py::module & m)
                 return false;
             },
              "name"_a)
+        .def("__repr__", [](const FormatMetadata & self)
+            {
+                std::ostringstream oss;
+                oss << self;
+                return oss.str();
+            })
 
         .def("getName", &FormatMetadata::getName)
         .def("setName", &FormatMetadata::setName, "name"_a)
@@ -73,7 +81,11 @@ void bindPyFormatMetadata(py::module & m)
                 return ConstChildElementIterator(self);
             })
         .def("getChildElements", [](FormatMetadata & self) { return ChildElementIterator(self); })
-        .def("addChildElement", &FormatMetadata::addChildElement, "name"_a, "value"_a)
+        .def("addChildElement",
+            [](FormatMetadata & self, const std::string & name, const std::string & value) -> void
+            {
+                self.addChildElement(name.c_str(), value.c_str());
+            }, "name"_a, "value"_a)
         .def("clear", &FormatMetadata::clear);
 
     py::class_<AttributeNameIterator>(cls, "AttributeNameIterator")

--- a/tests/cpu/fileformats/FileFormatCTF_tests.cpp
+++ b/tests/cpu/fileformats/FileFormatCTF_tests.cpp
@@ -4626,7 +4626,9 @@ OCIO_ADD_TEST(CTFTransform, load_edit_save_matrix)
     group->getFormatMetadata().addAttribute(OCIO::ATTR_INVERSE_OF, "added inverseOf");
     group->getFormatMetadata().addAttribute("Unknown", "not saved");
     group->getFormatMetadata().addChildElement("Unknown", "not saved");
-    auto & info = group->getFormatMetadata().addChildElement(OCIO::METADATA_INFO, "Preserved");
+    group->getFormatMetadata().addChildElement(OCIO::METADATA_INFO, "Preserved");
+    const auto indexInfo = group->getFormatMetadata().getNumChildrenElements() - 1;
+    auto & info = group->getFormatMetadata().getChildElement(indexInfo);
     info.addAttribute("attrib", "value");
     info.addChildElement("Child", "Preserved");
 
@@ -4639,7 +4641,9 @@ OCIO_ADD_TEST(CTFTransform, load_edit_save_matrix)
     const std::string shortName{ R"(A ' short ' " name)" };
     const std::string description1{ R"(A " short " description with a ' inside)" };
     const std::string description2{ R"(<test"'&>)" };
-    auto & desc = matTrans->getFormatMetadata().addChildElement(OCIO::METADATA_DESCRIPTION, description1.c_str());
+    matTrans->getFormatMetadata().addChildElement(OCIO::METADATA_DESCRIPTION, description1.c_str());
+    const auto indexDesc = matTrans->getFormatMetadata().getNumChildrenElements() - 1;
+    auto & desc = matTrans->getFormatMetadata().getChildElement(indexDesc);
     desc.addAttribute("Unknown", "not saved");
     matTrans->getFormatMetadata().addChildElement(OCIO::METADATA_DESCRIPTION, description2.c_str());
 
@@ -5587,19 +5591,25 @@ OCIO_ADD_TEST(CTFTransform, cdl_clf)
 
     group->appendTransform(cdl);
 
-    auto & info = group->getFormatMetadata().addChildElement(OCIO::METADATA_INFO, "");
+    group->getFormatMetadata().addChildElement(OCIO::METADATA_INFO, "");
+    auto & info = group->getFormatMetadata().getChildElement(2);
     info.addChildElement("Release", "2019");
-    auto & sub = info.addChildElement("Directors", "");
-    auto & subSub0 = sub.addChildElement("Director", "");
+    info.addChildElement("Directors", "");
+    auto & sub = info.getChildElement(1);
+    sub.addChildElement("Director", "");
+    auto & subSub0 = sub.getChildElement(0);
     subSub0.addAttribute("FirstName", "David");
     subSub0.addAttribute("LastName", "Cronenberg");
-    auto & subSub1 = sub.addChildElement("Director", "");
+    sub.addChildElement("Director", "");
+    auto & subSub1 = sub.getChildElement(1);
     subSub1.addAttribute("FirstName", "David");
     subSub1.addAttribute("LastName", "Lynch");
-    auto & subSub2 = sub.addChildElement("Director", "");
+    sub.addChildElement("Director", "");
+    auto & subSub2 = sub.getChildElement(2);
     subSub2.addAttribute("FirstName", "David");
     subSub2.addAttribute("LastName", "Fincher");
-    auto & subSub3 = sub.addChildElement("Director", "");
+    sub.addChildElement("Director", "");
+    auto & subSub3 = sub.getChildElement(3);
     subSub3.addAttribute("FirstName", "David");
     subSub3.addAttribute("LastName", "Lean");
 
@@ -8005,7 +8015,8 @@ OCIO_ADD_TEST(FileFormatCTF, bake_3d)
     data.addChildElement(OCIO::METADATA_INPUT_DESCRIPTOR, "Input descriptor");
     data.addChildElement(OCIO::METADATA_INPUT_DESCRIPTOR, "Only first is saved");
     data.addChildElement(OCIO::METADATA_OUTPUT_DESCRIPTOR, "Output descriptor");
-    auto & info = data.addChildElement(OCIO::METADATA_INFO, "");
+    data.addChildElement(OCIO::METADATA_INFO, "");
+    auto & info = data.getChildElement(6);
     info.addAttribute("attrib1", "val1");
     info.addAttribute("attrib2", "val2");
     info.addChildElement("anything", "is saved");

--- a/tests/cpu/fileformats/FormatMetadata_tests.cpp
+++ b/tests/cpu/fileformats/FormatMetadata_tests.cpp
@@ -159,9 +159,10 @@ OCIO_ADD_TEST(FormatMetadataImpl, test_accessors)
     OCIO_CHECK_EQUAL(std::string(info1.getName()), "Release");
     OCIO_CHECK_EQUAL(std::string(info1.getValue()), "2015");
 
-    auto & icInfo = info.addChildElement("InputColorSpace", "" );
+    info.addChildElement("InputColorSpace", "" );
     OCIO_REQUIRE_EQUAL(info.getNumChildrenElements(), 3);
     // 2 elements can have the same name.
+    auto & icInfo = info.getChildElement(2);
     icInfo.addChildElement(OCIO::METADATA_DESCRIPTION, "Input color space description");
     icInfo.addChildElement(OCIO::METADATA_DESCRIPTION, "Other description");
     icInfo.addChildElement("Profile", "Input color space profile");
@@ -182,6 +183,18 @@ OCIO_ADD_TEST(FormatMetadataImpl, test_accessors)
                      "Profile");
     OCIO_CHECK_EQUAL(std::string(icInfo.getChildElement(2).getValue()),
                      "Input color space profile");
+
+    std::ostringstream oss;
+    oss << info;
+    const std::string expectedRes{ "<Info version=\"2.0\">"
+                                   "<Copyright>Copyright 2013 Autodesk</Copyright>"
+                                   "<Release>2015</Release>"
+                                   "<InputColorSpace>"
+                                   "<Description>Input color space description</Description>"
+                                   "<Description>Other description</Description>"
+                                   "<Profile>Input color space profile</Profile>"
+                                   "</InputColorSpace></Info>" };
+    OCIO_CHECK_EQUAL(expectedRes, oss.str());
 }
 
 OCIO_ADD_TEST(FormatMetadataImpl, combine)
@@ -193,7 +206,8 @@ OCIO_ADD_TEST(FormatMetadataImpl, combine)
     OCIO::FormatMetadataImpl root1;
     root1.addAttribute(OCIO::METADATA_NAME, "root1");
     root1.addAttribute(OCIO::METADATA_ID, "ID1");
-    auto & sub1 = root1.addChildElement("test1", "val1");
+    root1.addChildElement("test1", "val1");
+    auto & sub1 = root1.getChildElement(0);
     sub1.addChildElement("sub1-test", "subval");
 
     root0.addAttribute("att0", "attval0");

--- a/tests/cpu/ops/gamma/GammaOp_tests.cpp
+++ b/tests/cpu/ops/gamma/GammaOp_tests.cpp
@@ -30,7 +30,8 @@ OCIO_ADD_TEST(GammaOp, combining)
     info1.addAttribute(OCIO::METADATA_ID, "ID1");
     info1.addAttribute("Attrib", "1");
     info1.addAttribute("Attrib1", "10");
-    auto & child1 = info1.addChildElement("Gamma1Child", "Some content");
+    info1.addChildElement("Gamma1Child", "Some content");
+    auto & child1 = info1.getChildElement(0);
 
     OCIO_CHECK_NO_THROW(OCIO::CreateGammaOp(ops, gammaData1, OCIO::TRANSFORM_DIR_FORWARD));
 
@@ -48,7 +49,8 @@ OCIO_ADD_TEST(GammaOp, combining)
     info2.addAttribute(OCIO::METADATA_ID, "ID2");
     info2.addAttribute("Attrib", "2");
     info2.addAttribute("Attrib2", "20");
-    auto & child2 = info2.addChildElement("Gamma2Child", "Other content");
+    info2.addChildElement("Gamma2Child", "Other content");
+    auto & child2 = info2.getChildElement(0);
 
     OCIO_CHECK_NO_THROW(OCIO::CreateGammaOp(ops, gammaData2, OCIO::TRANSFORM_DIR_FORWARD));
 

--- a/tests/python/FormatMetadataTest.py
+++ b/tests/python/FormatMetadataTest.py
@@ -122,8 +122,6 @@ class FormatMetadataTest(unittest.TestCase):
             child3.addChildElement('string', 42)
         with self.assertRaises(TypeError):
             child3.addChildElement(42, 'string')
-        with self.assertRaises(TypeError):
-            child3.addChildElement('name', None)
 
     def test_attributes(self):
         """

--- a/tests/python/FormatMetadataTest.py
+++ b/tests/python/FormatMetadataTest.py
@@ -1,0 +1,184 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+import unittest
+import os
+import sys
+
+import PyOpenColorIO as OCIO
+
+class FormatMetadataTest(unittest.TestCase):
+
+    def test_default(self):
+        """
+        Test the default FormatMetadata.
+        """
+
+        # FormatMetadata can not be constructed, it has to be retrieved.
+        # MatrixTransform has a FormatMetadata.
+        mat = OCIO.MatrixTransform()
+        fmd = mat.getFormatMetadata()
+
+        # Default name is ROOT and has no value.
+        self.assertEqual(fmd.getName(), 'ROOT')
+        self.assertEqual(fmd.getValue(), '')
+
+        # No attributes.
+        self.assertEqual(len(list(fmd)), 0)
+
+        # No children.
+        children = fmd.getChildElements()
+        self.assertEqual(len(list(children)), 0)
+
+    def test_children(self):
+        """
+        Test the FormatMetadata children.
+        """
+
+        # Create a hierarchy:
+        # ROOT |- C1-V1 |- C4-V4
+        #      |        |- C5-V5 |- C6-V6
+        #      |- C2
+        #      |- C3-V3
+        mat = OCIO.MatrixTransform()
+        fmd = mat.getFormatMetadata()
+        fmd.addChildElement('C1','V1')
+        fmd.addChildElement('C2', '')
+        fmd.addChildElement('C3','V3')
+        fmdc1 = fmd.getChildElements()[0]
+        fmdc1.addChildElement('C4','V4')
+        fmdc1.addChildElement('C5','V5')
+        fmdc5 = fmdc1.getChildElements()[1]
+        fmdc5.addChildElement('C6','V6')
+
+        # Access children.
+        self.assertEqual(len(list(fmd.getChildElements())), 3)
+
+        children = fmd.getChildElements()
+        child1 = next(children)
+        self.assertEqual(child1.getName(), 'C1')
+        self.assertEqual(child1.getValue(), 'V1')
+        self.assertEqual(len(list(child1.getChildElements())), 2)
+        childrenC1 = child1.getChildElements()
+        child4 = next(childrenC1)
+        self.assertEqual(child4.getName(), 'C4')
+        self.assertEqual(child4.getValue(), 'V4')
+        self.assertEqual(len(list(child4.getChildElements())), 0)
+        child5 = next(childrenC1)
+        self.assertEqual(child5.getName(), 'C5')
+        self.assertEqual(child5.getValue(), 'V5')
+        self.assertEqual(len(list(child5.getChildElements())), 1)
+        try:
+            next(childrenC1)
+        except StopIteration:
+            pass
+        else:
+            raise AssertionError("Child1 should not have other children.")
+
+        childrenC5 = child5.getChildElements()
+        child6 = next(childrenC5)
+        self.assertEqual(child6.getName(), 'C6')
+        self.assertEqual(child6.getValue(), 'V6')
+        self.assertEqual(len(list(child6.getChildElements())), 0)
+        child2 = next(children)
+        self.assertEqual(child2.getName(), 'C2')
+        self.assertEqual(child2.getValue(), '')
+        self.assertEqual(len(list(child2.getChildElements())), 0)
+        child3 = next(children)
+        self.assertEqual(child3.getName(), 'C3')
+        self.assertEqual(child3.getValue(), 'V3')
+        self.assertEqual(len(list(child3.getChildElements())), 0)
+        try:
+            next(children)
+        except StopIteration:
+            pass
+        else:
+            raise AssertionError("FormatMetadata should not have other children.")
+
+        # Test representation.
+        self.assertEqual(str(fmd), '<ROOT><C1>V1<C4>V4</C4><C5>V5<C6>V6</C6></C5></C1><C2></C2><C3>V3</C3></ROOT>')
+
+        # Add a new leaf.
+        child3.addChildElement('C7','V7')
+        self.assertEqual(len(list(child3.getChildElements())), 1)
+
+        # Clear removes children and value, but it preserves the name.
+        child3.clear()
+        self.assertEqual(len(list(child3.getChildElements())), 0)
+        self.assertEqual(child3.getName(), 'C3')
+        self.assertEqual(child3.getValue(), '')
+
+        # FormatMetadata must have a name.
+        with self.assertRaises(OCIO.Exception):
+            child3.addChildElement('','')
+
+        # Children might have the same name.
+        child3.addChildElement('same','')
+        child3.addChildElement('same','')
+        self.assertEqual(len(list(child3.getChildElements())), 2)
+
+        # Test invalid cases. Name and value have to be strings.
+        with self.assertRaises(TypeError):
+            child3.addChildElement('string', 42)
+        with self.assertRaises(TypeError):
+            child3.addChildElement(42, 'string')
+        with self.assertRaises(TypeError):
+            child3.addChildElement('name', None)
+
+    def test_attributes(self):
+        """
+        Test the FormatMetadata attributes.
+        """
+
+        mat = OCIO.MatrixTransform()
+        fmd = mat.getFormatMetadata()
+        fmd.addChildElement('C1','V1')
+        fmdc1 = fmd.getChildElements()[0]
+
+        fmdc1['att1'] = 'val1'
+        fmdc1['att2'] = 'val2'
+        fmdc1['att3'] = 'val3'
+
+        # Verify attributes names.
+        atts = list(fmdc1)
+        self.assertEqual(len(atts), 3)
+        self.assertEqual(atts[0], 'att1')
+        self.assertEqual(atts[1], 'att2')
+        self.assertEqual(atts[2], 'att3')
+
+        # Get attributes.
+        attsIt = fmdc1.getAttributes()
+        att1 = next(attsIt)
+        self.assertEqual(att1[0], 'att1')
+        self.assertEqual(att1[1], 'val1')
+        att2 = next(attsIt)
+        self.assertEqual(att2[0], 'att2')
+        self.assertEqual(att2[1], 'val2')
+        att3 = next(attsIt)
+        self.assertEqual(att3[0], 'att3')
+        self.assertEqual(att3[1], 'val3')
+
+        try:
+            next(attsIt)
+        except StopIteration:
+            pass
+        else:
+            raise AssertionError("FormatMetadata should not have other attributes.")
+
+        # Test representation.
+        self.assertEqual(str(fmd), '<ROOT><C1 att1="val1" att2="val2" att3="val3">V1</C1></ROOT>')
+
+        # Attribute names are unique. Setting a value to an existing attribute is replacing the
+        # existing attribute value.
+        fmdc1['att1'] = 'new val1'
+        atts = list(fmdc1)
+        self.assertEqual(len(atts), 3)
+        attsIt = fmdc1.getAttributes()
+        att1 = next(attsIt)
+        self.assertEqual(att1[0], 'att1')
+        self.assertEqual(att1[1], 'new val1')
+
+        # Clear removes attributes.
+        fmdc1.clear()
+        atts = list(fmdc1)
+        self.assertEqual(len(atts), 0)

--- a/tests/python/FormatMetadataTest.py
+++ b/tests/python/FormatMetadataTest.py
@@ -122,6 +122,8 @@ class FormatMetadataTest(unittest.TestCase):
             child3.addChildElement('string', 42)
         with self.assertRaises(TypeError):
             child3.addChildElement(42, 'string')
+        with self.assertRaises(TypeError):
+            child3.addChildElement('name', None)
 
     def test_attributes(self):
         """

--- a/tests/python/OpenColorIOTestSuite.py
+++ b/tests/python/OpenColorIOTestSuite.py
@@ -45,6 +45,7 @@ import ExponentWithLinearTransformTest
 import ExposureContrastTransformTest
 import FileTransformTest
 import FixedFunctionTransformTest
+import FormatMetadataTest
 import GroupTransformTest
 import LogTransformTest
 import LookTest
@@ -85,6 +86,7 @@ def suite():
     suite.addTest(loader.loadTestsFromModule(ExposureContrastTransformTest))
     suite.addTest(loader.loadTestsFromModule(FileTransformTest))
     suite.addTest(loader.loadTestsFromModule(FixedFunctionTransformTest))
+    suite.addTest(loader.loadTestsFromModule(FormatMetadataTest))
     suite.addTest(loader.loadTestsFromModule(GroupTransformTest))
     suite.addTest(loader.loadTestsFromModule(LogTransformTest))
     suite.addTest(loader.loadTestsFromModule(LookTest))


### PR DESCRIPTION
Add an operator<< for FormatMetadata so that it can be printed out (usefull in pyhton).
Adjust FormatMetadata::addChildElement so that it does not return.
Improve documentation.
Add python test for FormatMetadata.

Signed-off-by: Bernard Lefebvre <bernard.lefebvre@autodesk.com>