### PR TITLE
Restore OCIO_VERSION symbol that downstream clients expect

### DIFF
--- a/include/OpenColorIO/OpenColorABI.h.in
+++ b/include/OpenColorIO/OpenColorABI.h.in
@@ -12,6 +12,9 @@
 #define OCIO_VERSION_STATUS_STR "@OpenColorIO_VERSION_RELEASE_TYPE@"
 #define OCIO_VERSION_FULL_STR   "@OpenColorIO_VERSION@@OpenColorIO_VERSION_RELEASE_TYPE@"
 
+// Deprecated synonym for downstream projects that expect the 1.x name
+#define OCIO_VERSION            "@OpenColorIO_VERSION@"
+
 /* Version as a single 4-byte hex number, e.g. 0x01050200 == 1.5.2
    Use this for numeric comparisons, e.g. #if OCIO_VERSION_HEX >= ... 
    Note: in the case where SOVERSION is overridden at compile-time,


### PR DESCRIPTION
The name was changed to OCIO_VERSION_STR in PR #1167, but that can break
other software that might be looking for that symbol.

Fixes #1186