### PR TITLE
Adsk Contrib - Data bypass fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ project(OpenColorIO
     LANGUAGES CXX C)
 
 # "dev", "beta1", rc1", etc or "" for an official release.
-set(OpenColorIO_VERSION_RELEASE_TYPE "beta1")
+set(OpenColorIO_VERSION_RELEASE_TYPE "beta2")
 
 enable_testing()
 

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -3396,17 +3396,21 @@ void Config::setFileRules(ConstFileRulesRcPtr fileRules)
 
 const char * Config::getColorSpaceFromFilepath(const char * filePath) const
 {
-    return getImpl()->m_fileRules->getImpl()->getColorSpaceFromFilepath(*this, filePath);
+    return getImpl()->m_fileRules->getImpl()->getColorSpaceFromFilepath(*this,
+                                                                        filePath ? filePath : "");
 }
 
 const char * Config::getColorSpaceFromFilepath(const char * filePath, size_t & ruleIndex) const
 {
-    return getImpl()->m_fileRules->getImpl()->getColorSpaceFromFilepath(*this, filePath, ruleIndex);
+    return getImpl()->m_fileRules->getImpl()->getColorSpaceFromFilepath(*this,
+                                                                        filePath ? filePath : "",
+                                                                        ruleIndex);
 }
 
 bool Config::filepathOnlyMatchesDefaultRule(const char * filePath) const
 {
-    return getImpl()->m_fileRules->getImpl()->filepathOnlyMatchesDefaultRule(*this, filePath);
+    return getImpl()->m_fileRules->getImpl()->filepathOnlyMatchesDefaultRule(*this,
+                                                                             filePath ? filePath : "");
 }
 
 

--- a/src/OpenColorIO/Processor.cpp
+++ b/src/OpenColorIO/Processor.cpp
@@ -583,6 +583,8 @@ void Processor::Impl::setColorSpaceConversion(const Config & config,
         throw Exception("Internal error: Processor should be empty");
     }
 
+    // Default behavior is to bypass data color space. ColorSpaceTransform can be used to not bypass
+    // data color spaces.
     BuildColorSpaceOps(m_ops, config, context, srcColorSpace, dstColorSpace, true);
 
     std::ostringstream desc;

--- a/src/OpenColorIO/Processor.cpp
+++ b/src/OpenColorIO/Processor.cpp
@@ -583,7 +583,7 @@ void Processor::Impl::setColorSpaceConversion(const Config & config,
         throw Exception("Internal error: Processor should be empty");
     }
 
-    BuildColorSpaceOps(m_ops, config, context, srcColorSpace, dstColorSpace, false);
+    BuildColorSpaceOps(m_ops, config, context, srcColorSpace, dstColorSpace, true);
 
     std::ostringstream desc;
     desc << "Color space conversion from " << srcColorSpace->getName()

--- a/src/OpenColorIO/transforms/LookTransform.cpp
+++ b/src/OpenColorIO/transforms/LookTransform.cpp
@@ -289,6 +289,7 @@ void RunLookTokens(OpRcPtrVec & ops,
             if (!skipColorSpaceConversion &&
                 currentColorSpace.get() != processColorSpace.get())
             {
+                // Default behavior is to bypass data color space.
                 BuildColorSpaceOps(ops, config, context,
                                    currentColorSpace, processColorSpace, true);
                 currentColorSpace = processColorSpace;
@@ -352,6 +353,7 @@ void BuildLookOps(OpRcPtrVec & ops,
     // If current color space is already the dst space skip the conversion.
     if (!skipColorSpaceConversion && currentColorSpace.get() != dst.get())
     {
+        // Default behavior is to bypass data color space.
         BuildColorSpaceOps(ops, config, context, currentColorSpace, dst, true);
     }
 }

--- a/src/OpenColorIO/transforms/LookTransform.cpp
+++ b/src/OpenColorIO/transforms/LookTransform.cpp
@@ -290,7 +290,7 @@ void RunLookTokens(OpRcPtrVec & ops,
                 currentColorSpace.get() != processColorSpace.get())
             {
                 BuildColorSpaceOps(ops, config, context,
-                                   currentColorSpace, processColorSpace, false);
+                                   currentColorSpace, processColorSpace, true);
                 currentColorSpace = processColorSpace;
             }
 
@@ -352,8 +352,7 @@ void BuildLookOps(OpRcPtrVec & ops,
     // If current color space is already the dst space skip the conversion.
     if (!skipColorSpaceConversion && currentColorSpace.get() != dst.get())
     {
-        BuildColorSpaceOps(ops, config, context,
-                           currentColorSpace, dst, false);
+        BuildColorSpaceOps(ops, config, context, currentColorSpace, dst, true);
     }
 }
 

--- a/src/apps/ociochecklut/main.cpp
+++ b/src/apps/ociochecklut/main.cpp
@@ -218,8 +218,8 @@ int main (int argc, const char* argv[])
         {
             // What are the allowed formats?
             std::cout << "Formats supported:" << std::endl;
-            const auto nbFromats = OCIO::FileTransform::GetNumFormats();
-            for (int i = 0; i < nbFromats; ++i)
+            const auto nbFormats = OCIO::FileTransform::GetNumFormats();
+            for (int i = 0; i < nbFormats; ++i)
             {
                 std::cout << OCIO::FileTransform::GetFormatNameByIndex(i);
                 std::cout << " (." << OCIO::FileTransform::GetFormatExtensionByIndex(i) << ")";

--- a/tests/cpu/FileRules_tests.cpp
+++ b/tests/cpu/FileRules_tests.cpp
@@ -992,7 +992,7 @@ file_rules:
     OCIO_CHECK_EQUAL(std::string(rules->getColorSpace(0)), "cs1");
     OCIO_CHECK_EQUAL(std::string(config->getColorSpaceFromFilepath("anything")), "cs1");
 
-    // File defined default role is preserved.
+    // The color space of the default role is preserved.
     auto cs = config->getColorSpace(OCIO::ROLE_DEFAULT);
     OCIO_CHECK_EQUAL(std::string("raw"), cs->getName());
 }

--- a/tests/cpu/FileRules_tests.cpp
+++ b/tests/cpu/FileRules_tests.cpp
@@ -487,6 +487,10 @@ OCIO_ADD_TEST(FileRules, rules_filepattern)
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
     config->getColorSpaceFromFilepath("/An/Arbitrary.exr/Path/MyFileexr", rulePosition);
     OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
+    config->getColorSpaceFromFilepath("", rulePosition);
+    OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
+    config->getColorSpaceFromFilepath(nullptr, rulePosition);
+    OCIO_CHECK_EQUAL(rulePosition, 1); // Default rule.
 
     OCIO_CHECK_NO_THROW(rules->setPattern(0, "gamma"));
     config->setFileRules(rules);
@@ -984,6 +988,10 @@ file_rules:
     auto rules = config->getFileRules();
     OCIO_REQUIRE_ASSERT(rules);
     OCIO_REQUIRE_EQUAL(rules->getNumEntries(), 1);
+    OCIO_CHECK_EQUAL(std::string(rules->getName(0)), OCIO::FileRuleUtils::DefaultName);
+    OCIO_CHECK_EQUAL(std::string(rules->getColorSpace(0)), "cs1");
+    OCIO_CHECK_EQUAL(std::string(config->getColorSpaceFromFilepath("anything")), "cs1");
+
     // File defined default role is preserved.
     auto cs = config->getColorSpace(OCIO::ROLE_DEFAULT);
     OCIO_CHECK_EQUAL(std::string("raw"), cs->getName());

--- a/tests/cpu/transforms/ColorSpaceTransform_tests.cpp
+++ b/tests/cpu/transforms/ColorSpaceTransform_tests.cpp
@@ -137,12 +137,27 @@ OCIO_ADD_TEST(ColorSpaceTransform, build_colorspace_ops)
                                                      *cst, OCIO::TRANSFORM_DIR_FORWARD));
         OCIO_CHECK_NO_THROW(ops.validate());
         OCIO_CHECK_EQUAL(ops.size(), 0);
+        ops.clear();
+
+        OCIO::ConstProcessorRcPtr proc;
+        config->setProcessorCacheFlags(OCIO::PROCESSOR_CACHE_OFF); // Cache disabled
+        OCIO_CHECK_NO_THROW(proc = config->getProcessor(cst));
+        OCIO_CHECK_EQUAL(proc->getNumTransforms(), 0);
 
         cst->setDataBypass(false);
         OCIO_CHECK_NO_THROW(OCIO::BuildColorSpaceOps(ops, *config, config->getCurrentContext(),
                                                      *cst, OCIO::TRANSFORM_DIR_FORWARD));
         OCIO_CHECK_NO_THROW(ops.validate());
         OCIO_CHECK_EQUAL(ops.size(), 4);
+        ops.clear();
+
+        // Some of the ops are no-ops, processor has 2 transforms.
+        OCIO_CHECK_NO_THROW(proc = config->getProcessor(cst));
+        OCIO_CHECK_EQUAL(proc->getNumTransforms(), 2);
+
+        // Similar test with color space, data by-pass can't be controlled.
+        OCIO_CHECK_NO_THROW(proc = config->getProcessor(src.c_str(), dst.c_str()));
+        OCIO_CHECK_EQUAL(proc->getNumTransforms(), 0);
 
         // Restore default data flags.
         csSceneToRef->setIsData(false);
@@ -153,17 +168,28 @@ OCIO_ADD_TEST(ColorSpaceTransform, build_colorspace_ops)
         csSceneFromRef->setIsData(true);
         config->addColorSpace(csSceneFromRef);
 
-        ops.clear();
         OCIO_CHECK_NO_THROW(OCIO::BuildColorSpaceOps(ops, *config, config->getCurrentContext(),
                                                      *cst, OCIO::TRANSFORM_DIR_FORWARD));
         OCIO_CHECK_NO_THROW(ops.validate());
         OCIO_CHECK_EQUAL(ops.size(), 0);
+        ops.clear();
+
+        OCIO_CHECK_NO_THROW(proc = config->getProcessor(cst));
+        OCIO_CHECK_EQUAL(proc->getNumTransforms(), 0);
 
         cst->setDataBypass(false);
         OCIO_CHECK_NO_THROW(OCIO::BuildColorSpaceOps(ops, *config, config->getCurrentContext(),
                                                      *cst, OCIO::TRANSFORM_DIR_FORWARD));
         OCIO_CHECK_NO_THROW(ops.validate());
         OCIO_CHECK_EQUAL(ops.size(), 4);
+        ops.clear();
+
+        OCIO_CHECK_NO_THROW(proc = config->getProcessor(cst));
+        OCIO_CHECK_EQUAL(proc->getNumTransforms(), 2);
+
+        // Similar test with color space, data bypass can't be controlled.
+        OCIO_CHECK_NO_THROW(proc = config->getProcessor(src.c_str(), dst.c_str()));
+        OCIO_CHECK_EQUAL(proc->getNumTransforms(), 0);
 
         // Restore default data flags.
         csSceneFromRef->setIsData(false);

--- a/tests/cpu/transforms/LookTransform_tests.cpp
+++ b/tests/cpu/transforms/LookTransform_tests.cpp
@@ -624,7 +624,7 @@ colorspaces:
 
     OCIO::OpRcPtrVec ops;
     OCIO_CHECK_NO_THROW(BuildColorSpaceOps(ops, *config, config->getCurrentContext(),
-                                           srcColorSpace, dstColorSpace, false));
+                                           srcColorSpace, dstColorSpace, true));
     OCIO_CHECK_NO_THROW(ops.validate());
     OCIO_REQUIRE_EQUAL(ops.size(), 11);
     OCIO::ConstOpRcPtr op = ops[0];
@@ -665,7 +665,7 @@ colorspaces:
     // Test in inverse direction.
     ops.clear();
     OCIO_CHECK_NO_THROW(BuildColorSpaceOps(ops, *config, config->getCurrentContext(),
-                                           dstColorSpace, srcColorSpace, false));
+                                           dstColorSpace, srcColorSpace, true));
     OCIO_REQUIRE_EQUAL(ops.size(), 11);
     OCIO_CHECK_NO_THROW(ops.validate());
     op = ops[0];
@@ -711,7 +711,7 @@ colorspaces:
 
     OCIO::OpRcPtrVec ops2;
     OCIO_CHECK_NO_THROW(BuildColorSpaceOps(ops2, *config, config->getCurrentContext(),
-                                           dstColorSpaceInv, srcColorSpace, false));
+                                           dstColorSpaceInv, srcColorSpace, true));
     OCIO_REQUIRE_EQUAL(ops2.size(), ops.size());
     OCIO_CHECK_NO_THROW(ops2.validate());
     for (std::size_t i = 0; i < ops2.size(); ++i)


### PR DESCRIPTION
BuildColorSpaceOps was using false for the dataBypass parameter when when true should be used. This was causing data color spaces not to be bypassed when using Config::getProcessor(csa, csb).
Tests for this have been added.

Also add a nullptr check for file rules path resolution functions and fix a typo.

Signed-off-by: Bernard Lefebvre <bernard.lefebvre@autodesk.com>