### PR TITLE
Fix build break: Bump pybind11 required version to 2.6.1

### DIFF
--- a/share/cmake/modules/FindExtPackages.cmake
+++ b/share/cmake/modules/FindExtPackages.cmake
@@ -61,7 +61,7 @@ if(OCIO_BUILD_PYTHON)
 
     # pybind11
     # https://github.com/pybind/pybind11
-    find_package(pybind11 2.4.3 REQUIRED)
+    find_package(pybind11 2.6.1 REQUIRED)
 endif()
 
 if(OCIO_BUILD_DOCS)

--- a/share/cmake/modules/Findpybind11.cmake
+++ b/share/cmake/modules/Findpybind11.cmake
@@ -178,6 +178,8 @@ if(NOT pybind11_FOUND)
             GIT_TAG "v${pybind11_FIND_VERSION}"
             GIT_CONFIG advice.detachedHead=false
             GIT_SHALLOW TRUE
+            # Don't update git submodules (tools/clang)
+            GIT_SUBMODULES ""
             PREFIX "${_EXT_BUILD_ROOT}/pybind11"
             BUILD_BYPRODUCTS ${pybind11_INCLUDE_DIR}
             CMAKE_ARGS ${pybind11_CMAKE_ARGS}

--- a/share/cmake/modules/Findpybind11.cmake
+++ b/share/cmake/modules/Findpybind11.cmake
@@ -178,8 +178,6 @@ if(NOT pybind11_FOUND)
             GIT_TAG "v${pybind11_FIND_VERSION}"
             GIT_CONFIG advice.detachedHead=false
             GIT_SHALLOW TRUE
-            # Don't update git submodules (tools/clang)
-            GIT_SUBMODULES ""
             PREFIX "${_EXT_BUILD_ROOT}/pybind11"
             BUILD_BYPRODUCTS ${pybind11_INCLUDE_DIR}
             CMAKE_ARGS ${pybind11_CMAKE_ARGS}


### PR DESCRIPTION
pybind11 versions < 2.6 have a submodule of clang to support the pybind11_mkdoc feature, which we don't use. In 2.6 this was moved to it's own project. By default CMake's `ExternalProject_Add` command, which we use to install pybind11 if `OCIO_INSTALL_EXT_PACKAGES` is enabled, clones all submodules, so this change explicitly tells it not to for pybind11.

Signed-off-by: Michael Dolan <michdolan@gmail.com>