### PR TITLE
Add Photoshop plug-in to Compatible Software

### DIFF
--- a/docs/guides/using_ocio/compatible_software.rst
+++ b/docs/guides/using_ocio/compatible_software.rst
@@ -27,7 +27,7 @@ Documentation :
 
 - See `src/aftereffects <http://github.com/AcademySoftwareFoundation/OpenColorIO/tree/master/src/aftereffects>`__ if you are interested in building your own OCIO plugins.
 
-- Pre-built binaries are also available for `download <http://www.fnordware.com/OpenColorIO>`__, courtesy of `fnordware <http://www.fnordware.com>`__.
+- Pre-built binaries are also available for `download <http://fnordware.blogspot.com/2012/05/opencolorio-for-after-effects.html>`__, courtesy of `fnordware <http://www.fnordware.com>`__.
 
 
 Arnold (Autodesk)
@@ -298,6 +298,10 @@ Photoshop
 OpenColorIO display luts can be exported as ICC profiles for use in photoshop. The core idea is to create an .icc profile, with a valid description, and then to save it to the proper OS icc directory. (On OSX, ``~/Library/ColorSync/Profiles/``). Upon a Photoshop relaunch, Edit->Assign Profile, and then select your new OCIO lut.
 
 Website : `<https://www.adobe.com/products/photoshop.html>`__
+
+An OpenColorIO plugin is also available for use in Photoshop. The plug-in can perform color operations to an image as a filter and can also export LUTs and ICC profiles to be used by Photoshop.
+
+Plugin binaries are available for `download <http://fnordware.blogspot.com/2017/02/opencolorio-for-photoshop.html>`__, courtesy of `fnordware <http://www.fnordware.com>`__.
 
 Python
 ******

--- a/docs/site/homepage/data/en/supported_apps.yml
+++ b/docs/site/homepage/data/en/supported_apps.yml
@@ -8,7 +8,7 @@ supported_apps:
       image : images/supported_apps/ae.png
       categories : ["2D", "Compositing", "Animation"]
       content : Plugin required.
-      link : "http://www.fnordware.com/OpenColorIO"
+      link : "http://fnordware.blogspot.com/2012/05/opencolorio-for-after-effects.html"
     
     # portfolio item loop
     - name : Autodesk Arnold
@@ -140,8 +140,8 @@ supported_apps:
     - name : Adobe Photoshop
       image : images/supported_apps/ps.png
       categories : ["2D", "Photography", "Paint"]
-      content : Available via ICC profiles.
-      link : "https://www.adobe.com/products/photoshop.html"
+      content : Plugin required.
+      link : "http://fnordware.blogspot.com/2017/02/opencolorio-for-photoshop.html"
 
       # portfolio item loop
     - name : PhotoFlow


### PR DESCRIPTION
We didn't mention the OCIO Photoshop plug-in in the docs or website. I added a link to the binaries and updated the After Effects link.

Both Photoshop and After Effects can use ICC profiles, but Photoshop users are more likely to want to do that because the OCIO plug-in can't float above the rest of your layers like it can in After Effects. Then again, the profiles we're making don't give completely accurate results and using ICC profiles this way when working in 32-bit mode is basically non-functional.