### PR TITLE
Adsk Contrib - Description in config files

### DIFF
--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -224,6 +224,53 @@ inline void save(YAML::Emitter& out, Interpolation interp)
     out << InterpolationToString(interp);
 }
 
+inline void loadDescription(const YAML::Node& node, std::string& x)
+{
+    load(node, x);
+    if (!x.empty())
+    {
+        // YAML is changing the trailing newlines when reading them:
+        // - Written as YAML::Literal (starts with a "|"), descriptions will be read back with a
+        //   single newline. One is  added if there was none, only one is kept if there were
+        //   several.
+        // - Written as YAML::Value string (does not start with "|"), all trailing newlines ('\n')
+        //   are preserved.
+        // Trailing newlines are inconsistently preserved, lets remove them in all cases.
+        auto last = x.back();
+        while (last == '\n' && x.length())
+        {
+            x.pop_back();
+            last = x.back();
+        }
+    }
+    // Also, note that a \n is only interpreted as a newline if it is used in a string that is
+    // within double quotes.  E.g., "A string \n with embedded \n newlines."  Indeed, without the
+    // double quotes the backslash is generally not interpreted as an escape character in YAML.
+}
+
+inline void saveDescription(YAML::Emitter & out, const char * desc)
+{
+    if (desc && *desc)
+    {
+        // Remove trailing newlines so that only one is saved because they won't be read back.
+        std::string descStr{ desc };
+        {
+            auto last = descStr.back();
+            while (last == '\n' && descStr.length())
+            {
+                descStr.pop_back();
+                last = descStr.back();
+            }
+        }
+
+        out << YAML::Key << "description" << YAML::Value;
+        if (descStr.find_first_of('\n') != std::string::npos)
+        {
+            out << YAML::Literal;
+        }
+        out << descStr;
+    }
+}
 //
 
 inline void LogUnknownKeyWarning(const YAML::Node & node,
@@ -421,10 +468,7 @@ inline void save(YAML::Emitter& out, const View & view)
     {
         out << YAML::Key << "rule" << YAML::Value << view.m_rule;
     }
-    if (!view.m_description.empty())
-    {
-        out << YAML::Key << "description" << YAML::Value << view.m_description;
-    }
+    saveDescription(out, view.m_description.c_str());
     out << YAML::EndMap;
 }
 
@@ -3271,7 +3315,7 @@ inline void load(const YAML::Node& node, ColorSpaceRcPtr& cs)
         }
         else if(key == "description")
         {
-            load(second, stringval);
+            loadDescription(second, stringval);
             cs->setDescription(stringval.c_str());
         }
         else if(key == "family")
@@ -3381,11 +3425,7 @@ inline void save(YAML::Emitter& out, ConstColorSpaceRcPtr cs)
     out << YAML::Key << "equalitygroup" << YAML::Value << cs->getEqualityGroup();
     out << YAML::Key << "bitdepth" << YAML::Value;
     save(out, cs->getBitDepth());
-    if(cs->getDescription() != NULL && strlen(cs->getDescription()) > 0)
-    {
-        out << YAML::Key << "description";
-        out << YAML::Value << YAML::Literal << cs->getDescription();
-    }
+    saveDescription(out, cs->getDescription());
     out << YAML::Key << "isdata" << YAML::Value << cs->isData();
 
     if(cs->getNumCategories() > 0)
@@ -3479,7 +3519,7 @@ inline void load(const YAML::Node& node, LookRcPtr& look)
         }
         else if(key == "description")
         {
-            load(second, stringval);
+            loadDescription(second, stringval);
             look->setDescription(stringval.c_str());
         }
         else
@@ -3495,13 +3535,7 @@ inline void save(YAML::Emitter& out, ConstLookRcPtr look)
     out << YAML::BeginMap;
     out << YAML::Key << "name" << YAML::Value << look->getName();
     out << YAML::Key << "process_space" << YAML::Value << look->getProcessSpace();
-    if (look->getDescription() != NULL &&
-        strlen(look->getDescription()) > 0)
-    {
-        out << YAML::Key << "description";
-        out << YAML::Value << YAML::Literal << look->getDescription();
-    }
-
+    saveDescription(out, look->getDescription());
 
     if(look->getTransform())
     {
@@ -3608,7 +3642,7 @@ inline void load(const YAML::Node & node, ViewTransformRcPtr & vt)
         }
         else if (key == "description")
         {
-            load(second, stringval);
+            loadDescription(second, stringval);
             vt->setDescription(stringval.c_str());
         }
         else if (key == "family")
@@ -3662,15 +3696,12 @@ inline void save(YAML::Emitter & out, ConstViewTransformRcPtr & vt)
     out << YAML::BeginMap;
 
     out << YAML::Key << "name" << YAML::Value << vt->getName();
-    if (vt->getFamily() != NULL && strlen(vt->getFamily()) > 0)
+    const char * family = vt->getFamily();
+    if (family && *family)
     {
-        out << YAML::Key << "family" << YAML::Value << vt->getFamily();
+        out << YAML::Key << "family" << YAML::Value << family;
     }
-    if (vt->getDescription() != NULL && strlen(vt->getDescription()) > 0)
-    {
-        out << YAML::Key << "description";
-        out << YAML::Value << YAML::Literal << vt->getDescription();
-    }
+    saveDescription(out, vt->getDescription());
 
     if (vt->getNumCategories() > 0)
     {
@@ -4175,7 +4206,7 @@ inline void load(const YAML::Node& node, ConfigRcPtr & config, const char* filen
         }
         else if(key == "description")
         {
-            load(second, stringval);
+            loadDescription(second, stringval);
             config->setDescription(stringval.c_str());
         }
         else if(key == "luma")
@@ -4643,13 +4674,7 @@ inline void save(YAML::Emitter & out, const Config & config)
     config.getDefaultLumaCoefs(&luma[0]);
     out << YAML::Key << "luma" << YAML::Value << YAML::Flow << luma;
 
-    if(config.getDescription() != NULL && strlen(config.getDescription()) > 0)
-    {
-        out << YAML::Newline;
-        out << YAML::Key << "description";
-        out << YAML::Value << config.getDescription();
-        out << YAML::Newline;
-    }
+    saveDescription(out, config.getDescription());
 
     // Roles
     out << YAML::Newline;

--- a/tests/apphelpers/ColorSpaceHelpers_tests.cpp
+++ b/tests/apphelpers/ColorSpaceHelpers_tests.cpp
@@ -54,7 +54,7 @@ OCIO_ADD_TEST(ColorSpaceInfo, read_values)
     OCIO_CHECK_EQUAL(csInfo->getHierarchyLevels()->getString(2), std::string("Acme"));
     OCIO_CHECK_EQUAL(csInfo->getFamily(), std::string(cs->getFamily()));
 
-    OCIO_CHECK_EQUAL(cs->getDescription(), std::string("An input color space.\nFor the Acme camera.\n"));
+    OCIO_CHECK_EQUAL(cs->getDescription(), std::string("An input color space.\nFor the Acme camera."));
     OCIO_REQUIRE_EQUAL(csInfo->getDescriptions()->getNumString(), 2);
     OCIO_CHECK_EQUAL(csInfo->getDescriptions()->getString(0), std::string("An input color space."));
     OCIO_CHECK_EQUAL(csInfo->getDescriptions()->getString(1), std::string("For the Acme camera."));
@@ -155,8 +155,8 @@ OCIO_ADD_TEST(ColorSpaceInfo, change_values)
 
     // Change the description.
 
-    OCIO_CHECK_NO_THROW(cs->setDescription("desc 1\n\n\n desc 2\n"));
-    OCIO_CHECK_EQUAL(cs->getDescription(), std::string("desc 1\n\n\n desc 2\n"));
+    OCIO_CHECK_NO_THROW(cs->setDescription("desc 1\n\n\n desc 2"));
+    OCIO_CHECK_EQUAL(cs->getDescription(), std::string("desc 1\n\n\n desc 2"));
 
     OCIO_CHECK_NO_THROW(csInfo = OCIO::ColorSpaceInfo::Create(cfg, cs));
     OCIO_REQUIRE_EQUAL(csInfo->getDescriptions()->getNumString(), 4);

--- a/tests/cpu/ColorSpace_tests.cpp
+++ b/tests/cpu/ColorSpace_tests.cpp
@@ -101,3 +101,442 @@ OCIO_ADD_TEST(ColorSpace, category)
     OCIO_CHECK_NO_THROW(cs->clearCategories());
     OCIO_CHECK_EQUAL(cs->getNumCategories(), 0);
 }
+
+OCIO_ADD_TEST(Config, color_space_serialize)
+{
+    constexpr char Start[]{ R"(ocio_profile_version: 2
+
+environment:
+  {}
+search_path: ""
+strictparsing: false
+luma: [0.2126, 0.7152, 0.0722]
+
+roles:
+  default: raw
+
+file_rules:
+  - !<Rule> {name: ColorSpaceNamePathSearch}
+  - !<Rule> {name: Default, colorspace: default}
+
+displays:
+  sRGB:
+    - !<View> {name: Raw, colorspace: raw}
+
+active_displays: []
+active_views: []
+
+)" };
+
+    // The raw config.
+    {
+        constexpr char End[]{ R"(colorspaces:
+  - !<ColorSpace>
+    name: raw
+    family: raw
+    equalitygroup: ""
+    bitdepth: 32f
+    description: A raw color space. Conversions to and from this space are no-ops.
+    isdata: true
+    allocation: uniform
+)" };
+        std::string cfgString{ Start };
+        cfgString += End;
+
+        // Load config.
+
+        std::istringstream is;
+        is.str(cfgString);
+        OCIO::ConstConfigRcPtr config;
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_REQUIRE_ASSERT(config);
+        OCIO_CHECK_NO_THROW(config->validate());
+
+        // Check colorspace.
+
+        OCIO_CHECK_EQUAL(config->getNumColorSpaces(), 1);
+        OCIO::ConstColorSpaceRcPtr cs = config->getColorSpace(config->getColorSpaceNameByIndex(0));
+        OCIO_REQUIRE_ASSERT(cs);
+        OCIO_CHECK_EQUAL(cs->getAllocation(), OCIO::ALLOCATION_UNIFORM);
+        OCIO_CHECK_EQUAL(cs->getAllocationNumVars(), 0);
+        OCIO_CHECK_EQUAL(cs->getBitDepth(), OCIO::BIT_DEPTH_F32);
+        OCIO_CHECK_EQUAL(std::string(cs->getDescription()),
+                         "A raw color space. Conversions to and from this space are no-ops.");
+        OCIO_CHECK_EQUAL(std::string(cs->getEncoding()), "");
+        OCIO_CHECK_EQUAL(std::string(cs->getEqualityGroup()), "");
+        OCIO_CHECK_EQUAL(std::string(cs->getFamily()), "raw");
+        OCIO_CHECK_EQUAL(std::string(cs->getName()), "raw");
+        OCIO_CHECK_EQUAL(cs->getNumCategories(), 0);
+        OCIO_CHECK_EQUAL(cs->getReferenceSpaceType(), OCIO::REFERENCE_SPACE_SCENE);
+        OCIO_CHECK_ASSERT(!cs->getTransform(OCIO::COLORSPACE_DIR_TO_REFERENCE));
+        OCIO_CHECK_ASSERT(!cs->getTransform(OCIO::COLORSPACE_DIR_FROM_REFERENCE));
+        OCIO_CHECK_ASSERT(cs->isData());
+
+        // Save and compare output with input.
+
+        std::ostringstream os;
+        os << *config;
+
+        OCIO_CHECK_EQUAL(cfgString, os.str());
+    }
+
+    // Adding a color space that uses all parameters.
+    {
+        constexpr char End[]{ R"(colorspaces:
+  - !<ColorSpace>
+    name: raw
+    family: raw
+    equalitygroup: ""
+    bitdepth: 32f
+    description: A raw color space. Conversions to and from this space are no-ops.
+    isdata: true
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: colorspace
+    family: family
+    equalitygroup: group
+    bitdepth: 16f
+    description: |
+      A raw color space.
+      Second line.
+    isdata: false
+    categories: [one, two]
+    encoding: scene-linear
+    allocation: lg2
+    allocationvars: [0.1, 0.9, 0.15]
+    to_reference: !<LogTransform> {}
+    from_reference: !<LogTransform> {}
+)" };
+        std::string cfgString{ Start };
+        cfgString += End;
+
+        // Load config.
+
+        std::istringstream is;
+        is.str(cfgString);
+        OCIO::ConstConfigRcPtr config;
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_REQUIRE_ASSERT(config);
+        OCIO_CHECK_NO_THROW(config->validate());
+
+        // Check colorspace.
+
+        OCIO_CHECK_EQUAL(config->getNumColorSpaces(), 2);
+        OCIO::ConstColorSpaceRcPtr cs = config->getColorSpace(config->getColorSpaceNameByIndex(1));
+        OCIO_REQUIRE_ASSERT(cs);
+        OCIO_CHECK_EQUAL(cs->getAllocation(), OCIO::ALLOCATION_LG2);
+        OCIO_REQUIRE_EQUAL(cs->getAllocationNumVars(), 3);
+        float vars[3]{ 0.f };
+        cs->getAllocationVars(vars);
+        OCIO_CHECK_EQUAL(vars[0], 0.1f);
+        OCIO_CHECK_EQUAL(vars[1], 0.9f);
+        OCIO_CHECK_EQUAL(vars[2], 0.15f);
+        OCIO_CHECK_EQUAL(cs->getBitDepth(), OCIO::BIT_DEPTH_F16);
+        OCIO_CHECK_EQUAL(std::string(cs->getDescription()),
+                         "A raw color space.\nSecond line.");
+        OCIO_CHECK_EQUAL(std::string(cs->getEncoding()), "scene-linear");
+        OCIO_CHECK_EQUAL(std::string(cs->getEqualityGroup()), "group");
+        OCIO_CHECK_EQUAL(std::string(cs->getFamily()), "family");
+        OCIO_CHECK_EQUAL(std::string(cs->getName()), "colorspace");
+        OCIO_REQUIRE_EQUAL(cs->getNumCategories(), 2);
+        OCIO_CHECK_EQUAL(std::string(cs->getCategory(0)), "one");
+        OCIO_CHECK_EQUAL(std::string(cs->getCategory(1)), "two");
+        OCIO_CHECK_EQUAL(cs->getReferenceSpaceType(), OCIO::REFERENCE_SPACE_SCENE);
+        OCIO_CHECK_ASSERT(cs->getTransform(OCIO::COLORSPACE_DIR_TO_REFERENCE));
+        OCIO_CHECK_ASSERT(cs->getTransform(OCIO::COLORSPACE_DIR_FROM_REFERENCE));
+        OCIO_CHECK_ASSERT(!cs->isData());
+
+        // Save and compare output with input.
+
+        std::ostringstream os;
+        os << *config;
+
+        OCIO_CHECK_EQUAL(cfgString, os.str());
+    }
+
+    // Description trailing newlines are removed.
+    {
+        constexpr char End[]{ R"(colorspaces:
+  - !<ColorSpace>
+    name: raw
+    family: raw
+    equalitygroup: ""
+    bitdepth: 32f
+    description: Some text.
+    isdata: true
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: raw2
+    family: raw
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      One line.
+      
+      Other line.
+    isdata: true
+    allocation: uniform
+)" };
+        std::string cfgString{ Start };
+        cfgString += End;
+
+        // Load config.
+
+        std::istringstream is;
+        is.str(cfgString);
+        OCIO::ConstConfigRcPtr config;
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_REQUIRE_ASSERT(config);
+        OCIO_CHECK_NO_THROW(config->validate());
+
+        // Check colorspace.
+
+        OCIO_CHECK_EQUAL(config->getNumColorSpaces(), 2);
+        OCIO::ConstColorSpaceRcPtr cs = config->getColorSpace(config->getColorSpaceNameByIndex(0));
+        OCIO_REQUIRE_ASSERT(cs);
+        // Description has no trailing \n.
+        OCIO_CHECK_EQUAL(std::string(cs->getDescription()), "Some text.");
+
+        cs = config->getColorSpace(config->getColorSpaceNameByIndex(1));
+        OCIO_REQUIRE_ASSERT(cs);
+        // Description has no trailing \n.
+        OCIO_CHECK_EQUAL(std::string(cs->getDescription()), "One line.\n\nOther line.");
+
+        // Save and compare output with input.
+
+        std::ostringstream os;
+        os << *config;
+
+        OCIO_CHECK_EQUAL(cfgString, os.str());
+
+        // Even if some line feeds are added to the end of description they won't be saved.
+        auto csEdit = cs->createEditableCopy();
+
+        csEdit->setDescription("One line.\n\nOther line.\n");
+
+        auto configEdit = config->createEditableCopy();
+        configEdit->addColorSpace(csEdit);
+
+        os.clear();
+        os.str("");
+        os << *configEdit;
+
+        OCIO_CHECK_EQUAL(cfgString, os.str());
+
+        // Even if several line feeds are added.
+
+        csEdit->setDescription("One line.\n\nOther line.\n\n\n\n");
+        configEdit->addColorSpace(csEdit);
+
+        os.clear();
+        os.str("");
+        os << *configEdit;
+
+        OCIO_CHECK_EQUAL(cfgString, os.str());
+
+        // Single line descriptions are saved on one line and trailing \n are ignored.
+
+        cs = config->getColorSpace(config->getColorSpaceNameByIndex(0));
+        OCIO_REQUIRE_ASSERT(cs);
+        OCIO_CHECK_EQUAL(std::string(cs->getDescription()), "Some text.");
+
+        csEdit = cs->createEditableCopy();
+        csEdit->setDescription("Some text.\n\n\n");
+        configEdit->addColorSpace(csEdit);
+
+        os.clear();
+        os.str("");
+        os << *configEdit;
+
+        OCIO_CHECK_EQUAL(cfgString, os.str());
+    }
+
+    // Test different way of writing description, some are not written as they would be saved.
+    {
+        constexpr char End[]{ R"(colorspaces:
+  - !<ColorSpace>
+    name: raw
+    description: |
+      "Some text."
+
+  - !<ColorSpace>
+    name: raw2
+    description: "Multiple lines\n\nOther line.\n\n\n"
+
+  - !<ColorSpace>
+    name: raw3
+    description: |
+      Test \n backslash+n.
+
+  - !<ColorSpace>
+    name: raw4
+    description: "One"
+
+  - !<ColorSpace>
+    name: raw5
+    description: More "than" one
+
+  - !<ColorSpace>
+    name: raw6
+    description: Other \n test.
+
+  - !<ColorSpace>
+    name: raw7
+    description: Double backslash+n \\n test.
+
+  - !<ColorSpace>
+    name: raw8
+    description: "Double backslash+n \\n in quotes."
+)" };
+        std::string cfgString{ Start };
+        cfgString += End;
+
+        // Load config.
+
+        std::istringstream is;
+        is.str(cfgString);
+        OCIO::ConstConfigRcPtr config;
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_REQUIRE_ASSERT(config);
+        OCIO_CHECK_NO_THROW(config->validate());
+
+        // Check colorspace descriptions.
+
+        OCIO_CHECK_EQUAL(config->getNumColorSpaces(), 8);
+        OCIO::ConstColorSpaceRcPtr cs = config->getColorSpace(config->getColorSpaceNameByIndex(0));
+        OCIO_REQUIRE_ASSERT(cs);
+        // description: |
+        //   "Some text."
+        // A single line comment can be written using the multi-line syntax. Note that surounding
+        // quotes are preserved when multi-line syntax is used.
+        OCIO_CHECK_EQUAL(std::string(cs->getDescription()), "\"Some text.\"");
+
+        cs = config->getColorSpace(config->getColorSpaceNameByIndex(1));
+        OCIO_REQUIRE_ASSERT(cs);
+        // description: "Multiple lines\n\nOther line.\n\n\n"
+        // Multi-lines comment can be written using the single line syntax when "" are used.
+        // Note that trailing newlines are removed.
+        OCIO_CHECK_EQUAL(std::string(cs->getDescription()), "Multiple lines\n\nOther line.");
+
+        cs = config->getColorSpace(config->getColorSpaceNameByIndex(2));
+        OCIO_REQUIRE_ASSERT(cs);
+        // description: |
+        //     Test \n backslash+n.
+        // Without "" \n is just a backslash '\' on a 'n'. Would be written using single line
+        // syntax.
+        OCIO_CHECK_EQUAL(std::string(cs->getDescription()), "Test \\n backslash+n.");
+
+        cs = config->getColorSpace(config->getColorSpaceNameByIndex(3));
+        OCIO_REQUIRE_ASSERT(cs);
+        // description: "One"
+        // Surrounding "" for single line comment are removed.
+        OCIO_CHECK_EQUAL(std::string(cs->getDescription()), "One");
+
+        cs = config->getColorSpace(config->getColorSpaceNameByIndex(4));
+        OCIO_REQUIRE_ASSERT(cs);
+        // description: More "than" one
+        // In between "" are preserved.
+        OCIO_CHECK_EQUAL(std::string(cs->getDescription()), "More \"than\" one");
+
+        cs = config->getColorSpace(config->getColorSpaceNameByIndex(5));
+        OCIO_REQUIRE_ASSERT(cs);
+        // description: Other \n test.
+        OCIO_CHECK_EQUAL(std::string(cs->getDescription()), "Other \\n test.");
+
+        cs = config->getColorSpace(config->getColorSpaceNameByIndex(6));
+        OCIO_REQUIRE_ASSERT(cs);
+        // description: Double backslash+n \\n test.
+        OCIO_CHECK_EQUAL(std::string(cs->getDescription()), "Double backslash+n \\\\n test.");
+
+        cs = config->getColorSpace(config->getColorSpaceNameByIndex(7));
+        OCIO_REQUIRE_ASSERT(cs);
+        // description: "Double backslash+n \\n in quotes."
+        OCIO_CHECK_EQUAL(std::string(cs->getDescription()), "Double backslash+n \\n in quotes.");
+
+        std::ostringstream os;
+        os << *config;
+
+        constexpr char EndRes[]{ R"(colorspaces:
+  - !<ColorSpace>
+    name: raw
+    family: ""
+    equalitygroup: ""
+    bitdepth: unknown
+    description: "\"Some text.\""
+    isdata: false
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: raw2
+    family: ""
+    equalitygroup: ""
+    bitdepth: unknown
+    description: |
+      Multiple lines
+      
+      Other line.
+    isdata: false
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: raw3
+    family: ""
+    equalitygroup: ""
+    bitdepth: unknown
+    description: Test \n backslash+n.
+    isdata: false
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: raw4
+    family: ""
+    equalitygroup: ""
+    bitdepth: unknown
+    description: One
+    isdata: false
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: raw5
+    family: ""
+    equalitygroup: ""
+    bitdepth: unknown
+    description: More "than" one
+    isdata: false
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: raw6
+    family: ""
+    equalitygroup: ""
+    bitdepth: unknown
+    description: Other \n test.
+    isdata: false
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: raw7
+    family: ""
+    equalitygroup: ""
+    bitdepth: unknown
+    description: Double backslash+n \\n test.
+    isdata: false
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: raw8
+    family: ""
+    equalitygroup: ""
+    bitdepth: unknown
+    description: Double backslash+n \n in quotes.
+    isdata: false
+    allocation: uniform
+)" };
+        std::string cfgRes{ Start };
+        cfgRes += EndRes;
+
+        OCIO_CHECK_EQUAL(cfgRes, os.str());
+    }
+}

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -5810,8 +5810,7 @@ OCIO_ADD_TEST(Config, family_separator)
         "    family: raw\n"
         "    equalitygroup: \"\"\n"
         "    bitdepth: 32f\n"
-        "    description: |\n"
-        "      A raw color space. Conversions to and from this space are no-ops.\n"
+        "    description: A raw color space. Conversions to and from this space are no-ops.\n"
         "    isdata: true\n"
         "    allocation: uniform\n";
 

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -4376,8 +4376,7 @@ OCIO_ADD_TEST(Config, add_color_space)
         + u8"    family: \"\"\n"
         + u8"    equalitygroup: \"\"\n"
         + u8"    bitdepth: unknown\n"
-        + u8"    description: |\n"
-        + u8"      é À Â Ç É È ç -- $ € 円 £ 元\n"
+        + u8"    description: é À Â Ç É È ç -- $ € 円 £ 元\n"
         + u8"    isdata: false\n"
         + u8"    allocation: uniform\n"
         + u8"    to_reference: !<FixedFunctionTransform> {style: ACES_RedMod03}\n";
@@ -7270,4 +7269,128 @@ colorspaces:
                           OCIO::Exception,
                           "Display 'virtual_display' has a view 'Raw1' refers to a look, 'look',"
                           " which is not defined.");
+}
+
+OCIO_ADD_TEST(Config, description)
+{
+    auto cfg = OCIO::Config::CreateRaw()->createEditableCopy();
+    std::ostringstream oss;
+    cfg->serialize(oss);
+    static constexpr char CONFIG_NO_DESC[]{ R"(ocio_profile_version: 2
+
+environment:
+  {}
+search_path: ""
+strictparsing: false
+luma: [0.2126, 0.7152, 0.0722]
+
+roles:
+  default: raw
+
+file_rules:
+  - !<Rule> {name: ColorSpaceNamePathSearch}
+  - !<Rule> {name: Default, colorspace: default}
+
+displays:
+  sRGB:
+    - !<View> {name: Raw, colorspace: raw}
+
+active_displays: []
+active_views: []
+
+colorspaces:
+  - !<ColorSpace>
+    name: raw
+    family: raw
+    equalitygroup: ""
+    bitdepth: 32f
+    description: A raw color space. Conversions to and from this space are no-ops.
+    isdata: true
+    allocation: uniform
+)" };
+    OCIO_CHECK_EQUAL(oss.str(), std::string(CONFIG_NO_DESC));
+
+    oss.clear();
+    oss.str("");
+
+    cfg->setDescription("single line description");
+    cfg->serialize(oss);
+    static constexpr char CONFIG_DESC_SINGLELINE[]{ R"(ocio_profile_version: 2
+
+environment:
+  {}
+search_path: ""
+strictparsing: false
+luma: [0.2126, 0.7152, 0.0722]
+description: single line description
+
+roles:
+  default: raw
+
+file_rules:
+  - !<Rule> {name: ColorSpaceNamePathSearch}
+  - !<Rule> {name: Default, colorspace: default}
+
+displays:
+  sRGB:
+    - !<View> {name: Raw, colorspace: raw}
+
+active_displays: []
+active_views: []
+
+colorspaces:
+  - !<ColorSpace>
+    name: raw
+    family: raw
+    equalitygroup: ""
+    bitdepth: 32f
+    description: A raw color space. Conversions to and from this space are no-ops.
+    isdata: true
+    allocation: uniform
+)" };
+    OCIO_CHECK_EQUAL(oss.str(), std::string(CONFIG_DESC_SINGLELINE));
+
+    oss.clear();
+    oss.str("");
+
+    cfg->setDescription("multi line description\n\nother line");
+    cfg->serialize(oss);
+
+    static constexpr char CONFIG_DESC_MULTILINES[]{ R"(ocio_profile_version: 2
+
+environment:
+  {}
+search_path: ""
+strictparsing: false
+luma: [0.2126, 0.7152, 0.0722]
+description: |
+  multi line description
+  
+  other line
+
+roles:
+  default: raw
+
+file_rules:
+  - !<Rule> {name: ColorSpaceNamePathSearch}
+  - !<Rule> {name: Default, colorspace: default}
+
+displays:
+  sRGB:
+    - !<View> {name: Raw, colorspace: raw}
+
+active_displays: []
+active_views: []
+
+colorspaces:
+  - !<ColorSpace>
+    name: raw
+    family: raw
+    equalitygroup: ""
+    bitdepth: 32f
+    description: A raw color space. Conversions to and from this space are no-ops.
+    isdata: true
+    allocation: uniform
+)" };
+    OCIO_CHECK_EQUAL(oss.str(), std::string(CONFIG_DESC_MULTILINES));
 }

--- a/tests/cpu/FileRules_tests.cpp
+++ b/tests/cpu/FileRules_tests.cpp
@@ -235,8 +235,7 @@ colorspaces:
     family: raw
     equalitygroup: ""
     bitdepth: 32f
-    description: |
-      A raw color space. Conversions to and from this space are no-ops.
+    description: A raw color space. Conversions to and from this space are no-ops.
     isdata: true
     allocation: uniform
 )" };

--- a/tests/python/ColorSpaceTest.py
+++ b/tests/python/ColorSpaceTest.py
@@ -131,7 +131,7 @@ class ColorSpaceTest(unittest.TestCase):
         # Test ColorSpace class object getters from config
         cs = cfg.getColorSpace('vd8')
         self.assertEqual(cs.getName(), 'vd8')
-        self.assertEqual(cs.getDescription(), 'how many transforms can we use?\n')
+        self.assertEqual(cs.getDescription(), 'how many transforms can we use?')
         self.assertEqual(cs.getFamily(), 'vd8')
         self.assertEqual(cs.getAllocation(), OCIO.ALLOCATION_UNIFORM)
         self.assertEqual(cs.getAllocationVars(), [])

--- a/tests/python/UnitTestUtils.py
+++ b/tests/python/UnitTestUtils.py
@@ -124,9 +124,7 @@ colorspaces:
     family: raw
     equalitygroup: ""
     bitdepth: 32f
-    description: |
-      A raw color space. Conversions to and from this space are no-ops.
-
+    description: A raw color space. Conversions to and from this space are no-ops.
     isdata: true
     allocation: uniform
 
@@ -140,7 +138,6 @@ colorspaces:
       representation of the scene with primaries that correspond to
       scanned film. 0.18 in this space corresponds to a properly
       exposed 18% grey card.
-
     isdata: false
     allocation: lg2
 
@@ -149,9 +146,7 @@ colorspaces:
     family: vd8
     equalitygroup: ""
     bitdepth: 8ui
-    description: |
-      how many transforms can we use?
-
+    description: how many transforms can we use?
     isdata: false
     allocation: uniform
     to_reference: !<GroupTransform>


### PR DESCRIPTION
Review how description are saved in config file.
Add consistency on how various description fields are saved.
YALM can save string as string (first below) or as literal (second below).
`description: "Sample string.\nSecond line."
description: |
    Sample string.
    Second line.` 

Literal is more readable for multi-line strings but can be a waste of space for single-line strings.
Trailing newlines are not helpful and are not consistently read, so they are all removed.

Signed-off-by: Bernard Lefebvre <bernard.lefebvre@autodesk.com>