### PR TITLE
Adsk Contrib - Improve ACEScc and XYZ built-in transforms

### DIFF
--- a/src/OpenColorIO/transforms/builtins/ACES.cpp
+++ b/src/OpenColorIO/transforms/builtins/ACES.cpp
@@ -127,8 +127,8 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
         {
             // The CIE XYZ space has its conventional normalization (i.e., to illuminant E).
             // A neutral value of [1.,1.,1] in AP0 maps to the XYZ value of D65 ([0.9504..., 1., 1.089...]).
-            const MatrixOpData::Offsets null(0., 0., 0., 0.);
-            const MatrixOpData::Offsets d65_wht_XYZ(0.95045592705167, 1., 1.08905775075988, 0.);
+            static const MatrixOpData::Offsets null(0., 0., 0., 0.);
+            static const MatrixOpData::Offsets d65_wht_XYZ(0.95045592705167, 1., 1.08905775075988, 0.);
             MatrixOpData::MatrixArrayPtr matrix
                 = build_conversion_matrix(ACES_AP0::primaries, CIE_XYZ_ILLUM_E::primaries, 
                                           null, d65_wht_XYZ, ADAPTATION_BRADFORD);
@@ -142,8 +142,8 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
     {
         auto ACES_AP1_to_CIE_XYZ_D65_BFD_Functor = [](OpRcPtrVec & ops)
         {
-            const MatrixOpData::Offsets null(0., 0., 0., 0.);
-            const MatrixOpData::Offsets d65_wht_XYZ(0.95045592705167, 1., 1.08905775075988, 0.);
+            static const MatrixOpData::Offsets null(0., 0., 0., 0.);
+            static const MatrixOpData::Offsets d65_wht_XYZ(0.95045592705167, 1., 1.08905775075988, 0.);
             MatrixOpData::MatrixArrayPtr matrix
                 = build_conversion_matrix(ACES_AP1::primaries, CIE_XYZ_ILLUM_E::primaries, 
                                           null, d65_wht_XYZ, ADAPTATION_BRADFORD);
@@ -199,8 +199,8 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             {
                 // The functor input will be [0,1].  Remap this to a wider domain to better capture
                 // the full extent of ACEScc.
-                const double IN_MIN = -0.36;
-                const double IN_MAX =  1.50;
+                static constexpr double IN_MIN = -0.36;
+                static constexpr double IN_MAX =  1.50;
                 double in = input * (IN_MAX - IN_MIN) + IN_MIN;
 
                 double out = 0.0f;
@@ -209,7 +209,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
                 {
                     out = (std::pow( 2., in * 17.52 - 9.72) - std::pow( 2., -16.)) * 2.0;
                 }
-                else  // if (in < (log2(HALF_MAX) + 9.72) / 17.52)
+                else
                 {
                     out = std::pow( 2., in * 17.52 - 9.72);
                 }

--- a/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.cpp
+++ b/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.cpp
@@ -236,23 +236,23 @@ MatrixOpData::MatrixArrayPtr build_conversion_matrix(const Primaries & src_prims
     static const MatrixOpData::Offsets ones(1., 1., 1., 0.);
 
     // Calculate the primary conversion matrices.
-    MatrixOpData::MatrixArrayPtr rgb2xyz = rgb2xyz_from_xy(src_prims);
+    MatrixOpData::MatrixArrayPtr src_rgb2xyz = rgb2xyz_from_xy(src_prims);
     MatrixOpData::MatrixArrayPtr dst_rgb2xyz = rgb2xyz_from_xy(dst_prims);
-    MatrixOpData::MatrixArrayPtr xyz2rgb = dst_rgb2xyz->inverse();
+    MatrixOpData::MatrixArrayPtr dst_xyz2rgb = dst_rgb2xyz->inverse();
 
-    // Return the composed matrix if no adaptation is needed.
+    // Return the composed matrix if no white point adaptation is needed.
     if ( !src_wht_XYZ.isNotNull() && !dst_wht_XYZ.isNotNull() )
     {
         // If the white points are equal, don't need to adapt.
         if ( src_prims.m_wht.m_xy[0] == dst_prims.m_wht.m_xy[0] &&
              src_prims.m_wht.m_xy[1] == dst_prims.m_wht.m_xy[1] )
         {
-            return xyz2rgb->inner(rgb2xyz);
+            return dst_xyz2rgb->inner(src_rgb2xyz);
         }
     }
     else if ( method == ADAPTATION_NONE )
     {
-        return xyz2rgb->inner(rgb2xyz);
+        return dst_xyz2rgb->inner(src_rgb2xyz);
     }
 
     // Calculate src and dst white XYZ.
@@ -271,14 +271,14 @@ MatrixOpData::MatrixArrayPtr build_conversion_matrix(const Primaries & src_prims
     }
     else
     {
-        src_wht = rgb2xyz->inner(ones);
+        src_wht = src_rgb2xyz->inner(ones);
     }
 
     // Build the adaptation matrix (may be an identity).
     MatrixOpData::MatrixArrayPtr vkmat = build_vonkries_adapt(src_wht, dst_wht, method);
 
     // Compose the adaptation into the conversion matrix.
-    return xyz2rgb->inner(vkmat->inner(rgb2xyz));
+    return dst_xyz2rgb->inner(vkmat->inner(src_rgb2xyz));
 }
 
 MatrixOpData::MatrixArrayPtr build_conversion_matrix(const Primaries & src_prims,

--- a/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.cpp
+++ b/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.cpp
@@ -10,12 +10,12 @@
 namespace OCIO_NAMESPACE
 {
 
-namespace CIE_XYZ_D65
+namespace CIE_XYZ_ILLUM_E
 {
 static const Chromaticities red_xy(1.,     0.    );
 static const Chromaticities grn_xy(0.,     1.    );
 static const Chromaticities blu_xy(0.,     0.    );
-static const Chromaticities wht_xy(0.3127, 0.3290);
+static const Chromaticities wht_xy(1./3.,  1./3. );
 
 const Primaries primaries(red_xy, grn_xy, blu_xy, wht_xy);
 }
@@ -229,6 +229,8 @@ MatrixOpData::MatrixArrayPtr build_vonkries_adapt(const MatrixOpData::Offsets & 
 
 MatrixOpData::MatrixArrayPtr build_conversion_matrix(const Primaries & src_prims,
                                                      const Primaries & dst_prims,
+                                                     const MatrixOpData::Offsets & src_wht_XYZ,
+                                                     const MatrixOpData::Offsets & dst_wht_XYZ,
                                                      AdaptationMethod method)
 {
     static const MatrixOpData::Offsets ones(1., 1., 1., 0.);
@@ -238,23 +240,53 @@ MatrixOpData::MatrixArrayPtr build_conversion_matrix(const Primaries & src_prims
     MatrixOpData::MatrixArrayPtr dst_rgb2xyz = rgb2xyz_from_xy(dst_prims);
     MatrixOpData::MatrixArrayPtr xyz2rgb = dst_rgb2xyz->inverse();
 
-    // If the white points are equal, don't need to adapt.
-    if ( method == ADAPTATION_NONE ||
-        (src_prims.m_wht.m_xy[0] == dst_prims.m_wht.m_xy[0] &&
-         src_prims.m_wht.m_xy[1] == dst_prims.m_wht.m_xy[1]) )
+    // Return the composed matrix if no adaptation is needed.
+    if ( !src_wht_XYZ.isNotNull() && !dst_wht_XYZ.isNotNull() )
+    {
+        // If the white points are equal, don't need to adapt.
+        if ( src_prims.m_wht.m_xy[0] == dst_prims.m_wht.m_xy[0] &&
+             src_prims.m_wht.m_xy[1] == dst_prims.m_wht.m_xy[1] )
+        {
+            return xyz2rgb->inner(rgb2xyz);
+        }
+    }
+    else if ( method == ADAPTATION_NONE )
     {
         return xyz2rgb->inner(rgb2xyz);
     }
 
     // Calculate src and dst white XYZ.
-    MatrixOpData::Offsets dst_whtxyz = dst_rgb2xyz->inner(ones);
-    MatrixOpData::Offsets src_whtxyz = rgb2xyz->inner(ones);
+    MatrixOpData::Offsets src_wht, dst_wht;
+    if ( dst_wht_XYZ.isNotNull() )
+    {
+        dst_wht = dst_wht_XYZ;
+    }
+    else
+    {
+        dst_wht = dst_rgb2xyz->inner(ones);
+    }
+    if ( src_wht_XYZ.isNotNull() )
+    {
+        src_wht = src_wht_XYZ;
+    }
+    else
+    {
+        src_wht = rgb2xyz->inner(ones);
+    }
 
     // Build the adaptation matrix (may be an identity).
-    MatrixOpData::MatrixArrayPtr vkmat = build_vonkries_adapt(src_whtxyz, dst_whtxyz, method);
+    MatrixOpData::MatrixArrayPtr vkmat = build_vonkries_adapt(src_wht, dst_wht, method);
 
-    // Compose into the conversion matrix.
+    // Compose the adaptation into the conversion matrix.
     return xyz2rgb->inner(vkmat->inner(rgb2xyz));
+}
+
+MatrixOpData::MatrixArrayPtr build_conversion_matrix(const Primaries & src_prims,
+                                                     const Primaries & dst_prims,
+                                                     AdaptationMethod method)
+{
+    static const MatrixOpData::Offsets null(0., 0., 0., 0.);
+    return build_conversion_matrix( src_prims, dst_prims, null, null, method );
 }
 
 } // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.h
+++ b/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.h
@@ -82,7 +82,7 @@ struct Primaries
     Chromaticities m_wht; // CIE xy chromaticities for white (or gray).
 };
 
-namespace CIE_XYZ_D65
+namespace CIE_XYZ_ILLUM_E
 {
 extern const Primaries primaries;
 }
@@ -138,11 +138,21 @@ MatrixOpData::MatrixArrayPtr build_vonkries_adapt(const MatrixOpData::Offsets & 
                                                   AdaptationMethod method);
 
 // Build a conversion matrix from source primaries to destination primaries.
+// The resulting matrix will map [1,1,1] input RGB to [1,1,1] output RGB.
 
 MatrixOpData::MatrixArrayPtr build_conversion_matrix(const Primaries & src_prims,
                                                      const Primaries & dst_prims,
                                                      AdaptationMethod method);
 
+// Build a conversion matrix from source primaries to destination primaries with the option of
+// setting the adaptation source and destination manually.  If you pass zeros for either of the
+// white points, that corresponding white point will be taken from the primaries.
+
+MatrixOpData::MatrixArrayPtr build_conversion_matrix(const Primaries & src_prims,
+                                                     const Primaries & dst_prims,
+                                                     const MatrixOpData::Offsets & src_wht_XYZ,
+                                                     const MatrixOpData::Offsets & dst_wht_XYZ,
+                                                     AdaptationMethod method);
 } // namespace OCIO_NAMESPACE
 
 #endif // INCLUDED_OCIO_COLOR_MATRIX_HELPERS_H

--- a/tests/cpu/transforms/BuiltinTransform_tests.cpp
+++ b/tests/cpu/transforms/BuiltinTransform_tests.cpp
@@ -271,22 +271,24 @@ OCIO_ADD_TEST(Builtins, color_matrix_helpers)
     }
 
     {
-        // Note: Source and dest white points differ.
+        // Note: Source and dest white points differ, manual override specified.
+        const OCIO::MatrixOpData::Offsets null(0., 0., 0., 0.);
+        const OCIO::MatrixOpData::Offsets d65_wht_XYZ(0.95045592705167, 1., 1.08905775075988, 0.);
         OCIO::MatrixOpData::MatrixArrayPtr matrix
-            = build_conversion_matrix(OCIO::ACES_AP0::primaries, OCIO::CIE_XYZ_D65::primaries,
-                                      OCIO::ADAPTATION_BRADFORD);
+            = build_conversion_matrix(OCIO::ACES_AP0::primaries, OCIO::CIE_XYZ_ILLUM_E::primaries,
+                                      null, d65_wht_XYZ, OCIO::ADAPTATION_BRADFORD);
 
-        ValidateValues( 0U, matrix->getDoubleValue( 0),  0.987189224216, 1e-7, __LINE__);
-        ValidateValues( 1U, matrix->getDoubleValue( 1), -0.004683484721, 1e-7, __LINE__);
-        ValidateValues( 2U, matrix->getDoubleValue( 2),  0.017494260505, 1e-7, __LINE__);
+        ValidateValues( 0U, matrix->getDoubleValue( 0),  0.93827985, 1e-7, __LINE__);
+        ValidateValues( 1U, matrix->getDoubleValue( 1), -0.00445145, 1e-7, __LINE__);
+        ValidateValues( 2U, matrix->getDoubleValue( 2),  0.01662752, 1e-7, __LINE__);
 
-        ValidateValues( 4U, matrix->getDoubleValue( 4),  0.337368890788, 1e-7, __LINE__);
-        ValidateValues( 5U, matrix->getDoubleValue( 5),  0.729521566690 , 1e-7, __LINE__);
-        ValidateValues( 6U, matrix->getDoubleValue( 6), -0.066890457478, 1e-7, __LINE__);
+        ValidateValues( 4U, matrix->getDoubleValue( 4),  0.33736889, 1e-7, __LINE__);
+        ValidateValues( 5U, matrix->getDoubleValue( 5),  0.72952157, 1e-7, __LINE__);
+        ValidateValues( 6U, matrix->getDoubleValue( 6), -0.06689046, 1e-7, __LINE__);
 
-        ValidateValues( 8U, matrix->getDoubleValue( 8),  0.001077950962, 1e-7, __LINE__);
-        ValidateValues( 9U, matrix->getDoubleValue( 9), -0.003407263205, 1e-7, __LINE__);
-        ValidateValues(10U, matrix->getDoubleValue(10),  1.002329312243, 1e-7, __LINE__);
+        ValidateValues( 8U, matrix->getDoubleValue( 8),  0.00117395, 1e-7, __LINE__);
+        ValidateValues( 9U, matrix->getDoubleValue( 9), -0.00371071, 1e-7, __LINE__);
+        ValidateValues(10U, matrix->getDoubleValue(10),  1.09159451, 1e-7, __LINE__);
 
 
         OCIO_CHECK_EQUAL(matrix->getDoubleValue( 3), 0.);
@@ -365,9 +367,9 @@ AllValues UnitTestValues
     { "IDENTITY",
         { { 0.5f, 0.4f, 0.3f }, { 0.5f,            0.4f,            0.3f } } },
     { "ACES-AP0_to_CIE-XYZ-D65_BFD",
-        { { 0.5f, 0.4f, 0.3f }, { 0.496969496371f, 0.440425934827f, 0.299874863872f } } },
+        { { 0.5f, 0.4f, 0.3f }, { 0.472347603390f, 0.440425934827f, 0.326581044758f } } },
     { "ACES-AP1_to_CIE-XYZ-D65_BFD",
-        { { 0.5f, 0.4f, 0.3f }, { 0.450739364025f, 0.420968434905f, 0.299137367021f } } },
+        { { 0.5f, 0.4f, 0.3f }, { 0.428407900093f, 0.420968434905f, 0.325777868096f } } },
     { "ACES-AP1_to_LINEAR-REC709_BFD",
         { { 0.5f, 0.4f, 0.3f }, { 0.578830986466f, 0.388029190156f, 0.282302431033f } } },
     { "ACEScct-LOG_to_LIN",


### PR DESCRIPTION
- Improved the accuracy of the ACEScc built-in transform.
- Adjust the normalization of CIE XYZ D65.

Signed-off-by: Doug Walker <Doug.Walker@autodesk.com>