### PR TITLE
Adsk Contrib - Shader textures now available via Python

### DIFF
--- a/docs/api/python/frozen/pyopencolorio_gpushaderdesc.rst
+++ b/docs/api/python/frozen/pyopencolorio_gpushaderdesc.rst
@@ -87,10 +87,6 @@
       :module: PyOpenColorIO
 
 
-   .. py:method:: GpuShaderDesc.get3DTextureValues(self: PyOpenColorIO.GpuShaderDesc, index: int) -> numpy.ndarray
-      :module: PyOpenColorIO
-
-
    .. py:method:: GpuShaderDesc.get3DTextures(self: PyOpenColorIO.GpuShaderDesc) -> PyOpenColorIO.GpuShaderDesc.Texture3DIterator
       :module: PyOpenColorIO
 
@@ -121,14 +117,6 @@
       To avoid texture/unform name clashes always append an increasing number to the resource name.
 
 
-   .. py:method:: GpuShaderDesc.getNum3DTextures(self: PyOpenColorIO.GpuShaderDesc) -> int
-      :module: PyOpenColorIO
-
-
-   .. py:method:: GpuShaderDesc.getNumTextures(self: PyOpenColorIO.GpuShaderDesc) -> int
-      :module: PyOpenColorIO
-
-
    .. py:method:: GpuShaderDesc.getPixelName(self: PyOpenColorIO.GpuShaderCreator) -> str
       :module: PyOpenColorIO
 
@@ -141,10 +129,6 @@
 
 
    .. py:method:: GpuShaderDesc.getTextureMaxWidth(self: PyOpenColorIO.GpuShaderCreator) -> int
-      :module: PyOpenColorIO
-
-
-   .. py:method:: GpuShaderDesc.getTextureValues(self: PyOpenColorIO.GpuShaderDesc, index: int) -> numpy.ndarray
       :module: PyOpenColorIO
 
 
@@ -223,6 +207,10 @@
       :property:
 
 
+   .. py:method:: Texture.getValues(self: PyOpenColorIO.GpuShaderDesc.Texture) -> numpy.ndarray
+      :module: PyOpenColorIO.GpuShaderDesc
+
+
    .. py:method:: Texture.height
       :module: PyOpenColorIO.GpuShaderDesc
       :property:
@@ -255,6 +243,10 @@
    .. py:method:: Texture3D.edgeLen
       :module: PyOpenColorIO.GpuShaderDesc
       :property:
+
+
+   .. py:method:: Texture3D.getValues(self: PyOpenColorIO.GpuShaderDesc.Texture3D) -> numpy.ndarray
+      :module: PyOpenColorIO.GpuShaderDesc
 
 
    .. py:method:: Texture3D.interpolation

--- a/tests/python/GpuShaderDescTest.py
+++ b/tests/python/GpuShaderDescTest.py
@@ -1,18 +1,110 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 
-import unittest, os, sys
+import unittest
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    import numpy as np
+except ImportError:
+    logger.warning(
+        "NumPy could not be imported. "
+        "Test case will lack significant coverage!"
+    )
+    np = None
+
 import PyOpenColorIO as OCIO
 
 class GpuShaderDescTest(unittest.TestCase):
 
-    def test_interface(self):
-        desc = OCIO.GpuShaderDesc()
-        desc.setLanguage(OCIO.Constants.GPU_LANGUAGE_GLSL_1_3)
-        self.assertEqual(OCIO.Constants.GPU_LANGUAGE_GLSL_1_3, desc.getLanguage())
+    def test_shader_creator_interface(self):
+        desc = OCIO.GpuShaderDesc.CreateShaderDesc()
+        desc.setLanguage(OCIO.GPU_LANGUAGE_GLSL_1_3)
+        self.assertEqual(OCIO.GPU_LANGUAGE_GLSL_1_3, desc.getLanguage())
         desc.setFunctionName("foo123")
         self.assertEqual("foo123", desc.getFunctionName())
         desc.finalize()
         self.assertEqual("glsl_1.3 foo123 ocio outColor 0 $4dd1c89df8002b409e089089ce8f24e7",
                          desc.getCacheID())
 
+    def test_texture(self):
+        # Test addTexture() & getTextures().
+        if not np:
+            logger.warning("NumPy not found. Skipping test!")
+            return
+
+        desc = OCIO.GpuShaderDesc.CreateShaderDesc()
+        buf = np.array([0,0.1,0.2,0.3,0.4,0.5]).astype(np.float32)
+        desc.addTexture('tex', 'sampler', 2, 3,
+                        OCIO.GpuShaderCreator.TEXTURE_RED_CHANNEL,
+                        OCIO.INTERP_DEFAULT, buf)
+        desc.addTexture(textureName='tex2', samplerName='sampler2', width=3, height=2,
+                        channel=OCIO.GpuShaderCreator.TEXTURE_RED_CHANNEL,
+                        interpolation=OCIO.INTERP_DEFAULT, values=buf)
+        textures = desc.getTextures()
+        self.assertEqual(len(textures), 2)
+        t1 = next(textures)
+        self.assertEqual(t1.textureName, 'tex')
+        self.assertEqual(t1.samplerName, 'sampler')
+        self.assertEqual(t1.width, 2)
+        self.assertEqual(t1.height, 3)
+        self.assertEqual(t1.channel, OCIO.GpuShaderCreator.TEXTURE_RED_CHANNEL)
+        self.assertEqual(t1.interpolation, OCIO.INTERP_DEFAULT)
+        v1 = t1.getValues()
+        self.assertEqual(len(v1), 6)
+        self.assertEqual(v1[0], np.float32(0))
+        self.assertEqual(v1[1], np.float32(0.1))
+        self.assertEqual(v1[2], np.float32(0.2))
+        self.assertEqual(v1[3], np.float32(0.3))
+        self.assertEqual(v1[4], np.float32(0.4))
+        self.assertEqual(v1[5], np.float32(0.5))
+
+        t2 = next(textures)
+        self.assertEqual(t2.textureName, 'tex2')
+        self.assertEqual(t2.samplerName, 'sampler2')
+        self.assertEqual(t2.width, 3)
+        self.assertEqual(t2.height, 2)
+        self.assertEqual(t2.channel, OCIO.GpuShaderCreator.TEXTURE_RED_CHANNEL)
+        self.assertEqual(t2.interpolation, OCIO.INTERP_DEFAULT)
+        v2 = t2.getValues()
+        self.assertEqual(len(v2), 6)
+        self.assertEqual(v2[0], np.float32(0))
+        self.assertEqual(v2[1], np.float32(0.1))
+        self.assertEqual(v2[2], np.float32(0.2))
+        self.assertEqual(v2[3], np.float32(0.3))
+        self.assertEqual(v2[4], np.float32(0.4))
+        self.assertEqual(v2[5], np.float32(0.5))
+
+    def test_texture_3d(self):
+        # Test add3DTexture() & get3DTextures().
+        if not np:
+            logger.warning("NumPy not found. Skipping test!")
+            return
+
+        desc = OCIO.GpuShaderDesc.CreateShaderDesc()
+        buf = np.linspace(0, 1, num=8*3).astype(np.float32)
+        desc.add3DTexture('tex', 'sampler', 2,
+                          OCIO.INTERP_DEFAULT, buf)
+        buf = np.linspace(0, 1, num=27*3).astype(np.float32)
+        desc.add3DTexture('tex2', 'sampler2', 3,
+                          OCIO.INTERP_DEFAULT, buf)
+
+        textures = desc.get3DTextures()
+        self.assertEqual(len(textures), 2)
+        t1 = next(textures)
+        self.assertEqual(t1.textureName, 'tex')
+        self.assertEqual(t1.samplerName, 'sampler')
+        self.assertEqual(t1.edgeLen, 2)
+        self.assertEqual(t1.interpolation, OCIO.INTERP_DEFAULT)
+        v1 = t1.getValues()
+        self.assertEqual(len(v1), 3*8)
+        self.assertEqual(v1[3], np.float32(1/(3*8)))
+        t2 = next(textures)
+        self.assertEqual(t2.textureName, 'tex2')
+        self.assertEqual(t2.samplerName, 'sampler2')
+        self.assertEqual(t2.edgeLen, 3)
+        self.assertEqual(t2.interpolation, OCIO.INTERP_DEFAULT)
+        v2 = t2.getValues()
+        self.assertEqual(len(v2), 3*27)

--- a/tests/python/GpuShaderDescTest.py
+++ b/tests/python/GpuShaderDescTest.py
@@ -100,7 +100,7 @@ class GpuShaderDescTest(unittest.TestCase):
         self.assertEqual(t1.interpolation, OCIO.INTERP_DEFAULT)
         v1 = t1.getValues()
         self.assertEqual(len(v1), 3*8)
-        self.assertEqual(v1[3], np.float32(1/(3*8)))
+        self.assertEqual(v1[3], np.float32(3/(3*8 - 1)))
         t2 = next(textures)
         self.assertEqual(t2.textureName, 'tex2')
         self.assertEqual(t2.samplerName, 'sampler2')
@@ -108,3 +108,4 @@ class GpuShaderDescTest(unittest.TestCase):
         self.assertEqual(t2.interpolation, OCIO.INTERP_DEFAULT)
         v2 = t2.getValues()
         self.assertEqual(len(v2), 3*27)
+        self.assertEqual(v2[42], np.float32(42/(3*27 - 1)))

--- a/tests/python/GpuShaderDescTest.py
+++ b/tests/python/GpuShaderDescTest.py
@@ -85,9 +85,11 @@ class GpuShaderDescTest(unittest.TestCase):
 
         desc = OCIO.GpuShaderDesc.CreateShaderDesc()
         buf = np.linspace(0, 1, num=8*3).astype(np.float32)
+        bufTest1 = buf[3]
         desc.add3DTexture('tex', 'sampler', 2,
                           OCIO.INTERP_DEFAULT, buf)
         buf = np.linspace(0, 1, num=27*3).astype(np.float32)
+        bufTest2 = buf[42]
         desc.add3DTexture('tex2', 'sampler2', 3,
                           OCIO.INTERP_DEFAULT, buf)
 
@@ -100,7 +102,7 @@ class GpuShaderDescTest(unittest.TestCase):
         self.assertEqual(t1.interpolation, OCIO.INTERP_DEFAULT)
         v1 = t1.getValues()
         self.assertEqual(len(v1), 3*8)
-        self.assertEqual(v1[3], np.float32(3/(3*8 - 1)))
+        self.assertEqual(v1[3], bufTest1)
         t2 = next(textures)
         self.assertEqual(t2.textureName, 'tex2')
         self.assertEqual(t2.samplerName, 'sampler2')
@@ -108,4 +110,4 @@ class GpuShaderDescTest(unittest.TestCase):
         self.assertEqual(t2.interpolation, OCIO.INTERP_DEFAULT)
         v2 = t2.getValues()
         self.assertEqual(len(v2), 3*27)
-        self.assertEqual(v2[42], np.float32(42/(3*27 - 1)))
+        self.assertEqual(v2[42], bufTest2)

--- a/tests/python/OpenColorIOTestSuite.py
+++ b/tests/python/OpenColorIOTestSuite.py
@@ -57,6 +57,7 @@ import ExposureContrastTransformTest
 import FileTransformTest
 import FixedFunctionTransformTest
 import FormatMetadataTest
+import GpuShaderDescTest
 import GradingDataTest
 import GradingPrimaryTransformTest
 import GradingRGBCurveTransformTest
@@ -73,7 +74,6 @@ import ViewingRulesTest
 #from ConstantsTest import *
 #from ConfigTest import *
 #from ContextTest import *
-#from GpuShaderDescTest import *
 #from Baker import *
 #from TransformsTest import *
 #from RangeTransformTest import *
@@ -106,6 +106,7 @@ def suite():
     suite.addTest(loader.loadTestsFromModule(FileTransformTest))
     suite.addTest(loader.loadTestsFromModule(FixedFunctionTransformTest))
     suite.addTest(loader.loadTestsFromModule(FormatMetadataTest))
+    suite.addTest(loader.loadTestsFromModule(GpuShaderDescTest))
     suite.addTest(loader.loadTestsFromModule(GradingDataTest))
     suite.addTest(loader.loadTestsFromModule(GradingPrimaryTransformTest))
     suite.addTest(loader.loadTestsFromModule(GradingRGBCurveTransformTest))
@@ -130,7 +131,6 @@ def suite():
 
     # Processor
     # ProcessorMetadata
-    #suite.addTest(GpuShaderDescTest("test_interface"))
     #suite.addTest(BakerTest("test_interface", opencolorio_sse))
     # PackedImageDesc
     # PlanarImageDesc


### PR DESCRIPTION
Fix issue #1263 by updating GpuShaderDesc bindings and how Texture2D and Texture3D are exposed.

Signed-off-by: Bernard Lefebvre <bernard.lefebvre@autodesk.com>