### PR TITLE
Adsk Contrib - Fix Lut1dPython test when numpy is missing

### DIFF
--- a/tests/python/Lut1DTransformTest.py
+++ b/tests/python/Lut1DTransformTest.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 
+import logging
 import unittest
 
-import PyOpenColorIO as OCIO
+logger = logging.getLogger(__name__)
 
 try:
     import numpy as np
@@ -13,6 +14,9 @@ except ImportError:
         "Test case will lack significant coverage!"
     )
     np = None
+
+import PyOpenColorIO as OCIO
+
 
 class Lut1DTransformTest(unittest.TestCase):
 


### PR DESCRIPTION
Test forgot to declare logger and fails if numpy is missing

Signed-off-by: Bernard Lefebvre <bernard.lefebvre@autodesk.com>