### PR TITLE
Adsk Contrib - Fix CDL identity optimization issue

### DIFF
--- a/src/OpenColorIO/ops/cdl/CDLOpData.cpp
+++ b/src/OpenColorIO/ops/cdl/CDLOpData.cpp
@@ -303,14 +303,11 @@ OpDataRcPtr CDLOpData::getIdentityReplacement() const
     OpDataRcPtr op;
     switch(getStyle())
     {
-        // These clamp values below 0 -- replace with range.
+        // These clamp values -- replace with range.
         case CDL_V1_2_FWD:
         case CDL_V1_2_REV:
         {
-            op = std::make_shared<RangeOpData>(0.,
-                                               RangeOpData::EmptyValue(), // don't clamp high end
-                                               0.,
-                                               RangeOpData::EmptyValue());
+            op = std::make_shared<RangeOpData>(0., 1., 0., 1.);
             break;
         }
 

--- a/tests/cpu/ops/cdl/CDLOpData_tests.cpp
+++ b/tests/cpu/ops/cdl/CDLOpData_tests.cpp
@@ -236,26 +236,63 @@ OCIO_ADD_TEST(CDLOpData, style)
     OCIO::CDLOpData cdlOp;
 
     // Check CDL_V1_2_FWD
+
     cdlOp.setStyle(OCIO::CDLOpData::CDL_V1_2_FWD);
     OCIO_CHECK_EQUAL(cdlOp.getStyle(), OCIO::CDLOpData::CDL_V1_2_FWD);
     OCIO_CHECK_ASSERT(!cdlOp.isReverse());
 
+    // Check the identity replacement.
+    OCIO::OpDataRcPtr op = cdlOp.getIdentityReplacement();
+    OCIO::RangeOpDataRcPtr rg = OCIO::DynamicPtrCast<OCIO::RangeOpData>(op);
+    OCIO_REQUIRE_ASSERT(rg);
+    OCIO_CHECK_ASSERT(rg->hasMinInValue()  && (rg->getMinInValue()  == 0.));
+    OCIO_CHECK_ASSERT(rg->hasMaxInValue()  && (rg->getMaxInValue()  == 1.));
+    OCIO_CHECK_ASSERT(rg->hasMinOutValue() && (rg->getMinOutValue() == 0.));
+    OCIO_CHECK_ASSERT(rg->hasMaxOutValue() && (rg->getMaxOutValue() == 1.));
+    OCIO_CHECK_ASSERT(!rg->scales());
+
     // Check CDL_V1_2_REV
+
     cdlOp.setStyle(OCIO::CDLOpData::CDL_V1_2_REV);
     OCIO_CHECK_EQUAL(cdlOp.getStyle(), OCIO::CDLOpData::CDL_V1_2_REV);
     OCIO_CHECK_ASSERT(cdlOp.isReverse());
 
+    // Check the identity replacement.
+    op = cdlOp.getIdentityReplacement();
+    rg = OCIO::DynamicPtrCast<OCIO::RangeOpData>(op);
+    OCIO_REQUIRE_ASSERT(rg);
+    OCIO_CHECK_ASSERT(rg->hasMinInValue()  && (rg->getMinInValue()  == 0.));
+    OCIO_CHECK_ASSERT(rg->hasMaxInValue()  && (rg->getMaxInValue()  == 1.));
+    OCIO_CHECK_ASSERT(rg->hasMinOutValue() && (rg->getMinOutValue() == 0.));
+    OCIO_CHECK_ASSERT(rg->hasMaxOutValue() && (rg->getMaxOutValue() == 1.));
+    OCIO_CHECK_ASSERT(!rg->scales());
+
     // Check CDL_NO_CLAMP_FWD
+
     cdlOp.setStyle(OCIO::CDLOpData::CDL_NO_CLAMP_FWD);
     OCIO_CHECK_EQUAL(cdlOp.getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_FWD);
     OCIO_CHECK_ASSERT(!cdlOp.isReverse());
 
+    // Check the identity replacement.
+    op = cdlOp.getIdentityReplacement();
+    OCIO::MatrixOpDataRcPtr mtx = OCIO::DynamicPtrCast<OCIO::MatrixOpData>(op);
+    OCIO_REQUIRE_ASSERT(mtx);
+    OCIO_CHECK_ASSERT(mtx->isIdentity());
+
     // Check CDL_NO_CLAMP_REV
+
     cdlOp.setStyle(OCIO::CDLOpData::CDL_NO_CLAMP_REV);
     OCIO_CHECK_EQUAL(cdlOp.getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_REV);
     OCIO_CHECK_ASSERT(cdlOp.isReverse());
 
+    // Check the identity replacement.
+    op = cdlOp.getIdentityReplacement();
+    mtx = OCIO::DynamicPtrCast<OCIO::MatrixOpData>(op);
+    OCIO_REQUIRE_ASSERT(mtx);
+    OCIO_CHECK_ASSERT(mtx->isIdentity());
+
     // Check unknown style
+
     OCIO_CHECK_THROW_WHAT(OCIO::CDLOpData::GetStyle("unknown_style"),
                           OCIO::Exception, 
                           "Unknown style for CDL");


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

The pull request fixes a bug related to optimization of CDL Ops.   When an identity `CDL_V1_2` style CDL Op was replaced in the optimizer, it was only clamping negative values.  However, since the full op clamps on both sides (0 and 1), per the ASC specification, the identity replacement should also clamp on both sides. 

This bug only impacts v2 configs since v1 configs use the previous method of applying CDLs.  Also, it does not affect 'no clamp' CDL style in v2, the optimizer replaces those identities in a way that also does not clamp.