### PR TITLE
Adsk Contrib - Named color transforms

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -899,6 +899,33 @@ public:
 
     void clearViewTransforms();
 
+    /**
+    * \defgroup Methods related to named transforms.
+    * @{
+    */
+
+    /// Get the named transform from all the named transforms.
+    ConstNamedTransformRcPtr getNamedTransform(const char * name) const noexcept;
+
+    /// Number of named transforms.
+    size_t getNumNamedTransforms() const noexcept;
+
+    /// Name of named transform.
+    const char * getNamedTransformNameByIndex(size_t index) const noexcept;
+
+    /**
+    * \brief Add or replace named transform.
+    *
+    * \note
+    *    Throws if namedTransform is null, name is missing, or no transform is set.
+    */
+    void addNamedTransform(const ConstNamedTransformRcPtr & namedTransform);
+
+    /// Clear all named transforms.
+    void clearNamedTransforms();
+
+    /** @} */
+
     // 
     // File Rules
     //
@@ -1768,6 +1795,60 @@ private:
 };
 
 extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const Look&);
+
+
+/**
+ * \brief NamedTransform.
+ *
+ * A NamedTransform provides a way for config authors to include a set of color
+ * transforms that are independent of the color space being processed.  For example a "utility
+ * curve" transform where there is no need to convert to or from a reference space.
+ */
+
+class OCIOEXPORT NamedTransform
+{
+public:
+    static NamedTransformRcPtr Create();
+
+    virtual NamedTransformRcPtr createEditableCopy() const = 0;
+
+    virtual const char * getName() const noexcept = 0;
+    virtual void setName(const char * name) noexcept = 0;
+
+    /// \see ColorSpace::getFamily
+    virtual const char * getFamily() const noexcept = 0;
+    /// \see ColorSpace::setFamily
+    virtual void setFamily(const char * family) noexcept = 0;
+
+    virtual const char * getDescription() const noexcept = 0;
+    virtual void setDescription(const char * description) noexcept = 0;
+
+    /// \see ColorSpace::hasCategory
+    virtual bool hasCategory(const char * category) const noexcept = 0;
+    /// \see ColorSpace::addCategory
+    virtual void addCategory(const char * category) noexcept = 0;
+    /// \see ColorSpace::removeCategory
+    virtual void removeCategory(const char * category) noexcept = 0;
+    /// \see ColorSpace::getNumCategories
+    virtual int getNumCategories() const noexcept = 0;
+    /// \see ColorSpace::getCategory
+    virtual const char * getCategory(int index) const noexcept = 0;
+    /// \see ColorSpace::clearCategories
+    virtual void clearCategories() noexcept = 0;
+
+    virtual ConstTransformRcPtr getTransform(TransformDirection dir) const = 0;
+    virtual void setTransform(const ConstTransformRcPtr & transform, TransformDirection dir) = 0;
+
+    NamedTransform(const NamedTransform &) = delete;
+    NamedTransform & operator= (const NamedTransform &) = delete;
+    // Do not use (needed only for pybind11).
+    virtual ~NamedTransform() = default;
+
+protected:
+    NamedTransform() = default;
+};
+
+extern OCIOEXPORT std::ostream & operator<< (std::ostream &, const NamedTransform &);
 
 
 //

--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -430,18 +430,6 @@ public:
                                           ColorSpaceVisibility visibility, int index) const;
 
     /**
-     * \brief Get the color space from all the color spaces
-     *      (i.e. active and inactive) and return null if the name is not found.
-     *
-     * \note
-     *     The fcn accepts either a color space OR role name.
-     *     (Color space names take precedence over roles.)
-     */
-    ConstColorSpaceRcPtr getColorSpace(const char * name) const;
-
-    // The following three methods only work from the list of active color spaces.
-
-    /**
      * \brief Work on the active color spaces only.
      * 
      * \note
@@ -466,6 +454,16 @@ public:
      *    (Color space names take precedence over roles.)
      */
     int getIndexForColorSpace(const char * name) const;
+
+    /**
+     * \brief Get the color space from all the color spaces
+     *      (i.e. active and inactive) and return null if the name is not found.
+     *
+     * \note
+     *     The fcn accepts either a color space OR role name.
+     *     (Color space names take precedence over roles.)
+     */
+    ConstColorSpaceRcPtr getColorSpace(const char * name) const;
 
     /**
      * \brief Add a color space to the configuration.
@@ -519,10 +517,12 @@ public:
     void setStrictParsingEnabled(bool enabled);
 
     /**
-     * \brief Set/get a list of inactive color space names.
+     * \brief Set/get a list of inactive color space or named transform names.
      *
+     * Notes:
+     * * List can contain color space and/or named transform names.
      * * The inactive spaces are color spaces that should not appear in application menus.
-     * * These color spaces will still work in :cpp:func:`Config::getProcessor` calls.
+     * * These color spaces will still work in Config::getProcessor calls.
      * * The argument is a comma-delimited string.  A null or empty string empties the list.
      * * The environment variable OCIO_INACTIVE_COLORSPACES may also be used to set the
      *   inactive color space list.
@@ -906,25 +906,44 @@ public:
     void clearViewTransforms();
 
     /**
-    * \defgroup Methods related to named transforms.
-    * @{
-    */
-
-    /// Get the named transform from all the named transforms.
-    ConstNamedTransformRcPtr getNamedTransform(const char * name) const noexcept;
-
-    /// Number of named transforms.
-    size_t getNumNamedTransforms() const noexcept;
-
-    /// Name of named transform.
-    const char * getNamedTransformNameByIndex(size_t index) const noexcept;
+     * \defgroup Methods related to named transforms.
+     * @{
+     */
 
     /**
-    * \brief Add or replace named transform.
-    *
-    * \note
-    *    Throws if namedTransform is null, name is missing, or no transform is set.
-    */
+     * \brief Work on the named transforms selected by visibility.
+     */
+    int getNumNamedTransforms(NamedTransformVisibility visibility) const noexcept;
+
+    /**
+     * \brief Work on the named transforms selected by visibility (active or inactive).
+     *
+     * Return an empty string for invalid index.
+     */
+    const char * getNamedTransformNameByIndex(NamedTransformVisibility visibility,
+                                              int index) const noexcept;
+
+    /// Work on the active named transforms only.
+    int getNumNamedTransforms() const noexcept;
+
+    /// Work on the active named transforms only and return an empty string for invalid index.
+    const char * getNamedTransformNameByIndex(int index) const noexcept;
+
+    /// Get an index from the active named transforms only and return -1 if the name is not found.
+    int getIndexForNamedTransform(const char * name) const noexcept;
+
+    /**
+     * \brief Get the named transform from all the named transforms (i.e. active and inactive) and
+     *     return null if the name is not found.
+     */
+    ConstNamedTransformRcPtr getNamedTransform(const char * name) const noexcept;
+
+    /**
+     * \brief Add or replace named transform.
+     *
+     * \note
+     *    Throws if namedTransform is null, name is missing, or no transform is set.
+     */
     void addNamedTransform(const ConstNamedTransformRcPtr & namedTransform);
 
     /// Clear all named transforms.

--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -52,6 +52,10 @@ class OCIOEXPORT Look;
 typedef OCIO_SHARED_PTR<const Look> ConstLookRcPtr;
 typedef OCIO_SHARED_PTR<Look> LookRcPtr;
 
+class OCIOEXPORT NamedTransform;
+typedef OCIO_SHARED_PTR<const NamedTransform> ConstNamedTransformRcPtr;
+typedef OCIO_SHARED_PTR<NamedTransform> NamedTransformRcPtr;
+
 class OCIOEXPORT ViewTransform;
 typedef OCIO_SHARED_PTR<const ViewTransform> ConstViewTransformRcPtr;
 typedef OCIO_SHARED_PTR<ViewTransform> ViewTransformRcPtr;

--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -284,6 +284,13 @@ enum ColorSpaceVisibility
     COLORSPACE_ALL
 };
 
+enum NamedTransformVisibility
+{
+    NAMEDTRANSFORM_ACTIVE = 0,
+    NAMEDTRANSFORM_INACTIVE,
+    NAMEDTRANSFORM_ALL
+};
+
 enum ViewType
 {
     VIEW_SHARED = 0,

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -57,6 +57,7 @@ set(SOURCES
 	LookParse.cpp
 	MathUtils.cpp
 	md5/md5.cpp
+	NamedTransform.cpp
 	OCIOYaml.cpp
 	Op.cpp
 	OpOptimizers.cpp

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -2543,7 +2543,7 @@ int Config::getNumNamedTransforms(NamedTransformVisibility visibility) const noe
         res = (int)getImpl()->m_activeNamedTransformNames.size();
         break;
     }
-    case COLORSPACE_INACTIVE:
+    case NAMEDTRANSFORM_INACTIVE:
     {
         res = (int)getImpl()->m_inactiveNamedTransformNames.size();
         break;

--- a/src/OpenColorIO/FileRules.cpp
+++ b/src/OpenColorIO/FileRules.cpp
@@ -457,18 +457,21 @@ public:
         return false;
     }
 
-    void validate(std::function<ConstColorSpaceRcPtr(const char *)> colorSpaceAccesssor) const
+    void validate(const Config & cfg) const
     {
         if (m_type != FILE_RULE_PARSE_FILEPATH)
         {
-            // Can be a color space or a role (all color spaces).
-            ConstColorSpaceRcPtr cs = colorSpaceAccesssor(m_colorSpace.c_str());
-            if (!cs)
+            // Can be a color space, a role (all color spaces) or a named transform.
+            if (!cfg.getColorSpace(m_colorSpace.c_str()))
             {
-                std::ostringstream oss;
-                oss << "File rules: rule named '" << m_name << "' is referencing color space '"
-                    << m_colorSpace << "' that does not exist.";
-                throw Exception(oss.str().c_str());
+                if (!cfg.getNamedTransform(m_colorSpace.c_str()))
+                {
+                    std::ostringstream oss;
+                    oss << "File rules: rule named '" << m_name << "' is referencing '"
+                        << m_colorSpace << "' that is neither a color space nor a named "
+                                           "transform.";
+                    throw Exception(oss.str().c_str());
+                }
             }
         }
     }
@@ -613,11 +616,11 @@ void FileRules::Impl::moveRule(size_t ruleIndex, int offset)
 }
 
 
-void FileRules::Impl::validate(std::function<ConstColorSpaceRcPtr(const char *)> colorSpaceAccesssor) const
+void FileRules::Impl::validate(const Config & cfg) const
 {
     for (auto & rule : m_rules)
     {
-        rule->validate(colorSpaceAccesssor);
+        rule->validate(cfg);
     }
 }
 

--- a/src/OpenColorIO/FileRules.h
+++ b/src/OpenColorIO/FileRules.h
@@ -63,7 +63,7 @@ public:
 
     bool filepathOnlyMatchesDefaultRule(const Config & config, const char * filePath) const;
 
-    void validate(std::function<ConstColorSpaceRcPtr(const char *)> colorSpaceAccessor) const;
+    void validate(const Config & cfg) const;
 
 private:
 

--- a/src/OpenColorIO/NamedTransform.cpp
+++ b/src/OpenColorIO/NamedTransform.cpp
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "NamedTransform.h"
+
+namespace OCIO_NAMESPACE
+{
+NamedTransformRcPtr NamedTransform::Create()
+{
+    return NamedTransformRcPtr(new NamedTransformImpl(), &NamedTransformImpl::Deleter);
+}
+
+void NamedTransformImpl::Deleter(NamedTransform * t)
+{
+    delete static_cast<NamedTransformImpl *>(t);
+}
+
+NamedTransformRcPtr NamedTransformImpl::createEditableCopy() const
+{
+    auto copy = std::make_shared<NamedTransformImpl>();
+    copy->m_name = m_name;
+    copy->m_description = m_description;
+    copy->m_family = m_family;
+    copy->m_categories = m_categories;
+    if (m_forwardTransform)
+    {
+        copy->m_forwardTransform = m_forwardTransform->createEditableCopy();
+    }
+    if (m_inverseTransform)
+    {
+        copy->m_inverseTransform = m_inverseTransform->createEditableCopy();
+    }
+    return copy;
+}
+
+const char * NamedTransformImpl::getName() const noexcept
+{
+    return m_name.c_str();
+}
+
+void NamedTransformImpl::setName(const char * name) noexcept
+{
+    m_name = name ? name : "";
+}
+
+const char * NamedTransformImpl::getFamily() const noexcept
+{
+    return m_family.c_str();
+}
+
+void NamedTransformImpl::setFamily(const char * family) noexcept
+{
+    m_family = family ? family : "";
+}
+
+const char * NamedTransformImpl::getDescription() const noexcept
+{
+    return m_description.c_str();
+}
+
+void NamedTransformImpl::setDescription(const char * description) noexcept
+{
+    m_description = description ? description : "";
+}
+
+bool NamedTransformImpl::hasCategory(const char * category) const noexcept
+{
+    return m_categories.hasToken(category);
+}
+
+void NamedTransformImpl::addCategory(const char * category) noexcept
+{
+    m_categories.addToken(category);
+}
+
+void NamedTransformImpl::removeCategory(const char * category) noexcept
+{
+    m_categories.removeToken(category);
+}
+
+int NamedTransformImpl::getNumCategories() const noexcept
+{
+    return m_categories.getNumTokens();
+}
+
+const char * NamedTransformImpl::getCategory(int index) const noexcept
+{
+    return m_categories.getToken(index);
+}
+
+void NamedTransformImpl::clearCategories() noexcept
+{
+    m_categories.clearTokens();
+}
+
+ConstTransformRcPtr NamedTransformImpl::getTransform(TransformDirection dir) const
+{
+    if (dir == TRANSFORM_DIR_FORWARD)
+    {
+        return m_forwardTransform;
+    }
+    else if (dir == TRANSFORM_DIR_INVERSE)
+    {
+        return m_inverseTransform;
+    }
+    throw Exception("Named transform: Unspecified TransformDirection.");
+}
+
+ConstTransformRcPtr NamedTransformImpl::GetTransform(const ConstNamedTransformRcPtr & nt,
+                                                     TransformDirection dir)
+{
+    if (nt)
+    {
+        const auto forwardTransform = nt->getTransform(TRANSFORM_DIR_FORWARD);
+        const auto inverseTransform = nt->getTransform(TRANSFORM_DIR_INVERSE);
+        if (dir == TRANSFORM_DIR_FORWARD)
+        {
+            // If forward does not exist, inverse the inverse transform.
+            if (!forwardTransform)
+            {
+                auto transform = inverseTransform->createEditableCopy();
+                const auto dir = GetInverseTransformDirection(transform->getDirection());
+                transform->setDirection(dir);
+                return transform;
+            }
+            else
+            {
+                return forwardTransform;
+            }
+        }
+        else if (dir == TRANSFORM_DIR_INVERSE)
+        {
+            if (!inverseTransform)
+            {
+                // Inverse the forward transform.
+                auto transform = forwardTransform->createEditableCopy();
+                const auto dir = GetInverseTransformDirection(transform->getDirection());
+                transform->setDirection(dir);
+                return transform;
+            }
+            else
+            {
+                return inverseTransform;
+            }
+        }
+    }
+    throw Exception("Named transform: Unspecified TransformDirection.");
+}
+
+void NamedTransformImpl::setTransform(const ConstTransformRcPtr & transform, TransformDirection dir)
+{
+    if (dir == TRANSFORM_DIR_FORWARD)
+    {
+        if (!transform)
+        {
+            m_forwardTransform = ConstTransformRcPtr();
+        }
+        else
+        {
+            m_forwardTransform = transform->createEditableCopy();
+        }
+    }
+    else if (dir == TRANSFORM_DIR_INVERSE)
+    {
+        if (!transform)
+        {
+            m_inverseTransform = ConstTransformRcPtr();
+        }
+        else
+        {
+            m_inverseTransform = transform->createEditableCopy();
+        }
+    }
+    else
+    {
+        throw Exception("Named transform: Unspecified TransformDirection.");
+    }
+}
+
+std::ostream & operator<< (std::ostream & os, const NamedTransform & t)
+{
+    os << "<NamedTransform ";
+    const std::string strName{ t.getName() };
+    os << "name=" << strName;
+    const std::string strFamily{ t.getFamily() };
+    if (!strFamily.empty())
+    {
+        os << ", family=" << strFamily;
+    }
+    if (t.getNumCategories())
+    {
+        StringUtils::StringVec categories;
+        for (int i = 0; i < t.getNumCategories(); ++i)
+        {
+            categories.push_back(t.getCategory(i));
+        }
+        os << ", categories=[" << StringUtils::Join(categories, ',') << "]";
+    }
+    const std::string desc{ t.getDescription() };
+    if (!desc.empty())
+    {
+        os << ", description=" << desc;
+    }
+    if (t.getTransform(TRANSFORM_DIR_FORWARD))
+    {
+        os << ",\n    forward=";
+        os << "\n        " << *t.getTransform(TRANSFORM_DIR_FORWARD);
+    }
+    if (t.getTransform(TRANSFORM_DIR_INVERSE))
+    {
+        os << ",\n    inverse=";
+        os << "\n        " << *t.getTransform(TRANSFORM_DIR_INVERSE);
+    }
+    os << ">";
+    return os;
+}
+
+ConstTransformRcPtr GetTransform(const ConstNamedTransformRcPtr & src,
+                                 const ConstNamedTransformRcPtr & dst)
+{
+    if (src && dst)
+    {
+        // Both are named transforms.
+        auto group = GroupTransform::Create();
+        auto srcTransform = NamedTransformImpl::GetTransform(src, TRANSFORM_DIR_FORWARD);
+        group->appendTransform(srcTransform->createEditableCopy());
+        auto dstTransform = NamedTransformImpl::GetTransform(dst, TRANSFORM_DIR_INVERSE);
+        group->appendTransform(dstTransform->createEditableCopy());
+        return group;
+    }
+    else if (src)
+    {
+        // Src is a named transform, ignore dst color space.
+        return NamedTransformImpl::GetTransform(src, TRANSFORM_DIR_FORWARD);
+    }
+    else if (dst)
+    {
+        // Dst is a named transform, ignore src color space.
+        return NamedTransformImpl::GetTransform(dst, TRANSFORM_DIR_INVERSE);
+    }
+    throw Exception("GetTransform: one of the parameters has to be not null.");
+}
+
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/NamedTransform.h
+++ b/src/OpenColorIO/NamedTransform.h
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#ifndef INCLUDED_OCIO_NAMEDTRANSFORM_H
+#define INCLUDED_OCIO_NAMEDTRANSFORM_H
+
+#include <string>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "TokensManager.h"
+
+namespace OCIO_NAMESPACE
+{
+
+class NamedTransformImpl : public NamedTransform
+{
+public:
+    NamedTransformImpl() = default;
+    ~NamedTransformImpl() = default;
+
+    NamedTransformRcPtr createEditableCopy() const override;
+
+    const char * getName() const noexcept override;
+    void setName(const char * name) noexcept override;
+
+    const char * getFamily() const noexcept override;
+    void setFamily(const char * family) noexcept override;
+
+    const char * getDescription() const noexcept override;
+    void setDescription(const char * description) noexcept override;
+
+    bool hasCategory(const char * category) const noexcept override;
+    void addCategory(const char * category) noexcept override;
+    void removeCategory(const char * category) noexcept override;
+    int getNumCategories() const noexcept override;
+    const char * getCategory(int index) const noexcept override;
+    void clearCategories() noexcept override;
+
+    ConstTransformRcPtr getTransform(TransformDirection dir) const override;
+    void setTransform(const ConstTransformRcPtr & transform, TransformDirection dir) override;
+
+    // Will create the transform from the inverse direction if the transform for requested
+    // direction is missing.
+    static ConstTransformRcPtr GetTransform(const ConstNamedTransformRcPtr & nt,
+                                            TransformDirection dir);
+
+    static void Deleter(NamedTransform * nt);
+
+private:
+    std::string m_name;
+    ConstTransformRcPtr m_forwardTransform;
+    ConstTransformRcPtr m_inverseTransform;
+
+    std::string m_family;
+    std::string m_description;
+    TokensManager m_categories;
+};
+
+ConstTransformRcPtr GetTransform(const ConstNamedTransformRcPtr & src,
+                                 const ConstNamedTransformRcPtr & dst);
+
+} // namespace OCIO_NAMESPACE
+
+#endif // INCLUDED_OCIO_NAMEDTRANSFORM_H

--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -5104,15 +5104,15 @@ inline void save(YAML::Emitter & out, const Config & config)
     }
 
     // Named transforms.
-    const size_t numNT = config.getNumNamedTransforms();
+    const int numNT = config.getNumNamedTransforms(NAMEDTRANSFORM_ALL);
     if (numNT > 0)
     {
         out << YAML::Newline;
         out << YAML::Key << "named_transforms";
         out << YAML::Value << YAML::BeginSeq;
-        for (size_t i = 0; i < numNT; ++i)
+        for (int i = 0; i < numNT; ++i)
         {
-            auto name = config.getNamedTransformNameByIndex(i);
+            auto name = config.getNamedTransformNameByIndex(NAMEDTRANSFORM_ALL, i);
             auto nt = config.getNamedTransform(name);
             save(out, nt);
         }

--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -3818,7 +3818,7 @@ inline void load(const YAML::Node & node, NamedTransformRcPtr & nt)
     }
 }
 
-inline void save(YAML::Emitter & out, ConstNamedTransformRcPtr & nt)
+inline void save(YAML::Emitter & out, ConstNamedTransformRcPtr & nt, unsigned int majorVersion)
 {
     out << YAML::VerbatimTag("NamedTransform");
     out << YAML::BeginMap;
@@ -3848,14 +3848,14 @@ inline void save(YAML::Emitter & out, ConstNamedTransformRcPtr & nt)
     if (transform)
     {
         out << YAML::Key << "transform" << YAML::Value;
-        save(out, transform);
+        save(out, transform, majorVersion);
     }
 
     transform = nt->getTransform(TRANSFORM_DIR_INVERSE);
     if (transform)
     {
         out << YAML::Key << "inverse_transform" << YAML::Value;
-        save(out, transform);
+        save(out, transform, majorVersion);
     }
 
     out << YAML::EndMap;
@@ -5123,7 +5123,7 @@ inline void save(YAML::Emitter & out, const Config & config)
         {
             auto name = config.getNamedTransformNameByIndex(NAMEDTRANSFORM_ALL, i);
             auto nt = config.getNamedTransform(name);
-            save(out, nt);
+            save(out, nt, configMajorVersion);
         }
         out << YAML::EndSeq;
     }

--- a/src/OpenColorIO/TokensManager.h
+++ b/src/OpenColorIO/TokensManager.h
@@ -26,7 +26,7 @@ public:
 
     typedef StringUtils::StringVec Tokens;
 
-    Tokens::const_iterator findToken(const char * token) const
+    Tokens::const_iterator findToken(const char * token) const noexcept
     {
         if (!token || !*token) return m_tokens.end();
 
@@ -44,7 +44,7 @@ public:
         return m_tokens.end();
     }
 
-    bool hasToken(const char * token) const
+    bool hasToken(const char * token) const noexcept
     {
         return findToken(token) != m_tokens.end();
     }
@@ -57,7 +57,7 @@ public:
         }
     }
 
-    void removeToken(const char * token)
+    void removeToken(const char * token) noexcept
     {
         if (!token || !*token) return;
 
@@ -76,19 +76,19 @@ public:
         return;
     }
 
-    int getNumTokens() const
+    int getNumTokens() const noexcept
     {
         return static_cast<int>(m_tokens.size());
     }
 
-    const char * getToken(int index) const
+    const char * getToken(int index) const noexcept
     {
         if (index<0 || index >= (int)m_tokens.size()) return nullptr;
 
         return m_tokens[index].c_str();
     }
 
-    void clearTokens()
+    void clearTokens() noexcept
     {
         m_tokens.clear();
     }

--- a/src/OpenColorIO/transforms/DisplayViewTransform.cpp
+++ b/src/OpenColorIO/transforms/DisplayViewTransform.cpp
@@ -8,6 +8,7 @@
 
 #include "ContextVariableUtils.h"
 #include "Display.h"
+#include "NamedTransform.h"
 #include "OpBuilders.h"
 
 
@@ -249,17 +250,56 @@ void BuildDisplayToSource(OpRcPtrVec & ops,
 
     // Convert from the reference space back to the source color space.
     BuildColorSpaceFromReferenceOps(ops, config, context, sourceCS, dataBypass);
-
 }
 
-// Build ops for a display transform.
+void BuildNamedTransformToDisplay(OpRcPtrVec & ops,
+                                  const Config & config,
+                                  const ConstContextRcPtr & context,
+                                  const ConstNamedTransformRcPtr & viewNamedTransform,
+                                  const ConstColorSpaceRcPtr & displayCS,
+                                  bool dataBypass)
+{
+    // Apply view named transform.
+    auto transform = NamedTransformImpl::GetTransform(viewNamedTransform, TRANSFORM_DIR_FORWARD);
+    BuildOps(ops, config, context, transform, TRANSFORM_DIR_FORWARD);
+
+    // Convert from the display-referred reference space to the displayCS.
+    BuildColorSpaceFromReferenceOps(ops, config, context, displayCS, dataBypass);
+}
+
+void BuildDisplayToNamedTransform(OpRcPtrVec & ops,
+                                  const Config & config,
+                                  const ConstContextRcPtr & context,
+                                  const ConstColorSpaceRcPtr & displayCS,
+                                  const ConstNamedTransformRcPtr & viewNamedTransform,
+                                  bool dataBypass)
+{
+    // Convert to the display-referred reference space from the displayColorSpace.
+    BuildColorSpaceToReferenceOps(ops, config, context, displayCS, dataBypass);
+
+    // Apply view named transform.
+    auto transform = NamedTransformImpl::GetTransform(viewNamedTransform, TRANSFORM_DIR_INVERSE);
+    BuildOps(ops, config, context, transform, TRANSFORM_DIR_FORWARD);
+}
+
+// Build ops for a display/view transform.
 void BuildDisplayOps(OpRcPtrVec & ops,
                      const Config & config,
                      const ConstContextRcPtr & context,
                      const DisplayViewTransform & displayViewTransform,
                      TransformDirection dir)
 {
+    // There are two ways of specifying a DisplayViewTransform: either with a colorspace, or with
+    // a view_transform plus display_colorspace.  It is permitted to substitute a named_transform
+    // for either the colorspace or the view_transform.
+
     const auto combinedDir = CombineTransformDirections(dir, displayViewTransform.getDirection());
+    if (combinedDir == TRANSFORM_DIR_UNKNOWN)
+    {
+        std::ostringstream os;
+        os << "Cannot build display transform: unspecified transform direction.";
+        throw Exception(os.str().c_str());
+    }
 
     // Validate src color space.
     const std::string srcColorSpaceName = displayViewTransform.getSrc();
@@ -274,7 +314,7 @@ void BuildDisplayOps(OpRcPtrVec & ops,
         }
         else
         {
-            os <<  " Cannot find source color space, named '" << srcColorSpaceName << "'.";
+            os << " Cannot find source color space named '" << srcColorSpaceName << "'.";
         }
         throw Exception(os.str().c_str());
     }
@@ -282,12 +322,26 @@ void BuildDisplayOps(OpRcPtrVec & ops,
     const std::string display = displayViewTransform.getDisplay();
     const std::string view = displayViewTransform.getView();
 
-    // Get the view transform if any.
-    const std::string viewTransformName = config.getDisplayViewTransformName(display.c_str(), view.c_str());
+    // Get the view transform if any: if it exists, it can be a view transform or a named transform.
+    const std::string viewTransformName = config.getDisplayViewTransformName(display.c_str(),
+                                                                             view.c_str());
     ConstViewTransformRcPtr viewTransform;
+    ConstNamedTransformRcPtr viewNamedTransform;
     if (!viewTransformName.empty())
     {
         viewTransform = config.getViewTransform(viewTransformName.c_str());
+        if (!viewTransform)
+        {
+            viewNamedTransform = config.getNamedTransform(viewTransformName.c_str());
+            if (!viewNamedTransform)
+            {
+                // Config::validate catch this.
+                std::ostringstream os;
+                os << "DisplayViewTransform error. The view transform '";
+                os << viewTransformName << "' is neither a view transform nor a named transform.";
+                throw Exception(os.str().c_str());
+            }
+        }
     }
 
     // Get the color space associated to the (display, view) pair.
@@ -297,25 +351,43 @@ void BuildDisplayOps(OpRcPtrVec & ops,
     // in which case we look for a display color space with the same name as the display.
     const std::string displayColorSpaceName = View::UseDisplayName(csName) ? display : csName;
     ConstColorSpaceRcPtr displayColorSpace = config.getColorSpace(displayColorSpaceName.c_str());
+    ConstNamedTransformRcPtr displayNamedTransform;
     if (!displayColorSpace)
     {
-        std::ostringstream os;
-        os << "DisplayViewTransform error.";
         if (displayColorSpaceName.empty())
         {
+            std::ostringstream os;
+            os << "DisplayViewTransform error.";
             os << " Display color space name is unspecified.";
+            throw Exception(os.str().c_str());
         }
-        else
+
+        // If there is a view transform, the display color space can't be a named transform.
+        if (viewTransform || viewNamedTransform)
         {
-            os <<  " Cannot find display color space, '" << displayColorSpaceName << "'.";
+            // Config::validate catch this.
+            std::ostringstream os;
+            os << "DisplayViewTransform error." << " The view '";
+            os << viewTransformName << "' refers to a display color space '";
+            os << displayColorSpaceName << "' that can't be found.";
+            throw Exception(os.str().c_str());
         }
-        throw Exception(os.str().c_str());
+        displayNamedTransform = config.getNamedTransform(displayColorSpaceName.c_str());
+        if (!displayNamedTransform)
+        {
+            std::ostringstream os;
+            os << "DisplayViewTransform error.";
+            os << " Cannot find color space or named transform, named '";
+            os << displayColorSpaceName << "'.";
+            throw Exception(os.str().c_str());
+        }
     }
 
     // By default, data color spaces are not processed.
     const bool dataBypass = displayViewTransform.getDataBypass();
-    if (dataBypass &&
-        (srcColorSpace->isData() || displayColorSpace->isData()))
+    const bool srcData = (srcColorSpace && srcColorSpace->isData()) ? true : false;
+    const bool displayData = (displayColorSpace && displayColorSpace->isData()) ? true : false;
+    if (dataBypass && (srcData || displayData))
     {
         return;
     }
@@ -340,24 +412,31 @@ void BuildDisplayOps(OpRcPtrVec & ops,
         {
             // Note that this updates the currentCS to be the process space of the last look
             // applied.
-            BuildLookOps(ops,
-                         currentCS,
-                         false,
-                         config,
-                         context,
-                         looks);
+            BuildLookOps(ops, currentCS, false, config, context, looks);
         }
 
-        // Apply the conversion from the current color space to the display color space.
-        if (viewTransform)
+        if (displayNamedTransform)
+        {
+            // Ignore currentCS.  The forward direction NamedTransform is used for the forward
+            // direction DisplayViewTransform.
+            auto transform = NamedTransformImpl::GetTransform(displayNamedTransform,
+                                                              TRANSFORM_DIR_FORWARD);
+            BuildOps(ops, config, context, transform, TRANSFORM_DIR_FORWARD);
+        }
+        else if (viewNamedTransform)
+        {
+            BuildNamedTransformToDisplay(ops, config, context, viewNamedTransform,
+                                         displayColorSpace, dataBypass);
+        }
+        else if (viewTransform)
         {
             BuildSourceToDisplay(ops, config, context, currentCS, viewTransform,
                                  displayColorSpace, dataBypass);
         }
         else
         {
-            BuildColorSpaceOps(ops, config, context, currentCS, displayColorSpace,
-                                dataBypass);
+            // Apply the conversion from the current color space to the display color space.
+            BuildColorSpaceOps(ops, config, context, currentCS, displayColorSpace, dataBypass);
         }
     }
     else // TRANSFORM_DIR_INVERSE
@@ -369,38 +448,42 @@ void BuildDisplayOps(OpRcPtrVec & ops,
         ConstColorSpaceRcPtr vtSourceCS = srcColorSpace;
         if (!looks.empty())
         {
-            // Get result color space of apply looks in forward direction to find-out the source
-            // color space of the view transform.
+            // Get the result color space of applying the looks in the forward direction.
             const char * csRes = LooksResultColorSpace(config, context, looks);
             vtSourceCS = config.getColorSpace(csRes);
         }
 
-        // Apply the conversion from the display color space to the vtSourceCS.
-        if (viewTransform)
+        if (displayNamedTransform)
+        {
+            // Ignore currentCS.
+            auto transform = NamedTransformImpl::GetTransform(displayNamedTransform,
+                                                              TRANSFORM_DIR_INVERSE);
+            BuildOps(ops, config, context, transform, TRANSFORM_DIR_FORWARD);
+        }
+        else if (viewNamedTransform)
+        {
+            BuildDisplayToNamedTransform(ops, config, context, displayColorSpace,
+                                         viewNamedTransform, dataBypass);
+        }
+        else if (viewTransform)
         {
             BuildDisplayToSource(ops, config, context, displayColorSpace, viewTransform,
                                  vtSourceCS, dataBypass);
         }
         else
         {
-            BuildColorSpaceOps(ops, config, context, displayColorSpace, vtSourceCS,
-                               dataBypass);
+            // Apply the conversion from the display color space to the vtSourceCS.
+            BuildColorSpaceOps(ops, config, context, displayColorSpace, vtSourceCS, dataBypass);
         }
 
         if (!looks.empty())
         {
             // Apply looks in inverse direction.  Note that vtSourceCS is updated.
             looks.reverse();
-            BuildLookOps(ops,
-                         vtSourceCS,
-                         false,
-                         config,
-                         context,
-                         looks);
+            BuildLookOps(ops, vtSourceCS, false, config, context, looks);
 
             // End in srcColorSpace.
-            BuildColorSpaceOps(ops, config, context,
-                               vtSourceCS, srcColorSpace, dataBypass);
+            BuildColorSpaceOps(ops, config, context, vtSourceCS, srcColorSpace, dataBypass);
         }
     }
 }

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -19,55 +19,56 @@ find_package(Python REQUIRED COMPONENTS Interpreter Development)
 # Python libs
 
 set(SOURCES
-	PyOpenColorIO.cpp
-	PyUtils.cpp
-	PyTypes.cpp
-	PyFormatMetadata.cpp
-	PyDynamicProperty.cpp
-	PyTransform.cpp
 	PyAllocationTransform.cpp
+	PyBaker.cpp
 	PyBuiltinTransform.cpp
 	PyBuiltinTransformRegistry.cpp
 	PyCDLTransform.cpp
+	PyColorSpace.cpp
+	PyColorSpaceSet.cpp
 	PyColorSpaceTransform.cpp
+	PyConfig.cpp
+	PyContext.cpp
+	PyCPUProcessor.cpp
 	PyDisplayViewTransform.cpp
+	PyDynamicProperty.cpp
 	PyExponentTransform.cpp
 	PyExponentWithLinearTransform.cpp
 	PyExposureContrastTransform.cpp
+	PyFileRules.cpp
 	PyFileTransform.cpp
 	PyFixedFunctionTransform.cpp
+	PyFormatMetadata.cpp
+	PyGPUProcessor.cpp
+	PyGpuShaderCreator.cpp
+	PyGpuShaderDesc.cpp
 	PyGradingData.cpp
 	PyGradingPrimaryTransform.cpp
 	PyGradingRGBCurveTransform.cpp
 	PyGradingToneTransform.cpp
 	PyGroupTransform.cpp
+	PyImageDesc.cpp
 	PyLogAffineTransform.cpp
 	PyLogCameraTransform.cpp
 	PyLogTransform.cpp
+	PyLook.cpp
 	PyLookTransform.cpp
 	PyLut1DTransform.cpp
 	PyLut3DTransform.cpp
 	PyMatrixTransform.cpp
-	PyRangeTransform.cpp
-	PyConfig.cpp
-	PyFileRules.cpp
-	PyColorSpace.cpp
-	PyColorSpaceSet.cpp
-	PyLook.cpp
-	PyViewTransform.cpp
-	PyProcessor.cpp
-	PyCPUProcessor.cpp
-	PyGPUProcessor.cpp
-	PyProcessorMetadata.cpp
-	PyBaker.cpp
-	PyImageDesc.cpp
+	PyNamedTransform.cpp
+	PyOpenColorIO.cpp
 	PyPackedImageDesc.cpp
 	PyPlanarImageDesc.cpp
-	PyGpuShaderCreator.cpp
-	PyGpuShaderDesc.cpp
-	PyContext.cpp
+	PyProcessor.cpp
+	PyProcessorMetadata.cpp
+	PyRangeTransform.cpp
 	PySystemMonitors.cpp
+	PyTransform.cpp
+	PyTypes.cpp
+	PyUtils.cpp
 	PyViewingRules.cpp
+	PyViewTransform.cpp
 )
 
 add_library(PyOpenColorIO MODULE ${SOURCES} ${PYDOC_OUTPUT})

--- a/src/bindings/python/PyConfig.cpp
+++ b/src/bindings/python/PyConfig.cpp
@@ -29,7 +29,9 @@ enum ConfigIterator
     IT_LOOK_NAME,
     IT_LOOK,
     IT_VIEW_TRANSFORM_NAME,
-    IT_VIEW_TRANSFORM
+    IT_VIEW_TRANSFORM,
+    IT_NAMED_TRANSFORM_NAME,
+    IT_NAMED_TRANSFORM
 };
 
 using EnvironmentVarNameIterator   = PyIterator<ConfigRcPtr, IT_ENVIRONMENT_VAR_NAME>;
@@ -55,6 +57,8 @@ using LookNameIterator             = PyIterator<ConfigRcPtr, IT_LOOK_NAME>;
 using LookIterator                 = PyIterator<ConfigRcPtr, IT_LOOK>;
 using ViewTransformNameIterator    = PyIterator<ConfigRcPtr, IT_VIEW_TRANSFORM_NAME>;
 using ViewTransformIterator        = PyIterator<ConfigRcPtr, IT_VIEW_TRANSFORM>;
+using NamedTransformNameIterator   = PyIterator<ConfigRcPtr, IT_NAMED_TRANSFORM_NAME>;
+using NamedTransformIterator       = PyIterator<ConfigRcPtr, IT_NAMED_TRANSFORM>;
 
 } // namespace
 
@@ -254,6 +258,19 @@ void bindPyConfig(py::module & m)
         .def("getDefaultSceneToDisplayViewTransform", 
              &Config::getDefaultSceneToDisplayViewTransform)
         .def("clearViewTransforms", &Config::clearViewTransforms)
+
+        // Named Transforms.
+        .def("getNamedTransform", &Config::getNamedTransform, "name"_a)
+        .def("getNamedTransformNames", [](ConfigRcPtr & self)
+        {
+                return NamedTransformNameIterator(self);
+        })
+        .def("getNamedTransforms", [](ConfigRcPtr & self)
+        {
+                return NamedTransformIterator(self);
+        })
+        .def("addNamedTransform", &Config::addNamedTransform, "namedTransform"_a)
+        .def("clearNamedTransforms", &Config::clearNamedTransforms)
 
         // Viewing Rules
         .def("getViewingRules", &Config::getViewingRules)
@@ -672,6 +689,49 @@ void bindPyConfig(py::module & m)
                 const char * name = it.m_obj->getViewTransformNameByIndex(i);
                 return it.m_obj->getViewTransform(name);
             });
+
+    py::class_<NamedTransformNameIterator>(cls, "NamedTransformNameIterator")
+        .def("__len__", [](NamedTransformNameIterator & it)
+            {
+                return it.m_obj->getNumNamedTransforms();
+            })
+        .def("__getitem__", [](NamedTransformNameIterator & it, int i)
+            {
+                it.checkIndex(i, (int)it.m_obj->getNumNamedTransforms());
+                return it.m_obj->getNamedTransformNameByIndex(i);
+            })
+        .def("__iter__", [](NamedTransformNameIterator & it) -> NamedTransformNameIterator &
+            {
+                return it;
+            })
+        .def("__next__", [](NamedTransformNameIterator & it)
+            {
+                int i = it.nextIndex((int)it.m_obj->getNumNamedTransforms());
+                return it.m_obj->getNamedTransformNameByIndex(i);
+            });
+
+    py::class_<NamedTransformIterator>(cls, "NamedTransformIterator")
+        .def("__len__", [](NamedTransformIterator & it)
+            {
+                return it.m_obj->getNumNamedTransforms();
+            })
+        .def("__getitem__", [](NamedTransformIterator & it, int i)
+            {
+                it.checkIndex(i, (int)it.m_obj->getNumNamedTransforms());
+                const char * name = it.m_obj->getNamedTransformNameByIndex(i);
+                return it.m_obj->getNamedTransform(name);
+            })
+        .def("__iter__", [](NamedTransformIterator & it) -> NamedTransformIterator &
+            {
+                return it;
+            })
+        .def("__next__", [](NamedTransformIterator & it)
+            {
+                int i = it.nextIndex((int)it.m_obj->getNumNamedTransforms());
+                const char * name = it.m_obj->getNamedTransformNameByIndex(i);
+                return it.m_obj->getNamedTransform(name);
+            });
+
 
     m.def("GetCurrentConfig", &GetCurrentConfig);
     m.def("SetCurrentConfig", &SetCurrentConfig, "config"_a);

--- a/src/bindings/python/PyConfig.cpp
+++ b/src/bindings/python/PyConfig.cpp
@@ -31,34 +31,40 @@ enum ConfigIterator
     IT_VIEW_TRANSFORM_NAME,
     IT_VIEW_TRANSFORM,
     IT_NAMED_TRANSFORM_NAME,
-    IT_NAMED_TRANSFORM
+    IT_NAMED_TRANSFORM,
+    IT_ACTIVE_NAMED_TRANSFORM_NAME,
+    IT_ACTIVE_NAMED_TRANSFORM
 };
 
-using EnvironmentVarNameIterator   = PyIterator<ConfigRcPtr, IT_ENVIRONMENT_VAR_NAME>;
-using SearchPathIterator           = PyIterator<ConfigRcPtr, IT_SEARCH_PATH>;
-using ColorSpaceNameIterator       = PyIterator<ConfigRcPtr, 
-                                                IT_COLOR_SPACE_NAME, 
-                                                SearchReferenceSpaceType,
-                                                ColorSpaceVisibility>;
-using ColorSpaceIterator           = PyIterator<ConfigRcPtr, 
-                                                IT_COLOR_SPACE, 
-                                                SearchReferenceSpaceType,
-                                                ColorSpaceVisibility>;
-using ActiveColorSpaceNameIterator = PyIterator<ConfigRcPtr, IT_ACTIVE_COLOR_SPACE_NAME>;
-using ActiveColorSpaceIterator     = PyIterator<ConfigRcPtr, IT_ACTIVE_COLOR_SPACE>;
-using RoleNameIterator             = PyIterator<ConfigRcPtr, IT_ROLE_NAME>;
-using RoleColorSpaceIterator       = PyIterator<ConfigRcPtr, IT_ROLE_COLOR_SPACE>;
-using DisplayIterator              = PyIterator<ConfigRcPtr, IT_DISPLAY>;
-using SharedViewIterator           = PyIterator<ConfigRcPtr, IT_SHARED_VIEW>;
-using ViewIterator                 = PyIterator<ConfigRcPtr, IT_DISPLAY_VIEW, std::string>;
-using ViewForColorSpaceIterator    = PyIterator<ConfigRcPtr, IT_DISPLAY_VIEW_COLORSPACE,
-                                                std::string, std::string>;
-using LookNameIterator             = PyIterator<ConfigRcPtr, IT_LOOK_NAME>;
-using LookIterator                 = PyIterator<ConfigRcPtr, IT_LOOK>;
-using ViewTransformNameIterator    = PyIterator<ConfigRcPtr, IT_VIEW_TRANSFORM_NAME>;
-using ViewTransformIterator        = PyIterator<ConfigRcPtr, IT_VIEW_TRANSFORM>;
-using NamedTransformNameIterator   = PyIterator<ConfigRcPtr, IT_NAMED_TRANSFORM_NAME>;
-using NamedTransformIterator       = PyIterator<ConfigRcPtr, IT_NAMED_TRANSFORM>;
+using EnvironmentVarNameIterator       = PyIterator<ConfigRcPtr, IT_ENVIRONMENT_VAR_NAME>;
+using SearchPathIterator               = PyIterator<ConfigRcPtr, IT_SEARCH_PATH>;
+using ColorSpaceNameIterator           = PyIterator<ConfigRcPtr, 
+                                                    IT_COLOR_SPACE_NAME, 
+                                                    SearchReferenceSpaceType,
+                                                    ColorSpaceVisibility>;
+using ColorSpaceIterator               = PyIterator<ConfigRcPtr, 
+                                                    IT_COLOR_SPACE, 
+                                                    SearchReferenceSpaceType,
+                                                     ColorSpaceVisibility>;
+using ActiveColorSpaceNameIterator     = PyIterator<ConfigRcPtr, IT_ACTIVE_COLOR_SPACE_NAME>;
+using ActiveColorSpaceIterator         = PyIterator<ConfigRcPtr, IT_ACTIVE_COLOR_SPACE>;
+using RoleNameIterator                 = PyIterator<ConfigRcPtr, IT_ROLE_NAME>;
+using RoleColorSpaceIterator           = PyIterator<ConfigRcPtr, IT_ROLE_COLOR_SPACE>;
+using DisplayIterator                  = PyIterator<ConfigRcPtr, IT_DISPLAY>;
+using SharedViewIterator               = PyIterator<ConfigRcPtr, IT_SHARED_VIEW>;
+using ViewIterator                     = PyIterator<ConfigRcPtr, IT_DISPLAY_VIEW, std::string>;
+using ViewForColorSpaceIterator        = PyIterator<ConfigRcPtr, IT_DISPLAY_VIEW_COLORSPACE,
+                                                    std::string, std::string>;
+using LookNameIterator                 = PyIterator<ConfigRcPtr, IT_LOOK_NAME>;
+using LookIterator                     = PyIterator<ConfigRcPtr, IT_LOOK>;
+using ViewTransformNameIterator        = PyIterator<ConfigRcPtr, IT_VIEW_TRANSFORM_NAME>;
+using ViewTransformIterator            = PyIterator<ConfigRcPtr, IT_VIEW_TRANSFORM>;
+using NamedTransformNameIterator       = PyIterator<ConfigRcPtr, IT_NAMED_TRANSFORM_NAME,
+                                                    NamedTransformVisibility>;
+using NamedTransformIterator           = PyIterator<ConfigRcPtr, IT_NAMED_TRANSFORM,
+                                                    NamedTransformVisibility>;
+using ActiveNamedTransformNameIterator = PyIterator<ConfigRcPtr, IT_ACTIVE_NAMED_TRANSFORM_NAME>;
+using ActiveNamedTransformIterator     = PyIterator<ConfigRcPtr, IT_ACTIVE_NAMED_TRANSFORM>;
 
 } // namespace
 
@@ -261,13 +267,25 @@ void bindPyConfig(py::module & m)
 
         // Named Transforms.
         .def("getNamedTransform", &Config::getNamedTransform, "name"_a)
+
+        .def("getNamedTransformNames", [](ConfigRcPtr & self,
+                                          NamedTransformVisibility visibility)
+            {
+                return NamedTransformNameIterator(self, visibility);
+            }, "visibility"_a)
+        .def("getNamedTransforms", [](ConfigRcPtr & self,
+                                      NamedTransformVisibility visibility)
+            {
+                return NamedTransformIterator(self, visibility);
+            }, "visibility"_a)
+
         .def("getNamedTransformNames", [](ConfigRcPtr & self)
         {
-                return NamedTransformNameIterator(self);
+                return ActiveNamedTransformNameIterator(self);
         })
         .def("getNamedTransforms", [](ConfigRcPtr & self)
         {
-                return NamedTransformIterator(self);
+                return ActiveNamedTransformIterator(self);
         })
         .def("addNamedTransform", &Config::addNamedTransform, "namedTransform"_a)
         .def("clearNamedTransforms", &Config::clearNamedTransforms)
@@ -693,12 +711,12 @@ void bindPyConfig(py::module & m)
     py::class_<NamedTransformNameIterator>(cls, "NamedTransformNameIterator")
         .def("__len__", [](NamedTransformNameIterator & it)
             {
-                return it.m_obj->getNumNamedTransforms();
+                return it.m_obj->getNumNamedTransforms(std::get<0>(it.m_args));
             })
         .def("__getitem__", [](NamedTransformNameIterator & it, int i)
             {
-                it.checkIndex(i, (int)it.m_obj->getNumNamedTransforms());
-                return it.m_obj->getNamedTransformNameByIndex(i);
+                it.checkIndex(i, it.m_obj->getNumNamedTransforms(std::get<0>(it.m_args)));
+                return it.m_obj->getNamedTransformNameByIndex(std::get<0>(it.m_args), i);
             })
         .def("__iter__", [](NamedTransformNameIterator & it) -> NamedTransformNameIterator &
             {
@@ -706,19 +724,19 @@ void bindPyConfig(py::module & m)
             })
         .def("__next__", [](NamedTransformNameIterator & it)
             {
-                int i = it.nextIndex((int)it.m_obj->getNumNamedTransforms());
-                return it.m_obj->getNamedTransformNameByIndex(i);
+                int i = it.nextIndex(it.m_obj->getNumNamedTransforms(std::get<0>(it.m_args)));
+                return it.m_obj->getNamedTransformNameByIndex(std::get<0>(it.m_args), i);
             });
 
     py::class_<NamedTransformIterator>(cls, "NamedTransformIterator")
         .def("__len__", [](NamedTransformIterator & it)
             {
-                return it.m_obj->getNumNamedTransforms();
+                return it.m_obj->getNumNamedTransforms(std::get<0>(it.m_args));
             })
         .def("__getitem__", [](NamedTransformIterator & it, int i)
             {
-                it.checkIndex(i, (int)it.m_obj->getNumNamedTransforms());
-                const char * name = it.m_obj->getNamedTransformNameByIndex(i);
+                it.checkIndex(i, it.m_obj->getNumNamedTransforms(std::get<0>(it.m_args)));
+                const char * name = it.m_obj->getNamedTransformNameByIndex(std::get<0>(it.m_args), i);
                 return it.m_obj->getNamedTransform(name);
             })
         .def("__iter__", [](NamedTransformIterator & it) -> NamedTransformIterator &
@@ -727,11 +745,52 @@ void bindPyConfig(py::module & m)
             })
         .def("__next__", [](NamedTransformIterator & it)
             {
+                int i = it.nextIndex(it.m_obj->getNumNamedTransforms(std::get<0>(it.m_args)));
+                const char * name = it.m_obj->getNamedTransformNameByIndex(std::get<0>(it.m_args), i);
+                return it.m_obj->getNamedTransform(name);
+            });
+
+    py::class_<ActiveNamedTransformNameIterator>(cls, "ActiveNamedTransformNameIterator")
+        .def("__len__", [](ActiveNamedTransformNameIterator & it)
+            {
+                return it.m_obj->getNumNamedTransforms();
+            })
+        .def("__getitem__", [](ActiveNamedTransformNameIterator & it, int i)
+            {
+                it.checkIndex(i, (int)it.m_obj->getNumNamedTransforms());
+                return it.m_obj->getNamedTransformNameByIndex(i);
+            })
+        .def("__iter__", [](ActiveNamedTransformNameIterator & it) -> ActiveNamedTransformNameIterator &
+            {
+                return it;
+            })
+        .def("__next__", [](ActiveNamedTransformNameIterator & it)
+            {
+                int i = it.nextIndex((int)it.m_obj->getNumNamedTransforms());
+                return it.m_obj->getNamedTransformNameByIndex(i);
+            });
+
+    py::class_<ActiveNamedTransformIterator>(cls, "ActiveNamedTransformIterator")
+        .def("__len__", [](ActiveNamedTransformIterator & it)
+            {
+                return it.m_obj->getNumNamedTransforms();
+            })
+        .def("__getitem__", [](ActiveNamedTransformIterator & it, int i)
+            {
+                it.checkIndex(i, (int)it.m_obj->getNumNamedTransforms());
+                const char * name = it.m_obj->getNamedTransformNameByIndex(i);
+                return it.m_obj->getNamedTransform(name);
+            })
+        .def("__iter__", [](ActiveNamedTransformIterator & it) -> ActiveNamedTransformIterator &
+            {
+                return it;
+            })
+        .def("__next__", [](ActiveNamedTransformIterator & it)
+            {
                 int i = it.nextIndex((int)it.m_obj->getNumNamedTransforms());
                 const char * name = it.m_obj->getNamedTransformNameByIndex(i);
                 return it.m_obj->getNamedTransform(name);
             });
-
 
     m.def("GetCurrentConfig", &GetCurrentConfig);
     m.def("SetCurrentConfig", &SetCurrentConfig, "config"_a);

--- a/src/bindings/python/PyNamedTransform.cpp
+++ b/src/bindings/python/PyNamedTransform.cpp
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#include <sstream>
+
+#include "PyTransform.h"
+
+namespace OCIO_NAMESPACE
+{
+
+enum NamedTransformIterator
+{
+    IT_NAMED_TRANSFORM_DEFINITION_CATEGORY = 0
+};
+
+using NamedTransformCategoryIterator = PyIterator<NamedTransformRcPtr,
+                                                  IT_NAMED_TRANSFORM_DEFINITION_CATEGORY>;
+
+std::vector<std::string> getCategoriesStdVec(const NamedTransformRcPtr & p)
+{
+    std::vector<std::string> categories;
+    categories.reserve(p->getNumCategories());
+    for (int i = 0; i < p->getNumCategories(); i++)
+    {
+        categories.push_back(p->getCategory(i));
+    }
+    return categories;
+}
+
+void bindPyNamedTransform(py::module & m)
+{
+    NamedTransformRcPtr DEFAULT = NamedTransform::Create();
+
+    auto cls = py::class_<NamedTransform,
+                          NamedTransformRcPtr /* holder */>(m, "NamedTransform")
+        .def(py::init([]() { return NamedTransform::Create(); }))
+        .def(py::init([](const std::string & name,
+                         const std::string & family,
+                         const std::string & description,
+                         const ConstTransformRcPtr & forwardTransform,
+                         const ConstTransformRcPtr & inverseTransform,
+                         const std::vector<std::string> & categories)
+            {
+                NamedTransformRcPtr p = NamedTransform::Create();
+                if (!name.empty())
+                {
+                    p->setName(name.c_str());
+                }
+                if (!family.empty())
+                {
+                    p->setFamily(family.c_str());
+                }
+                if (!description.empty())
+                {
+                    p->setDescription(description.c_str());
+                }
+                if (forwardTransform)
+                {
+                    p->setTransform(forwardTransform, TRANSFORM_DIR_FORWARD);
+                }
+                if (inverseTransform)
+                {
+                    p->setTransform(inverseTransform, TRANSFORM_DIR_INVERSE);
+                }
+                if (!categories.empty())
+                {
+                    p->clearCategories();
+                    for (const auto & cat : categories)
+                    {
+                        p->addCategory(cat.c_str());
+                    }
+                }
+                return p;
+            }),
+            "name"_a = "",
+            "family"_a = "",
+            "description"_a = "",
+            "forwardTransform"_a = ConstTransformRcPtr(),
+            "inverseTransform"_a = ConstTransformRcPtr(),
+            "categories"_a = getCategoriesStdVec(DEFAULT))
+
+        .def("getName", &NamedTransform::getName)
+        .def("setName", &NamedTransform::setName, "name"_a)
+        .def("getFamily", &NamedTransform::getFamily)
+        .def("setFamily", &NamedTransform::setFamily, "family"_a)
+        .def("getDescription", &NamedTransform::getDescription)
+        .def("setDescription", &NamedTransform::setDescription, "description"_a)
+
+        // Transform
+        .def("getTransform", &NamedTransform::getTransform, "direction"_a)
+        .def("setTransform", &NamedTransform::setTransform, "transform"_a, "direction"_a)
+
+        // Categories
+        .def("hasCategory", &NamedTransform::hasCategory, "category"_a)
+        .def("addCategory", &NamedTransform::addCategory, "category"_a)
+        .def("removeCategory", &NamedTransform::removeCategory, "category"_a)
+        .def("getCategories", [](NamedTransformRcPtr & self)
+            {
+                return NamedTransformCategoryIterator(self);
+            })
+        .def("clearCategories", &NamedTransform::clearCategories);
+
+    defStr(cls);
+
+    py::class_<NamedTransformCategoryIterator>(cls, "NamedTransformCategoryIterator")
+        .def("__len__", [](NamedTransformCategoryIterator & it)
+            {
+                return it.m_obj->getNumCategories();
+            })
+        .def("__getitem__", [](NamedTransformCategoryIterator & it, int i)
+            {
+                it.checkIndex(i, it.m_obj->getNumCategories());
+                return it.m_obj->getCategory(i);
+            })
+        .def("__iter__", [](NamedTransformCategoryIterator & it) -> NamedTransformCategoryIterator &
+            {
+                return it;
+            })
+        .def("__next__", [](NamedTransformCategoryIterator & it)
+            {
+                int i = it.nextIndex(it.m_obj->getNumCategories());
+                return it.m_obj->getCategory(i);
+            });
+}
+
+} // namespace OCIO_NAMESPACE

--- a/src/bindings/python/PyOpenColorIO.cpp
+++ b/src/bindings/python/PyOpenColorIO.cpp
@@ -58,6 +58,7 @@ PYBIND11_MODULE(PyOpenColorIO, m)
     bindPyGradingPrimaryTransform(m);
     bindPyGradingRGBCurveTransform(m);
     bindPyGradingToneTransform(m);
+    bindPyNamedTransform(m);
 }
 
 } // namespace OCIO_NAMESPACE

--- a/src/bindings/python/PyOpenColorIO.h
+++ b/src/bindings/python/PyOpenColorIO.h
@@ -41,6 +41,7 @@ void bindPyGradingData(py::module & m);
 void bindPyGradingPrimaryTransform(py::module & m);
 void bindPyGradingRGBCurveTransform(py::module & m);
 void bindPyGradingToneTransform(py::module & m);
+void bindPyNamedTransform(py::module & m);
 
 } // namespace OCIO_NAMESPACE
 

--- a/src/bindings/python/PyTransform.h
+++ b/src/bindings/python/PyTransform.h
@@ -35,6 +35,7 @@ void bindPyLookTransform(py::module & m);
 void bindPyLut1DTransform(py::module & m);
 void bindPyLut3DTransform(py::module & m);
 void bindPyMatrixTransform(py::module & m);
+void bindPyNamedTransform(py::module & m);
 void bindPyRangeTransform(py::module & m);
 
 } // namespace OCIO_NAMESPACE

--- a/src/bindings/python/PyTypes.cpp
+++ b/src/bindings/python/PyTypes.cpp
@@ -34,6 +34,12 @@ void bindPyTypes(py::module & m)
         .value("COLORSPACE_ALL", COLORSPACE_ALL)
         .export_values();
 
+    py::enum_<NamedTransformVisibility>(m, "NamedTransformVisibility")
+        .value("NAMEDTRANSFORM_ACTIVE", NAMEDTRANSFORM_ACTIVE)
+        .value("NAMEDTRANSFORM_INACTIVE", NAMEDTRANSFORM_INACTIVE)
+        .value("NAMEDTRANSFORM_ALL", NAMEDTRANSFORM_ALL)
+        .export_values();
+
     py::enum_<ColorSpaceDirection>(m, "ColorSpaceDirection")
         .value("COLORSPACE_DIR_TO_REFERENCE", COLORSPACE_DIR_TO_REFERENCE)
         .value("COLORSPACE_DIR_FROM_REFERENCE", COLORSPACE_DIR_FROM_REFERENCE)

--- a/src/libutils/apphelpers/CategoryHelpers.cpp
+++ b/src/libutils/apphelpers/CategoryHelpers.cpp
@@ -73,7 +73,7 @@ ColorSpaceNames FindAllColorSpaceNames(ConstConfigRcPtr config, bool includeName
     auto res = GetNames(config);
     if (includeNamedTransforms)
     {
-        for (size_t idx = 0; idx < config->getNumNamedTransforms(); ++idx)
+        for (int idx = 0; idx < config->getNumNamedTransforms(); ++idx)
         {
             const char * ntName = config->getNamedTransformNameByIndex(idx);
             res.push_back(ntName);
@@ -100,7 +100,7 @@ Infos FindColorSpaceInfos(ConstConfigRcPtr config,
     {
         for (const auto & cat : categories)
         {
-            for (size_t idx = 0; idx < config->getNumNamedTransforms(); ++idx)
+            for (int idx = 0; idx < config->getNumNamedTransforms(); ++idx)
             {
                 const char * ntName = config->getNamedTransformNameByIndex(idx);
                 ConstNamedTransformRcPtr nt = config->getNamedTransform(ntName);
@@ -128,7 +128,7 @@ Infos FindAllColorSpaceInfos(ConstConfigRcPtr config, bool includeNamedTransform
 
     if (includeNamedTransforms)
     {
-        for (size_t idx = 0; idx < config->getNumNamedTransforms(); ++idx)
+        for (int idx = 0; idx < config->getNumNamedTransforms(); ++idx)
         {
             const char * ntName = config->getNamedTransformNameByIndex(idx);
             ConstNamedTransformRcPtr nt = config->getNamedTransform(ntName);

--- a/src/libutils/apphelpers/CategoryHelpers.h
+++ b/src/libutils/apphelpers/CategoryHelpers.h
@@ -22,23 +22,32 @@ Categories ExtractCategories(const char * categories);
 
 using ColorSpaceNames = std::vector<std::string>;
 // Return all the active color space names having at least one of the categories.
-ColorSpaceNames FindColorSpaceNames(ConstConfigRcPtr config, const Categories & categories);
+ColorSpaceNames FindColorSpaceNames(ConstConfigRcPtr config,
+                                    const Categories & categories);
 // Return all the active color space names.
-ColorSpaceNames FindAllColorSpaceNames(ConstConfigRcPtr config);
+ColorSpaceNames FindAllColorSpaceNames(ConstConfigRcPtr config, bool includeNamedTransforms);
 
 using Infos = std::vector<ConstColorSpaceInfoRcPtr>;
 // Return information on all the active color spaces having at least one of the categories.
-Infos FindColorSpaceInfos(ConstConfigRcPtr config, const Categories & categories);
+Infos FindColorSpaceInfos(ConstConfigRcPtr config,
+                          const Categories & categories,
+                          bool includeNamedTransforms);
 // Return information on all the active color spaces.
-Infos FindAllColorSpaceInfos(ConstConfigRcPtr config);
+Infos FindAllColorSpaceInfos(ConstConfigRcPtr config, bool includeNamedTransforms);
 
-// Return information for a role which could be empty if not found.
+// Return information for a role (result will be empty if the role doesn't exist).
 ConstColorSpaceInfoRcPtr GetRoleInfo(ConstConfigRcPtr config, const char * roleName);
 
 
+// Return information useful for building color space menus using the following heuristics.  If the
+// role is non-empty and exists, just return that space.  If the categories are non-empty, return
+// all color spaces that have at least one of the categories.  Otherwise if categories are empty or
+// none of them match any color spaces, return all the color spaces. Set includeNamedTransforms to
+// true to also search named transforms.
 Infos getColorSpaceInfosFromCategories(ConstConfigRcPtr config,
                                        const char * role,        // Could be null or empty.
-                                       const char * categories); // Could be null or empty.
+                                       const char * categories,  // Could be null or empty.
+                                       bool includeNamedTransforms);
 
 } // namespace OCIO_NAMESPACE
 

--- a/src/libutils/apphelpers/ColorSpaceHelpers.h
+++ b/src/libutils/apphelpers/ColorSpaceHelpers.h
@@ -62,6 +62,9 @@ public:
     static ConstColorSpaceInfoRcPtr Create(ConstConfigRcPtr config,
                                            ConstColorSpaceRcPtr cs);
 
+    static ConstColorSpaceInfoRcPtr Create(ConstConfigRcPtr config,
+                                           ConstNamedTransformRcPtr nt);
+
     virtual const char * getName() const noexcept = 0;
     virtual const char * getUIName() const noexcept = 0;
     virtual const char * getFamily() const noexcept = 0;
@@ -94,9 +97,11 @@ using ColorSpaceMenuHelperRcPtr = OCIO_SHARED_PTR<ColorSpaceMenuHelper>;
 class ColorSpaceMenuHelper
 {
 public:
+    // If role is part of the config, ignore categories and named transforms.
     static ColorSpaceMenuHelperRcPtr Create(const ConstConfigRcPtr & config,
                                             const char * role,
-                                            const char * categories);
+                                            const char * categories,
+                                            bool includeNamedTransforms);
 
     // Access to the color space names.
     virtual size_t getNumColorSpaces() const noexcept = 0;

--- a/src/libutils/apphelpers/DisplayViewHelpers.cpp
+++ b/src/libutils/apphelpers/DisplayViewHelpers.cpp
@@ -48,7 +48,8 @@ ConstProcessorRcPtr GetProcessor(const ConstConfigRcPtr & config,
                                  const ConstMatrixTransformRcPtr & channelView,
                                  TransformDirection direction)
 {
-    ColorSpaceMenuHelperRcPtr menuHelper = ColorSpaceMenuHelper::Create(config, nullptr, nullptr);
+    // Src of a display view can't be a named transform (don't include them).
+    auto menuHelper = ColorSpaceMenuHelper::Create(config, nullptr, nullptr, false);
 
     DisplayViewTransformRcPtr displayTransform = DisplayViewTransform::Create();
     displayTransform->setDirection(direction);

--- a/tests/apphelpers/CategoryHelpers_tests.cpp
+++ b/tests/apphelpers/CategoryHelpers_tests.cpp
@@ -68,11 +68,36 @@ OCIO_ADD_TEST(CategoryHelpers, basic)
 
         OCIO_CHECK_NO_THROW(names = OCIO::FindColorSpaceNames(config, categories));
 
-        OCIO_CHECK_EQUAL(names.size(), 4);
+        OCIO_REQUIRE_EQUAL(names.size(), 4);
         OCIO_CHECK_EQUAL(names[0], std::string("in_1"));
         OCIO_CHECK_EQUAL(names[1], std::string("in_2"));
         OCIO_CHECK_EQUAL(names[2], std::string("in_3"));
         OCIO_CHECK_EQUAL(names[3], std::string("lut_input_3"));
+
+        OCIO::Infos infos;
+        OCIO_CHECK_NO_THROW(infos = OCIO::FindColorSpaceInfos(config, categories, false));
+        OCIO_REQUIRE_EQUAL(infos.size(), 4);
+
+        for (size_t idx = 0; idx < names.size(); ++idx)
+        {
+            OCIO_CHECK_EQUAL(std::string(infos[idx]->getName()), names[idx]);
+        }
+    }
+
+    {
+        OCIO::Categories categories{ OCIO::ColorSpaceCategoryNames::Input };
+
+        // There are 4 color space and 2 named transforms using "input" category.
+        OCIO::Infos infos;
+        OCIO_CHECK_NO_THROW(infos = OCIO::FindColorSpaceInfos(config, categories, true));
+        OCIO_REQUIRE_EQUAL(infos.size(), 6);
+
+        OCIO_CHECK_EQUAL(std::string(infos[0]->getName()), std::string("in_1"));
+        OCIO_CHECK_EQUAL(std::string(infos[1]->getName()), std::string("in_2"));
+        OCIO_CHECK_EQUAL(std::string(infos[2]->getName()), std::string("in_3"));
+        OCIO_CHECK_EQUAL(std::string(infos[3]->getName()), std::string("lut_input_3"));
+        OCIO_CHECK_EQUAL(std::string(infos[4]->getName()), std::string("named_transform1"));
+        OCIO_CHECK_EQUAL(std::string(infos[5]->getName()), std::string("named_transform3"));
     }
 
     {
@@ -82,8 +107,16 @@ OCIO_ADD_TEST(CategoryHelpers, basic)
         OCIO_CHECK_EQUAL(names.size(), 0);
 
         OCIO::Infos infos;
-        OCIO_CHECK_NO_THROW(infos = OCIO::FindColorSpaceInfos(config, categories));
-        OCIO_REQUIRE_EQUAL(infos.size(), 0);
+        OCIO_CHECK_NO_THROW(infos = OCIO::FindColorSpaceInfos(config, categories, false));
+        OCIO_CHECK_EQUAL(infos.size(), 0);
+    }
+
+    {
+        OCIO::Categories categories{};
+
+        OCIO::Infos infos;
+        OCIO_CHECK_NO_THROW(infos = OCIO::FindColorSpaceInfos(config, categories, true));
+        OCIO_CHECK_EQUAL(infos.size(), 0);
     }
 
     {
@@ -92,7 +125,7 @@ OCIO_ADD_TEST(CategoryHelpers, basic)
 
         OCIO_CHECK_NO_THROW(names = OCIO::FindColorSpaceNames(config, categories));
 
-        OCIO_CHECK_EQUAL(names.size(), 4);
+        OCIO_REQUIRE_EQUAL(names.size(), 4);
         OCIO_CHECK_EQUAL(names[0], std::string("lin_1"));
         OCIO_CHECK_EQUAL(names[1], std::string("lin_2"));
         OCIO_CHECK_EQUAL(names[2], std::string("log_1"));
@@ -102,7 +135,7 @@ OCIO_ADD_TEST(CategoryHelpers, basic)
 
         OCIO_CHECK_NO_THROW(names = OCIO::FindColorSpaceNames(config, categories));
 
-        OCIO_CHECK_EQUAL(names.size(), 7);
+        OCIO_REQUIRE_EQUAL(names.size(), 7);
         OCIO_CHECK_EQUAL(names[0], std::string("lin_1"));
         OCIO_CHECK_EQUAL(names[1], std::string("lin_2"));
         OCIO_CHECK_EQUAL(names[2], std::string("log_1"));
@@ -117,10 +150,25 @@ OCIO_ADD_TEST(CategoryHelpers, basic)
                                       OCIO::ColorSpaceCategoryNames::LogWorkingSpace };
 
         OCIO_CHECK_NO_THROW(names = OCIO::FindColorSpaceNames(config, categories));
-        OCIO_REQUIRE_EQUAL(names.size(), 4);
+        OCIO_CHECK_EQUAL(names.size(), 4);
 
         OCIO::Infos infos;
-        OCIO_CHECK_NO_THROW(infos = OCIO::FindColorSpaceInfos(config, categories));
+        OCIO_CHECK_NO_THROW(infos = OCIO::FindColorSpaceInfos(config, categories, false));
+        OCIO_REQUIRE_EQUAL(infos.size(), 4);
+
+        for (size_t idx = 0; idx < names.size(); ++idx)
+        {
+            OCIO_CHECK_EQUAL(std::string(infos[idx]->getName()), names[idx]);
+        }
+    }
+
+    {
+        // These categories are not used by any named transform, so results are the same.
+        OCIO::Categories categories{ OCIO::ColorSpaceCategoryNames::SceneLinearWorkingSpace,
+                                     OCIO::ColorSpaceCategoryNames::LogWorkingSpace };
+
+        OCIO::Infos infos;
+        OCIO_CHECK_NO_THROW(infos = OCIO::FindColorSpaceInfos(config, categories, true));
         OCIO_REQUIRE_EQUAL(infos.size(), 4);
 
         for (size_t idx = 0; idx < names.size(); ++idx)
@@ -131,8 +179,14 @@ OCIO_ADD_TEST(CategoryHelpers, basic)
 
     {
         OCIO::Infos infos;
-        OCIO_CHECK_NO_THROW(infos = OCIO::FindAllColorSpaceInfos(config));
-        OCIO_REQUIRE_EQUAL(infos.size(), 12);
+        OCIO_CHECK_NO_THROW(infos = OCIO::FindAllColorSpaceInfos(config, false));
+        OCIO_CHECK_EQUAL(infos.size(), 12);
+    }
+
+    {
+        OCIO::Infos infos;
+        OCIO_CHECK_NO_THROW(infos = OCIO::FindAllColorSpaceInfos(config, true));
+        OCIO_CHECK_EQUAL(infos.size(), 15);
     }
 
     {

--- a/tests/apphelpers/ColorSpaceHelpers_tests.cpp
+++ b/tests/apphelpers/ColorSpaceHelpers_tests.cpp
@@ -183,13 +183,17 @@ OCIO_ADD_TEST(ColorSpaceMenuHelper, categories)
         menuHelper
             = OCIO::ColorSpaceMenuHelper::Create(config,
                                                  nullptr,
-                                                 OCIO::ColorSpaceCategoryNames::Input));
+                                                 OCIO::ColorSpaceCategoryNames::Input,
+                                                 false));
 
     OCIO_REQUIRE_EQUAL(menuHelper->getNumColorSpaces(), 4);
 
     // Select 'rendering' and include roles.
 
-    OCIO_CHECK_NO_THROW(menuHelper = OCIO::ColorSpaceMenuHelper::Create(config, "rendering", nullptr));
+    OCIO_CHECK_NO_THROW(menuHelper = OCIO::ColorSpaceMenuHelper::Create(config,
+                                                                        "rendering",
+                                                                        nullptr,
+                                                                        false));
 
     // Selected role supersedes the role adds.
     OCIO_REQUIRE_EQUAL(menuHelper->getNumColorSpaces(), 1);
@@ -198,27 +202,56 @@ OCIO_ADD_TEST(ColorSpaceMenuHelper, categories)
 
     // Use custom categories.
 
-    OCIO_CHECK_NO_THROW(menuHelper = OCIO::ColorSpaceMenuHelper::Create(config, nullptr, "input"));
+    OCIO_CHECK_NO_THROW(menuHelper = OCIO::ColorSpaceMenuHelper::Create(config,
+                                                                        nullptr,
+                                                                        "input",
+                                                                        false));
 
     OCIO_REQUIRE_EQUAL(menuHelper->getNumColorSpaces(), 4);
 
+    // Use custom categories, including named transforms.
+
+    OCIO_CHECK_NO_THROW(menuHelper = OCIO::ColorSpaceMenuHelper::Create(config,
+                                                                        nullptr,
+                                                                        "input",
+                                                                        true));
+
+    OCIO_REQUIRE_EQUAL(menuHelper->getNumColorSpaces(), 6);
+
     // Use null categories & null role.
 
-    OCIO_CHECK_NO_THROW(menuHelper = OCIO::ColorSpaceMenuHelper::Create(config, nullptr, nullptr));
+    OCIO_CHECK_NO_THROW(menuHelper = OCIO::ColorSpaceMenuHelper::Create(config,
+                                                                        nullptr,
+                                                                        nullptr,
+                                                                        false));
 
     OCIO_REQUIRE_EQUAL(menuHelper->getNumColorSpaces(), 12);  // All color spaces.
 
+    // Use null categories & null role.
+
+    OCIO_CHECK_NO_THROW(menuHelper = OCIO::ColorSpaceMenuHelper::Create(config,
+                                                                        nullptr,
+                                                                        nullptr,
+                                                                        true));
+
+    OCIO_REQUIRE_EQUAL(menuHelper->getNumColorSpaces(), 15);  // All color spaces and named transforms.
+
     // Use null categories with a role.
 
-    OCIO_CHECK_NO_THROW(menuHelper = OCIO::ColorSpaceMenuHelper::Create(config, "rendering", nullptr));
+    OCIO_CHECK_NO_THROW(menuHelper = OCIO::ColorSpaceMenuHelper::Create(config,
+                                                                        "rendering",
+                                                                        nullptr,
+                                                                        false));
 
     OCIO_REQUIRE_EQUAL(menuHelper->getNumColorSpaces(), 1);
     OCIO_CHECK_EQUAL(menuHelper->getColorSpaceName(0), std::string("lin_1"));
 
     // Use an arbitrary (but existing) category i.e. user could use some custom categories.
 
-    OCIO_CHECK_NO_THROW(
-        menuHelper = OCIO::ColorSpaceMenuHelper::Create(config, nullptr, "lut_input_space"));
+    OCIO_CHECK_NO_THROW(menuHelper = OCIO::ColorSpaceMenuHelper::Create(config,
+                                                                        nullptr,
+                                                                        "lut_input_space",
+                                                                        false));
 
     OCIO_REQUIRE_EQUAL(menuHelper->getNumColorSpaces(), 3);
     OCIO_CHECK_EQUAL(menuHelper->getColorSpaceName(0), std::string("lut_input_1"));
@@ -227,8 +260,10 @@ OCIO_ADD_TEST(ColorSpaceMenuHelper, categories)
 
     // Use categories and a role.
 
-    OCIO_CHECK_NO_THROW(
-        menuHelper = OCIO::ColorSpaceMenuHelper::Create(config, "rendering", "lut_input_space"));
+    OCIO_CHECK_NO_THROW(menuHelper = OCIO::ColorSpaceMenuHelper::Create(config,
+                                                                        "rendering",
+                                                                        "lut_input_space",
+                                                                        false));
 
     OCIO_REQUIRE_EQUAL(menuHelper->getNumColorSpaces(),  1);
 
@@ -239,18 +274,38 @@ OCIO_ADD_TEST(ColorSpaceMenuHelper, categories)
         OCIO::MuteLogging guard;
 
         // Return all the color spaces.
-        OCIO_CHECK_NO_THROW(
-            menuHelper = OCIO::ColorSpaceMenuHelper::Create(config, nullptr, "unknown_category"));
+        OCIO_CHECK_NO_THROW(menuHelper = OCIO::ColorSpaceMenuHelper::Create(config,
+                                                                            nullptr,
+                                                                            "unknown_category",
+                                                                            false));
         OCIO_REQUIRE_EQUAL(menuHelper->getNumColorSpaces(), 12);
+
+        // Return all the color spaces and named transforms.
+        OCIO_CHECK_NO_THROW(menuHelper = OCIO::ColorSpaceMenuHelper::Create(config,
+                                                                            nullptr,
+                                                                            "unknown_category",
+                                                                            true));
+        OCIO_REQUIRE_EQUAL(menuHelper->getNumColorSpaces(), 15);
 
         // Return all the color spaces.
-        OCIO_CHECK_NO_THROW(
-            menuHelper = OCIO::ColorSpaceMenuHelper::Create(config, "unknown_role", nullptr));
+        OCIO_CHECK_NO_THROW(menuHelper = OCIO::ColorSpaceMenuHelper::Create(config,
+                                                                            "unknown_role",
+                                                                            nullptr,
+                                                                            false));
         OCIO_REQUIRE_EQUAL(menuHelper->getNumColorSpaces(), 12);
 
+        // Return all the color spaces and named transforms.
+        OCIO_CHECK_NO_THROW(menuHelper = OCIO::ColorSpaceMenuHelper::Create(config,
+                                                                            "unknown_role",
+                                                                            nullptr,
+                                                                            true));
+        OCIO_REQUIRE_EQUAL(menuHelper->getNumColorSpaces(), 15);
+
         // Only return the color space associated to the role.
-        OCIO_CHECK_NO_THROW(
-            menuHelper = OCIO::ColorSpaceMenuHelper::Create(config, "rendering", "unknown_category"));
+        OCIO_CHECK_NO_THROW(menuHelper = OCIO::ColorSpaceMenuHelper::Create(config,
+                                                                            "rendering",
+                                                                            "unknown_category",
+                                                                            false));
         OCIO_REQUIRE_EQUAL(menuHelper->getNumColorSpaces(), 1);
     }
 }
@@ -268,11 +323,11 @@ OCIO_ADD_TEST(ColorSpaceMenuHelper, input_color_transformation)
     //
 
     OCIO::ColorSpaceMenuHelperRcPtr inputMenuHelper;
-    OCIO_CHECK_NO_THROW(
-        inputMenuHelper
+    OCIO_CHECK_NO_THROW(inputMenuHelper 
             = OCIO::ColorSpaceMenuHelper::Create(config,
                                                  nullptr,
-                                                 OCIO::ColorSpaceCategoryNames::Input));
+                                                 OCIO::ColorSpaceCategoryNames::Input,
+                                                 false));
 
     OCIO_REQUIRE_EQUAL(inputMenuHelper->getNumColorSpaces(), 4);
 
@@ -315,7 +370,8 @@ OCIO_ADD_TEST(ColorSpaceMenuHelper, input_color_transformation)
         workingMenuHelper
             =   OCIO::ColorSpaceMenuHelper::Create(config,
                                                    nullptr,
-                                                   OCIO::ColorSpaceCategoryNames::SceneLinearWorkingSpace));
+                                                   OCIO::ColorSpaceCategoryNames::SceneLinearWorkingSpace,
+                                                   false));
 
     OCIO_REQUIRE_EQUAL(workingMenuHelper->getNumColorSpaces(), 2);
 
@@ -356,6 +412,23 @@ OCIO_ADD_TEST(ColorSpaceMenuHelper, input_color_transformation)
         OCIO_CHECK_EQUAL(values[3], 1.);
     }
 
+    // Repeat including named transforms.
+
+    OCIO_CHECK_NO_THROW(
+        workingMenuHelper
+            =   OCIO::ColorSpaceMenuHelper::Create(config,
+                                                   nullptr,
+                                                   OCIO::ColorSpaceCategoryNames::Input,
+                                                   true));
+
+    OCIO_REQUIRE_EQUAL(workingMenuHelper->getNumColorSpaces(), 6);
+
+    OCIO_CHECK_EQUAL(workingMenuHelper->getColorSpaceName(0), std::string("in_1"));
+    OCIO_CHECK_EQUAL(workingMenuHelper->getColorSpaceName(1), std::string("in_2"));
+    OCIO_CHECK_EQUAL(workingMenuHelper->getColorSpaceName(2), std::string("in_3"));
+    OCIO_CHECK_EQUAL(workingMenuHelper->getColorSpaceName(3), std::string("lut_input_3"));
+    OCIO_CHECK_EQUAL(workingMenuHelper->getColorSpaceName(4), std::string("named_transform1"));
+    OCIO_CHECK_EQUAL(workingMenuHelper->getColorSpaceName(5), std::string("named_transform3"));
 }
 
 OCIO_ADD_TEST(ColorSpaceMenuHelper, additional_color_space)
@@ -376,7 +449,8 @@ OCIO_ADD_TEST(ColorSpaceMenuHelper, additional_color_space)
         menuHelper
             = OCIO::ColorSpaceMenuHelper::Create(config,
                                                  nullptr,
-                                                 OCIO::ColorSpaceCategoryNames::Input));
+                                                 OCIO::ColorSpaceCategoryNames::Input,
+                                                 false));
 
     OCIO_REQUIRE_EQUAL(menuHelper->getNumColorSpaces(), 4);
 

--- a/tests/apphelpers/DisplayViewHelpers_tests.cpp
+++ b/tests/apphelpers/DisplayViewHelpers_tests.cpp
@@ -46,7 +46,8 @@ OCIO_ADD_TEST(DisplayViewHelpers, basic)
         workingMenuHelper
             = OCIO::ColorSpaceMenuHelper::Create(cfg,
                                                  nullptr,
-                                                 OCIO::ColorSpaceCategoryNames::SceneLinearWorkingSpace));
+                                                 OCIO::ColorSpaceCategoryNames::SceneLinearWorkingSpace,
+                                                 false));
 
     OCIO_REQUIRE_EQUAL(workingMenuHelper->getNumColorSpaces(), 2);
 
@@ -62,7 +63,8 @@ OCIO_ADD_TEST(DisplayViewHelpers, basic)
         connectionMenuHelper
             = OCIO::ColorSpaceMenuHelper::Create(cfg,
                                                  nullptr,
-                                                 OCIO::ColorSpaceCategoryNames::LutInputSpace));
+                                                 OCIO::ColorSpaceCategoryNames::LutInputSpace,
+                                                 false));
 
     OCIO_REQUIRE_EQUAL(connectionMenuHelper->getNumColorSpaces(), 3);
 

--- a/tests/apphelpers/configs.data
+++ b/tests/apphelpers/configs.data
@@ -103,4 +103,20 @@ colorspaces:
     name: lut_input_3
     categories: [ input, lut_input_space ]
     from_reference: !<ExponentTransform> {value: [2.4, 2.4, 2.4, 1], direction: inverse}
+
+named_transforms:
+  - !<NamedTransform>
+    name: named_transform1
+    categories: [ conditioning, input ]
+    transform: !<MatrixTransform> {offset: [0.1, 0.2, 0.3, 0.4]}
+
+  - !<NamedTransform>
+    name: named_transform2
+    inverse_transform: !<MatrixTransform> {offset: [-0.2, -0.1, -0.1, 0]}
+
+  - !<NamedTransform>
+    name: named_transform3
+    categories: [ input, basic ]
+    transform: !<MatrixTransform> {offset: [0.1, 0.2, 0.3, 0]}
+    inverse_transform: !<MatrixTransform> {offset: [-0.1, -0.2, -0.3, 0]}
 )"};

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -163,6 +163,7 @@ set(TESTS
     Logging_tests.cpp
     LookParse_tests.cpp
     MathUtils_tests.cpp
+    NamedTransform_tests.cpp
     Op_tests.cpp
     OpOptimizers_tests.cpp
     ops/allocation/AllocationOp_tests.cpp

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -106,9 +106,9 @@ OCIO_ADD_TEST(Config, create_raw_config)
     OCIO_CHECK_NO_THROW(proc->getDefaultCPUProcessor());
 
     OCIO_CHECK_THROW_WHAT(config->getProcessor("not_found", "raw"), OCIO::Exception,
-                          "Could not find source color space");
+                          "Color space 'not_found' could not be found");
     OCIO_CHECK_THROW_WHAT(config->getProcessor("raw", "not_found"), OCIO::Exception,
-                          "Could not find destination color space");
+                          "Color space 'not_found' could not be found");
 }
 
 OCIO_ADD_TEST(Config, simple_config)
@@ -797,7 +797,7 @@ OCIO_ADD_TEST(Config, context_variable_faulty_cases)
 
         OCIO_CHECK_THROW_WHAT(cfg->getProcessor("cs1", "disp1", "view1", OCIO::TRANSFORM_DIR_FORWARD),
                               OCIO::Exception,
-                              "destination color space '$DST3' could not be found");
+                              "Color space '$DST3' could not be found");
     }
 
     {
@@ -810,7 +810,7 @@ OCIO_ADD_TEST(Config, context_variable_faulty_cases)
 
         OCIO_CHECK_THROW_WHAT(cfg->getProcessor("cs1", "disp1", "view2", OCIO::TRANSFORM_DIR_FORWARD),
                               OCIO::Exception,
-                              "destination color space '$DST2' could not be found");
+                              "Color space '$DST2' could not be found");
     }
 
     {
@@ -824,7 +824,7 @@ OCIO_ADD_TEST(Config, context_variable_faulty_cases)
 
         OCIO_CHECK_THROW_WHAT(cfg->getProcessor("cs1", "disp1", "view2", OCIO::TRANSFORM_DIR_FORWARD),
                               OCIO::Exception,
-                              "destination color space '$DST1' could not be found");
+                              "Color space '$DST1' could not be found");
     }
 }
 
@@ -1216,13 +1216,13 @@ OCIO_ADD_TEST(Config, context_variable_with_colorspacename)
 
         OCIO_CHECK_THROW_WHAT(cfg->getProcessor("cs1", "cs2"),
                               OCIO::Exception,
-                              "source color space '$VAR3' could not be found.");
+                              "Color space '$VAR3' could not be found.");
 
         OCIO::ContextRcPtr ctx;
         OCIO_CHECK_NO_THROW(ctx = cfg->getCurrentContext()->createEditableCopy());
         OCIO_CHECK_THROW_WHAT(cfg->getProcessor(ctx, "cs1", "cs2"),
                               OCIO::Exception,
-                              "source color space '$VAR3' could not be found.");
+                              "Color space '$VAR3' could not be found.");
 
         OCIO_CHECK_NO_THROW(ctx->setStringVar("VAR3", "cs1"));
         OCIO_CHECK_NO_THROW(cfg->getProcessor(ctx, "cs1", "cs2"));
@@ -1233,7 +1233,7 @@ OCIO_ADD_TEST(Config, context_variable_with_colorspacename)
         OCIO_CHECK_NO_THROW(ctx->setStringVar("VAR3", ""));
         OCIO_CHECK_THROW_WHAT(cfg->getProcessor(ctx, "cs1", "cs2"),
                               OCIO::Exception,
-                              "source color space '$VAR3' could not be found.");
+                              "Color space '$VAR3' could not be found.");
     }
 }
 
@@ -1283,7 +1283,7 @@ OCIO_ADD_TEST(Config, context_variable_with_role)
                               "The role 'reference' refers to a color space, '$ENV1', which is not defined.");
 
         OCIO_CHECK_THROW_WHAT(cfg->getProcessor("cs1", "cs3"), OCIO::Exception,
-                              "source color space 'reference' could not be found.");
+                              "Color space 'reference' could not be found.");
     }
 }
 
@@ -1323,12 +1323,13 @@ OCIO_ADD_TEST(Config, context_variable_with_display_view)
 
         OCIO_CHECK_THROW_WHAT(config->validate(),
                               OCIO::Exception,
-                              "Display 'disp1' has a view 'view1' that refers to a color space, '$ENV1',"
-                              " which is not defined.");
+                              "Display 'disp1' has a view 'view1' that refers to a color space or "
+                              "a named transform, '$ENV1', which is not defined.");
 
         OCIO_CHECK_THROW_WHAT(config->getProcessor("cs1", "disp1", "view1", OCIO::TRANSFORM_DIR_FORWARD),
                               OCIO::Exception,
-                              "DisplayViewTransform error. Cannot find display color space, '$ENV1'.");
+                              "DisplayViewTransform error. Cannot find color space or "
+                              "named transform, named '$ENV1'.");
     }
 }
 
@@ -1461,8 +1462,7 @@ OCIO_ADD_TEST(Config, env_colorspace_name)
                               "This config references a color space '$MISSING_ENV' "
                               "using an unknown context variable");
         OCIO_CHECK_THROW_WHAT(config->getProcessor("raw", "lgh"), OCIO::Exception,
-                              "BuildColorSpaceOps failed: destination color space '$MISSING_ENV' "
-                              "could not be found");
+                              "Color space '$MISSING_ENV' could not be found");
     }
 
     {
@@ -1481,8 +1481,7 @@ OCIO_ADD_TEST(Config, env_colorspace_name)
         OCIO_CHECK_THROW_WHAT(config->validate(), OCIO::Exception,
                               "color space, 'FaultyColorSpaceName', which is not defined");
         OCIO_CHECK_THROW_WHAT(config->getProcessor("raw", "lgh"), OCIO::Exception,
-                              "BuildColorSpaceOps failed: destination color space '$OCIO_TEST' "
-                              "could not be found");
+                              "Color space '$OCIO_TEST' could not be found");
     }
 
     {
@@ -7259,8 +7258,8 @@ colorspaces:
     OCIO_CHECK_NO_THROW(cfg->addVirtualDisplayView("Raw1", nullptr, "raw1", nullptr, nullptr, nullptr));
     OCIO_CHECK_THROW_WHAT(cfg->validate(),
                           OCIO::Exception,
-                          "Display 'virtual_display' has a view 'Raw1' that refers to a color space,"
-                          " 'raw1', which is not defined.");
+                          "Display 'virtual_display' has a view 'Raw1' that refers to a color space"
+                          " or a named transform, 'raw1', which is not defined.");
 
     cfg->removeVirtualDisplayView("Raw1");
     OCIO_CHECK_NO_THROW(cfg->validate());

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -5014,7 +5014,8 @@ OCIO_ADD_TEST(Config, inactive_color_space_read_write)
             OCIO::LogGuard log;
             OCIO_CHECK_NO_THROW(config->validate());
             OCIO_CHECK_EQUAL(log.output(), 
-                             "[OpenColorIO Warning]: Inactive color space 'unknown' does not exist.\n");
+                             "[OpenColorIO Warning]: Inactive 'unknown' is neither a color "
+                             "space nor a named transform.\n");
         }
 
         OCIO_CHECK_EQUAL(config->getNumColorSpaces(OCIO::SEARCH_REFERENCE_SPACE_ALL,

--- a/tests/cpu/Display_tests.cpp
+++ b/tests/cpu/Display_tests.cpp
@@ -27,7 +27,7 @@ OCIO_ADD_TEST(SharedViews, basic)
     // Shared views need to refer to existing colorspaces.
     OCIO_CHECK_NO_THROW(config->addSharedView("shared1", "", "colorspace1", "", "", ""));
     OCIO_CHECK_THROW_WHAT(config->validate(), OCIO::Exception,
-                          "color space, 'colorspace1', which is not defined");
+                          "color space or a named transform, 'colorspace1', which is not defined");
 
     OCIO::ColorSpaceRcPtr cs = OCIO::ColorSpace::Create();
     cs->setName("colorspace1");
@@ -56,7 +56,8 @@ OCIO_ADD_TEST(SharedViews, basic)
     OCIO_CHECK_NO_THROW(config->addSharedView("shared3", "viewTransform1", "colorspace3", "", "",
                                               "shared view description"));
     OCIO_CHECK_THROW_WHAT(config->validate(), OCIO::Exception,
-                          "refers to a view transform, 'viewTransform1', which is not defined");
+                          "refers to a view transform, 'viewTransform1', which is neither a view "
+                          "transform nor a named transform");
 
     OCIO::ViewTransformRcPtr vt = OCIO::ViewTransform::Create(OCIO::REFERENCE_SPACE_SCENE);
     vt->setName("viewTransform1");

--- a/tests/cpu/FileRules_tests.cpp
+++ b/tests/cpu/FileRules_tests.cpp
@@ -357,7 +357,9 @@ OCIO_ADD_TEST(FileRules, rule_invalid)
 
     OCIO_CHECK_NO_THROW(rules->setColorSpace(0, "invalid_color_space"));
     config->setFileRules(rules);
-    OCIO_CHECK_THROW_WHAT(config->validate(), OCIO::Exception, "does not exist");
+    OCIO_CHECK_THROW_WHAT(config->validate(), OCIO::Exception, "rule named 'rule1' is referencing "
+                          "'invalid_color_space' that is neither a color space nor a named "
+                          "transform");
 }
 
 OCIO_ADD_TEST(FileRules, pattern_error)
@@ -1091,7 +1093,9 @@ colorspaces:
         config->setMajorVersion(2);
 
         // Default rule is using 'Default' role that does not exist.
-        OCIO_CHECK_THROW_WHAT(config->validate(), OCIO::Exception, "does not exist");
+        OCIO_CHECK_THROW_WHAT(config->validate(), OCIO::Exception, "rule named 'Default' is "
+                              "referencing 'default' that is neither a color space nor a named "
+                              "transform");
 
         config = constConfig->createEditableCopy();
         OCIO_CHECK_EQUAL(config->getNumColorSpaces(), 3);
@@ -1142,7 +1146,8 @@ colorspaces:
 
         // Default rule is using 'Default' role that does not exist.
         OCIO_CHECK_THROW_WHAT(config->validate(), OCIO::Exception, "rule named 'Default' is "
-                              "referencing color space 'default' that does not exist");
+                              "referencing 'default' that is neither a color space nor a named "
+                              "transform");
 
         config = constConfig->createEditableCopy();
         OCIO_CHECK_EQUAL(config->getNumColorSpaces(), 3);

--- a/tests/cpu/NamedTransform_tests.cpp
+++ b/tests/cpu/NamedTransform_tests.cpp
@@ -1,0 +1,554 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include "NamedTransform.cpp"
+
+#include "testutils/UnitTest.h"
+
+namespace OCIO = OCIO_NAMESPACE;
+
+OCIO_ADD_TEST(NamedTransform, basic)
+{
+    auto namedTransform = OCIO::NamedTransform::Create();
+    OCIO_REQUIRE_ASSERT(namedTransform);
+    const std::string name{ namedTransform->getName() };
+    OCIO_CHECK_ASSERT(name.empty());
+    OCIO_CHECK_ASSERT(!namedTransform->getTransform(OCIO::TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_ASSERT(!namedTransform->getTransform(OCIO::TRANSFORM_DIR_INVERSE));
+    const std::string newName{ "NewName" };
+    namedTransform->setName(newName.c_str());
+    OCIO_CHECK_EQUAL(newName, namedTransform->getName());
+
+    auto mat = OCIO::MatrixTransform::Create();
+    namedTransform->setTransform(mat, OCIO::TRANSFORM_DIR_FORWARD);
+    auto fwdTransform = namedTransform->getTransform(OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_ASSERT(OCIO_DYNAMIC_POINTER_CAST<const OCIO::MatrixTransform>(fwdTransform));
+    // Transform is copied when set, so pointers are different.
+    OCIO_CHECK_NE(namedTransform->getTransform(OCIO::TRANSFORM_DIR_FORWARD), mat);
+    OCIO_CHECK_ASSERT(!namedTransform->getTransform(OCIO::TRANSFORM_DIR_INVERSE));
+
+    auto actualFwdTransform = OCIO::NamedTransformImpl::GetTransform(namedTransform,
+                                                                     OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_ASSERT(OCIO_DYNAMIC_POINTER_CAST<const OCIO::MatrixTransform>(actualFwdTransform));
+    auto actualInvTransform = OCIO::NamedTransformImpl::GetTransform(namedTransform,
+                                                                     OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_ASSERT(OCIO_DYNAMIC_POINTER_CAST<const OCIO::MatrixTransform>(actualInvTransform));
+
+    std::ostringstream oss;
+    OCIO_CHECK_NO_THROW(oss << *namedTransform);
+    OCIO_CHECK_EQUAL(oss.str(), "<NamedTransform name=NewName,\n    forward=\n        "
+                                "<MatrixTransform direction=forward, fileindepth=unknown, "
+                                "fileoutdepth=unknown, matrix=1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1, "
+                                "offset=0 0 0 0>>");
+
+    // Test faulty cases.
+
+    OCIO::ConfigRcPtr config = OCIO::Config::CreateRaw()->createEditableCopy();
+
+    OCIO::NamedTransformRcPtr namedTransformInv;
+    OCIO_CHECK_THROW_WHAT(config->addNamedTransform(namedTransformInv), OCIO::Exception,
+                          "Named transform is null");
+
+    namedTransformInv = OCIO::NamedTransform::Create();
+    OCIO_CHECK_THROW_WHAT(config->addNamedTransform(namedTransformInv), OCIO::Exception,
+                          "Named transform must have a non-empty name");
+
+    const std::string name1{ "name" };
+    namedTransformInv->setName(name1.c_str());
+    OCIO_CHECK_THROW_WHAT(config->addNamedTransform(namedTransformInv), OCIO::Exception,
+                          "Named transform must define at least one transform");
+}
+
+OCIO_ADD_TEST(Config, named_transform_processor)
+{
+    // Create a config with color spaces and named transforms.
+    
+    constexpr const char * Config{ R"(ocio_profile_version: 2
+
+search_path: ""
+strictparsing: false
+luma: [0.2126, 0.7152, 0.0722]
+
+roles:
+  default: raw
+
+file_rules:
+  - !<Rule> {name: ColorSpaceNamePathSearch}
+  - !<Rule> {name: Default, colorspace: default}
+
+displays:
+  sRGB:
+    - !<View> {name: Raw, colorspace: raw}
+
+active_displays: []
+active_views: []
+
+display_colorspaces:
+  - !<ColorSpace>
+    name: dcs
+    isdata: false
+    allocation: uniform
+    from_display_reference: !<RangeTransform> {min_in_value: 0, min_out_value: 0}
+
+colorspaces:
+  - !<ColorSpace>
+    name: raw
+    family: raw
+    bitdepth: 32f
+    description: |
+      A raw color space. Conversions to and from this space are no-ops.
+    isdata: true
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: cs
+    isdata: false
+    allocation: uniform
+    to_reference: !<RangeTransform> {max_in_value: 1, max_out_value: 1}
+
+named_transforms:
+  - !<NamedTransform>
+    name: forward
+    transform: !<MatrixTransform> {name: forward, offset: [0.1, 0.2, 0.3, 0.4]}
+
+  - !<NamedTransform>
+    name: inverse
+    inverse_transform: !<MatrixTransform> {name: inverse, offset: [-0.2, -0.1, -0.1, 0]}
+
+  - !<NamedTransform>
+    name: both
+    transform: !<MatrixTransform> {name: forward, offset: [0.1, 0.2, 0.3, 0.4]}
+    inverse_transform: !<MatrixTransform> {name: inverse, offset: [-0.2, -0.1, -0.1, 0]}
+)" };
+
+    std::istringstream iss;
+    iss.str(Config);
+
+    OCIO::ConstConfigRcPtr config;
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(iss));
+
+    const std::string forward{ "forward" };
+    static constexpr double offsetF[4]{ 0.1, 0.2, 0.3, 0.4 };
+    const std::string inverse{ "inverse" };
+    static constexpr double offsetI[4]{ -0.2, -0.1, -0.1, 0. };
+    const std::string both{ "both" };
+    const std::string dcsName{ "dcs" };
+    const std::string csName{ "cs" };
+
+    // Basic named transform access.
+    {
+        auto nt = config->getNamedTransform(forward.c_str());
+        OCIO_REQUIRE_ASSERT(nt);
+        // Get the transform in the wanted direction and make sure it exists (else use the other
+        // transform in the other direction).
+        auto tf = nt->getTransform(OCIO::TRANSFORM_DIR_FORWARD);
+        OCIO_REQUIRE_ASSERT(tf);
+
+        OCIO::ConstProcessorRcPtr proc;
+        OCIO_CHECK_NO_THROW(proc = config->getProcessor(tf));
+        OCIO_REQUIRE_ASSERT(proc);
+        OCIO::GroupTransformRcPtr group;
+        OCIO_CHECK_NO_THROW(group = proc->createGroupTransform());
+        OCIO_REQUIRE_ASSERT(group);
+        OCIO_REQUIRE_EQUAL(group->getNumTransforms(), 1);
+        OCIO::TransformRcPtr transform;
+        OCIO_CHECK_NO_THROW(transform = group->getTransform(0));
+        auto matrix = OCIO_DYNAMIC_POINTER_CAST<OCIO::MatrixTransform>(transform);
+        OCIO_REQUIRE_ASSERT(matrix);
+        OCIO_CHECK_EQUAL(forward, proc->getTransformFormatMetadata(0).getAttributeValue(0));
+        double offset[]{ 0., 0., 0., 0. };
+        matrix->getOffset(offset);
+        OCIO_CHECK_EQUAL(offset[0], offsetF[0]);
+        OCIO_CHECK_EQUAL(offset[1], offsetF[1]);
+        OCIO_CHECK_EQUAL(offset[2], offsetF[2]);
+    }
+
+    // Diplay color space to named transform.
+    {
+        OCIO::ConstProcessorRcPtr proc;
+        OCIO_CHECK_NO_THROW(proc = config->getProcessor(dcsName.c_str(), forward.c_str()));
+        OCIO_REQUIRE_ASSERT(proc);
+        OCIO::GroupTransformRcPtr group;
+        OCIO_CHECK_NO_THROW(group = proc->createGroupTransform());
+        OCIO_REQUIRE_ASSERT(group);
+        OCIO_REQUIRE_EQUAL(group->getNumTransforms(), 1);
+        OCIO::TransformRcPtr transform;
+        OCIO_CHECK_NO_THROW(transform = group->getTransform(0));
+        auto matrix = OCIO_DYNAMIC_POINTER_CAST<OCIO::MatrixTransform>(transform);
+        OCIO_REQUIRE_ASSERT(matrix);
+        // Named transform inverse transform not available, use forward transform inverted.
+        OCIO_CHECK_EQUAL(forward, proc->getTransformFormatMetadata(0).getAttributeValue(0));
+        double offset[]{ 0., 0., 0., 0. };
+        matrix->getOffset(offset);
+        OCIO_CHECK_EQUAL(offset[0], -offsetF[0]);
+        OCIO_CHECK_EQUAL(offset[1], -offsetF[1]);
+        OCIO_CHECK_EQUAL(offset[2], -offsetF[2]);
+    }
+
+    // Color space to named transform.
+    {
+        OCIO::ConstProcessorRcPtr proc;
+        OCIO_CHECK_NO_THROW(proc = config->getProcessor(csName.c_str(), inverse.c_str()));
+        OCIO_REQUIRE_ASSERT(proc);
+        OCIO::GroupTransformRcPtr group;
+        OCIO_CHECK_NO_THROW(group = proc->createGroupTransform());
+        OCIO_REQUIRE_ASSERT(group);
+        OCIO_REQUIRE_EQUAL(group->getNumTransforms(), 1);
+        OCIO::TransformRcPtr transform;
+        OCIO_CHECK_NO_THROW(transform = group->getTransform(0));
+        auto matrix = OCIO_DYNAMIC_POINTER_CAST<OCIO::MatrixTransform>(transform);
+        OCIO_REQUIRE_ASSERT(matrix);
+        // Named transform inverse transform.
+        OCIO_CHECK_EQUAL(inverse, proc->getTransformFormatMetadata(0).getAttributeValue(0));
+        double offset[]{ 0., 0., 0., 0. };
+        matrix->getOffset(offset);
+        OCIO_CHECK_EQUAL(offset[0], offsetI[0]);
+        OCIO_CHECK_EQUAL(offset[1], offsetI[1]);
+        OCIO_CHECK_EQUAL(offset[2], offsetI[2]);
+    }
+
+    // Diplay color space to named transform (using ColorSpaceTransform).
+    {
+        OCIO::ConstProcessorRcPtr proc;
+        auto csTransform = OCIO::ColorSpaceTransform::Create();
+        csTransform->setSrc(dcsName.c_str());
+        csTransform->setDst(both.c_str());
+        OCIO_CHECK_NO_THROW(proc = config->getProcessor(csTransform));
+        OCIO_REQUIRE_ASSERT(proc);
+        OCIO::GroupTransformRcPtr group;
+        OCIO_CHECK_NO_THROW(group = proc->createGroupTransform());
+        OCIO_REQUIRE_ASSERT(group);
+        OCIO_REQUIRE_EQUAL(group->getNumTransforms(), 1);
+        OCIO::TransformRcPtr transform;
+        OCIO_CHECK_NO_THROW(transform = group->getTransform(0));
+        auto matrix = OCIO_DYNAMIC_POINTER_CAST<OCIO::MatrixTransform>(transform);
+        OCIO_REQUIRE_ASSERT(matrix);
+        // Named transform has both transforms, use inverse transform.
+        OCIO_CHECK_EQUAL(inverse, proc->getTransformFormatMetadata(0).getAttributeValue(0));
+        double offset[]{ 0., 0., 0., 0. };
+        matrix->getOffset(offset);
+        OCIO_CHECK_EQUAL(offset[0], offsetI[0]);
+        OCIO_CHECK_EQUAL(offset[1], offsetI[1]);
+        OCIO_CHECK_EQUAL(offset[2], offsetI[2]);
+    }
+
+    // Named transform to color space.
+    {
+        OCIO::ConstProcessorRcPtr proc;
+        OCIO_CHECK_NO_THROW(proc = config->getProcessor(forward.c_str(), csName.c_str()));
+        OCIO_REQUIRE_ASSERT(proc);
+        OCIO::GroupTransformRcPtr group;
+        OCIO_CHECK_NO_THROW(group = proc->createGroupTransform());
+        OCIO_REQUIRE_ASSERT(group);
+        OCIO_REQUIRE_EQUAL(group->getNumTransforms(), 1);
+        OCIO::TransformRcPtr transform;
+        OCIO_CHECK_NO_THROW(transform = group->getTransform(0));
+        auto matrix = OCIO_DYNAMIC_POINTER_CAST<OCIO::MatrixTransform>(transform);
+        OCIO_REQUIRE_ASSERT(matrix);
+        // Named transform forward transform.
+        OCIO_CHECK_EQUAL(forward, matrix->getFormatMetadata().getAttributeValue(0));
+        double offset[]{ 0., 0., 0., 0. };
+        matrix->getOffset(offset);
+        OCIO_CHECK_EQUAL(offset[0], offsetF[0]);
+        OCIO_CHECK_EQUAL(offset[1], offsetF[1]);
+        OCIO_CHECK_EQUAL(offset[2], offsetF[2]);
+    }
+
+    // Named transform to display color space.
+    {
+        OCIO::ConstProcessorRcPtr proc;
+        OCIO_CHECK_NO_THROW(proc = config->getProcessor(inverse.c_str(), dcsName.c_str()));
+        OCIO_REQUIRE_ASSERT(proc);
+        OCIO::GroupTransformRcPtr group;
+        OCIO_CHECK_NO_THROW(group = proc->createGroupTransform());
+        OCIO_REQUIRE_ASSERT(group);
+        OCIO_REQUIRE_EQUAL(group->getNumTransforms(), 1);
+        OCIO::TransformRcPtr transform;
+        OCIO_CHECK_NO_THROW(transform = group->getTransform(0));
+        auto matrix = OCIO_DYNAMIC_POINTER_CAST<OCIO::MatrixTransform>(transform);
+        OCIO_REQUIRE_ASSERT(matrix);
+        // Named transform forward transform not available, use inverse transform inverted.
+        OCIO_CHECK_EQUAL(inverse, matrix->getFormatMetadata().getAttributeValue(0));
+        double offset[]{ 0., 0., 0., 0. };
+        matrix->getOffset(offset);
+        OCIO_CHECK_EQUAL(offset[0], -offsetI[0]);
+        OCIO_CHECK_EQUAL(offset[1], -offsetI[1]);
+        OCIO_CHECK_EQUAL(offset[2], -offsetI[2]);
+    }
+
+    // Named transform to color space.
+    {
+        OCIO::ConstProcessorRcPtr proc;
+        OCIO_CHECK_NO_THROW(proc = config->getProcessor(both.c_str(), csName.c_str()));
+        OCIO_REQUIRE_ASSERT(proc);
+        OCIO::GroupTransformRcPtr group;
+        OCIO_CHECK_NO_THROW(group = proc->createGroupTransform());
+        OCIO_REQUIRE_ASSERT(group);
+        OCIO_REQUIRE_EQUAL(group->getNumTransforms(), 1);
+        OCIO::TransformRcPtr transform;
+        OCIO_CHECK_NO_THROW(transform = group->getTransform(0));
+        auto matrix = OCIO_DYNAMIC_POINTER_CAST<OCIO::MatrixTransform>(transform);
+        OCIO_REQUIRE_ASSERT(matrix);
+        // Named transform has both transforms, use forward transform.
+        OCIO_CHECK_EQUAL(forward, matrix->getFormatMetadata().getAttributeValue(0));
+        double offset[]{ 0., 0., 0., 0. };
+        matrix->getOffset(offset);
+        OCIO_CHECK_EQUAL(offset[0], offsetF[0]);
+        OCIO_CHECK_EQUAL(offset[1], offsetF[1]);
+        OCIO_CHECK_EQUAL(offset[2], offsetF[2]);
+    }
+
+    // Named transform to named transform.
+    {
+        OCIO::ConstProcessorRcPtr proc;
+        OCIO_CHECK_NO_THROW(proc = config->getProcessor(both.c_str(), both.c_str()));
+        OCIO_REQUIRE_ASSERT(proc);
+        OCIO::GroupTransformRcPtr group;
+        OCIO_CHECK_NO_THROW(group = proc->createGroupTransform());
+        OCIO_REQUIRE_ASSERT(group);
+        OCIO_REQUIRE_EQUAL(group->getNumTransforms(), 2);
+        OCIO::TransformRcPtr transform;
+        OCIO_CHECK_NO_THROW(transform = group->getTransform(0));
+        auto matrix = OCIO_DYNAMIC_POINTER_CAST<OCIO::MatrixTransform>(transform);
+        OCIO_REQUIRE_ASSERT(matrix);
+        double offset[]{ 0., 0., 0., 0. };
+        matrix->getOffset(offset);
+        // Named transform forward transform.
+        OCIO_CHECK_EQUAL(forward, proc->getTransformFormatMetadata(0).getAttributeValue(0));
+        matrix->getOffset(offset);
+        OCIO_CHECK_EQUAL(offset[0], offsetF[0]);
+        OCIO_CHECK_EQUAL(offset[1], offsetF[1]);
+        OCIO_CHECK_EQUAL(offset[2], offsetF[2]);
+
+        OCIO_CHECK_NO_THROW(transform = group->getTransform(1));
+        matrix = OCIO_DYNAMIC_POINTER_CAST<OCIO::MatrixTransform>(transform);
+        OCIO_REQUIRE_ASSERT(matrix);
+        // Named transform inverse transform.
+        OCIO_CHECK_EQUAL(inverse, proc->getTransformFormatMetadata(1).getAttributeValue(0));
+        matrix->getOffset(offset);
+        OCIO_CHECK_EQUAL(offset[0], offsetI[0]);
+        OCIO_CHECK_EQUAL(offset[1], offsetI[1]);
+        OCIO_CHECK_EQUAL(offset[2], offsetI[2]);
+    }
+}
+
+OCIO_ADD_TEST(Config, named_transform_validation)
+{
+    OCIO::ConfigRcPtr config = OCIO::Config::CreateRaw()->createEditableCopy();
+
+    OCIO::NamedTransformRcPtr namedTransform = OCIO::NamedTransform::Create();
+    const std::string name1{ "name" };
+    namedTransform->setName(name1.c_str());
+    auto mat = OCIO::MatrixTransform::Create();
+    const double offset[4]{ 0.1, 0.2, 0.3, 0.4 };
+    mat->setOffset(offset);
+    namedTransform->setTransform(mat, OCIO::TRANSFORM_DIR_FORWARD);
+
+    OCIO_CHECK_NO_THROW(config->addNamedTransform(namedTransform));
+    OCIO_CHECK_EQUAL(config->getNumNamedTransforms(), 1);
+
+    const std::string name2{ "other_name" };
+    namedTransform->setName(name2.c_str());
+    namedTransform->setTransform(mat, OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_NO_THROW(config->addNamedTransform(namedTransform));
+    OCIO_CHECK_EQUAL(config->getNumNamedTransforms(), 2);
+
+    OCIO_CHECK_NO_THROW(config->validate());
+
+    OCIO_CHECK_EQUAL(name1, config->getNamedTransformNameByIndex(0));
+    OCIO_CHECK_EQUAL(name2, config->getNamedTransformNameByIndex(1));
+    OCIO_CHECK_EQUAL(std::string(), config->getNamedTransformNameByIndex(2));
+
+    OCIO::ConstNamedTransformRcPtr nt = config->getNamedTransform(name1.c_str());
+    OCIO_REQUIRE_ASSERT(nt);
+    OCIO_CHECK_ASSERT(nt->getTransform(OCIO::TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_ASSERT(!nt->getTransform(OCIO::TRANSFORM_DIR_INVERSE));
+
+    nt = config->getNamedTransform(name2.c_str());
+    OCIO_REQUIRE_ASSERT(nt);
+    OCIO_CHECK_ASSERT(nt->getTransform(OCIO::TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_ASSERT(nt->getTransform(OCIO::TRANSFORM_DIR_INVERSE));
+
+    OCIO::ConstProcessorRcPtr proc;
+    OCIO_CHECK_NO_THROW(proc = config->getProcessor("raw", name1.c_str()));
+    OCIO_REQUIRE_ASSERT(proc);
+
+    OCIO_CHECK_NO_THROW(proc = config->getProcessor(name1.c_str(), name1.c_str()));
+    OCIO_REQUIRE_ASSERT(proc);
+
+    OCIO_CHECK_THROW_WHAT(proc = config->getProcessor("raw", "missing"), OCIO::Exception,
+                          "Color space 'missing' could not be found");
+
+    // NamedTransform can't use a role name.
+    config->setRole(name1.c_str(), "raw");
+    OCIO_CHECK_THROW_WHAT(config->validate(), OCIO::Exception,
+                          "This name is already used for a role");
+    config->setRole(name1.c_str(), nullptr);
+
+    // NamedTransform can't use a color space name.
+    OCIO::ColorSpaceRcPtr cs = OCIO::ColorSpace::Create();
+    cs->setName(name1.c_str());
+    config->addColorSpace(cs);
+    OCIO_CHECK_THROW_WHAT(config->validate(), OCIO::Exception,
+                          "This name is already used for a color space");
+    config->removeColorSpace(name1.c_str());
+
+    // NamedTransform can't use a look name.
+    OCIO::LookRcPtr look = OCIO::Look::Create();
+    look->setName(name1.c_str());
+    look->setProcessSpace("raw");
+
+    config->addLook(look);
+    OCIO_CHECK_THROW_WHAT(config->validate(), OCIO::Exception,
+                          "This name is already used for a look");
+    config->clearLooks();
+
+    // NamedTransform can't use a view transform name.
+    OCIO::ViewTransformRcPtr vt = OCIO::ViewTransform::Create(OCIO::REFERENCE_SPACE_SCENE);
+    vt->setName(name1.c_str());
+    vt->setTransform(OCIO::MatrixTransform::Create(), OCIO::VIEWTRANSFORM_DIR_TO_REFERENCE);
+
+    config->addViewTransform(vt);
+    OCIO_CHECK_THROW_WHAT(config->validate(), OCIO::Exception,
+                          "This name is already used for a view transform");
+    config->clearViewTransforms();
+
+    config->setMajorVersion(1);
+    config->setFileRules(OCIO::FileRules::Create());
+    OCIO_CHECK_THROW_WHAT(config->validate(), OCIO::Exception,
+                          "Only version 2 (or higher) can have NamedTransforms");
+}
+
+OCIO_ADD_TEST(Config, named_transform_io)
+{
+    // Validate Config::validate() on config file containing named transforms.
+
+    constexpr const char * OCIO_CONFIG_START{ R"(ocio_profile_version: 2
+
+environment:
+  {}
+search_path: ""
+strictparsing: true
+luma: [0.2126, 0.7152, 0.0722]
+
+roles:
+  default: raw
+
+file_rules:
+  - !<Rule> {name: Default, colorspace: default}
+
+displays:
+  Disp1:
+    - !<View> {name: View1, colorspace: raw}
+
+active_displays: []
+active_views: []
+
+colorspaces:
+  - !<ColorSpace>
+    name: raw
+    family: ""
+    equalitygroup: ""
+    bitdepth: unknown
+    isdata: false
+    allocation: uniform
+
+)" };
+
+    // Test a valid config with 2 named transforms, then using this valid config test that look,
+    // role, and file rules can't use named transforms.
+    {
+        constexpr const char * NT{ R"(named_transforms:
+  - !<NamedTransform>
+    name: namedTransform1
+    family: family
+    categories: [input, basic]
+    transform: !<ColorSpaceTransform> {src: default, dst: raw}
+
+  - !<NamedTransform>
+    name: namedTransform2
+    inverse_transform: !<ColorSpaceTransform> {src: default, dst: raw}
+)" };
+
+        const std::string configStr = std::string(OCIO_CONFIG_START) + std::string(NT);
+
+        std::istringstream is;
+        is.str(configStr);
+
+        OCIO::ConstConfigRcPtr config;
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->validate());
+
+        OCIO_REQUIRE_EQUAL(config->getNumNamedTransforms(), 2);
+        OCIO_CHECK_EQUAL(std::string(config->getNamedTransformNameByIndex(0)),
+                         "namedTransform1");
+        OCIO_CHECK_EQUAL(std::string(config->getNamedTransformNameByIndex(1)),
+                         "namedTransform2");
+        auto nt = config->getNamedTransform("namedTransform1");
+        OCIO_REQUIRE_ASSERT(nt);
+        OCIO_CHECK_EQUAL(std::string(nt->getFamily()), "family");
+        OCIO_REQUIRE_EQUAL(nt->getNumCategories(), 2);
+        OCIO_CHECK_EQUAL(std::string(nt->getCategory(0)), "input");
+        OCIO_CHECK_EQUAL(std::string(nt->getCategory(1)), "basic");
+        std::ostringstream oss;
+        OCIO_CHECK_NO_THROW(oss << *config.get());
+        OCIO_CHECK_EQUAL(oss.str(), configStr);
+
+        // Look can't use named transform.
+        auto look = OCIO::Look::Create();
+        look->setName("look");
+        look->setProcessSpace("namedTransform1");
+        auto configEdit = config->createEditableCopy();
+        configEdit->addLook(look);
+        OCIO_CHECK_THROW_WHAT(configEdit->validate(), OCIO::Exception,
+                              "process color space, 'namedTransform1', which is not defined");
+        configEdit->clearLooks();
+
+        // Role can't use named transform.
+        configEdit->setRole("newrole", "namedTransform1");
+        OCIO_CHECK_THROW_WHAT(configEdit->validate(), OCIO::Exception,
+                              "refers to a color space, 'namedTransform1', which is not defined");
+        configEdit->setRole("newrole", nullptr);
+
+        // File rule can use named transform.
+        auto rules = configEdit->getFileRules()->createEditableCopy();
+        rules->insertRule(0, "newrule", "namedTransform1", "*", "*");
+        configEdit->setFileRules(rules);
+        OCIO_CHECK_NO_THROW(configEdit->validate());
+    }
+
+    // Config can't be read: named transform must define a transform.
+    {
+        constexpr const char * NT{ R"(named_transforms:
+  - !<NamedTransform>
+    name: namedTransform1)" };
+
+        const std::string configStr = std::string(OCIO_CONFIG_START) + std::string(NT);
+
+        std::istringstream is;
+        is.str(configStr);
+
+        OCIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(is), OCIO::Exception,
+                              "Named transform must define at least one transform.");
+    }
+
+    // Invalid config, named transform holds an invalid transform.
+    {
+        constexpr const char * NT{ R"(named_transforms:
+  - !<NamedTransform>
+    name: namedTransform1
+    transform: !<ColorSpaceTransform> {src: default}
+)" };
+
+        const std::string configStr = std::string(OCIO_CONFIG_START) + std::string(NT);
+
+        std::istringstream is;
+        is.str(configStr);
+
+        OCIO::ConstConfigRcPtr config;
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_THROW_WHAT(config->validate(), OCIO::Exception,
+                              "ColorSpaceTransform: empty destination color space name");
+    }
+}

--- a/tests/cpu/transforms/ColorSpaceTransform_tests.cpp
+++ b/tests/cpu/transforms/ColorSpaceTransform_tests.cpp
@@ -369,7 +369,7 @@ OCIO_ADD_TEST(ColorSpaceTransform, build_colorspace_ops)
         OCIO_CHECK_THROW_WHAT(OCIO::BuildColorSpaceOps(ops, *config,
                                                        config->getCurrentContext(), *cst,
                                                        OCIO::TRANSFORM_DIR_FORWARD), OCIO::Exception,
-                              "source color space 'source_missing' could not be found");
+                              "Color space 'source_missing' could not be found");
     
         cst = OCIO::ColorSpaceTransform::Create();
         cst->setSrc(src.c_str());
@@ -378,7 +378,7 @@ OCIO_ADD_TEST(ColorSpaceTransform, build_colorspace_ops)
         OCIO_CHECK_THROW_WHAT(OCIO::BuildColorSpaceOps(ops, *config,
                                                        config->getCurrentContext(), *cst,
                                                        OCIO::TRANSFORM_DIR_FORWARD), OCIO::Exception,
-                              "destination color space 'destination_missing' could not be found");
+                              "Color space 'destination_missing' could not be found");
     }
 }
 
@@ -751,5 +751,9 @@ OCIO_ADD_TEST(ColorSpaceTransform, context_variables)
     OCIO_CHECK_ASSERT(OCIO::CollectContextVariables(*cfg, *ctx, *cst, usedContextVars));
     OCIO_CHECK_EQUAL(1, usedContextVars->getNumStringVars());
     OCIO_CHECK_EQUAL(std::string("ENV1"), usedContextVars->getStringVarNameByIndex(0));
-    OCIO_CHECK_EQUAL(std::string("exposure_contrast_linear.ctf"), usedContextVars->getStringVarByIndex(0));
+    OCIO_CHECK_EQUAL(std::string("exposure_contrast_linear.ctf"),
+                     usedContextVars->getStringVarByIndex(0));
 }
+
+// Please see (Config, named_transform_processor) in NamedTransform_tests.cpp for coverage of
+// ColorSpaceTransform where the arguments are NamedTransforms.

--- a/tests/python/ConfigTest.py
+++ b/tests/python/ConfigTest.py
@@ -513,6 +513,7 @@ colorspaces:
         self.assertEqual(1, len(displays))
 
         # Check shared views defined by config.
+
         views = cfg.getSharedViews()
         self.assertEqual(5, len(views))
         self.assertEqual('SView_a', next(views))
@@ -522,16 +523,19 @@ colorspaces:
         self.assertEqual('SView_e', next(views))
 
         # Check views for sRGB display.
+
         views = cfg.getViews('sRGB')
         self.assertEqual(12, len(views))
 
         # Active views are taken into account for getViews.
+
         cfg.setActiveViews('View_a, View_b, SView_a, SView_b')
         views = cfg.getViews('sRGB')
         self.assertEqual(4, len(views))
         cfg.setActiveViews('')
 
         # Views filtered by viewing rules.
+
         views = cfg.getViews('sRGB', 'c3')
         self.assertEqual(8, len(views))
         # View_b rule is Rule_2 that lists c3.
@@ -634,5 +638,88 @@ colorspaces:
 
         cfg.clearNamedTransforms()
         nts = cfg.getNamedTransforms()
+        self.assertEqual(0, len(nts))
+
+    def test_inactive_named_transform(self):
+        # Test the active/inactive version of these Config functions and classes: getNamedTransforms,
+        # getNamedTransformNames, NamedTransformIterator, NamedTransformNameIterator.
+
+        cfg = OCIO.Config().CreateRaw()
+        nt_names = cfg.getNamedTransformNames()
+        self.assertEqual(0, len(nt_names))
+        nts = cfg.getNamedTransforms()
+        self.assertEqual(0, len(nts))
+
+        # Add named transforms.
+
+        nt = OCIO.NamedTransform(
+            name = "nt1",
+            forwardTransform = OCIO.RangeTransform())
+        cfg.addNamedTransform(nt)
+
+        nt = OCIO.NamedTransform(
+            name = "nt2",
+            inverseTransform = OCIO.RangeTransform())
+        cfg.addNamedTransform(nt)
+
+        nt = OCIO.NamedTransform(
+            name = "nt3",
+            forwardTransform = OCIO.RangeTransform())
+        cfg.addNamedTransform(nt)
+
+        cfg.setInactiveColorSpaces("nt2")
+
+        # Check the list of active/inactive named transforms.
+
+        nt_names = cfg.getNamedTransformNames()
+        self.assertEqual(2, len(nt_names))
+        self.assertEqual('nt1', next(nt_names))
+        self.assertEqual('nt3', next(nt_names))
+
+        nts = cfg.getNamedTransforms()
+        self.assertEqual(2, len(nts))
+        nt = next(nts)
+        self.assertEqual('nt1', nt.getName())
+        nt = next(nts)
+        self.assertEqual('nt3', nt.getName())
+
+        nt_names = cfg.getNamedTransformNames(OCIO.NAMEDTRANSFORM_ACTIVE)
+        self.assertEqual(2, len(nt_names))
+        self.assertEqual('nt1', next(nt_names))
+        self.assertEqual('nt3', next(nt_names))
+
+        nts = cfg.getNamedTransforms(OCIO.NAMEDTRANSFORM_ACTIVE)
+        self.assertEqual(2, len(nts))
+        nt = next(nts)
+        self.assertEqual('nt1', nt.getName())
+        nt = next(nts)
+        self.assertEqual('nt3', nt.getName())
+
+        nt_names = cfg.getNamedTransformNames(OCIO.NAMEDTRANSFORM_ALL)
+        self.assertEqual(3, len(nt_names))
+        self.assertEqual('nt1', next(nt_names))
+        self.assertEqual('nt2', next(nt_names))
+        self.assertEqual('nt3', next(nt_names))
+
+        nts = cfg.getNamedTransforms(OCIO.NAMEDTRANSFORM_ALL)
+        self.assertEqual(3, len(nts))
+        nt = next(nts)
+        self.assertEqual('nt1', nt.getName())
+        nt = next(nts)
+        self.assertEqual('nt2', nt.getName())
+        nt = next(nts)
+        self.assertEqual('nt3', nt.getName())
+
+        nt_names = cfg.getNamedTransformNames(OCIO.NAMEDTRANSFORM_INACTIVE)
+        self.assertEqual(1, len(nt_names))
+        self.assertEqual('nt2', next(nt_names))
+
+        nts = cfg.getNamedTransforms(OCIO.NAMEDTRANSFORM_INACTIVE)
+        self.assertEqual(1, len(nts))
+        nt = next(nts)
+        self.assertEqual('nt2', nt.getName())
+
+        cfg.clearNamedTransforms()
+        nts = cfg.getNamedTransforms(OCIO.NAMEDTRANSFORM_ALL)
         self.assertEqual(0, len(nts))
 

--- a/tests/python/DisplayViewTransformTest.py
+++ b/tests/python/DisplayViewTransformTest.py
@@ -226,3 +226,90 @@ class DisplayViewTransformTest(unittest.TestCase):
         self.assertEqual(True, dv_tr.getLooksBypass())
         self.assertEqual(False, dv_tr.getDataBypass())
         self.assertEqual(OCIO.TRANSFORM_DIR_INVERSE, dv_tr.getDirection())
+
+    def test_processor(self):
+        """
+        Test creating a processor from a display view and a named transform.
+        """
+        SIMPLE_PROFILE = """ocio_profile_version: 2
+
+roles:
+  default: raw
+
+displays:
+  sRGB:
+    - !<View> {name: Raw, colorspace: raw}
+  display:
+    - !<View> {name: view, view_transform: display_vt, display_colorspace: displayCSOut}
+    - !<View> {name: viewCSNT, colorspace: nt_inverse}
+    - !<View> {name: viewVTNT, view_transform: nt_forward, display_colorspace: displayCSOut}
+
+view_transforms:
+  - !<ViewTransform>
+    name: display_vt
+    to_display_reference: !<CDLTransform> {name: display vt to ref, sat: 1.5}
+    from_display_reference: !<CDLTransform> {name: display vt from ref, sat: 1.5}
+
+display_colorspaces:
+  - !<ColorSpace>
+    name: displayCSOut
+    to_display_reference: !<CDLTransform> {name: out cs to ref, sat: 1.5}
+    from_display_reference: !<CDLTransform> {name: out cs from ref, sat: 1.5}
+
+colorspaces:
+  - !<ColorSpace>
+    name: raw
+    isdata: true
+
+  - !<ColorSpace>
+    name: in
+    to_reference: !<MatrixTransform> {offset: [0.11, 0.12, 0.13, 0]}
+
+named_transforms:
+  - !<NamedTransform>
+    name: nt_forward
+    transform: !<CDLTransform> {name: forward, sat: 1.5}
+
+  - !<NamedTransform>
+    name: nt_inverse
+    inverse_transform: !<CDLTransform> {name: inverse, sat: 1.5}
+"""
+        # Create a config.
+        cfg = OCIO.Config().CreateFromStream(SIMPLE_PROFILE)
+
+        # Src can't be a named transform.
+        dv_tr = OCIO.DisplayViewTransform(src='nt_forward',
+                                          display='display',
+                                          view='view')
+        with self.assertRaises(OCIO.Exception):
+            proc = cfg.getProcessor(dv_tr)
+
+        # Dst is a named transform.
+        dv_tr.setSrc('in')
+        dv_tr.setView('viewCSNT');
+        proc = cfg.getProcessor(dv_tr)
+        group = proc.createGroupTransform()
+        groupTransformsList = list(group)
+        self.assertEqual(len(groupTransformsList), 1);
+        self.assertIsInstance(groupTransformsList[0], OCIO.CDLTransform)
+        metadata = groupTransformsList[0].getFormatMetadata()
+        atts = metadata.getAttributes()
+        self.assertEqual('inverse', next(atts)[1] )
+
+        # View transform is a named transform.
+        dv_tr.setSrc('in')
+        dv_tr.setView('viewVTNT');
+        proc = cfg.getProcessor(dv_tr)
+        group = proc.createGroupTransform()
+        groupTransformsList = list(group)
+        self.assertEqual(len(groupTransformsList), 2);
+        self.assertIsInstance(groupTransformsList[0], OCIO.CDLTransform)
+        metadata = groupTransformsList[0].getFormatMetadata()
+        atts = metadata.getAttributes()
+        self.assertEqual('forward', next(atts)[1] )
+        self.assertIsInstance(groupTransformsList[1], OCIO.CDLTransform)
+        metadata = groupTransformsList[1].getFormatMetadata()
+        atts = metadata.getAttributes()
+        self.assertEqual('out cs from ref', next(atts)[1] )
+
+

--- a/tests/python/NamedTransformTest.py
+++ b/tests/python/NamedTransformTest.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+import unittest
+
+import PyOpenColorIO as OCIO
+
+
+class NamedTransformTest(unittest.TestCase):
+    TEST_NAME = 'namedTransform'
+    TEST_FAMILY = 'myFamily'
+    TEST_DESCRIPTION = 'used for tests'
+    TEST_CATEGORIES = ['good', 'not so good', 'bad']
+    TEST_INVALIDS = (OCIO.TRANSFORM_DIR_INVERSE, 42, [1, 2, 3])
+
+    def setUp(self):
+        self.named_tr = OCIO.NamedTransform()
+
+    def tearDown(self):
+        self.named_tr = None
+
+    def test_name(self):
+        """
+        Test the setName() and getName() methods.
+        """
+
+        # Default initialized name is empty.
+        self.assertEqual(self.named_tr.getName(), '')
+
+        self.named_tr.setName(self.TEST_NAME)
+        self.assertEqual(self.named_tr.getName(), self.TEST_NAME)
+
+        # Wrong type tests.
+        for invalid in self.TEST_INVALIDS:
+            with self.assertRaises(TypeError):
+                self.named_tr.setName(invalid)
+
+    def test_family(self):
+        """
+        Test the setFamily() and getFamily() methods.
+        """
+
+        # Default initialized family is empty.
+        self.assertEqual(self.named_tr.getFamily(), '')
+
+        self.named_tr.setFamily(self.TEST_FAMILY)
+        self.assertEqual(self.named_tr.getFamily(), self.TEST_FAMILY)
+
+        # Wrong type tests.
+        for invalid in self.TEST_INVALIDS:
+            with self.assertRaises(TypeError):
+                self.named_tr.setFamily(invalid)
+
+    def test_description(self):
+        """
+        Test the setDescription() and getDescription() methods.
+        """
+
+        # Default initialized description is empty.
+        self.assertEqual(self.named_tr.getDescription(), '')
+
+        self.named_tr.setDescription(self.TEST_DESCRIPTION)
+        self.assertEqual(self.named_tr.getDescription(), self.TEST_DESCRIPTION)
+
+        # Wrong type tests.
+        for invalid in self.TEST_INVALIDS:
+            with self.assertRaises(TypeError):
+                self.named_tr.setDescription(invalid)
+
+    def test_transform(self):
+        """
+        Test the setTransform() and getTransform() methods.
+        """
+
+        # Default initialized transform are None.
+        self.assertEqual(self.named_tr.getTransform(OCIO.TRANSFORM_DIR_FORWARD), None)
+        self.assertEqual(self.named_tr.getTransform(OCIO.TRANSFORM_DIR_INVERSE), None)
+
+        offsetTest = [0.1, 0.2, 0.3, 0.4]
+        mat_tr = OCIO.MatrixTransform(offset=offsetTest)
+        self.named_tr.setTransform(mat_tr, OCIO.TRANSFORM_DIR_FORWARD)
+        cur_tr = self.named_tr.getTransform(OCIO.TRANSFORM_DIR_FORWARD)
+        self.assertIsInstance(cur_tr, OCIO.MatrixTransform)
+        self.assertEqual(cur_tr.getOffset(), offsetTest)
+        self.named_tr.setTransform(None, OCIO.TRANSFORM_DIR_FORWARD)
+        self.assertEqual(self.named_tr.getTransform(OCIO.TRANSFORM_DIR_FORWARD), None)
+
+        # Wrong type tests.
+        for invalid in self.TEST_INVALIDS:
+            with self.assertRaises(TypeError):
+                self.named_tr.setTransform(invalid, OCIO.TRANSFORM_DIR_FORWARD)
+
+
+    def test_constructor_with_keywords(self):
+        """
+        Test NamedTransform constructor with keywords and validate its values.
+        """
+
+        offsetTest = [0.1, 0.2, 0.3, 0.4]
+        fwd_tr = OCIO.MatrixTransform(offset=offsetTest)
+        inv_tr = OCIO.RangeTransform()
+
+        named_tr = OCIO.NamedTransform(
+            name = self.TEST_NAME,
+            family = self.TEST_FAMILY,
+            description = self.TEST_DESCRIPTION,
+            forwardTransform = fwd_tr,
+            inverseTransform = inv_tr,
+            categories = self.TEST_CATEGORIES)
+
+        self.assertEqual(named_tr.getName(), self.TEST_NAME)
+        self.assertEqual(named_tr.getFamily(), self.TEST_FAMILY)
+        self.assertEqual(named_tr.getDescription(), self.TEST_DESCRIPTION)
+        cur_tr = named_tr.getTransform(OCIO.TRANSFORM_DIR_FORWARD)
+        self.assertIsInstance(cur_tr, OCIO.MatrixTransform)
+        cur_tr = named_tr.getTransform(OCIO.TRANSFORM_DIR_INVERSE)
+        self.assertIsInstance(cur_tr, OCIO.RangeTransform)
+        catIt = named_tr.getCategories()
+        cats = [cat for cat in catIt]
+        self.assertEqual(cats, self.TEST_CATEGORIES)
+
+        # With keywords not in their proper order.
+        named_tr2 = OCIO.NamedTransform(
+            categories = self.TEST_CATEGORIES,
+            inverseTransform = inv_tr,
+            forwardTransform = fwd_tr,
+            description = self.TEST_DESCRIPTION,
+            name = self.TEST_NAME,
+            family = self.TEST_FAMILY)
+
+        self.assertEqual(named_tr2.getName(), self.TEST_NAME)
+        self.assertEqual(named_tr2.getFamily(), self.TEST_FAMILY)
+        self.assertEqual(named_tr2.getDescription(), self.TEST_DESCRIPTION)
+        cur_tr = named_tr2.getTransform(OCIO.TRANSFORM_DIR_FORWARD)
+        self.assertIsInstance(cur_tr, OCIO.MatrixTransform)
+        cur_tr = named_tr2.getTransform(OCIO.TRANSFORM_DIR_INVERSE)
+        self.assertIsInstance(cur_tr, OCIO.RangeTransform)
+        catIt = named_tr2.getCategories()
+        cats = [cat for cat in catIt]
+        self.assertEqual(cats, self.TEST_CATEGORIES)
+
+    def test_constructor_with_positional(self):
+        """
+        Test NamedTransform constructor without keywords and validate its values.
+        """
+
+        fwd_tr = OCIO.MatrixTransform()
+        inv_tr = OCIO.RangeTransform()
+
+        named_tr = OCIO.NamedTransform(
+            self.TEST_NAME,
+            self.TEST_FAMILY,
+            self.TEST_DESCRIPTION,
+            fwd_tr,
+            inv_tr,
+            self.TEST_CATEGORIES)
+
+        self.assertEqual(named_tr.getName(), self.TEST_NAME)
+        self.assertEqual(named_tr.getFamily(), self.TEST_FAMILY)
+        self.assertEqual(named_tr.getDescription(), self.TEST_DESCRIPTION)
+        cur_tr = named_tr.getTransform(OCIO.TRANSFORM_DIR_FORWARD)
+        self.assertIsInstance(cur_tr, OCIO.MatrixTransform)
+        cur_tr = named_tr.getTransform(OCIO.TRANSFORM_DIR_INVERSE)
+        self.assertIsInstance(cur_tr, OCIO.RangeTransform)
+        catIt = named_tr.getCategories()
+        cats = [cat for cat in catIt]
+        self.assertEqual(cats, self.TEST_CATEGORIES)
+
+    def test_constructor_wrong_parameter_type(self):
+        """
+        Test NamedTransform constructor with a wrong parameter type.
+        """
+
+        for invalid in self.TEST_INVALIDS:
+            with self.assertRaises(TypeError):
+                named_tr = OCIO.NamedTransform(invalid)
+
+    def test_processor(self):
+        """
+        Test creating a processor from named transforms and color spaces.
+        """
+        SIMPLE_PROFILE = """ocio_profile_version: 2
+
+roles:
+  default: raw
+
+file_rules:
+  - !<Rule> {name: ColorSpaceNamePathSearch}
+  - !<Rule> {name: Default, colorspace: default}
+
+displays:
+  sRGB:
+    - !<View> {name: Raw, colorspace: raw}
+
+active_displays: []
+active_views: []
+
+display_colorspaces:
+  - !<ColorSpace>
+    name: dcs
+
+colorspaces:
+  - !<ColorSpace>
+    name: raw
+
+named_transforms:
+  - !<NamedTransform>
+    name: forward
+    transform: !<MatrixTransform> {name: forward, offset: [0.1, 0.2, 0.3, 0.4]}
+
+  - !<NamedTransform>
+    name: inverse
+    inverse_transform: !<MatrixTransform> {name: inverse, offset: [-0.2, -0.1, -0.1, 0]}
+
+  - !<NamedTransform>
+    name: both
+    transform: !<MatrixTransform> {name: forward_both, offset: [0.1, 0.2, 0.3, 0.4]}
+    inverse_transform: !<MatrixTransform> {name: inverse_both, offset: [-0.2, -0.1, -0.1, 0]}
+"""
+
+        # Create a config.
+        cfg = OCIO.Config().CreateFromStream(SIMPLE_PROFILE)
+
+        offsetF = [0.1, 0.2, 0.3, 0.4]
+        offsetFInv = [x * -1. for x in offsetF]
+        offsetI = [-0.2, -0.1, -0.1, 0.]
+        offsetIInv = [x * -1. for x in offsetI]
+
+        # Display color space to forward named transform.
+
+        proc = cfg.getProcessor('dcs', 'forward')
+        group = proc.createGroupTransform()
+        groupTransformsList = list(group)
+        self.assertEqual(len(groupTransformsList), 1);
+        self.assertIsInstance(groupTransformsList[0], OCIO.MatrixTransform)
+        metadata = groupTransformsList[0].getFormatMetadata()
+        atts = metadata.getAttributes()
+        
+        self.assertEqual('forward', next(atts)[1] )
+        self.assertEqual(groupTransformsList[0].getOffset(), offsetFInv)
+
+        # Display color space to inverse named transform.
+
+        proc = cfg.getProcessor('dcs', 'inverse')
+        group = proc.createGroupTransform()
+        groupTransformsList = list(group)
+        self.assertEqual(len(groupTransformsList), 1);
+        self.assertIsInstance(groupTransformsList[0], OCIO.MatrixTransform)
+        metadata = groupTransformsList[0].getFormatMetadata()
+        atts = metadata.getAttributes()
+        
+        self.assertEqual('inverse', next(atts)[1] )
+        self.assertEqual(groupTransformsList[0].getOffset(), offsetI)
+
+        # Both named transform to display color space.
+
+        proc = cfg.getProcessor('both', 'dcs')
+        group = proc.createGroupTransform()
+        groupTransformsList = list(group)
+        self.assertEqual(len(groupTransformsList), 1);
+        self.assertIsInstance(groupTransformsList[0], OCIO.MatrixTransform)
+        metadata = groupTransformsList[0].getFormatMetadata()
+        atts = metadata.getAttributes()
+        
+        self.assertEqual('forward_both', next(atts)[1] )
+        self.assertEqual(groupTransformsList[0].getOffset(), offsetF)
+
+        # Forward named transforn to both named transform.
+
+        proc = cfg.getProcessor('forward', 'both')
+        group = proc.createGroupTransform()
+        groupTransformsList = list(group)
+        self.assertEqual(len(groupTransformsList), 2);
+        self.assertIsInstance(groupTransformsList[0], OCIO.MatrixTransform)
+        metadata = groupTransformsList[0].getFormatMetadata()
+        atts = metadata.getAttributes()
+
+        self.assertEqual('forward', next(atts)[1] )
+        self.assertEqual(groupTransformsList[0].getOffset(), offsetF)
+
+        self.assertIsInstance(groupTransformsList[1], OCIO.MatrixTransform)
+        metadata = groupTransformsList[1].getFormatMetadata()
+        atts = metadata.getAttributes()
+
+        self.assertEqual('inverse_both', next(atts)[1] )
+        self.assertEqual(groupTransformsList[1].getOffset(), offsetI)

--- a/tests/python/OpenColorIOTestSuite.py
+++ b/tests/python/OpenColorIOTestSuite.py
@@ -40,20 +40,23 @@ import BuiltinTransformTest
 import CDLTransformTest
 import ColorSpaceTest
 import ColorSpaceTransformTest
+import ConfigTest
+import DisplayViewTransformTest
 import ExponentTransformTest
 import ExponentWithLinearTransformTest
 import ExposureContrastTransformTest
 import FileTransformTest
 import FixedFunctionTransformTest
-import GroupTransformTest
-import LogTransformTest
-import LookTest
-import OpenColorIOTest
-import ViewingRulesTest
 import GradingDataTest
 import GradingPrimaryTransformTest
 import GradingRGBCurveTransformTest
 import GradingToneTransformTest
+import GroupTransformTest
+import LogTransformTest
+import LookTest
+import NamedTransformTest
+import OpenColorIOTest
+import ViewingRulesTest
 #from MainTest import *
 #from ConstantsTest import *
 #from ConfigTest import *
@@ -80,20 +83,23 @@ def suite():
     suite.addTest(loader.loadTestsFromModule(CDLTransformTest))
     suite.addTest(loader.loadTestsFromModule(ColorSpaceTest))
     suite.addTest(loader.loadTestsFromModule(ColorSpaceTransformTest))
+    suite.addTest(loader.loadTestsFromModule(ConfigTest))
+    suite.addTest(loader.loadTestsFromModule(DisplayViewTransformTest))
     suite.addTest(loader.loadTestsFromModule(ExponentTransformTest))
     suite.addTest(loader.loadTestsFromModule(ExponentWithLinearTransformTest))
     suite.addTest(loader.loadTestsFromModule(ExposureContrastTransformTest))
     suite.addTest(loader.loadTestsFromModule(FileTransformTest))
     suite.addTest(loader.loadTestsFromModule(FixedFunctionTransformTest))
-    suite.addTest(loader.loadTestsFromModule(GroupTransformTest))
-    suite.addTest(loader.loadTestsFromModule(LogTransformTest))
-    suite.addTest(loader.loadTestsFromModule(LookTest))
-    suite.addTest(loader.loadTestsFromModule(OpenColorIOTest))
-    suite.addTest(loader.loadTestsFromModule(ViewingRulesTest))
     suite.addTest(loader.loadTestsFromModule(GradingDataTest))
     suite.addTest(loader.loadTestsFromModule(GradingPrimaryTransformTest))
     suite.addTest(loader.loadTestsFromModule(GradingRGBCurveTransformTest))
     suite.addTest(loader.loadTestsFromModule(GradingToneTransformTest))
+    suite.addTest(loader.loadTestsFromModule(GroupTransformTest))
+    suite.addTest(loader.loadTestsFromModule(LogTransformTest))
+    suite.addTest(loader.loadTestsFromModule(LookTest))
+    suite.addTest(loader.loadTestsFromModule(NamedTransformTest))
+    suite.addTest(loader.loadTestsFromModule(OpenColorIOTest))
+    suite.addTest(loader.loadTestsFromModule(ViewingRulesTest))
     #suite.addTest(MainTest("test_interface"))
     #suite.addTest(ConstantsTest("test_interface"))
     #suite.addTest(ConfigTest("test_interface"))


### PR DESCRIPTION
Implement named color transform described by issue #1101

New NamedTransform class and related functions to manage them in Config. Named transforms can be used with colorSpaceTransforms and DisplayViewTransform.

Signed-off-by: Bernard Lefebvre <bernard.lefebvre@autodesk.com>