### PR TITLE
Adsk Contrib - Fix CPUProcessor::applyRGB

### DIFF
--- a/src/OpenColorIO/CPUProcessor.cpp
+++ b/src/OpenColorIO/CPUProcessor.cpp
@@ -406,7 +406,7 @@ void CPUProcessor::Impl::applyRGB(float * pixel) const
     const size_t numOps = m_cpuOps.size();
     for(size_t i = 0; i<numOps; ++i)
     {
-        m_cpuOps[i]->apply(pixel, pixel, 1);
+        m_cpuOps[i]->apply(v, v, 1);
     }
 
     m_outBitDepthOp->apply(v, v, 1);

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -389,6 +389,7 @@ public:
 
             m_env = rhs.m_env;
             m_context = rhs.m_context->createEditableCopy();
+            m_name = rhs.m_name;
             m_familySeparator = rhs.m_familySeparator;
             m_description = rhs.m_description;
 

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -7823,6 +7823,13 @@ colorspaces:
 
     cfg->setDescription("single line description");
     cfg->setName("Test config name");
+
+    // Verify name is copied.
+    {
+        auto cfg2 = cfg->createEditableCopy();
+        OCIO_CHECK_EQUAL(std::string(cfg2->getName()), "Test config name");
+    }
+
     cfg->serialize(oss);
     static constexpr char CONFIG_DESC_SINGLELINE[]{ R"(ocio_profile_version: 2
 


### PR DESCRIPTION
Fix CPUProcessor::applyRGB when there is more than 1 op. Adjust test to create several ops.
Copy config name.

Signed-off-by: Bernard Lefebvre <bernard.lefebvre@autodesk.com>