### PR TITLE
Adsk Contrib - Add new ACES builtin transforms

### DIFF
--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -167,6 +167,7 @@ if(OCIO_ADD_EXTRA_BUILTINS)
 	set(SOURCES_BUILTINS
 		transforms/builtins/ArriCameras.cpp
 		transforms/builtins/CanonCameras.cpp
+		transforms/builtins/Displays.cpp
 		transforms/builtins/PanasonicCameras.cpp
 		transforms/builtins/RedCameras.cpp
 		transforms/builtins/SonyCameras.cpp

--- a/src/OpenColorIO/ops/matrix/MatrixOpData.cpp
+++ b/src/OpenColorIO/ops/matrix/MatrixOpData.cpp
@@ -750,7 +750,6 @@ void MatrixOpData::cleanUp(double offsetScale)
     // args.  In any case, the tolerance is small enough to pick up anything
     // that would be significant in the context of color management.
     const double scale = max_val > 1e-4 ? max_val : 1e-4;
-//    const double abs_tol = scale * 1e-6;
     const double abs_tol = scale * 1e-7;
 
     // Replace values that are close to integers by exact values.

--- a/src/OpenColorIO/ops/matrix/MatrixOpData.cpp
+++ b/src/OpenColorIO/ops/matrix/MatrixOpData.cpp
@@ -750,7 +750,8 @@ void MatrixOpData::cleanUp(double offsetScale)
     // args.  In any case, the tolerance is small enough to pick up anything
     // that would be significant in the context of color management.
     const double scale = max_val > 1e-4 ? max_val : 1e-4;
-    const double abs_tol = scale * 1e-6;
+//    const double abs_tol = scale * 1e-6;
+    const double abs_tol = scale * 1e-7;
 
     // Replace values that are close to integers by exact values.
     for (unsigned long i = 0; i<dim; ++i)
@@ -769,7 +770,7 @@ void MatrixOpData::cleanUp(double offsetScale)
 
     // Do likewise for the offsets.
     const double scale2 = offsetScale > 1e-4 ? offsetScale : 1e-4;
-    const double abs_tol2 = scale2 * 1e-6;
+    const double abs_tol2 = scale2 * 1e-7;
 
     for (unsigned long i = 0; i<dim; ++i)
     {

--- a/src/OpenColorIO/transforms/builtins/ACES.cpp
+++ b/src/OpenColorIO/transforms/builtins/ACES.cpp
@@ -517,7 +517,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("UTILITY--ACES-AP0_to_CIE-XYZ-D65_BFD", 
+        registry.addBuiltin("UTILITY - ACES-AP0_to_CIE-XYZ-D65_BFD", 
                             "Convert ACES AP0 primaries to CIE XYZ with a D65 white point with Bradford adaptation",
                             ACES_AP0_to_CIE_XYZ_D65_BFD_Functor);
     }
@@ -527,7 +527,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             AP1_to_CIE_XYZ_D65::GenerateOps(ops);
         };
 
-        registry.addBuiltin("UTILITY--ACES-AP1_to_CIE-XYZ-D65_BFD", 
+        registry.addBuiltin("UTILITY - ACES-AP1_to_CIE-XYZ-D65_BFD", 
                             "Convert ACES AP1 primaries to CIE XYZ with a D65 white point with Bradford adaptation",
                             ACES_AP1_to_CIE_XYZ_D65_BFD_Functor);
     }
@@ -539,7 +539,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("UTILITY--ACES-AP1_to_LINEAR-REC709_BFD", 
+        registry.addBuiltin("UTILITY - ACES-AP1_to_LINEAR-REC709_BFD", 
                             "Convert ACES AP1 primaries to linear Rec.709 primaries with Bradford adaptation",
                             ACES_AP1_to_LINEAR_REC709_BFD_Functor);
     }
@@ -550,7 +550,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateLogOp(ops, log, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("CURVE--ACEScct-LOG_to_LINEAR", 
+        registry.addBuiltin("CURVE - ACEScct-LOG_to_LINEAR", 
                             "Apply the log-to-lin curve used in ACEScct",
                             ACEScct_LOG_to_LIN_Functor);
     }
@@ -704,7 +704,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateMatrixOp(ops, &BLUE_LIGHT_FIX[0], TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("ACES-LMT--BLUE_LIGHT_ARTIFACT_FIX",
+        registry.addBuiltin("ACES-LMT - BLUE_LIGHT_ARTIFACT_FIX",
                             "LMT for desaturating blue hues to reduce clipping artifacts",
                             BLUE_LIGHT_FIX_Functor);
     }
@@ -723,7 +723,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             AP1_to_CIE_XYZ_D65::GenerateOps(ops);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA_1.0", 
+        registry.addBuiltin("ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA_1.0", 
                             "Component of ACES Output Transforms for SDR cinema",
                             ACES2065_1_to_CIE_XYZ_cinema_1_0_Functor);
     }
@@ -740,7 +740,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             AP1_to_CIE_XYZ_D65::GenerateOps(ops);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-VIDEO_1.0", 
+        registry.addBuiltin("ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-VIDEO_1.0", 
                             "Component of ACES Output Transforms for SDR D65 video",
                             ACES2065_1_to_CIE_XYZ_video_1_0_Functor);
     }
@@ -755,7 +755,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             ACES_OUTPUT::Generate_sdr_primary_clamp_ops(ops, REC709::primaries);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA-REC709lim_1.1", 
+        registry.addBuiltin("ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA-REC709lim_1.1", 
                             "Component of ACES Output Transforms for SDR cinema",
                             ACES2065_1_to_CIE_XYZ_cinema_rec709lim_1_1_Functor);
     }
@@ -772,7 +772,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             ACES_OUTPUT::Generate_sdr_primary_clamp_ops(ops, REC709::primaries);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-VIDEO-REC709lim_1.1", 
+        registry.addBuiltin("ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-VIDEO-REC709lim_1.1", 
                             "Component of ACES Output Transforms for SDR D65 video",
                             ACES2065_1_to_CIE_XYZ_video_rec709lim_1_1_Functor);
     }
@@ -789,7 +789,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             ACES_OUTPUT::Generate_sdr_primary_clamp_ops(ops, P3_D65::primaries);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-VIDEO-P3lim_1.1", 
+        registry.addBuiltin("ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-VIDEO-P3lim_1.1", 
                             "Component of ACES Output Transforms for SDR D65 video",
                             ACES2065_1_to_CIE_XYZ_video_p3lim_1_1_Functor);
     }
@@ -815,7 +815,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA-D60sim-D65_1.1", 
+        registry.addBuiltin("ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA-D60sim-D65_1.1", 
                             "Component of ACES Output Transforms for SDR D65 cinema simulating D60 white",
                             ACES2065_1_to_CIE_XYZ_cinema_d60sim_1_1_Functor);
     }
@@ -843,7 +843,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-VIDEO-D60sim-D65_1.0", 
+        registry.addBuiltin("ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-VIDEO-D60sim-D65_1.0", 
                             "Component of ACES Output Transforms for SDR D65 video simulating D60 white",
                             ACES2065_1_to_CIE_XYZ_video_d60sim_1_0_Functor);
     }
@@ -875,7 +875,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateMatrixOp(ops, matrix2, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA-D60sim-DCI_1.0", 
+        registry.addBuiltin("ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA-D60sim-DCI_1.0", 
                             "Component of ACES Output Transforms for SDR DCI cinema simulating D60 white",
                             ACES2065_1_to_CIE_XYZ_cinema_d60sim_dci_1_0_Functor);
     }
@@ -905,7 +905,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateMatrixOp(ops, matrix2, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA-D65sim-DCI_1.1", 
+        registry.addBuiltin("ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA-D65sim-DCI_1.1", 
                             "Component of ACES Output Transforms for SDR DCI cinema simulating D65 white",
                             ACES2065_1_to_CIE_XYZ_cinema_d65sim_dci_1_1_Functor);
     }
@@ -922,7 +922,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             ACES_OUTPUT::Generate_nit_normalization_ops(ops, 1000.);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-1000nit-15nit-REC2020lim_1.1", 
+        registry.addBuiltin("ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-1000nit-15nit-REC2020lim_1.1", 
                             "Component of ACES Output Transforms for 1000 nit HDR D65 video",
                             ACES2065_1_to_CIE_XYZ_hdr_video_1000nits_rec2020lim_1_1_Functor);
     }
@@ -939,7 +939,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             ACES_OUTPUT::Generate_nit_normalization_ops(ops, 1000.);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-1000nit-15nit-P3lim_1.1", 
+        registry.addBuiltin("ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-1000nit-15nit-P3lim_1.1", 
                             "Component of ACES Output Transforms for 1000 nit HDR D65 video",
                             ACES2065_1_to_CIE_XYZ_hdr_video_1000nits_p3lim_1_1_Functor);
     }
@@ -956,7 +956,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             ACES_OUTPUT::Generate_nit_normalization_ops(ops, 2000.);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-2000nit-15nit-REC2020lim_1.1", 
+        registry.addBuiltin("ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-2000nit-15nit-REC2020lim_1.1", 
                             "Component of ACES Output Transforms for 2000 nit HDR D65 video",
                             ACES2065_1_to_CIE_XYZ_hdr_video_2000nits_rec2020lim_1_1_Functor);
     }
@@ -973,7 +973,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             ACES_OUTPUT::Generate_nit_normalization_ops(ops, 2000.);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-2000nit-15nit-P3lim_1.1", 
+        registry.addBuiltin("ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-2000nit-15nit-P3lim_1.1", 
                             "Component of ACES Output Transforms for 2000 nit HDR D65 video",
                             ACES2065_1_to_CIE_XYZ_hdr_video_2000nits_p3lim_1_1_Functor);
     }
@@ -990,7 +990,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             ACES_OUTPUT::Generate_nit_normalization_ops(ops, 4000.);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-4000nit-15nit-REC2020lim_1.1", 
+        registry.addBuiltin("ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-4000nit-15nit-REC2020lim_1.1", 
                             "Component of ACES Output Transforms for 4000 nit HDR D65 video",
                             ACES2065_1_to_CIE_XYZ_hdr_video_4000nits_rec2020lim_1_1_Functor);
     }
@@ -1007,7 +1007,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             ACES_OUTPUT::Generate_nit_normalization_ops(ops, 4000.);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-4000nit-15nit-P3lim_1.1", 
+        registry.addBuiltin("ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-4000nit-15nit-P3lim_1.1", 
                             "Component of ACES Output Transforms for 4000 nit HDR D65 video",
                             ACES2065_1_to_CIE_XYZ_hdr_video_4000nits_p3lim_1_1_Functor);
     }
@@ -1024,7 +1024,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             ACES_OUTPUT::Generate_nit_normalization_ops(ops, 108.);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-CINEMA-108nit-7.2nit-P3lim_1.1", 
+        registry.addBuiltin("ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-CINEMA-108nit-7.2nit-P3lim_1.1", 
                             "Component of ACES Output Transforms for 108 nit HDR D65 cinema",
                             ACES2065_1_to_CIE_XYZ_hdr_cinema_108nits_p3lim_1_1_Functor);
     }

--- a/src/OpenColorIO/transforms/builtins/ACES.cpp
+++ b/src/OpenColorIO/transforms/builtins/ACES.cpp
@@ -7,6 +7,8 @@
 #include <OpenColorIO/OpenColorIO.h>
 
 #include "OpenEXR/half.h"
+#include "ops/fixedfunction/FixedFunctionOp.h"
+#include "ops/gradingrgbcurve/GradingRGBCurveOp.h"
 #include "ops/log/LogOp.h"
 #include "ops/matrix/MatrixOp.h"
 #include "ops/range/RangeOp.h"
@@ -18,8 +20,25 @@
 namespace OCIO_NAMESPACE
 {
 
+//
+// Define component functions for reuse in multiple built-ins.
+//
+
+namespace AP1_to_CIE_XYZ_D65
+{
+
+void GenerateOps(OpRcPtrVec & ops)
+{
+    MatrixOpData::MatrixArrayPtr matrix
+        = build_conversion_matrix_to_XYZ_D65(ACES_AP1::primaries, ADAPTATION_BRADFORD);
+    CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+}
+
+}  // namespace AP1_to_CIE_XYZ_D65
+
 namespace ACEScct_to_LINEAR
 {
+
 static constexpr double linSideSlope  = 1.;
 static constexpr double linSideOffset = 0.;
 static constexpr double logSideSlope  = 1. / 17.52;
@@ -31,10 +50,12 @@ static const LogOpData::Params
     params { logSideSlope, logSideOffset, linSideSlope, linSideOffset, linSideBreak };
 
 static const LogOpData log(base, params, params, params, TRANSFORM_DIR_INVERSE);
-}
+
+}  // namespace ACEScct_to_LINEAR
 
 namespace ADX_to_ACES
 {
+
 static constexpr unsigned lutSize = 11;
 static constexpr double nonuniform_LUT[lutSize * 2]
 {
@@ -53,6 +74,7 @@ static constexpr double nonuniform_LUT[lutSize * 2]
 
 void GenerateOps(OpRcPtrVec & ops)
 {
+    // Note that in CTL, the matrices are stored transposed.
     static constexpr double CDD_TO_CID[4 * 4]
     {
         0.75573,  0.22197,  0.02230,  0.,
@@ -115,6 +137,214 @@ void GenerateOps(OpRcPtrVec & ops)
 
 }  // namespace ADX_to_ACES
 
+namespace ACES_OUTPUT
+{
+
+void Generate_ACES_to_APO_ops(OpRcPtrVec & ops)
+{
+    CreateFixedFunctionOp(ops, FixedFunctionOpData::ACES_GLOW_10_FWD, {});
+
+    CreateFixedFunctionOp(ops, FixedFunctionOpData::ACES_RED_MOD_10_FWD, {});
+
+    CreateRangeOp(ops, 
+                  0., RangeOpData::EmptyValue(),  // don't clamp high end
+                  0., RangeOpData::EmptyValue(),  // don't clamp high end
+                  TRANSFORM_DIR_FORWARD);
+
+    MatrixOpData::MatrixArrayPtr matrix
+        = build_conversion_matrix(ACES_AP0::primaries, ACES_AP1::primaries, ADAPTATION_NONE);
+    CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+
+    CreateRangeOp(ops, 
+                  0., RangeOpData::EmptyValue(),  // don't clamp high end
+                  0., RangeOpData::EmptyValue(),  // don't clamp high end
+                  TRANSFORM_DIR_FORWARD);
+
+    static constexpr double RRT_SAT_MAT[4 * 4]
+    {
+        0.970889148671, 0.026963270632, 0.002147580696, 0., 
+        0.010889148671, 0.986963270632, 0.002147580696, 0., 
+        0.010889148671, 0.026963270632, 0.962147580696, 0., 
+        0., 0., 0., 1.
+    };
+    CreateMatrixOp(ops, &RRT_SAT_MAT[0], TRANSFORM_DIR_FORWARD);            
+}
+
+void Generate_tonecurve_ops(OpRcPtrVec & ops)
+{
+    // Convert to Log space.
+    CreateLogOp(ops, 10., TRANSFORM_DIR_FORWARD);
+
+    // Apply RRT shaper using the same quadratic B-spline as the CTL.
+    {
+        auto curve = GradingBSplineCurve::Create({
+                {-5.26017743f, -4.f},
+                {-3.75502745f, -3.57868829f},
+                {-2.24987747f, -1.82131329f},
+                {-0.74472749f,  0.68124124f},
+                { 1.06145248f,  2.87457742f},
+                { 2.86763245f,  3.83406206f},
+                { 4.67381243f,  4.f}
+            });
+        float slopes[] = { 0.f,  0.55982688f,  1.77532247f,  1.55f,  0.8787017f,  0.18374463f,  0.f };
+        for (size_t i = 0; i < 7; ++i)
+        {
+            curve->setSlope( i, slopes[i] );
+        }
+        ConstGradingBSplineCurveRcPtr m = curve;
+        auto identity = GradingBSplineCurve::Create({ { 0.f, 0.f }, { 1.f, 1.f } });
+        ConstGradingBSplineCurveRcPtr z = identity;
+        auto gc = std::make_shared<GradingRGBCurveOpData>(GRADING_LOG, z, z, z, m);
+
+        CreateGradingRGBCurveOp(ops, gc, TRANSFORM_DIR_FORWARD);
+    }
+
+    // Apply SDR ODT shaper using the same quadratic B-spline as the CTL.
+    {
+        auto curve = GradingBSplineCurve::Create({
+                {-2.54062362f,  -1.69897000f},
+                {-2.08035721f,  -1.58843500f},
+                {-1.62009080f,  -1.35350000f},
+                {-1.15982439f,  -1.04695000f},
+                {-0.69955799f,  -0.65640000f},
+                {-0.23929158f,  -0.22141000f},
+                { 0.22097483f,   0.22814402f},
+                { 0.68124124f,   0.68124124f},
+                { 1.01284632f,   0.99142189f},
+                { 1.34445140f,   1.25800000f},
+                { 1.67605648f,   1.44995000f},
+                { 2.00766156f,   1.55910000f},
+                { 2.33926665f,   1.62260000f},
+                { 2.67087173f,   1.66065457f},
+                { 3.00247681f,   1.68124124f}
+            });
+        float slopes[] = { 0.f,  0.4803088f,   0.5405565f,   0.79149813f,  0.9055625f,  0.98460368f,
+                           0.96884766f,  1.f,  0.87078346f,  0.73702127f,  0.42068113f,  0.23763206f,
+                           0.14535362f,  0.08416378f,  0.04f };
+        for (size_t i = 0; i < 15; ++i)
+        {
+            curve->setSlope( i, slopes[i] );
+        }
+        ConstGradingBSplineCurveRcPtr m = curve;
+        auto identity = GradingBSplineCurve::Create({ { 0.f, 0.f }, { 1.f, 1.f } });
+        ConstGradingBSplineCurveRcPtr z = identity;
+        auto gc = std::make_shared<GradingRGBCurveOpData>(GRADING_LOG, z, z, z, m);
+
+        CreateGradingRGBCurveOp(ops, gc, TRANSFORM_DIR_FORWARD);
+    }
+
+    // Undo the logarithm.
+    CreateLogOp(ops, 10., TRANSFORM_DIR_INVERSE);
+
+    // Apply Cinema White/Black correction.
+    {
+        static constexpr double CINEMA_WHITE = 48.;
+        // Note: ACESlib.ODT_Common.ctl claims that using pow10(log10(0.02) for black improves performance at 0,
+        // but that does not seem to be the case here, 0 input currently gives about 4e-11 XYZ output either way.
+        static constexpr double CINEMA_BLACK = 0.02;
+        static constexpr double scale        = 1. / (CINEMA_WHITE - CINEMA_BLACK);
+        static constexpr double scale4[4]    = { scale, scale, scale, 1. };
+        static constexpr double offset       = -CINEMA_BLACK * scale;
+        static constexpr double offset4[4]   = { offset, offset, offset, 0. };
+
+        CreateScaleOffsetOp(ops, scale4, offset4, TRANSFORM_DIR_FORWARD);
+    }
+}
+
+void Generate_video_adjustment_ops(OpRcPtrVec & ops)
+{
+    // Surround correction for cinema to video.
+    CreateFixedFunctionOp(ops, FixedFunctionOpData::ACES_DARK_TO_DIM_10_FWD, {});
+
+    // Desat to compensate 48 nit to 100 nit brightness.
+    static constexpr double DESAT_100_NITS[4 * 4]
+    {
+        0.949056010175, 0.047185723607, 0.003758266219, 0., 
+        0.019056010175, 0.977185723607, 0.003758266219, 0., 
+        0.019056010175, 0.047185723607, 0.933758266219, 0., 
+        0., 0., 0., 1.
+    };
+    CreateMatrixOp(ops, &DESAT_100_NITS[0], TRANSFORM_DIR_FORWARD);
+}
+
+void Generate_hdr_tonecurve_ops(OpRcPtrVec & ops, double Y_MAX)
+{
+    // Convert to Log space.
+    CreateLogOp(ops, 10., TRANSFORM_DIR_FORWARD);
+
+    // Apply RRT shaper using the same quadratic B-spline as the CTL.
+    {
+        auto curve = GradingBSplineCurve::Create({
+                { -5.60050155f,  -4.00000000f, },
+                { -4.09535157f,  -3.57868829f, },
+                { -2.59020159f,  -1.82131329f, },
+                { -1.08505161f,   0.68124124f, },
+                {  0.22347059f,   2.22673503f, },
+                {  1.53199279f,   2.87906206f, },
+                {  2.84051500f,   3.00000000f, }
+            });
+        float slopes[] = { 0.f,  0.55982688f,  1.77532247f,  1.55f,  0.81219728f,  0.1848466f,  0.f };
+        for (size_t i = 0; i < 7; ++i)
+        {
+            curve->setSlope( i, slopes[i] );
+        }
+        ConstGradingBSplineCurveRcPtr m = curve;
+        auto identity = GradingBSplineCurve::Create({ { 0.f, 0.f }, { 1.f, 1.f } });
+        ConstGradingBSplineCurveRcPtr z = identity;
+        auto gc = std::make_shared<GradingRGBCurveOpData>(GRADING_LOG, z, z, z, m);
+
+        CreateGradingRGBCurveOp(ops, gc, TRANSFORM_DIR_FORWARD);
+    }
+    // Undo the logarithm.
+    CreateLogOp(ops, 10., TRANSFORM_DIR_INVERSE);
+
+    // Apply Cinema White/Black correction.
+    {
+        const double Y_MIN = 0.0001;
+        const double scale        = 1. / (Y_MAX - Y_MIN);
+        const double scale4[4]    = { scale, scale, scale, 1. };
+        const double offset       = -Y_MIN * scale;
+        const double offset4[4]   = { offset, offset, offset, 0. };
+
+        CreateScaleOffsetOp(ops, scale4, offset4, TRANSFORM_DIR_FORWARD);
+    }
+}
+
+void Generate_primary_clamp_ops(OpRcPtrVec & ops)
+{
+    MatrixOpData::MatrixArrayPtr matrix1
+        = build_conversion_matrix(ACES_AP1::primaries, REC2020::primaries, ADAPTATION_NONE);
+    CreateMatrixOp(ops, matrix1, TRANSFORM_DIR_FORWARD);
+
+    CreateRangeOp(ops, 
+                  0., 1.,
+                  0., 1.,
+                  TRANSFORM_DIR_FORWARD);
+
+    MatrixOpData::MatrixArrayPtr matrix2
+        = rgb2xyz_from_xy(REC2020::primaries);
+    CreateMatrixOp(ops, matrix2, TRANSFORM_DIR_FORWARD);
+
+    MatrixOpData::MatrixArrayPtr matrix3
+        = build_vonkries_adapt(WHITEPOINT::D60_XYZ, WHITEPOINT::D65_XYZ, ADAPTATION_BRADFORD);
+    CreateMatrixOp(ops, matrix3, TRANSFORM_DIR_FORWARD);
+}
+
+void Generate_nit_normalization_ops(OpRcPtrVec & ops, double nit_level)
+{
+    // The PQ curve expects nits / 100 as input.  Unnormalize 1.0 to the nit level for the transform
+    // and then renormalize to put 100 nits at 1.0.
+    const double scale     = nit_level * 0.01;
+    const double scale4[4] = { scale, scale, scale, 1. };
+    CreateScaleOp(ops, scale4, TRANSFORM_DIR_FORWARD);
+}
+
+}  // namespace ACES_OUTPUT
+
+
+//
+// Create the built-in transforms.
+//
 
 namespace ACES
 {
@@ -127,30 +357,22 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
         {
             // The CIE XYZ space has its conventional normalization (i.e., to illuminant E).
             // A neutral value of [1.,1.,1] in AP0 maps to the XYZ value of D65 ([0.9504..., 1., 1.089...]).
-            static const MatrixOpData::Offsets null(0., 0., 0., 0.);
-            static const MatrixOpData::Offsets d65_wht_XYZ(0.95045592705167, 1., 1.08905775075988, 0.);
             MatrixOpData::MatrixArrayPtr matrix
-                = build_conversion_matrix(ACES_AP0::primaries, CIE_XYZ_ILLUM_E::primaries, 
-                                          null, d65_wht_XYZ, ADAPTATION_BRADFORD);
+                = build_conversion_matrix_to_XYZ_D65(ACES_AP0::primaries, ADAPTATION_BRADFORD);
             CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("ACES-AP0_to_CIE-XYZ-D65_BFD", 
+        registry.addBuiltin("UTILITY--ACES-AP0_to_CIE-XYZ-D65_BFD", 
                             "Convert ACES AP0 primaries to CIE XYZ with a D65 white point with Bradford adaptation",
                             ACES_AP0_to_CIE_XYZ_D65_BFD_Functor);
     }
     {
         auto ACES_AP1_to_CIE_XYZ_D65_BFD_Functor = [](OpRcPtrVec & ops)
         {
-            static const MatrixOpData::Offsets null(0., 0., 0., 0.);
-            static const MatrixOpData::Offsets d65_wht_XYZ(0.95045592705167, 1., 1.08905775075988, 0.);
-            MatrixOpData::MatrixArrayPtr matrix
-                = build_conversion_matrix(ACES_AP1::primaries, CIE_XYZ_ILLUM_E::primaries, 
-                                          null, d65_wht_XYZ, ADAPTATION_BRADFORD);
-            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+            AP1_to_CIE_XYZ_D65::GenerateOps(ops);
         };
 
-        registry.addBuiltin("ACES-AP1_to_CIE-XYZ-D65_BFD", 
+        registry.addBuiltin("UTILITY--ACES-AP1_to_CIE-XYZ-D65_BFD", 
                             "Convert ACES AP1 primaries to CIE XYZ with a D65 white point with Bradford adaptation",
                             ACES_AP1_to_CIE_XYZ_D65_BFD_Functor);
     }
@@ -162,7 +384,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("ACES-AP1_to_LINEAR-REC709_BFD", 
+        registry.addBuiltin("UTILITY--ACES-AP1_to_LINEAR-REC709_BFD", 
                             "Convert ACES AP1 primaries to linear Rec.709 primaries with Bradford adaptation",
                             ACES_AP1_to_LINEAR_REC709_BFD_Functor);
     }
@@ -173,7 +395,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateLogOp(ops, log, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("ACEScct-LOG_to_LIN", 
+        registry.addBuiltin("CURVE--ACEScct-LOG_to_LINEAR", 
                             "Apply the log-to-lin curve used in ACEScct",
                             ACEScct_LOG_to_LIN_Functor);
     }
@@ -312,6 +534,90 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
         registry.addBuiltin("ADX16_to_ACES2065-1",
                             "Convert ADX16 to ACES2065-1",
                             ADX16_to_ACES2065_1_Functor);
+    }
+    {
+        auto BLUE_LIGHT_FIX_Functor = [](OpRcPtrVec & ops)
+        {
+            // Note that in CTL, the matrices are stored transposed.
+            static constexpr double BLUE_LIGHT_FIX[4 * 4]
+            {
+                0.9404372683, -0.0183068787,  0.0778696104, 0., 
+                0.0083786969,  0.8286599939,  0.1629613092, 0., 
+                0.0005471261, -0.0008833746,  1.0003362486, 0., 
+                0., 0., 0., 1.
+            };
+            CreateMatrixOp(ops, &BLUE_LIGHT_FIX[0], TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("ACES-LMT--BLUE_LIGHT_ARTIFACT_FIX",
+                            "LMT for desaturating blue hues to reduce clipping artifacts",
+                            BLUE_LIGHT_FIX_Functor);
+    }
+
+    //
+    // ACES OUTPUT TRANSFORMS
+    //
+
+    {
+        auto ACES2065_1_to_CIE_XYZ_video_1_0_Functor = [](OpRcPtrVec & ops)
+        {
+            ACES_OUTPUT::Generate_ACES_to_APO_ops(ops);
+
+            ACES_OUTPUT::Generate_tonecurve_ops(ops);
+
+            ACES_OUTPUT::Generate_video_adjustment_ops(ops);
+
+            AP1_to_CIE_XYZ_D65::GenerateOps(ops);
+        };
+
+        registry.addBuiltin("ACES-OUTPUT--ACES2065-1_to_CIE-XYZ_VIDEO_1.0", 
+                            "Component of ACES Output Transforms for SDR D65 video",
+                            ACES2065_1_to_CIE_XYZ_video_1_0_Functor);
+    }
+
+    {
+        auto ACES2065_1_to_CIE_XYZ_video_d60sim_1_0_Functor = [](OpRcPtrVec & ops)
+        {
+            ACES_OUTPUT::Generate_ACES_to_APO_ops(ops);
+
+            ACES_OUTPUT::Generate_tonecurve_ops(ops);
+
+            CreateRangeOp(ops, 
+                          RangeOpData::EmptyValue(), 1.0,  // don't clamp low end
+                          RangeOpData::EmptyValue(), 1.0,  // don't clamp low end
+                          TRANSFORM_DIR_FORWARD);
+
+            static constexpr double scale     = 0.955;
+            static constexpr double scale4[4] = { scale, scale, scale, 1. };
+            CreateScaleOp(ops, scale4, TRANSFORM_DIR_FORWARD);
+
+            ACES_OUTPUT::Generate_video_adjustment_ops(ops);
+
+            MatrixOpData::MatrixArrayPtr matrix
+                = rgb2xyz_from_xy(ACES_AP1::primaries);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("ACES-OUTPUT--ACES2065-1_to_CIE-XYZ_VIDEO-D60sim_1.0", 
+                            "Component of ACES Output Transforms for SDR D65 video simulating D60 white",
+                            ACES2065_1_to_CIE_XYZ_video_d60sim_1_0_Functor);
+    }
+
+    {
+        auto ACES2065_1_to_CIE_XYZ_hdr_video_1000nits_1_1_Functor = [](OpRcPtrVec & ops)
+        {
+            ACES_OUTPUT::Generate_ACES_to_APO_ops(ops);
+
+            ACES_OUTPUT::Generate_hdr_tonecurve_ops(ops, 1000.);
+
+            ACES_OUTPUT::Generate_primary_clamp_ops(ops);
+
+            ACES_OUTPUT::Generate_nit_normalization_ops(ops, 1000.);
+        };
+
+        registry.addBuiltin("ACES-OUTPUT--ACES2065-1_to_CIE-XYZ_HDR-VIDEO-1000nits_1.1", 
+                            "Component of ACES Output Transforms for 1000 nit HDR D65 video",
+                            ACES2065_1_to_CIE_XYZ_hdr_video_1000nits_1_1_Functor);
     }
 }
 

--- a/src/OpenColorIO/transforms/builtins/ACES.cpp
+++ b/src/OpenColorIO/transforms/builtins/ACES.cpp
@@ -140,7 +140,7 @@ void GenerateOps(OpRcPtrVec & ops)
 namespace ACES_OUTPUT
 {
 
-void Generate_ACES_to_APO_ops(OpRcPtrVec & ops)
+void Generate_RRT_preamble_ops(OpRcPtrVec & ops)
 {
     CreateFixedFunctionOp(ops, FixedFunctionOpData::ACES_GLOW_10_FWD, {});
 
@@ -273,17 +273,18 @@ void Generate_hdr_tonecurve_ops(OpRcPtrVec & ops, double Y_MAX)
     CreateLogOp(ops, 10., TRANSFORM_DIR_FORWARD);
 
     // Apply RRT shaper using the same quadratic B-spline as the CTL.
+    if (Y_MAX == 1000.)
     {
         auto curve = GradingBSplineCurve::Create({
-                { -5.60050155f,  -4.00000000f, },
-                { -4.09535157f,  -3.57868829f, },
-                { -2.59020159f,  -1.82131329f, },
-                { -1.08505161f,   0.68124124f, },
-                {  0.22347059f,   2.22673503f, },
-                {  1.53199279f,   2.87906206f, },
-                {  2.84051500f,   3.00000000f, }
+                { -5.60050155f,  -4.00000000f },
+                { -4.09535157f,  -3.57868829f },
+                { -2.59020159f,  -1.82131329f },
+                { -1.08505161f,   0.68124124f },
+                {  0.22347059f,   2.22673503f },
+                {  1.53199279f,   2.87906206f },
+                {  2.84051500f,   3.00000000f }
             });
-        float slopes[] = { 0.f,  0.55982688f,  1.77532247f,  1.55f,  0.81219728f,  0.1848466f,  0.f };
+        const float slopes[] = { 0.f,  0.55982688f,  1.77532247f,  1.55f,  0.81219728f,  0.1848466f,  0.f };
         for (size_t i = 0; i < 7; ++i)
         {
             curve->setSlope( i, slopes[i] );
@@ -295,12 +296,82 @@ void Generate_hdr_tonecurve_ops(OpRcPtrVec & ops, double Y_MAX)
 
         CreateGradingRGBCurveOp(ops, gc, TRANSFORM_DIR_FORWARD);
     }
+    else if (Y_MAX == 2000.)
+    {
+        auto curve = GradingBSplineCurve::Create({
+                { -5.59738488f,  -4.00000000f },
+                { -4.09223490f,  -3.57868829f },
+                { -2.58708492f,  -1.82131329f },
+                { -1.08193494f,   0.68124124f },
+                {  0.37639718f,   2.42130131f },
+                {  1.83472930f,   3.16609199f },
+                {  3.29306142f,   3.30103000f },
+            });
+        const float slopes[] = { 0.f,  0.55982688f,  1.77532247f,  1.55f,  0.83637009f,  0.18505799f,  0.f };
+        for (size_t i = 0; i < 7; ++i)
+        {
+            curve->setSlope( i, slopes[i] );
+        }
+        ConstGradingBSplineCurveRcPtr m = curve;
+        auto identity = GradingBSplineCurve::Create({ { 0.f, 0.f }, { 1.f, 1.f } });
+        ConstGradingBSplineCurveRcPtr z = identity;
+        auto gc = std::make_shared<GradingRGBCurveOpData>(GRADING_LOG, z, z, z, m);
+
+        CreateGradingRGBCurveOp(ops, gc, TRANSFORM_DIR_FORWARD);
+    }
+    else if (Y_MAX == 4000.)
+    {
+        auto curve = GradingBSplineCurve::Create({
+                { -5.59503319f,  -4.00000000f },
+                { -4.08988322f,  -3.57868829f },
+                { -2.58473324f,  -1.82131329f },
+                { -1.07958326f,   0.68124124f },
+                {  0.52855878f,   2.61625839f },
+                {  2.13670081f,   3.45351273f },
+                {  3.74484285f,   3.60205999f },
+            });
+        const float slopes[] = { 0.f,  0.55982688f,  1.77532247f,  1.55f,  0.85652519f,  0.18474395f,  0.f };
+        for (size_t i = 0; i < 7; ++i)
+        {
+            curve->setSlope( i, slopes[i] );
+        }
+        ConstGradingBSplineCurveRcPtr m = curve;
+        auto identity = GradingBSplineCurve::Create({ { 0.f, 0.f }, { 1.f, 1.f } });
+        ConstGradingBSplineCurveRcPtr z = identity;
+        auto gc = std::make_shared<GradingRGBCurveOpData>(GRADING_LOG, z, z, z, m);
+
+        CreateGradingRGBCurveOp(ops, gc, TRANSFORM_DIR_FORWARD);
+    }
+    else if (Y_MAX == 108.)
+    {
+        auto curve = GradingBSplineCurve::Create({
+                { -5.37852506f,  -4.00000000f },
+                { -3.87337508f,  -3.57868829f },
+                { -2.36822510f,  -1.82131329f },
+                { -0.86307513f,   0.68124124f },
+                { -0.03557710f,   1.60464482f },
+                {  0.79192092f,   1.96008059f },
+                {  1.61941895f,   2.03342376f },
+            });
+        const float slopes[] = { 0.f,  0.55982688f,  1.77532247f,  1.55f,  0.68179646f,  0.17726487f,  0.f };
+        for (size_t i = 0; i < 7; ++i)
+        {
+            curve->setSlope( i, slopes[i] );
+        }
+        ConstGradingBSplineCurveRcPtr m = curve;
+        auto identity = GradingBSplineCurve::Create({ { 0.f, 0.f }, { 1.f, 1.f } });
+        ConstGradingBSplineCurveRcPtr z = identity;
+        auto gc = std::make_shared<GradingRGBCurveOpData>(GRADING_LOG, z, z, z, m);
+
+        CreateGradingRGBCurveOp(ops, gc, TRANSFORM_DIR_FORWARD);
+    }
+
     // Undo the logarithm.
     CreateLogOp(ops, 10., TRANSFORM_DIR_INVERSE);
 
     // Apply Cinema White/Black correction.
     {
-        const double Y_MIN = 0.0001;
+        const double Y_MIN        = 0.0001;
         const double scale        = 1. / (Y_MAX - Y_MIN);
         const double scale4[4]    = { scale, scale, scale, 1. };
         const double offset       = -Y_MIN * scale;
@@ -310,10 +381,10 @@ void Generate_hdr_tonecurve_ops(OpRcPtrVec & ops, double Y_MAX)
     }
 }
 
-void Generate_primary_clamp_ops(OpRcPtrVec & ops)
+void Generate_sdr_primary_clamp_ops(OpRcPtrVec & ops, const Primaries & limitPrimaries)
 {
     MatrixOpData::MatrixArrayPtr matrix1
-        = build_conversion_matrix(ACES_AP1::primaries, REC2020::primaries, ADAPTATION_NONE);
+        = build_conversion_matrix(ACES_AP1::primaries, limitPrimaries, ADAPTATION_BRADFORD);
     CreateMatrixOp(ops, matrix1, TRANSFORM_DIR_FORWARD);
 
     CreateRangeOp(ops, 
@@ -322,7 +393,23 @@ void Generate_primary_clamp_ops(OpRcPtrVec & ops)
                   TRANSFORM_DIR_FORWARD);
 
     MatrixOpData::MatrixArrayPtr matrix2
-        = rgb2xyz_from_xy(REC2020::primaries);
+        = rgb2xyz_from_xy(limitPrimaries);
+    CreateMatrixOp(ops, matrix2, TRANSFORM_DIR_FORWARD);
+}
+
+void Generate_hdr_primary_clamp_ops(OpRcPtrVec & ops, const Primaries & limitPrimaries)
+{
+    MatrixOpData::MatrixArrayPtr matrix1
+        = build_conversion_matrix(ACES_AP1::primaries, limitPrimaries, ADAPTATION_NONE);
+    CreateMatrixOp(ops, matrix1, TRANSFORM_DIR_FORWARD);
+
+    CreateRangeOp(ops, 
+                  0., 1.,
+                  0., 1.,
+                  TRANSFORM_DIR_FORWARD);
+
+    MatrixOpData::MatrixArrayPtr matrix2
+        = rgb2xyz_from_xy(limitPrimaries);
     CreateMatrixOp(ops, matrix2, TRANSFORM_DIR_FORWARD);
 
     MatrixOpData::MatrixArrayPtr matrix3
@@ -337,6 +424,74 @@ void Generate_nit_normalization_ops(OpRcPtrVec & ops, double nit_level)
     const double scale     = nit_level * 0.01;
     const double scale4[4] = { scale, scale, scale, 1. };
     CreateScaleOp(ops, scale4, TRANSFORM_DIR_FORWARD);
+}
+
+void Generate_roll_white_d60_ops(OpRcPtrVec & ops)
+{
+    auto GenerateLutValues = [](double in) -> float
+    {
+        const double new_wht = 0.918;
+        const double width = 0.5;
+        const double x0 = -1.0;
+        const double x1 = x0 + width;
+        const double y0 = -new_wht;
+        const double y1 = x1;
+        const double m1 = (x1 - x0);
+        const double a = y0 - y1 + m1;
+        const double b = 2. * ( y1 - y0) - m1;
+        const double c = y0;
+        const double t = (-in - x0) / (x1 - x0);
+        double out = 0.0;
+        if (t < 0.0)
+        {
+            out = -(t * b + c);
+        }
+        else if (t > 1.0)
+        {
+            out = in;
+        }
+        else
+        {
+            out = -(( t * a + b) * t + c);
+        }
+        return float(out);
+    };
+
+    CreateHalfLut(ops, GenerateLutValues);
+}
+
+void Generate_roll_white_d65_ops(OpRcPtrVec & ops)
+{
+    auto GenerateLutValues = [](double in) -> float
+    {
+        const double new_wht = 0.908;
+        const double width = 0.5;
+        const double x0 = -1.0;
+        const double x1 = x0 + width;
+        const double y0 = -new_wht;
+        const double y1 = x1;
+        const double m1 = (x1 - x0);
+        const double a = y0 - y1 + m1;
+        const double b = 2. * ( y1 - y0) - m1;
+        const double c = y0;
+        const double t = (-in - x0) / (x1 - x0);
+        double out = 0.0;
+        if (t < 0.0)
+        {
+            out = -(t * b + c);
+        }
+        else if (t > 1.0)
+        {
+            out = in;
+        }
+        else
+        {
+            out = -(( t * a + b) * t + c);
+        }
+        return float(out);
+    };
+
+    CreateHalfLut(ops, GenerateLutValues);
 }
 
 }  // namespace ACES_OUTPUT
@@ -559,9 +714,24 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
     //
 
     {
+        auto ACES2065_1_to_CIE_XYZ_cinema_1_0_Functor = [](OpRcPtrVec & ops)
+        {
+            ACES_OUTPUT::Generate_RRT_preamble_ops(ops);
+
+            ACES_OUTPUT::Generate_tonecurve_ops(ops);
+
+            AP1_to_CIE_XYZ_D65::GenerateOps(ops);
+        };
+
+        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA_1.0", 
+                            "Component of ACES Output Transforms for SDR cinema",
+                            ACES2065_1_to_CIE_XYZ_cinema_1_0_Functor);
+    }
+
+    {
         auto ACES2065_1_to_CIE_XYZ_video_1_0_Functor = [](OpRcPtrVec & ops)
         {
-            ACES_OUTPUT::Generate_ACES_to_APO_ops(ops);
+            ACES_OUTPUT::Generate_RRT_preamble_ops(ops);
 
             ACES_OUTPUT::Generate_tonecurve_ops(ops);
 
@@ -570,15 +740,90 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             AP1_to_CIE_XYZ_D65::GenerateOps(ops);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES2065-1_to_CIE-XYZ_VIDEO_1.0", 
+        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-VIDEO_1.0", 
                             "Component of ACES Output Transforms for SDR D65 video",
                             ACES2065_1_to_CIE_XYZ_video_1_0_Functor);
     }
 
     {
+        auto ACES2065_1_to_CIE_XYZ_cinema_rec709lim_1_1_Functor = [](OpRcPtrVec & ops)
+        {
+            ACES_OUTPUT::Generate_RRT_preamble_ops(ops);
+
+            ACES_OUTPUT::Generate_tonecurve_ops(ops);
+
+            ACES_OUTPUT::Generate_sdr_primary_clamp_ops(ops, REC709::primaries);
+        };
+
+        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA-REC709lim_1.1", 
+                            "Component of ACES Output Transforms for SDR cinema",
+                            ACES2065_1_to_CIE_XYZ_cinema_rec709lim_1_1_Functor);
+    }
+
+    {
+        auto ACES2065_1_to_CIE_XYZ_video_rec709lim_1_1_Functor = [](OpRcPtrVec & ops)
+        {
+            ACES_OUTPUT::Generate_RRT_preamble_ops(ops);
+
+            ACES_OUTPUT::Generate_tonecurve_ops(ops);
+
+            ACES_OUTPUT::Generate_video_adjustment_ops(ops);
+
+            ACES_OUTPUT::Generate_sdr_primary_clamp_ops(ops, REC709::primaries);
+        };
+
+        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-VIDEO-REC709lim_1.1", 
+                            "Component of ACES Output Transforms for SDR D65 video",
+                            ACES2065_1_to_CIE_XYZ_video_rec709lim_1_1_Functor);
+    }
+
+    {
+        auto ACES2065_1_to_CIE_XYZ_video_p3lim_1_1_Functor = [](OpRcPtrVec & ops)
+        {
+            ACES_OUTPUT::Generate_RRT_preamble_ops(ops);
+
+            ACES_OUTPUT::Generate_tonecurve_ops(ops);
+
+            ACES_OUTPUT::Generate_video_adjustment_ops(ops);
+
+            ACES_OUTPUT::Generate_sdr_primary_clamp_ops(ops, P3_D65::primaries);
+        };
+
+        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-VIDEO-P3lim_1.1", 
+                            "Component of ACES Output Transforms for SDR D65 video",
+                            ACES2065_1_to_CIE_XYZ_video_p3lim_1_1_Functor);
+    }
+
+    {
+        auto ACES2065_1_to_CIE_XYZ_cinema_d60sim_1_1_Functor = [](OpRcPtrVec & ops)
+        {
+            ACES_OUTPUT::Generate_RRT_preamble_ops(ops);
+
+            ACES_OUTPUT::Generate_tonecurve_ops(ops);
+
+            CreateRangeOp(ops, 
+                          RangeOpData::EmptyValue(), 1.0,  // don't clamp low end
+                          RangeOpData::EmptyValue(), 1.0,  // don't clamp low end
+                          TRANSFORM_DIR_FORWARD);
+
+            static constexpr double scale     = 0.964;
+            static constexpr double scale4[4] = { scale, scale, scale, 1. };
+            CreateScaleOp(ops, scale4, TRANSFORM_DIR_FORWARD);
+
+            MatrixOpData::MatrixArrayPtr matrix
+                = rgb2xyz_from_xy(ACES_AP1::primaries);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA-D60sim-D65_1.1", 
+                            "Component of ACES Output Transforms for SDR D65 cinema simulating D60 white",
+                            ACES2065_1_to_CIE_XYZ_cinema_d60sim_1_1_Functor);
+    }
+
+    {
         auto ACES2065_1_to_CIE_XYZ_video_d60sim_1_0_Functor = [](OpRcPtrVec & ops)
         {
-            ACES_OUTPUT::Generate_ACES_to_APO_ops(ops);
+            ACES_OUTPUT::Generate_RRT_preamble_ops(ops);
 
             ACES_OUTPUT::Generate_tonecurve_ops(ops);
 
@@ -598,26 +843,190 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES2065-1_to_CIE-XYZ_VIDEO-D60sim_1.0", 
+        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-VIDEO-D60sim-D65_1.0", 
                             "Component of ACES Output Transforms for SDR D65 video simulating D60 white",
                             ACES2065_1_to_CIE_XYZ_video_d60sim_1_0_Functor);
     }
 
     {
-        auto ACES2065_1_to_CIE_XYZ_hdr_video_1000nits_1_1_Functor = [](OpRcPtrVec & ops)
+        auto ACES2065_1_to_CIE_XYZ_cinema_d60sim_dci_1_0_Functor = [](OpRcPtrVec & ops)
         {
-            ACES_OUTPUT::Generate_ACES_to_APO_ops(ops);
+            ACES_OUTPUT::Generate_RRT_preamble_ops(ops);
+
+            ACES_OUTPUT::Generate_tonecurve_ops(ops);
+
+            ACES_OUTPUT::Generate_roll_white_d60_ops(ops);
+
+            CreateRangeOp(ops, 
+                          RangeOpData::EmptyValue(), 0.918,  // don't clamp low end
+                          RangeOpData::EmptyValue(), 0.918,  // don't clamp low end
+                          TRANSFORM_DIR_FORWARD);
+
+            static constexpr double scale     = 0.96;
+            static constexpr double scale4[4] = { scale, scale, scale, 1. };
+            CreateScaleOp(ops, scale4, TRANSFORM_DIR_FORWARD);
+
+            MatrixOpData::MatrixArrayPtr matrix
+                = rgb2xyz_from_xy(ACES_AP1::primaries);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+
+            MatrixOpData::MatrixArrayPtr matrix2
+                = build_vonkries_adapt(WHITEPOINT::DCI_XYZ, WHITEPOINT::D65_XYZ, ADAPTATION_BRADFORD);
+            CreateMatrixOp(ops, matrix2, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA-D60sim-DCI_1.0", 
+                            "Component of ACES Output Transforms for SDR DCI cinema simulating D60 white",
+                            ACES2065_1_to_CIE_XYZ_cinema_d60sim_dci_1_0_Functor);
+    }
+
+    {
+        auto ACES2065_1_to_CIE_XYZ_cinema_d65sim_dci_1_1_Functor = [](OpRcPtrVec & ops)
+        {
+            ACES_OUTPUT::Generate_RRT_preamble_ops(ops);
+
+            ACES_OUTPUT::Generate_tonecurve_ops(ops);
+
+            ACES_OUTPUT::Generate_roll_white_d65_ops(ops);
+
+            CreateRangeOp(ops, 
+                          RangeOpData::EmptyValue(), 0.908,  // don't clamp low end
+                          RangeOpData::EmptyValue(), 0.908,  // don't clamp low end
+                          TRANSFORM_DIR_FORWARD);
+
+            static constexpr double scale     = 0.9575;
+            static constexpr double scale4[4] = { scale, scale, scale, 1. };
+            CreateScaleOp(ops, scale4, TRANSFORM_DIR_FORWARD);
+
+            AP1_to_CIE_XYZ_D65::GenerateOps(ops);
+
+            MatrixOpData::MatrixArrayPtr matrix2
+                = build_vonkries_adapt(WHITEPOINT::DCI_XYZ, WHITEPOINT::D65_XYZ, ADAPTATION_BRADFORD);
+            CreateMatrixOp(ops, matrix2, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA-D65sim-DCI_1.1", 
+                            "Component of ACES Output Transforms for SDR DCI cinema simulating D65 white",
+                            ACES2065_1_to_CIE_XYZ_cinema_d65sim_dci_1_1_Functor);
+    }
+
+    {
+        auto ACES2065_1_to_CIE_XYZ_hdr_video_1000nits_rec2020lim_1_1_Functor = [](OpRcPtrVec & ops)
+        {
+            ACES_OUTPUT::Generate_RRT_preamble_ops(ops);
 
             ACES_OUTPUT::Generate_hdr_tonecurve_ops(ops, 1000.);
 
-            ACES_OUTPUT::Generate_primary_clamp_ops(ops);
+            ACES_OUTPUT::Generate_hdr_primary_clamp_ops(ops, REC2020::primaries);
 
             ACES_OUTPUT::Generate_nit_normalization_ops(ops, 1000.);
         };
 
-        registry.addBuiltin("ACES-OUTPUT--ACES2065-1_to_CIE-XYZ_HDR-VIDEO-1000nits_1.1", 
+        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-1000nit-15nit-REC2020lim_1.1", 
                             "Component of ACES Output Transforms for 1000 nit HDR D65 video",
-                            ACES2065_1_to_CIE_XYZ_hdr_video_1000nits_1_1_Functor);
+                            ACES2065_1_to_CIE_XYZ_hdr_video_1000nits_rec2020lim_1_1_Functor);
+    }
+
+    {
+        auto ACES2065_1_to_CIE_XYZ_hdr_video_1000nits_p3lim_1_1_Functor = [](OpRcPtrVec & ops)
+        {
+            ACES_OUTPUT::Generate_RRT_preamble_ops(ops);
+
+            ACES_OUTPUT::Generate_hdr_tonecurve_ops(ops, 1000.);
+
+            ACES_OUTPUT::Generate_hdr_primary_clamp_ops(ops, P3_D65::primaries);
+
+            ACES_OUTPUT::Generate_nit_normalization_ops(ops, 1000.);
+        };
+
+        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-1000nit-15nit-P3lim_1.1", 
+                            "Component of ACES Output Transforms for 1000 nit HDR D65 video",
+                            ACES2065_1_to_CIE_XYZ_hdr_video_1000nits_p3lim_1_1_Functor);
+    }
+
+    {
+        auto ACES2065_1_to_CIE_XYZ_hdr_video_2000nits_rec2020lim_1_1_Functor = [](OpRcPtrVec & ops)
+        {
+            ACES_OUTPUT::Generate_RRT_preamble_ops(ops);
+
+            ACES_OUTPUT::Generate_hdr_tonecurve_ops(ops, 2000.);
+
+            ACES_OUTPUT::Generate_hdr_primary_clamp_ops(ops, REC2020::primaries);
+
+            ACES_OUTPUT::Generate_nit_normalization_ops(ops, 2000.);
+        };
+
+        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-2000nit-15nit-REC2020lim_1.1", 
+                            "Component of ACES Output Transforms for 2000 nit HDR D65 video",
+                            ACES2065_1_to_CIE_XYZ_hdr_video_2000nits_rec2020lim_1_1_Functor);
+    }
+
+    {
+        auto ACES2065_1_to_CIE_XYZ_hdr_video_2000nits_p3lim_1_1_Functor = [](OpRcPtrVec & ops)
+        {
+            ACES_OUTPUT::Generate_RRT_preamble_ops(ops);
+
+            ACES_OUTPUT::Generate_hdr_tonecurve_ops(ops, 2000.);
+
+            ACES_OUTPUT::Generate_hdr_primary_clamp_ops(ops, P3_D65::primaries);
+
+            ACES_OUTPUT::Generate_nit_normalization_ops(ops, 2000.);
+        };
+
+        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-2000nit-15nit-P3lim_1.1", 
+                            "Component of ACES Output Transforms for 2000 nit HDR D65 video",
+                            ACES2065_1_to_CIE_XYZ_hdr_video_2000nits_p3lim_1_1_Functor);
+    }
+
+    {
+        auto ACES2065_1_to_CIE_XYZ_hdr_video_4000nits_rec2020lim_1_1_Functor = [](OpRcPtrVec & ops)
+        {
+            ACES_OUTPUT::Generate_RRT_preamble_ops(ops);
+
+            ACES_OUTPUT::Generate_hdr_tonecurve_ops(ops, 4000.);
+
+            ACES_OUTPUT::Generate_hdr_primary_clamp_ops(ops, REC2020::primaries);
+
+            ACES_OUTPUT::Generate_nit_normalization_ops(ops, 4000.);
+        };
+
+        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-4000nit-15nit-REC2020lim_1.1", 
+                            "Component of ACES Output Transforms for 4000 nit HDR D65 video",
+                            ACES2065_1_to_CIE_XYZ_hdr_video_4000nits_rec2020lim_1_1_Functor);
+    }
+
+    {
+        auto ACES2065_1_to_CIE_XYZ_hdr_video_4000nits_p3lim_1_1_Functor = [](OpRcPtrVec & ops)
+        {
+            ACES_OUTPUT::Generate_RRT_preamble_ops(ops);
+
+            ACES_OUTPUT::Generate_hdr_tonecurve_ops(ops, 4000.);
+
+            ACES_OUTPUT::Generate_hdr_primary_clamp_ops(ops, P3_D65::primaries);
+
+            ACES_OUTPUT::Generate_nit_normalization_ops(ops, 4000.);
+        };
+
+        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-4000nit-15nit-P3lim_1.1", 
+                            "Component of ACES Output Transforms for 4000 nit HDR D65 video",
+                            ACES2065_1_to_CIE_XYZ_hdr_video_4000nits_p3lim_1_1_Functor);
+    }
+
+    {
+        auto ACES2065_1_to_CIE_XYZ_hdr_cinema_108nits_p3lim_1_1_Functor = [](OpRcPtrVec & ops)
+        {
+            ACES_OUTPUT::Generate_RRT_preamble_ops(ops);
+
+            ACES_OUTPUT::Generate_hdr_tonecurve_ops(ops, 108.);
+
+            ACES_OUTPUT::Generate_hdr_primary_clamp_ops(ops, P3_D65::primaries);
+
+            ACES_OUTPUT::Generate_nit_normalization_ops(ops, 108.);
+        };
+
+        registry.addBuiltin("ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-CINEMA-108nit-7.2nit-P3lim_1.1", 
+                            "Component of ACES Output Transforms for 108 nit HDR D65 cinema",
+                            ACES2065_1_to_CIE_XYZ_hdr_cinema_108nits_p3lim_1_1_Functor);
     }
 }
 

--- a/src/OpenColorIO/transforms/builtins/BuiltinTransformRegistry.cpp
+++ b/src/OpenColorIO/transforms/builtins/BuiltinTransformRegistry.cpp
@@ -17,8 +17,9 @@
 #ifdef ADD_EXTRA_BUILTINS
 
 #include "transforms/builtins/ArriCameras.h"
-#include "transforms/builtins/PanasonicCameras.h"
 #include "transforms/builtins/CanonCameras.h"
+#include "transforms/builtins/Displays.h"
+#include "transforms/builtins/PanasonicCameras.h"
 #include "transforms/builtins/RedCameras.h"
 #include "transforms/builtins/SonyCameras.h"
 
@@ -34,7 +35,7 @@ static BuiltinTransformRegistryRcPtr globalRegistry;
 static Mutex globalRegistryMutex;
 
 
-void AddCameraBuiltins(BuiltinTransformRegistryImpl & registry)
+void AddExtraBuiltins(BuiltinTransformRegistryImpl & registry)
 {
 #ifdef ADD_EXTRA_BUILTINS
 
@@ -44,6 +45,8 @@ void AddCameraBuiltins(BuiltinTransformRegistryImpl & registry)
     CAMERA::PANASONIC::RegisterAll(registry);
     CAMERA::RED::RegisterAll(registry);
     CAMERA::SONY::RegisterAll(registry);
+    // Other transforms.
+    DISPLAY::RegisterAll(registry);
 
 #endif // ADD_EXTRA_BUILTINS
 }
@@ -125,7 +128,7 @@ void BuiltinTransformRegistryImpl::registerAll() noexcept
 
     ACES::RegisterAll(*this);
 
-    AddCameraBuiltins(*this);
+    AddExtraBuiltins(*this);
 }
 
 

--- a/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.cpp
+++ b/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.cpp
@@ -51,6 +51,16 @@ static const Chromaticities wht_xy(0.3127, 0.3290);
 const Primaries primaries(red_xy, grn_xy, blu_xy, wht_xy);
 }
 
+namespace REC2020
+{
+static const Chromaticities red_xy(0.708,  0.292 );
+static const Chromaticities grn_xy(0.170,  0.797 );
+static const Chromaticities blu_xy(0.131,  0.046 );
+static const Chromaticities wht_xy(0.3127, 0.3290);
+
+const Primaries primaries(red_xy, grn_xy, blu_xy, wht_xy);
+}
+
 namespace P3_DCI
 {
 static const Chromaticities red_xy(0.680, 0.320);
@@ -71,6 +81,21 @@ static const Chromaticities wht_xy(0.3127, 0.3290);
 const Primaries primaries(red_xy, grn_xy, blu_xy, wht_xy);
 }
 
+namespace P3_D60
+{
+static const Chromaticities red_xy(0.680,  0.320 );
+static const Chromaticities grn_xy(0.265,  0.690 );
+static const Chromaticities blu_xy(0.150,  0.060 );
+static const Chromaticities wht_xy(0.32168, 0.33767);
+
+const Primaries primaries(red_xy, grn_xy, blu_xy, wht_xy);
+}
+
+namespace WHITEPOINT
+{
+const MatrixOpData::Offsets D60_XYZ(0.95264607456985, 1., 1.00882518435159, 0.);
+const MatrixOpData::Offsets D65_XYZ(0.95045592705167, 1., 1.08905775075988, 0.);
+}
 
 // Here are some notes on how one derives the color space conversion
 // matrix starting with chromaticity coordinates.
@@ -250,7 +275,7 @@ MatrixOpData::MatrixArrayPtr build_conversion_matrix(const Primaries & src_prims
             return dst_xyz2rgb->inner(src_rgb2xyz);
         }
     }
-    else if ( method == ADAPTATION_NONE )
+    if ( method == ADAPTATION_NONE )
     {
         return dst_xyz2rgb->inner(src_rgb2xyz);
     }
@@ -285,8 +310,22 @@ MatrixOpData::MatrixArrayPtr build_conversion_matrix(const Primaries & src_prims
                                                      const Primaries & dst_prims,
                                                      AdaptationMethod method)
 {
-    static const MatrixOpData::Offsets null(0., 0., 0., 0.);
-    return build_conversion_matrix( src_prims, dst_prims, null, null, method );
+    static const MatrixOpData::Offsets zero(0., 0., 0., 0.);
+    return build_conversion_matrix( src_prims, dst_prims, zero, zero, method );
+}
+
+MatrixOpData::MatrixArrayPtr build_conversion_matrix_to_XYZ_D65(const Primaries & src_prims,
+                                                                AdaptationMethod method)
+{
+    static const MatrixOpData::Offsets zero(0., 0., 0., 0.);
+    return build_conversion_matrix( src_prims, CIE_XYZ_ILLUM_E::primaries, zero, WHITEPOINT::D65_XYZ, method );
+}
+
+MatrixOpData::MatrixArrayPtr build_conversion_matrix_from_XYZ_D65(const Primaries & dst_prims,
+                                                                  AdaptationMethod method)
+{
+    static const MatrixOpData::Offsets zero(0., 0., 0., 0.);
+    return build_conversion_matrix( CIE_XYZ_ILLUM_E::primaries, dst_prims, WHITEPOINT::D65_XYZ, zero, method );
 }
 
 } // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.cpp
+++ b/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.cpp
@@ -95,6 +95,7 @@ namespace WHITEPOINT
 {
 const MatrixOpData::Offsets D60_XYZ(0.95264607456985, 1., 1.00882518435159, 0.);
 const MatrixOpData::Offsets D65_XYZ(0.95045592705167, 1., 1.08905775075988, 0.);
+const MatrixOpData::Offsets DCI_XYZ(0.89458689458689, 1., 0.95441595441595, 0.);
 }
 
 // Here are some notes on how one derives the color space conversion

--- a/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.h
+++ b/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.h
@@ -102,6 +102,11 @@ namespace REC709
 extern const Primaries primaries;
 }
 
+namespace REC2020
+{
+extern const Primaries primaries;
+}
+
 namespace P3_DCI
 {
 extern const Primaries primaries;
@@ -112,6 +117,16 @@ namespace P3_D65
 extern const Primaries primaries;
 }
 
+namespace P3_D60
+{
+extern const Primaries primaries;
+}
+
+namespace WHITEPOINT
+{
+extern const MatrixOpData::Offsets D60_XYZ;
+extern const MatrixOpData::Offsets D65_XYZ;
+}
 
 // Calculate a matrix to convert arbitrary RGB primary tristimulus values
 // to CIE XYZ tristimulus values using the CIE xy chromaticity coordinates
@@ -153,6 +168,16 @@ MatrixOpData::MatrixArrayPtr build_conversion_matrix(const Primaries & src_prims
                                                      const MatrixOpData::Offsets & src_wht_XYZ,
                                                      const MatrixOpData::Offsets & dst_wht_XYZ,
                                                      AdaptationMethod method);
+
+// Build a conversion matrix to CIE XYZ D65 to the destination primaries.
+
+MatrixOpData::MatrixArrayPtr build_conversion_matrix_to_XYZ_D65(const Primaries & src_prims,
+                                                                AdaptationMethod method);
+
+// Build a conversion matrix from CIE XYZ D65 to the destination primaries.
+
+MatrixOpData::MatrixArrayPtr build_conversion_matrix_from_XYZ_D65(const Primaries & dst_prims,
+                                                                  AdaptationMethod method);
 } // namespace OCIO_NAMESPACE
 
 #endif // INCLUDED_OCIO_COLOR_MATRIX_HELPERS_H

--- a/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.h
+++ b/src/OpenColorIO/transforms/builtins/ColorMatrixHelpers.h
@@ -126,6 +126,7 @@ namespace WHITEPOINT
 {
 extern const MatrixOpData::Offsets D60_XYZ;
 extern const MatrixOpData::Offsets D65_XYZ;
+extern const MatrixOpData::Offsets DCI_XYZ;
 }
 
 // Calculate a matrix to convert arbitrary RGB primary tristimulus values
@@ -169,7 +170,7 @@ MatrixOpData::MatrixArrayPtr build_conversion_matrix(const Primaries & src_prims
                                                      const MatrixOpData::Offsets & dst_wht_XYZ,
                                                      AdaptationMethod method);
 
-// Build a conversion matrix to CIE XYZ D65 to the destination primaries.
+// Build a conversion matrix to CIE XYZ D65 from the source primaries.
 
 MatrixOpData::MatrixArrayPtr build_conversion_matrix_to_XYZ_D65(const Primaries & src_prims,
                                                                 AdaptationMethod method);

--- a/src/OpenColorIO/transforms/builtins/Displays.cpp
+++ b/src/OpenColorIO/transforms/builtins/Displays.cpp
@@ -82,7 +82,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateGammaOp(ops, gammaData, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_REC.1886-REC.709", 
+        registry.addBuiltin("DISPLAY - CIE-XYZ-D65_to_REC.1886-REC.709", 
                             "Convert CIE XYZ (D65 white) to Rec.1886/Rec.709 (HD video)",
                             CIE_XYZ_D65_to_REC1886_REC709_Functor);
     }
@@ -101,7 +101,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateGammaOp(ops, gammaData, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_REC.1886-REC.2020", 
+        registry.addBuiltin("DISPLAY - CIE-XYZ-D65_to_REC.1886-REC.2020", 
                             "Convert CIE XYZ (D65 white) to Rec.1886/Rec.2020 (UHD video)",
                             CIE_XYZ_D65_to_REC1886_REC2020_Functor);
     }
@@ -120,7 +120,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateGammaOp(ops, gammaData, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_G2.2-REC.709", 
+        registry.addBuiltin("DISPLAY - CIE-XYZ-D65_to_G2.2-REC.709", 
                             "Convert CIE XYZ (D65 white) to Gamma2.2, Rec.709",
                             CIE_XYZ_D65_to_G22_REC709_Functor);
     }
@@ -139,7 +139,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateGammaOp(ops, gammaData, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_sRGB", 
+        registry.addBuiltin("DISPLAY - CIE-XYZ-D65_to_sRGB", 
                             "Convert CIE XYZ (D65 white) to sRGB (piecewise EOTF)",
                             CIE_XYZ_D65_to_SRGB_Functor);
     }
@@ -158,7 +158,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateGammaOp(ops, gammaData, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_G2.6-P3-DCI-BFD", 
+        registry.addBuiltin("DISPLAY - CIE-XYZ-D65_to_G2.6-P3-DCI-BFD", 
                             "Convert CIE XYZ (D65 white) to Gamma 2.6, P3-DCI (DCI white with Bradford adaptation)",
                             CIE_XYZ_D65_to_P3_DCI_BFD_Functor);
     }
@@ -177,7 +177,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateGammaOp(ops, gammaData, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_G2.6-P3-D65", 
+        registry.addBuiltin("DISPLAY - CIE-XYZ-D65_to_G2.6-P3-D65", 
                             "Convert CIE XYZ (D65 white) to Gamma 2.6, P3-D65",
                             CIE_XYZ_D65_to_P3_D65_Functor);
     }
@@ -196,7 +196,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateGammaOp(ops, gammaData, TRANSFORM_DIR_FORWARD);
         };
 
-        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_G2.6-P3-D60-BFD", 
+        registry.addBuiltin("DISPLAY - CIE-XYZ-D65_to_G2.6-P3-D60-BFD", 
                             "Convert CIE XYZ (D65 white) to Gamma 2.6, P3-D60 (Bradford adaptation)",
                             CIE_XYZ_D65_to_P3_D60_BFD_Functor);
     }
@@ -207,7 +207,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             ST_2084::GeneratePQToLinearOps(ops);
         };
 
-        registry.addBuiltin("CURVE--ST-2084_to_LINEAR",
+        registry.addBuiltin("CURVE - ST-2084_to_LINEAR",
                             "Convert SMPTE ST-2084 (PQ) full-range to linear nits/100",
                             ST2084_to_Linear_Functor);
     }
@@ -218,7 +218,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             ST_2084::GenerateLinearToPQOps(ops);
         };
 
-        registry.addBuiltin("CURVE--LINEAR_to_ST-2084",
+        registry.addBuiltin("CURVE - LINEAR_to_ST-2084",
                             "Convert linear nits/100 to SMPTE ST-2084 (PQ) full-range",
                             Linear_to_ST2084_Functor);
     }
@@ -233,7 +233,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             ST_2084::GenerateLinearToPQOps(ops);
         };
 
-        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_REC.2100-PQ", 
+        registry.addBuiltin("DISPLAY - CIE-XYZ-D65_to_REC.2100-PQ", 
                             "Convert CIE XYZ (D65 white) to Rec.2100-PQ",
                             CIE_XYZ_D65_to_REC2100_PQ_Functor);
     }
@@ -248,7 +248,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             ST_2084::GenerateLinearToPQOps(ops);
         };
 
-        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_ST2084-P3-D65", 
+        registry.addBuiltin("DISPLAY - CIE-XYZ-D65_to_ST2084-P3-D65", 
                             "Convert CIE XYZ (D65 white) to ST-2084 (PQ), P3-D65 primaries",
                             CIE_XYZ_D65_to_ST2084_P3_D65_Functor);
     }
@@ -301,7 +301,7 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
             CreateHalfLut(ops, GenerateLutValues);
         };
 
-        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_REC.2100-HLG-1000nit", 
+        registry.addBuiltin("DISPLAY - CIE-XYZ-D65_to_REC.2100-HLG-1000nit", 
                             "Convert CIE XYZ (D65 white) to Rec.2100-HLG, 1000 nit",
                             CIE_XYZ_D65_to_REC2100_HLG_1000nit_Functor);
     }

--- a/src/OpenColorIO/transforms/builtins/Displays.cpp
+++ b/src/OpenColorIO/transforms/builtins/Displays.cpp
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <cmath>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "ops/gamma/GammaOp.h"
+#include "ops/matrix/MatrixOp.h"
+#include "ops/range/RangeOp.h"
+#include "transforms/builtins/BuiltinTransformRegistry.h"
+#include "transforms/builtins/ColorMatrixHelpers.h"
+#include "transforms/builtins/Displays.h"
+#include "transforms/builtins/OpHelpers.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+namespace DISPLAY
+{
+
+namespace ST_2084
+{
+
+static constexpr double m1 = 0.25 * 2610. / 4096.;
+static constexpr double m2 = 128. * 2523. / 4096.;
+static constexpr double c2 = 32. * 2413. / 4096.;
+static constexpr double c3 = 32. * 2392. / 4096.;
+static constexpr double c1 = c3 - c2 + 1.;
+
+void GeneratePQToLinearOps(OpRcPtrVec & ops)
+{
+    auto GenerateLutValues = [](double input) -> float
+    {
+        const double N = std::max(0., input);
+        const double x = std::pow(N, 1. / m2);
+        double L = std::pow( std::max(0., x - c1) / (c2 - c3 * x), 1. / m1 );
+        // L is in nits/10000, convert to nits/100.
+        L *= 100.;
+
+        return float(L);
+    };
+
+    CreateLut(ops, 4096, GenerateLutValues);
+}
+
+void GenerateLinearToPQOps(OpRcPtrVec & ops)
+{
+    auto GenerateLutValues = [](double input) -> float
+    {
+        // Input is in nits/100, convert to [0,1], where 1 is 10000 nits.
+        const double L = std::max(0., input * 0.01);
+        const double y = std::pow(L, m1);
+        const double ratpoly = (c1 + c2 * y) / (1. + c3 * y);
+        const double N = std::pow( std::max(0., ratpoly), m2 );
+
+        return float(N);
+    };
+
+    CreateHalfLut(ops, GenerateLutValues);
+}
+
+} // ST_2084
+
+
+void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
+{
+    {
+        auto CIE_XYZ_D65_to_REC1886_REC709_Functor = [](OpRcPtrVec & ops)
+        {
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix_from_XYZ_D65(REC709::primaries, ADAPTATION_NONE);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+
+            const GammaOpData::Params rgbParams   = { 2.4 };
+            const GammaOpData::Params alphaParams = { 1.0 };
+            auto gammaData = std::make_shared<GammaOpData>(GammaOpData::BASIC_REV,
+                                                           rgbParams, rgbParams, rgbParams, alphaParams);
+            CreateGammaOp(ops, gammaData, TRANSFORM_DIR_FORWARD);
+        };
+        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_REC.1886-REC.709", 
+                            "Convert CIE XYZ (D65 white) to Rec.1886/Rec.709 (HD video)",
+                            CIE_XYZ_D65_to_REC1886_REC709_Functor);
+    }
+
+    {
+        auto CIE_XYZ_D65_to_REC1886_REC2020_Functor = [](OpRcPtrVec & ops)
+        {
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix_from_XYZ_D65(REC2020::primaries, ADAPTATION_NONE);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+
+            const GammaOpData::Params rgbParams   = { 2.4 };
+            const GammaOpData::Params alphaParams = { 1.0 };
+            auto gammaData = std::make_shared<GammaOpData>(GammaOpData::BASIC_REV,
+                                                           rgbParams, rgbParams, rgbParams, alphaParams);
+            CreateGammaOp(ops, gammaData, TRANSFORM_DIR_FORWARD);
+        };
+        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_REC.1886-REC.2020", 
+                            "Convert CIE XYZ (D65 white) to Rec.1886/Rec.2020 (UHD video)",
+                            CIE_XYZ_D65_to_REC1886_REC2020_Functor);
+    }
+
+    {
+        auto CIE_XYZ_D65_to_G22_REC709_Functor = [](OpRcPtrVec & ops)
+        {
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix_from_XYZ_D65(REC709::primaries, ADAPTATION_NONE);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+
+            const GammaOpData::Params rgbParams   = { 2.2 };
+            const GammaOpData::Params alphaParams = { 1.0 };
+            auto gammaData = std::make_shared<GammaOpData>(GammaOpData::BASIC_REV,
+                                                           rgbParams, rgbParams, rgbParams, alphaParams);
+            CreateGammaOp(ops, gammaData, TRANSFORM_DIR_FORWARD);
+        };
+        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_G2.2-REC.709", 
+                            "Convert CIE XYZ (D65 white) to Gamma2.2, Rec.709",
+                            CIE_XYZ_D65_to_G22_REC709_Functor);
+    }
+
+    {
+        auto CIE_XYZ_D65_to_SRGB_Functor = [](OpRcPtrVec & ops)
+        {
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix_from_XYZ_D65(REC709::primaries, ADAPTATION_NONE);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+
+            const GammaOpData::Params rgbParams   = { 2.4, 0.055 };
+            const GammaOpData::Params alphaParams = { 1.0, 0.0 };
+            auto gammaData = std::make_shared<GammaOpData>(GammaOpData::MONCURVE_REV,
+                                                           rgbParams, rgbParams, rgbParams, alphaParams);
+            CreateGammaOp(ops, gammaData, TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_sRGB", 
+                            "Convert CIE XYZ (D65 white) to sRGB (piecewise EOTF)",
+                            CIE_XYZ_D65_to_SRGB_Functor);
+    }
+
+    {
+        auto CIE_XYZ_D65_to_P3_DCI_BFD_Functor = [](OpRcPtrVec & ops)
+        {
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix_from_XYZ_D65(P3_DCI::primaries, ADAPTATION_BRADFORD);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+
+            const GammaOpData::Params rgbParams   = { 2.6 };
+            const GammaOpData::Params alphaParams = { 1.0 };
+            auto gammaData = std::make_shared<GammaOpData>(GammaOpData::BASIC_REV,
+                                                           rgbParams, rgbParams, rgbParams, alphaParams);
+            CreateGammaOp(ops, gammaData, TRANSFORM_DIR_FORWARD);
+        };
+        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_G2.6-P3-DCI-BFD", 
+                            "Convert CIE XYZ (D65 white) to Gamma 2.6, P3-DCI (DCI white with Bradford adaptation)",
+                            CIE_XYZ_D65_to_P3_DCI_BFD_Functor);
+    }
+
+    {
+        auto CIE_XYZ_D65_to_P3_D65_Functor = [](OpRcPtrVec & ops)
+        {
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix_from_XYZ_D65(P3_D65::primaries, ADAPTATION_NONE);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+
+            const GammaOpData::Params rgbParams   = { 2.6 };
+            const GammaOpData::Params alphaParams = { 1.0 };
+            auto gammaData = std::make_shared<GammaOpData>(GammaOpData::BASIC_REV,
+                                                           rgbParams, rgbParams, rgbParams, alphaParams);
+            CreateGammaOp(ops, gammaData, TRANSFORM_DIR_FORWARD);
+        };
+        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_G2.6-P3-D65", 
+                            "Convert CIE XYZ (D65 white) to Gamma 2.6, P3-D65",
+                            CIE_XYZ_D65_to_P3_D65_Functor);
+    }
+
+    {
+        auto CIE_XYZ_D65_to_P3_D60_BFD_Functor = [](OpRcPtrVec & ops)
+        {
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix_from_XYZ_D65(P3_D60::primaries, ADAPTATION_BRADFORD);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+
+            const GammaOpData::Params rgbParams   = { 2.6 };
+            const GammaOpData::Params alphaParams = { 1.0 };
+            auto gammaData = std::make_shared<GammaOpData>(GammaOpData::BASIC_REV,
+                                                           rgbParams, rgbParams, rgbParams, alphaParams);
+            CreateGammaOp(ops, gammaData, TRANSFORM_DIR_FORWARD);
+        };
+        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_G2.6-P3-D60-BFD", 
+                            "Convert CIE XYZ (D65 white) to Gamma 2.6, P3-D60 (Bradford adaptation)",
+                            CIE_XYZ_D65_to_P3_D60_BFD_Functor);
+    }
+
+    {
+        auto ST2084_to_Linear_Functor = [](OpRcPtrVec & ops)
+        {
+            ST_2084::GeneratePQToLinearOps(ops);
+        };
+
+        registry.addBuiltin("CURVE--ST-2084_to_LINEAR",
+                            "Convert SMPTE ST-2084 (PQ) full-range to linear nits/100",
+                            ST2084_to_Linear_Functor);
+    }
+
+    {
+        auto Linear_to_ST2084_Functor = [](OpRcPtrVec & ops)
+        {
+            ST_2084::GenerateLinearToPQOps(ops);
+        };
+
+        registry.addBuiltin("CURVE--LINEAR_to_ST-2084",
+                            "Convert linear nits/100 to SMPTE ST-2084 (PQ) full-range",
+                            Linear_to_ST2084_Functor);
+    }
+
+    {
+        auto CIE_XYZ_D65_to_REC2100_PQ_Functor = [](OpRcPtrVec & ops)
+        {
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix_from_XYZ_D65(REC2020::primaries, ADAPTATION_NONE);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+
+            ST_2084::GenerateLinearToPQOps(ops);
+        };
+
+        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_REC.2100-PQ", 
+                            "Convert CIE XYZ (D65 white) to Rec.2100-PQ",
+                            CIE_XYZ_D65_to_REC2100_PQ_Functor);
+    }
+
+    {
+        auto CIE_XYZ_D65_to_ST2084_P3_D65_Functor = [](OpRcPtrVec & ops)
+        {
+            MatrixOpData::MatrixArrayPtr matrix
+                = build_conversion_matrix_from_XYZ_D65(P3_D65::primaries, ADAPTATION_NONE);
+            CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD);
+
+            ST_2084::GenerateLinearToPQOps(ops);
+        };
+
+        registry.addBuiltin("DISPLAY--CIE-XYZ-D65_to_ST2084-P3-D65", 
+                            "Convert CIE XYZ (D65 white) to ST-2084 (PQ), P3-D65 primaries",
+                            CIE_XYZ_D65_to_ST2084_P3_D65_Functor);
+    }
+
+}
+
+} // namespace DISPLAY
+
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/transforms/builtins/Displays.h
+++ b/src/OpenColorIO/transforms/builtins/Displays.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#ifndef INCLUDED_OCIO_DISPLAYS_TRANSFORMS_H
+#define INCLUDED_OCIO_DISPLAYS_TRANSFORMS_H
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+
+namespace OCIO_NAMESPACE
+{
+
+class BuiltinTransformRegistryImpl;
+
+namespace DISPLAY
+{
+
+void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept;
+
+} // namespace DISPLAY
+
+} // namespace OCIO_NAMESPACE
+
+#endif // INCLUDED_OCIO_DISPLAYS_TRANSFORMS_H

--- a/src/OpenColorIO/transforms/builtins/OpHelpers.cpp
+++ b/src/OpenColorIO/transforms/builtins/OpHelpers.cpp
@@ -110,7 +110,6 @@ void CreateHalfLut(OpRcPtrVec & ops, std::function<float(double)> lutValueGenera
                                                          65536, true);
     lut->setInterpolation(INTERP_LINEAR);
     lut->setDirection(TRANSFORM_DIR_FORWARD);
-    lut->setFileOutputBitDepth(BIT_DEPTH_F16);
 
     Array & array = lut->getArray();
     Array::Values & values = array.getValues();

--- a/src/OpenColorIO/transforms/builtins/SonyCameras.cpp
+++ b/src/OpenColorIO/transforms/builtins/SonyCameras.cpp
@@ -94,6 +94,52 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
                             "Convert Sony S-Log3 S-Gamut3.Cine to ACES2065-1",
                             SONY_SLOG3_SGAMUT3_CINE_to_ACES2065_1_Functor);
     }
+
+    {
+        auto SONY_SLOG3_SGAMUT3_VENICE_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)
+        {
+            LogOpDataRcPtr log = SONY_SLOG3_to_LINEAR::log.clone();
+            CreateLogOp(ops, log, TRANSFORM_DIR_FORWARD);
+
+            // NB: Primaries were not provided for this case, only the matrix.
+            // Note that in CTL, the matrices are stored transposed.
+            static constexpr double SGAMUT3_VENICE[4 * 4]
+            {
+                0.7933297411,  0.0890786256,  0.1175916333, 0., 
+                0.0155810585,  1.0327123069, -0.0482933654, 0., 
+               -0.0188647478,  0.0127694121,  1.0060953358, 0., 
+                0., 0., 0., 1.
+            };
+            CreateMatrixOp(ops, &SGAMUT3_VENICE[0], TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("SONY_SLOG3-SGAMUT3-VENICE_to_ACES2065-1",
+                            "Convert Sony S-Log3 S-Gamut3 for the Venice camera to ACES2065-1",
+                            SONY_SLOG3_SGAMUT3_VENICE_to_ACES2065_1_Functor);
+    }
+
+    {
+        auto SONY_SLOG3_SGAMUT3_CINE_VENICE_to_ACES2065_1_Functor = [](OpRcPtrVec & ops)
+        {
+            LogOpDataRcPtr log = SONY_SLOG3_to_LINEAR::log.clone();
+            CreateLogOp(ops, log, TRANSFORM_DIR_FORWARD);
+
+            // NB: Primaries were not provided for this case, only the matrix.
+            // Note that in CTL, the matrices are stored transposed.
+            static constexpr double SGAMUT3_CINE_VENICE[4 * 4]
+            {
+                0.6742570921,  0.2205717359,  0.1051711720, 0., 
+               -0.0093136061,  1.1059588614, -0.0966452553, 0., 
+               -0.0382090673, -0.0179383766,  1.0561474439, 0., 
+                0., 0., 0., 1.
+            };
+            CreateMatrixOp(ops, &SGAMUT3_CINE_VENICE[0], TRANSFORM_DIR_FORWARD);
+        };
+
+        registry.addBuiltin("SONY_SLOG3-SGAMUT3.CINE-VENICE_to_ACES2065-1", 
+                            "Convert Sony S-Log3 S-Gamut3.Cine for the Venice camera to ACES2065-1",
+                            SONY_SLOG3_SGAMUT3_CINE_VENICE_to_ACES2065_1_Functor);
+    }
 }
 
 } // namespace SONY

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -114,7 +114,7 @@ if(OCIO_ADD_EXTRA_BUILTINS)
     set(SOURCES_BUILTINS
         transforms/builtins/ArriCameras.cpp
         transforms/builtins/CanonCameras.cpp
-		transforms/builtins/Displays.cpp
+        transforms/builtins/Displays.cpp
         transforms/builtins/PanasonicCameras.cpp
         transforms/builtins/RedCameras.cpp
         transforms/builtins/SonyCameras.cpp

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -114,6 +114,7 @@ if(OCIO_ADD_EXTRA_BUILTINS)
     set(SOURCES_BUILTINS
         transforms/builtins/ArriCameras.cpp
         transforms/builtins/CanonCameras.cpp
+		transforms/builtins/Displays.cpp
         transforms/builtins/PanasonicCameras.cpp
         transforms/builtins/RedCameras.cpp
         transforms/builtins/SonyCameras.cpp

--- a/tests/cpu/transforms/BuiltinTransform_tests.cpp
+++ b/tests/cpu/transforms/BuiltinTransform_tests.cpp
@@ -29,8 +29,8 @@ OCIO_ADD_TEST(BuiltinTransform, creation)
     OCIO_CHECK_EQUAL(std::string(blt->getStyle()), "IDENTITY");
     OCIO_CHECK_NO_THROW(blt->validate());
 
-    OCIO_CHECK_NO_THROW(blt->setStyle("UTILITY--ACES-AP0_to_CIE-XYZ-D65_BFD"));
-    OCIO_CHECK_EQUAL(std::string(blt->getStyle()), "UTILITY--ACES-AP0_to_CIE-XYZ-D65_BFD");
+    OCIO_CHECK_NO_THROW(blt->setStyle("UTILITY - ACES-AP0_to_CIE-XYZ-D65_BFD"));
+    OCIO_CHECK_EQUAL(std::string(blt->getStyle()), "UTILITY - ACES-AP0_to_CIE-XYZ-D65_BFD");
     OCIO_CHECK_NO_THROW(blt->validate());
 
     OCIO_CHECK_EQUAL(std::string("Convert ACES AP0 primaries to CIE XYZ with a D65 white point with Bradford adaptation"),
@@ -41,13 +41,13 @@ OCIO_ADD_TEST(BuiltinTransform, creation)
     OCIO_CHECK_NO_THROW(blt->validate());
 
     // The style is case insensitive.
-    OCIO_CHECK_NO_THROW(blt->setStyle("UTILITY--ACES-AP0_to_cie-xyz-D65_BFD"));
+    OCIO_CHECK_NO_THROW(blt->setStyle("UTILITY - ACES-AP0_to_cie-xyz-D65_BFD"));
     OCIO_CHECK_NO_THROW(blt->validate());
 
     // Try an unknown style.
-    OCIO_CHECK_THROW_WHAT(blt->setStyle("UTILITY--ACES-AP0_to_CIE-XYZ-D65_BFD_UNKNOWN"),
+    OCIO_CHECK_THROW_WHAT(blt->setStyle("UTILITY - ACES-AP0_to_CIE-XYZ-D65_BFD_UNKNOWN"),
                           OCIO::Exception,
-                          "BuiltinTransform: invalid built-in transform style 'UTILITY--ACES-AP0_to_CIE-XYZ-D65_BFD_UNKNOWN'.");
+                          "BuiltinTransform: invalid built-in transform style 'UTILITY - ACES-AP0_to_CIE-XYZ-D65_BFD_UNKNOWN'.");
 }
 
 OCIO_ADD_TEST(BuiltinTransform, access)
@@ -57,7 +57,7 @@ OCIO_ADD_TEST(BuiltinTransform, access)
     OCIO_CHECK_EQUAL(std::string("IDENTITY"),
                      OCIO::BuiltinTransformRegistry::Get()->getBuiltinStyle(0));
 
-    OCIO_CHECK_EQUAL(std::string("UTILITY--ACES-AP0_to_CIE-XYZ-D65_BFD"),
+    OCIO_CHECK_EQUAL(std::string("UTILITY - ACES-AP0_to_CIE-XYZ-D65_BFD"),
                      OCIO::BuiltinTransformRegistry::Get()->getBuiltinStyle(1));
 
     OCIO_CHECK_EQUAL(std::string("Convert ACES AP0 primaries to CIE XYZ with a D65 white point with Bradford adaptation"),
@@ -343,7 +343,6 @@ void ValidateBuiltinTransform(const char * style, const Values & in, const Value
     OCIO::ConstCPUProcessorRcPtr cpu;
     // Use lossless mode for these tests (e.g. FAST_LOG_EXP_POW limits to about 4 sig. digits).
     OCIO_CHECK_NO_THROW_FROM(cpu = proc->getOptimizedCPUProcessor(OCIO::OPTIMIZATION_LOSSLESS), lineNo);
-//     OCIO_CHECK_NO_THROW_FROM(cpu = proc->getOptimizedCPUProcessor(OCIO::OPTIMIZATION_NONE), lineNo);
 
     OCIO::PackedImageDesc inDesc((void *)&in[0], long(in.size() / 3), 1, 3);
 
@@ -369,13 +368,13 @@ AllValues UnitTestValues
     { "IDENTITY",
         { { 0.5f, 0.4f, 0.3f }, { 0.5f,            0.4f,            0.3f } } },
 
-    { "UTILITY--ACES-AP0_to_CIE-XYZ-D65_BFD",
+    { "UTILITY - ACES-AP0_to_CIE-XYZ-D65_BFD",
         { { 0.5f, 0.4f, 0.3f }, { 0.472347603390f, 0.440425934827f, 0.326581044758f } } },
-    { "UTILITY--ACES-AP1_to_CIE-XYZ-D65_BFD",
+    { "UTILITY - ACES-AP1_to_CIE-XYZ-D65_BFD",
         { { 0.5f, 0.4f, 0.3f }, { 0.428407900093f, 0.420968434905f, 0.325777868096f } } },
-    { "UTILITY--ACES-AP1_to_LINEAR-REC709_BFD",
+    { "UTILITY - ACES-AP1_to_LINEAR-REC709_BFD",
         { { 0.5f, 0.4f, 0.3f }, { 0.578830986466f, 0.388029190156f, 0.282302431033f } } },
-    { "CURVE--ACEScct-LOG_to_LINEAR",
+    { "CURVE - ACEScct-LOG_to_LINEAR",
         { { 0.5f, 0.4f, 0.3f }, { 0.514056913328f, 0.152618314084f, 0.045310838527f } } },
     { "ACEScct_to_ACES2065-1",
         { { 0.5f, 0.4f, 0.3f }, { 0.386397222658f, 0.158557251811f, 0.043152537925f } } },
@@ -391,41 +390,41 @@ AllValues UnitTestValues
         { { 0.5f, 0.4f, 0.3f }, { 0.210518101020f, 0.148655364394f, 0.085189053481f } } },
     { "ADX16_to_ACES2065-1",
         { { 0.125f, 0.1f, 0.075f }, { 0.211320835792f, 0.149169650771f, 0.085452970479f } } },
-    { "ACES-LMT--BLUE_LIGHT_ARTIFACT_FIX",
+    { "ACES-LMT - BLUE_LIGHT_ARTIFACT_FIX",
         { { 0.5f, 0.4f, 0.3f }, { 0.48625676579f,  0.38454173877f,  0.30002108779f } } },
 
-    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA_1.0",
+    { "ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA_1.0",
         { { 0.5f, 0.4f, 0.3f }, { 0.33629957f,     0.31832799f,     0.22867827f } } },
-    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-VIDEO_1.0",
+    { "ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-VIDEO_1.0",
         { { 0.5f, 0.4f, 0.3f }, { 0.34128153f,     0.32533440f,     0.24217427f } } },
-    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA-REC709lim_1.1",
+    { "ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA-REC709lim_1.1",
         { { 0.5f, 0.4f, 0.3f }, { 0.33629954f,     0.31832793f,     0.22867827f } } },
-    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-VIDEO-REC709lim_1.1",
+    { "ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-VIDEO-REC709lim_1.1",
         { { 0.5f, 0.4f, 0.3f }, { 0.34128147f,     0.32533434f,     0.24217427f } } },
-    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-VIDEO-P3lim_1.1",
+    { "ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-VIDEO-P3lim_1.1",
         { { 0.5f, 0.4f, 0.3f }, { 0.34128150f,     0.32533440f,     0.24217424f } } },
-    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA-D60sim-D65_1.1",
+    { "ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA-D60sim-D65_1.1",
         { { 0.5f, 0.4f, 0.3f }, { 0.32699189f,     0.30769098f,     0.20432013f } } },
-    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-VIDEO-D60sim-D65_1.0",
+    { "ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-VIDEO-D60sim-D65_1.0",
         { { 0.5f, 0.4f, 0.3f }, { 0.32889283f,     0.31174013f,     0.21453267f } } },
-    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA-D60sim-DCI_1.0",
+    { "ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA-D60sim-DCI_1.0",
         { { 0.5f, 0.4f, 0.3f }, { 0.34226444f,     0.30731421f,     0.23189434f } } },
-    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA-D65sim-DCI_1.1",
+    { "ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA-D65sim-DCI_1.1",
         { { 0.5f, 0.4f, 0.3f }, { 0.33882778f,     0.30572337f,     0.24966924f } } },
 
-    { "ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-1000nit-15nit-REC2020lim_1.1",
+    { "ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-1000nit-15nit-REC2020lim_1.1",
         { { 0.5f, 0.4f, 0.3f }, { 0.48334542f,     0.45336276f,     0.32364485f } } },
-    { "ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-1000nit-15nit-P3lim_1.1",
+    { "ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-1000nit-15nit-P3lim_1.1",
         { { 0.5f, 0.4f, 0.3f }, { 0.48334542f,     0.45336276f,     0.32364485f } } },
-    { "ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-2000nit-15nit-REC2020lim_1.1",
+    { "ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-2000nit-15nit-REC2020lim_1.1",
         { { 0.5f, 0.4f, 0.3f }, { 0.50538367f,     0.47084737f,     0.32972121f } } },
-    { "ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-2000nit-15nit-P3lim_1.1",
+    { "ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-2000nit-15nit-P3lim_1.1",
         { { 0.5f, 0.4f, 0.3f }, { 0.50538367f,     0.47084737f,     0.32972121f } } },
-    { "ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-4000nit-15nit-REC2020lim_1.1",
+    { "ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-4000nit-15nit-REC2020lim_1.1",
         { { 0.5f, 0.4f, 0.3f }, { 0.52311981f,     0.48482567f,     0.33447576f } } },
-    { "ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-4000nit-15nit-P3lim_1.1",
+    { "ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-4000nit-15nit-P3lim_1.1",
         { { 0.5f, 0.4f, 0.3f }, { 0.52311981f,     0.48482567f,     0.33447576f } } },
-    { "ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-CINEMA-108nit-7.2nit-P3lim_1.1",
+    { "ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-CINEMA-108nit-7.2nit-P3lim_1.1",
         { { 0.5f, 0.4f, 0.3f }, { 0.22214814f,     0.21179835f,     0.15639816f } } },
 
     { "ARRI_ALEXA-LOGC-EI800-AWG_to_ACES2065-1",
@@ -449,30 +448,30 @@ AllValues UnitTestValues
     { "SONY_SLOG3-SGAMUT3.CINE-VENICE_to_ACES2065-1",
         { { 0.5f, 0.4f, 0.3f }, { 0.32222527f,     0.17032611f,      0.04477848f } } },
 
-    { "DISPLAY--CIE-XYZ-D65_to_REC.1886-REC.709",
+    { "DISPLAY - CIE-XYZ-D65_to_REC.1886-REC.709",
         { { 0.5f, 0.4f, 0.3f }, { 0.937245093108f, 0.586817090358f,  0.573498106368f } } },
-    { "DISPLAY--CIE-XYZ-D65_to_REC.1886-REC.2020",
+    { "DISPLAY - CIE-XYZ-D65_to_REC.1886-REC.2020",
         { { 0.5f, 0.4f, 0.3f }, { 0.830338272693f, 0.620393283803f,  0.583385370254f } } },
-    { "DISPLAY--CIE-XYZ-D65_to_G2.2-REC.709",
+    { "DISPLAY - CIE-XYZ-D65_to_G2.2-REC.709",
         { { 0.5f, 0.4f, 0.3f }, { 0.931739212204f, 0.559058879141f,  0.545230761999f } } },
-    { "DISPLAY--CIE-XYZ-D65_to_sRGB",
+    { "DISPLAY - CIE-XYZ-D65_to_sRGB",
         { { 0.5f, 0.4f, 0.3f }, { 0.933793573229f, 0.564092030327f,  0.550040502218f } } },
-    { "DISPLAY--CIE-XYZ-D65_to_G2.6-P3-DCI-BFD",
+    { "DISPLAY - CIE-XYZ-D65_to_G2.6-P3-DCI-BFD",
         { { 0.5f, 0.4f, 0.3f }, { 0.908856342287f, 0.627840575107f,  0.608053675805f } } },
-    { "DISPLAY--CIE-XYZ-D65_to_G2.6-P3-D65",
+    { "DISPLAY - CIE-XYZ-D65_to_G2.6-P3-D65",
         { { 0.5f, 0.4f, 0.3f }, { 0.896805202281f, 0.627254277624f,  0.608228132100f } } },
-    { "DISPLAY--CIE-XYZ-D65_to_G2.6-P3-D60-BFD",
+    { "DISPLAY - CIE-XYZ-D65_to_G2.6-P3-D60-BFD",
         { { 0.5f, 0.4f, 0.3f }, { 0.892433142142f, 0.627011653770f,  0.608093643982f } } },
 
-    { "CURVE--ST-2084_to_LINEAR",
+    { "CURVE - ST-2084_to_LINEAR",
         { { 0.5f, 0.4f, 0.3f }, { 0.922457089941f, 0.324479178538f,  0.100382263105f } } },
-    { "CURVE--LINEAR_to_ST-2084",
+    { "CURVE - LINEAR_to_ST-2084",
         { { 0.5f, 0.4f, 0.3f }, { 0.440281573420f, 0.419284117712f,  0.392876186489f } } },
-    { "DISPLAY--CIE-XYZ-D65_to_REC.2100-PQ",
+    { "DISPLAY - CIE-XYZ-D65_to_REC.2100-PQ",
         { { 0.5f, 0.4f, 0.3f }, { 0.464008302136f, 0.398157119110f,  0.384828370950f } } },
-    { "DISPLAY--CIE-XYZ-D65_to_ST2084-P3-D65",
+    { "DISPLAY - CIE-XYZ-D65_to_ST2084-P3-D65",
         { { 0.5f, 0.4f, 0.3f }, { 0.479939091128f, 0.392091860770f,  0.384886051856f } } },
-    { "DISPLAY--CIE-XYZ-D65_to_REC.2100-HLG-1000nit",
+    { "DISPLAY - CIE-XYZ-D65_to_REC.2100-HLG-1000nit",
         { { 0.5f, 0.4f, 0.3f }, { 0.5649694f,      0.4038837f,       0.3751478f } } }
 };
 

--- a/tests/cpu/transforms/BuiltinTransform_tests.cpp
+++ b/tests/cpu/transforms/BuiltinTransform_tests.cpp
@@ -343,6 +343,7 @@ void ValidateBuiltinTransform(const char * style, const Values & in, const Value
     OCIO::ConstCPUProcessorRcPtr cpu;
     // Use lossless mode for these tests (e.g. FAST_LOG_EXP_POW limits to about 4 sig. digits).
     OCIO_CHECK_NO_THROW_FROM(cpu = proc->getOptimizedCPUProcessor(OCIO::OPTIMIZATION_LOSSLESS), lineNo);
+//     OCIO_CHECK_NO_THROW_FROM(cpu = proc->getOptimizedCPUProcessor(OCIO::OPTIMIZATION_NONE), lineNo);
 
     OCIO::PackedImageDesc inDesc((void *)&in[0], long(in.size() / 3), 1, 3);
 
@@ -393,12 +394,39 @@ AllValues UnitTestValues
     { "ACES-LMT--BLUE_LIGHT_ARTIFACT_FIX",
         { { 0.5f, 0.4f, 0.3f }, { 0.48625676579f,  0.38454173877f,  0.30002108779f } } },
 
-    { "ACES-OUTPUT--ACES2065-1_to_CIE-XYZ_VIDEO_1.0",
+    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA_1.0",
+        { { 0.5f, 0.4f, 0.3f }, { 0.33629957f,     0.31832799f,     0.22867827f } } },
+    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-VIDEO_1.0",
         { { 0.5f, 0.4f, 0.3f }, { 0.34128153f,     0.32533440f,     0.24217427f } } },
-    { "ACES-OUTPUT--ACES2065-1_to_CIE-XYZ_VIDEO-D60sim_1.0",
+    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA-REC709lim_1.1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.33629954f,     0.31832793f,     0.22867827f } } },
+    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-VIDEO-REC709lim_1.1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.34128147f,     0.32533434f,     0.24217427f } } },
+    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-VIDEO-P3lim_1.1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.34128150f,     0.32533440f,     0.24217424f } } },
+    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA-D60sim-D65_1.1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.32699189f,     0.30769098f,     0.20432013f } } },
+    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-VIDEO-D60sim-D65_1.0",
         { { 0.5f, 0.4f, 0.3f }, { 0.32889283f,     0.31174013f,     0.21453267f } } },
-    { "ACES-OUTPUT--ACES2065-1_to_CIE-XYZ_HDR-VIDEO-1000nits_1.1",
+    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA-D60sim-DCI_1.0",
+        { { 0.5f, 0.4f, 0.3f }, { 0.34226444f,     0.30731421f,     0.23189434f } } },
+    { "ACES-OUTPUT--ACES_to_CIE-XYZ_SDR-CINEMA-D65sim-DCI_1.1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.33882778f,     0.30572337f,     0.24966924f } } },
+
+    { "ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-1000nit-15nit-REC2020lim_1.1",
         { { 0.5f, 0.4f, 0.3f }, { 0.48334542f,     0.45336276f,     0.32364485f } } },
+    { "ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-1000nit-15nit-P3lim_1.1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.48334542f,     0.45336276f,     0.32364485f } } },
+    { "ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-2000nit-15nit-REC2020lim_1.1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.50538367f,     0.47084737f,     0.32972121f } } },
+    { "ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-2000nit-15nit-P3lim_1.1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.50538367f,     0.47084737f,     0.32972121f } } },
+    { "ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-4000nit-15nit-REC2020lim_1.1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.52311981f,     0.48482567f,     0.33447576f } } },
+    { "ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-VIDEO-4000nit-15nit-P3lim_1.1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.52311981f,     0.48482567f,     0.33447576f } } },
+    { "ACES-OUTPUT--ACES_to_CIE-XYZ_HDR-CINEMA-108nit-7.2nit-P3lim_1.1",
+        { { 0.5f, 0.4f, 0.3f }, { 0.22214814f,     0.21179835f,     0.15639816f } } },
 
     { "ARRI_ALEXA-LOGC-EI800-AWG_to_ACES2065-1",
         { { 0.5f, 0.4f, 0.3f }, { 0.401621427766f, 0.236455447604f,  0.064830001192f } } },
@@ -443,7 +471,9 @@ AllValues UnitTestValues
     { "DISPLAY--CIE-XYZ-D65_to_REC.2100-PQ",
         { { 0.5f, 0.4f, 0.3f }, { 0.464008302136f, 0.398157119110f,  0.384828370950f } } },
     { "DISPLAY--CIE-XYZ-D65_to_ST2084-P3-D65",
-        { { 0.5f, 0.4f, 0.3f }, { 0.479939091128f, 0.392091860770f,  0.384886051856f } } }
+        { { 0.5f, 0.4f, 0.3f }, { 0.479939091128f, 0.392091860770f,  0.384886051856f } } },
+    { "DISPLAY--CIE-XYZ-D65_to_REC.2100-HLG-1000nit",
+        { { 0.5f, 0.4f, 0.3f }, { 0.5649694f,      0.4038837f,       0.3751478f } } }
 };
 
 } // anon.

--- a/tests/cpu/transforms/builtins/BuiltinTransformRegistry_tests.cpp
+++ b/tests/cpu/transforms/builtins/BuiltinTransformRegistry_tests.cpp
@@ -77,14 +77,14 @@ OCIO_ADD_TEST(Builtins, aces)
 
     {
         ops.clear();
-        CreateOps("UTILITY--ACES-AP0_to_CIE-XYZ-D65_BFD", OCIO::TRANSFORM_DIR_FORWARD, ops, __LINE__);
+        CreateOps("UTILITY - ACES-AP0_to_CIE-XYZ-D65_BFD", OCIO::TRANSFORM_DIR_FORWARD, ops, __LINE__);
         OCIO_REQUIRE_EQUAL(ops.size(), 1);
         OCIO_REQUIRE_EQUAL(std::string(ops[0]->getInfo()), "<MatrixOffsetOp>");
     }
 
     {
         ops.clear();
-        CreateOps("CURVE--ACEScct-LOG_to_LINEAR", OCIO::TRANSFORM_DIR_FORWARD, ops, __LINE__);
+        CreateOps("CURVE - ACEScct-LOG_to_LINEAR", OCIO::TRANSFORM_DIR_FORWARD, ops, __LINE__);
         OCIO_REQUIRE_EQUAL(ops.size(), 1);
         OCIO_REQUIRE_EQUAL(std::string(ops[0]->getInfo()), "<LogOp>");
     }

--- a/tests/cpu/transforms/builtins/BuiltinTransformRegistry_tests.cpp
+++ b/tests/cpu/transforms/builtins/BuiltinTransformRegistry_tests.cpp
@@ -77,14 +77,14 @@ OCIO_ADD_TEST(Builtins, aces)
 
     {
         ops.clear();
-        CreateOps("ACES-AP0_to_CIE-XYZ-D65_BFD", OCIO::TRANSFORM_DIR_FORWARD, ops, __LINE__);
+        CreateOps("UTILITY--ACES-AP0_to_CIE-XYZ-D65_BFD", OCIO::TRANSFORM_DIR_FORWARD, ops, __LINE__);
         OCIO_REQUIRE_EQUAL(ops.size(), 1);
         OCIO_REQUIRE_EQUAL(std::string(ops[0]->getInfo()), "<MatrixOffsetOp>");
     }
 
     {
         ops.clear();
-        CreateOps("ACEScct-LOG_to_LIN", OCIO::TRANSFORM_DIR_FORWARD, ops, __LINE__);
+        CreateOps("CURVE--ACEScct-LOG_to_LINEAR", OCIO::TRANSFORM_DIR_FORWARD, ops, __LINE__);
         OCIO_REQUIRE_EQUAL(ops.size(), 1);
         OCIO_REQUIRE_EQUAL(std::string(ops[0]->getInfo()), "<LogOp>");
     }

--- a/tests/python/BuiltinTransformTest.py
+++ b/tests/python/BuiltinTransformTest.py
@@ -16,7 +16,7 @@ class BuiltinTransformTest(unittest.TestCase):
     DEFAULT_STR = '<BuiltinTransform direction = forward, style = IDENTITY>'
 
     # One reference style
-    EXAMPLE_STYLE = 'UTILITY--ACES-AP0_to_CIE-XYZ-D65_BFD'
+    EXAMPLE_STYLE = 'UTILITY - ACES-AP0_to_CIE-XYZ-D65_BFD'
     EXAMPLE_DESC = (
         'Convert ACES AP0 primaries to CIE XYZ with a D65 white point with '
         'Bradford adaptation')

--- a/tests/python/BuiltinTransformTest.py
+++ b/tests/python/BuiltinTransformTest.py
@@ -16,7 +16,7 @@ class BuiltinTransformTest(unittest.TestCase):
     DEFAULT_STR = '<BuiltinTransform direction = forward, style = IDENTITY>'
 
     # One reference style
-    EXAMPLE_STYLE = 'ACES-AP0_to_CIE-XYZ-D65_BFD'
+    EXAMPLE_STYLE = 'UTILITY--ACES-AP0_to_CIE-XYZ-D65_BFD'
     EXAMPLE_DESC = (
         'Convert ACES AP0 primaries to CIE XYZ with a D65 white point with '
         'Bradford adaptation')


### PR DESCRIPTION
Add Built-in Transforms requested by the ACES Config working group.
- View Transforms needed for ACES Output Transforms
- Display color spaces needed for ACES Output Transforms
- Sony Venice IDTs
- LMT-Blue light fix

Signed-off-by: Doug Walker <Doug.Walker@autodesk.com>