### PR TITLE
Transform Python Binding Fix

### DIFF
--- a/src/bindings/python/PyOpenColorIO.h
+++ b/src/bindings/python/PyOpenColorIO.h
@@ -71,6 +71,10 @@ struct polymorphic_type_hook<OCIO::Transform> {
             {
                 type = &typeid(OCIO::AllocationTransform);
             }
+            if(dynamic_cast<const OCIO::BuiltinTransform*>(src))
+            {
+                type = &typeid(OCIO::BuiltinTransform);
+            }
             else if(dynamic_cast<const OCIO::CDLTransform*>(src))
             {
                 type = &typeid(OCIO::CDLTransform);
@@ -111,6 +115,10 @@ struct polymorphic_type_hook<OCIO::Transform> {
             {
                 type = &typeid(OCIO::GradingRGBCurveTransform);
             }
+            if(dynamic_cast<const OCIO::GradingToneTransform*>(src))
+            {
+                type = &typeid(OCIO::GradingToneTransform);
+            }
             else if(dynamic_cast<const OCIO::GroupTransform*>(src))
             {
                 type = &typeid(OCIO::GroupTransform);
@@ -118,6 +126,10 @@ struct polymorphic_type_hook<OCIO::Transform> {
             else if(dynamic_cast<const OCIO::LogAffineTransform*>(src))
             {
                 type = &typeid(OCIO::LogAffineTransform);
+            }
+            else if(dynamic_cast<const OCIO::LogCameraTransform*>(src))
+            {
+                type = &typeid(OCIO::LogCameraTransform);
             }
             else if(dynamic_cast<const OCIO::LogTransform*>(src))
             {

--- a/tests/python/OpenColorIOTestSuite.py
+++ b/tests/python/OpenColorIOTestSuite.py
@@ -73,13 +73,13 @@ import MixingHelpersTest
 import NamedTransformTest
 import OpenColorIOTest
 import ProcessorTest
+import TransformsTest
 import ViewingRulesTest
 #from MainTest import *
 #from ConstantsTest import *
 #from ConfigTest import *
 #from ContextTest import *
 #from Baker import *
-#from TransformsTest import *
 #from RangeTransformTest import *
 
 def suite():
@@ -126,6 +126,7 @@ def suite():
     suite.addTest(loader.loadTestsFromModule(NamedTransformTest))
     suite.addTest(loader.loadTestsFromModule(OpenColorIOTest))
     suite.addTest(loader.loadTestsFromModule(ProcessorTest))
+    suite.addTest(loader.loadTestsFromModule(TransformsTest))
     suite.addTest(loader.loadTestsFromModule(ViewingRulesTest))
     #suite.addTest(MainTest("test_interface"))
     #suite.addTest(ConstantsTest("test_interface"))
@@ -134,8 +135,7 @@ def suite():
     #suite.addTest(ContextTest("test_interface"))
     #suite.addTest(RangeTransformTest("test_interface"))
     #suite.addTest(RangeTransformTest("test_equality"))
-    #suite.addTest(RangeTransformTest("test_validation"))
-    #suite.addTest(TransformsTest("test_interface"))
+    #suite.addTest(RangeTransformTest("test_validation"))\
 
     # Processor
     # ProcessorMetadata

--- a/tests/python/TransformsTest.py
+++ b/tests/python/TransformsTest.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+import unittest, os, sys
+import PyOpenColorIO as OCIO
+import inspect
+
+class TransformsTest(unittest.TestCase):
+
+    def test_binding_polymorphism(self):
+        """
+        Tests polymorphism issue where transforms are cast as parent class when using
+        GroupTransforms. Flagged in https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1211
+        """
+        allTransformsAsGroup = OCIO.GroupTransform()
+        # Search for all transform types in order to handle future transforms
+        for n, c in inspect.getmembers(OCIO):
+            if hasattr(c, 'getTransformType'):
+                try:
+                    # Attempt to construct each Transform subclass, raising exception in order to
+                    # filter the parent OCIO.Transform class
+                    allTransformsAsGroup.appendTransform(c())
+                except TypeError as e:
+                    # Ensure we only catch and filter for this specific error
+                    self.assertEqual(
+                        str(e),
+                        'PyOpenColorIO.Transform: No constructor defined!',
+                        'Unintended Error Raised: {0}'.format(e)
+                    )
+        for transform in allTransformsAsGroup:
+            # Ensure no transforms have been cast as parent transform
+            self.assertNotEqual(
+                type(transform),
+                OCIO.Transform,
+                """Transform has unintentionally been cast as parent class!
+                transform.getTransformType(): {0}
+                type(transform): {1}
+
+                Are there pybind polymorphic_type_hooks in src/bindings/PyOpenColorIO.h for this transform?
+                """.format(transform.getTransformType(), type(transform))
+            )


### PR DESCRIPTION
Fixed pybind polymorphism issue where subclasses of Transform were cast as parent class due to missing type hooks declarations, for instance when iterating a GroupTransform. Included tests to avoid this issue when adding new Transforms in the future.