### PR TITLE
Adsk Contrib - Fix some GLSL version mismatches.

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -3045,7 +3045,7 @@ protected:
 //    //
 //    OCIO::GpuShaderDescRcPtr shaderDesc = MyCustomGpuShader::Create();
 //
-//    shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_GLSL_1_3);
+//    shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_GLSL_1_2);
 //    shaderDesc->setFunctionName("OCIODisplay");
 //
 //    // Step 2: Collect the shader program information for a specific processor

--- a/src/apps/ociochecklut/main.cpp
+++ b/src/apps/ociochecklut/main.cpp
@@ -69,7 +69,7 @@ public:
         {
             shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
         }
-        shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_GLSL_1_3);
+        shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_GLSL_1_2);
         m_gpu->extractGpuShaderInfo(shaderDesc);
         m_oglApp->setShader(shaderDesc);
 #endif // OCIO_GPU_ENABLED

--- a/src/apps/ocioconvert/main.cpp
+++ b/src/apps/ocioconvert/main.cpp
@@ -189,9 +189,11 @@ int main(int argc, const char **argv)
             try
             {
                 std::cout << std::endl;
-                std::cout << "OCIO Configuration: '" << env << "'" << std::endl;
+                std::cout << "OCIO Config. file:    '" << env << "'" << std::endl;
                 OCIO::ConstConfigRcPtr config = OCIO::GetCurrentConfig();
-                std::cout << "OCIO search_path:    " << config->getSearchPath() << std::endl;
+                std::cout << "OCIO Config. version: " << config->getMajorVersion() << "." 
+                                                      << config->getMinorVersion() << std::endl;
+                std::cout << "OCIO search_path:     " << config->getSearchPath() << std::endl;
             }
             catch (const OCIO::Exception & e)
             {
@@ -498,7 +500,7 @@ int main(int argc, const char **argv)
             {
                 shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
             }
-            shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_GLSL_1_3);
+            shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_GLSL_1_2);
             processor->getDefaultGPUProcessor()->extractGpuShaderInfo(shaderDesc);
             oglApp->setShader(shaderDesc);
 

--- a/src/apps/ociodisplay/main.cpp
+++ b/src/apps/ociodisplay/main.cpp
@@ -694,8 +694,10 @@ int main(int argc, char **argv)
         if(env && *env)
         {
             std::cout << std::endl;
-            std::cout << "OCIO Configuration: '" << env << "'" << std::endl;
-            std::cout << "OCIO search_path:    " << config->getSearchPath() << std::endl;
+            std::cout << "OCIO Config. file   : '" << env << "'" << std::endl;
+            std::cout << "OCIO Config. version: " << config->getMajorVersion() << "." 
+                                                  << config->getMinorVersion() << std::endl;
+            std::cout << "OCIO search_path    : " << config->getSearchPath() << std::endl;
         }
     }
 

--- a/src/apps/ocioperf/main.cpp
+++ b/src/apps/ocioperf/main.cpp
@@ -317,9 +317,11 @@ int main(int argc, const char **argv)
             try
             {
                 std::cout << std::endl;
-                std::cout << "OCIO Configuration: '" << env << "'" << std::endl;
+                std::cout << "OCIO Config. file:    '" << env << "'" << std::endl;
                 OCIO::ConstConfigRcPtr config = OCIO::GetCurrentConfig();
-                std::cout << "OCIO search_path:    " << config->getSearchPath() << std::endl;
+                std::cout << "OCIO Config. version: " << config->getMajorVersion() << "." 
+                                                      << config->getMinorVersion() << std::endl;
+                std::cout << "OCIO search_path:     " << config->getSearchPath() << std::endl;
             }
             catch(...)
             {
@@ -546,7 +548,7 @@ int main(int argc, const char **argv)
 
         // Get the GPU Shader.
         OCIO::GpuShaderDescRcPtr shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
-        shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_GLSL_1_3);
+        shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_GLSL_1_2);
 
         {
             CustomMeasure m("Create the GPU shader:\t\t\t", iterations);


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul Patrick.Hodoul@autodesk.com

The pull request mainly sets the lower version needed to support all GLSL Op shader code. The version 1.2 is the lower version but the code was inconsistent. The change also includes the output of the config file version when using command line apps in verbose mode. It might be useful when debugging. 

