### PR TITLE
Adsk Contrib - File transform interpolation v1 compatibility

### DIFF
--- a/include/OpenColorIO/OpenColorTransforms.h
+++ b/include/OpenColorIO/OpenColorTransforms.h
@@ -999,6 +999,12 @@ public:
      */
     void setCDLStyle(CDLStyle);
 
+    /**
+     * The file parsers that care about interpolation (LUTs) will try to make use of the requested
+     * interpolation method when loading the file.  In these cases, if the requested method could
+     * not be used, a warning is logged.  If no method is provided, or a method cannot be used,
+     * INTERP_DEFAULT is used.
+     */
     Interpolation getInterpolation() const;
     void setInterpolation(Interpolation interp);
 

--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -1442,7 +1442,7 @@ inline void load(const YAML::Node& node, FileTransformRcPtr& t)
     }
 }
 
-inline void save(YAML::Emitter& out, ConstFileTransformRcPtr t)
+inline void save(YAML::Emitter& out, ConstFileTransformRcPtr t, unsigned int majorVersion)
 {
     out << YAML::VerbatimTag("FileTransform");
     out << YAML::Flow << YAML::BeginMap;
@@ -1456,11 +1456,20 @@ inline void save(YAML::Emitter& out, ConstFileTransformRcPtr t)
     {
         out << YAML::Key << "cdl_style" << YAML::Value << CDLStyleToString(t->getCDLStyle());
     }
-    if (t->getInterpolation() != INTERP_UNKNOWN && t->getInterpolation() != INTERP_DEFAULT)
+    Interpolation interp = t->getInterpolation();
+    if (majorVersion == 1 && interp == INTERP_DEFAULT)
+    {
+        // The DEFAULT method is not available in a v1 library.  If the v1 config is read by a v1
+        // library and the file is a LUT, a missing interp would end up set to UNKNOWN and a
+        // throw would happen when the processor is built.  Setting to LINEAR to provide more
+        // robust compatibility.
+        interp = INTERP_LINEAR;
+    }
+    if (interp != INTERP_DEFAULT)
     {
         out << YAML::Key << "interpolation";
         out << YAML::Value;
-        save(out, t->getInterpolation());
+        save(out, interp);
     }
 
     EmitBaseTransformKeyValues(out, t);
@@ -2356,7 +2365,7 @@ inline void save(YAML::Emitter & out, ConstGradingToneTransformRcPtr t)
 // GroupTransform
 
 void load(const YAML::Node& node, TransformRcPtr& t);
-void save(YAML::Emitter& out, ConstTransformRcPtr t);
+void save(YAML::Emitter& out, ConstTransformRcPtr t, unsigned int majorVersion);
 
 inline void load(const YAML::Node& node, GroupTransformRcPtr& t)
 {
@@ -2412,7 +2421,7 @@ inline void load(const YAML::Node& node, GroupTransformRcPtr& t)
     }
 }
 
-inline void save(YAML::Emitter& out, ConstGroupTransformRcPtr t)
+inline void save(YAML::Emitter& out, ConstGroupTransformRcPtr t, unsigned int majorVersion)
 {
     out << YAML::VerbatimTag("GroupTransform");
     out << YAML::BeginMap;
@@ -2426,7 +2435,7 @@ inline void save(YAML::Emitter& out, ConstGroupTransformRcPtr t)
     out << YAML::BeginSeq;
     for(int i = 0; i < t->getNumTransforms(); ++i)
     {
-        save(out, t->getTransform(i));
+        save(out, t->getTransform(i), majorVersion);
     }
     out << YAML::EndSeq;
 
@@ -3217,7 +3226,7 @@ void load(const YAML::Node& node, TransformRcPtr& t)
     }
 }
 
-void save(YAML::Emitter& out, ConstTransformRcPtr t)
+void save(YAML::Emitter& out, ConstTransformRcPtr t, unsigned int majorVersion)
 {
     if(ConstAllocationTransformRcPtr Allocation_tran = \
         DynamicPtrCast<const AllocationTransform>(t))
@@ -3243,7 +3252,7 @@ void save(YAML::Emitter& out, ConstTransformRcPtr t)
     else if(ConstFileTransformRcPtr File_tran = \
         DynamicPtrCast<const FileTransform>(t))
         // TODO: if (File_tran->getCDLStyle() != CDL_TRANSFORM_DEFAULT) should throw with config v1.
-        save(out, File_tran);
+        save(out, File_tran, majorVersion);
     else if (ConstExposureContrastTransformRcPtr File_tran = \
         DynamicPtrCast<const ExposureContrastTransform>(t))
         save(out, File_tran);
@@ -3261,7 +3270,7 @@ void save(YAML::Emitter& out, ConstTransformRcPtr t)
         save(out, GT_tran);
     else if(ConstGroupTransformRcPtr Group_tran = \
         DynamicPtrCast<const GroupTransform>(t))
-        save(out, Group_tran);
+        save(out, Group_tran, majorVersion);
     else if(ConstLogAffineTransformRcPtr Log_tran = \
         DynamicPtrCast<const LogAffineTransform>(t))
         save(out, Log_tran);
@@ -3419,7 +3428,7 @@ inline void load(const YAML::Node& node, ColorSpaceRcPtr& cs)
     }
 }
 
-inline void save(YAML::Emitter& out, ConstColorSpaceRcPtr cs)
+inline void save(YAML::Emitter& out, ConstColorSpaceRcPtr cs, unsigned int majorVersion)
 {
     out << YAML::VerbatimTag("ColorSpace");
     out << YAML::BeginMap;
@@ -3465,14 +3474,14 @@ inline void save(YAML::Emitter& out, ConstColorSpaceRcPtr cs)
     if(toref)
     {
         out << YAML::Key << (isDisplay ? "to_display_reference" : "to_reference") << YAML::Value;
-        save(out, toref);
+        save(out, toref, majorVersion);
     }
 
     ConstTransformRcPtr fromref = cs->getTransform(COLORSPACE_DIR_FROM_REFERENCE);
     if(fromref)
     {
         out << YAML::Key << (isDisplay ? "from_display_reference" : "from_reference") << YAML::Value;
-        save(out, fromref);
+        save(out, fromref, majorVersion);
     }
 
     out << YAML::EndMap;
@@ -3533,7 +3542,7 @@ inline void load(const YAML::Node& node, LookRcPtr& look)
     }
 }
 
-inline void save(YAML::Emitter& out, ConstLookRcPtr look)
+inline void save(YAML::Emitter& out, ConstLookRcPtr look, unsigned int majorVersion)
 {
     out << YAML::VerbatimTag("Look");
     out << YAML::BeginMap;
@@ -3545,14 +3554,14 @@ inline void save(YAML::Emitter& out, ConstLookRcPtr look)
     {
         out << YAML::Key << "transform";
         out << YAML::Value;
-        save(out, look->getTransform());
+        save(out, look->getTransform(), majorVersion);
     }
 
     if(look->getInverseTransform())
     {
         out << YAML::Key << "inverse_transform";
         out << YAML::Value;
-        save(out, look->getInverseTransform());
+        save(out, look->getInverseTransform(), majorVersion);
     }
 
     out << YAML::EndMap;
@@ -3694,7 +3703,7 @@ inline void load(const YAML::Node & node, ViewTransformRcPtr & vt)
     }
 }
 
-inline void save(YAML::Emitter & out, ConstViewTransformRcPtr & vt)
+inline void save(YAML::Emitter & out, ConstViewTransformRcPtr & vt, unsigned int majorVersion)
 {
     out << YAML::VerbatimTag("ViewTransform");
     out << YAML::BeginMap;
@@ -3723,14 +3732,14 @@ inline void save(YAML::Emitter & out, ConstViewTransformRcPtr & vt)
     if (toref)
     {
         out << YAML::Key << (isDisplay ? "to_display_reference" : "to_reference") << YAML::Value;
-        save(out, toref);
+        save(out, toref, majorVersion);
     }
 
     ConstTransformRcPtr fromref = vt->getTransform(VIEWTRANSFORM_DIR_FROM_REFERENCE);
     if (fromref)
     {
         out << YAML::Key << (isDisplay ? "from_display_reference" : "from_reference") << YAML::Value;
-        save(out, fromref);
+        save(out, fromref, majorVersion);
     }
 
     out << YAML::EndMap;
@@ -4878,7 +4887,7 @@ inline void save(YAML::Emitter & out, const Config & config)
         for(int i = 0; i < config.getNumLooks(); ++i)
         {
             const char* name = config.getLookNameByIndex(i);
-            save(out, config.getLook(name));
+            save(out, config.getLook(name), configMajorVersion);
         }
         out << YAML::EndSeq;
         out << YAML::Newline;
@@ -4895,7 +4904,7 @@ inline void save(YAML::Emitter & out, const Config & config)
         {
             auto name = config.getViewTransformNameByIndex(i);
             auto vt = config.getViewTransform(name);
-            save(out, vt);
+            save(out, vt, configMajorVersion);
         }
         out << YAML::EndSeq;
     }
@@ -4933,7 +4942,7 @@ inline void save(YAML::Emitter & out, const Config & config)
         out << YAML::Value << YAML::BeginSeq;
         for (const auto & cs : displayCS)
         {
-            save(out, cs);
+            save(out, cs, configMajorVersion);
         }
         out << YAML::EndSeq;
     }
@@ -4945,7 +4954,7 @@ inline void save(YAML::Emitter & out, const Config & config)
         out << YAML::Value << YAML::BeginSeq;
         for (const auto & cs : sceneCS)
         {
-            save(out, cs);
+            save(out, cs, configMajorVersion);
         }
         out << YAML::EndSeq;
     }

--- a/src/OpenColorIO/transforms/FileTransform.cpp
+++ b/src/OpenColorIO/transforms/FileTransform.cpp
@@ -97,13 +97,8 @@ void FileTransform::validate() const
         throw Exception("FileTransform: empty file path");
     }
 
-    if (getInterpolation() == INTERP_UNKNOWN)
-    {
-        std::ostringstream oss;
-        oss << "FileTransform can't use unknown interpolation. ";
-        oss << "File: '" << std::string(getImpl()->m_src) << "'.";
-        throw Exception(oss.str().c_str());
-    }
+    // NB: Not validating interpolation since v1 configs such as the spi examples use
+    // interpolation=unknown.  So that is a legal usage, even if it makes no sense.
 }
 
 const char * FileTransform::getSrc() const

--- a/tests/python/CDLTransformTest.py
+++ b/tests/python/CDLTransformTest.py
@@ -241,8 +241,14 @@ class CDLTransformTest(unittest.TestCase):
         # Try env var first to get test file path.
         test_file = '%s/cdl_test1.cdl' % TEST_DATAFILES_DIR
 
+        # Mute warnings being logged.
+        curLogLevel = OCIO.GetLoggingLevel()
+        OCIO.SetLoggingLevel(OCIO.LOGGING_LEVEL_NONE)
+
         # Test a specified id member of the cdl file.
         cdl = OCIO.CDLTransform.CreateFromFile(test_file, 'cc0003')
+        OCIO.SetLoggingLevel(curLogLevel)
+
         self.assertEqual(cdl.getID(), 'cc0003')
         self.assertEqual(cdl.getDescription(), 'golden')
         self.assertListEqual(cdl.getSlope(), [1.2, 1.1, 1.0])

--- a/tests/python/FileTransformTest.py
+++ b/tests/python/FileTransformTest.py
@@ -208,16 +208,20 @@ class FileTransformTest(unittest.TestCase):
 
     def test_get_processor(self):
         """
-        Test FileTransform default interpolation is valid and unknown interpolation is not valid.
+        Test that interpolation values of default and unknown do not cause a problem for
+        getProcessor.
         """
+
         config = OCIO.Config.CreateRaw()
         test_file = '%s/lut1d_1.spi1d' % TEST_DATAFILES_DIR
         file_tr = OCIO.FileTransform(src=test_file)
         processor = config.getProcessor(file_tr)
-        # INTERP_UNKNOWN is not a valid interpolation.
+        # INTERP_UNKNOWN will be ignored by the LUT and a warning will be logged.
+        curLogLevel = OCIO.GetLoggingLevel()
+        OCIO.SetLoggingLevel(OCIO.LOGGING_LEVEL_NONE)
         file_tr.setInterpolation(OCIO.INTERP_UNKNOWN)
-        with self.assertRaises(OCIO.Exception):
-            processor = config.getProcessor(file_tr)
+        processor = config.getProcessor(file_tr)
+        OCIO.SetLoggingLevel(curLogLevel)
 
 # TODO:
 # No CDLStyle parameter in constructor?


### PR DESCRIPTION
This removes the validation of the interpolation for file transforms that was introduced during v2 development. If an interpolation (including unknown) does not apply to a transform of the file that requires a interpolation, default interpolation is used.

When saving a v1 config, an interpolation valid for v1 will be saved (for instance, default and unknown will be saved as linear).

Solves issue 1194.

Signed-off-by: Bernard Lefebvre <bernard.lefebvre@autodesk.com>