### PR TITLE
Add UNIFORM_FLOAT3, setStrictParsingEnabled to PyOpenColorIO

### DIFF
--- a/docs/api/python/frozen/pyopencolorio_config.rst
+++ b/docs/api/python/frozen/pyopencolorio_config.rst
@@ -708,6 +708,10 @@
       See :ref:`addSearchPath` for a more robust and platform-agnostic method of setting the search paths.
 
 
+   .. py:method:: Config.setStrictParsingEnabled(self: PyOpenColorIO.Config, enabled: bool) -> None
+      :module: PyOpenColorIO
+
+
    .. py:method:: Config.setVersion(self: PyOpenColorIO.Config, major: int, minor: int) -> None
       :module: PyOpenColorIO
 

--- a/docs/api/python/frozen/pyopencolorio_uniformdatatype.rst
+++ b/docs/api/python/frozen/pyopencolorio_uniformdatatype.rst
@@ -14,6 +14,8 @@
 
      UNIFORM_BOOL :
 
+     UNIFORM_FLOAT3 : Array of 3 floats.
+
      UNIFORM_VECTOR_FLOAT : Vector of floats (size is set by uniform).
 
      UNIFORM_VECTOR_INT : Vector of int pairs (size is set by uniform).
@@ -31,6 +33,11 @@
    .. py:attribute:: UniformDataType.UNIFORM_DOUBLE
       :module: PyOpenColorIO
       :value: <UniformDataType.UNIFORM_DOUBLE: 0>
+
+
+   .. py:attribute:: UniformDataType.UNIFORM_FLOAT3
+      :module: PyOpenColorIO
+      :value: <UniformDataType.UNIFORM_FLOAT3: 2>
 
 
    .. py:attribute:: UniformDataType.UNIFORM_UNKNOWN

--- a/src/bindings/python/PyConfig.cpp
+++ b/src/bindings/python/PyConfig.cpp
@@ -296,6 +296,8 @@ void bindPyConfig(py::module & m)
              DOC(Config, parseColorSpaceFromString))
         .def("isStrictParsingEnabled", &Config::isStrictParsingEnabled, 
              DOC(Config, isStrictParsingEnabled))
+        .def("setStrictParsingEnabled", &Config::setStrictParsingEnabled, "enabled"_a,
+             DOC(Config, setStrictParsingEnabled))
         .def("setInactiveColorSpaces", &Config::setInactiveColorSpaces, "inactiveColorSpaces"_a,
              DOC(Config, setInactiveColorSpaces))
         .def("getInactiveColorSpaces", &Config::getInactiveColorSpaces, 

--- a/src/bindings/python/PyTypes.cpp
+++ b/src/bindings/python/PyTypes.cpp
@@ -664,6 +664,8 @@ void bindPyTypes(py::module & m)
                DOC(PyOpenColorIO, UniformDataType, UNIFORM_DOUBLE))
         .value("UNIFORM_BOOL", UNIFORM_BOOL, 
                DOC(PyOpenColorIO, UniformDataType, UNIFORM_BOOL))
+        .value("UNIFORM_FLOAT3", UNIFORM_FLOAT3, 
+               DOC(PyOpenColorIO, UniformDataType, UNIFORM_FLOAT3))
         .value("UNIFORM_VECTOR_FLOAT", UNIFORM_VECTOR_FLOAT, 
                DOC(PyOpenColorIO, UniformDataType, UNIFORM_VECTOR_FLOAT))
         .value("UNIFORM_VECTOR_INT", UNIFORM_VECTOR_INT, 


### PR DESCRIPTION
This small PR fixes some missing API in PyOpenColorIO.

Signed-off-by: Michael Dolan <michdolan@gmail.com>