### PR TITLE
Add Python wheel generation

### DIFF
--- a/.github/workflows/wheel_workflow.yml
+++ b/.github/workflows/wheel_workflow.yml
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+#
+
+name: Wheel
+
+on: [pull_request]
+
+jobs:
+  # Linux jobs run in Docker containers (manylinux), so the latest OS version
+  # is OK. macOS and Windows jobs need to be locked to specific virtual
+  # environment versions to mitigate issues from OS updates, and will require
+  # maintenance as OS versions are retired.
+  #
+  # Notes:
+  #
+  # Documentation fails to build on manylinux2010, maybe too old
+  # doxygen ? First fail in PyColorSpaceSet for documentation
+  # referencing PyOpenColorIO (eg. __sub__). Consequence is we don't
+  # support python 2.7, alternatively build without docstrings, or
+  # fix the doxygen issue.
+  #
+  # When installing doc environment, Python package are not used as the wheel
+  # is built in it's own isolated environment, hence package are listed again
+  # in pyproject.toml.
+  #
+  # Wheels are currently uploaded to the test package index for testing
+  # https://test.pypi.org/
+  #
+  # Filters on event to decide when to build and upload the wheels are up for
+  # dicussions.
+  #
+
+  # ---------------------------------------------------------------------------
+  # Linux
+  # ---------------------------------------------------------------------------
+
+  linux:
+    name: Build wheels on Linux
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # -------------------------------------------------------------------
+          # CPython 32 bits
+          # -------------------------------------------------------------------
+          - build: CPython 3.6 32 bits
+            python: cp36-*
+            arch: i686
+          - build: CPython 3.7 32 bits
+            python: cp37-*
+            arch: i686
+          - build: CPython 3.8 32 bits
+            python: cp38-*
+            arch: i686
+          - build: CPython 3.9 32 bits
+            python: cp39-*
+            arch: i686
+          # -------------------------------------------------------------------
+          # CPython 64 bits
+          # -------------------------------------------------------------------
+          - build: CPython 3.6 64 bits
+            python: cp36-*
+            arch: x86_64
+          - build: CPython 3.7 64 bits
+            python: cp37-*
+            arch: x86_64
+          - build: CPython 3.8 64 bits
+            python: cp38-*
+            arch: x86_64
+          - build: CPython 3.9 64 bits
+            python: cp39-*
+            arch: x86_64
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.8'
+
+      - name: Build wheels
+        uses: joerick/cibuildwheel@v1.11.0
+        env:
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_BUILD: ${{ matrix.python }}
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BEFORE_BUILD: share/ci/scripts/linux/yum/install_docs_env.sh
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+  # ---------------------------------------------------------------------------
+  # macOS
+  # ---------------------------------------------------------------------------
+
+  macos:
+    name: Build wheels on macOS
+    runs-on: macos-10.15
+    strategy:
+      matrix:
+        include:
+          # -------------------------------------------------------------------
+          # CPython 64 bits
+          # -------------------------------------------------------------------
+          - build: CPython 3.6 64 bits
+            python: cp36-*
+            arch: x86_64
+          - build: CPython 3.7 64 bits
+            python: cp37-*
+            arch: x86_64
+          - build: CPython 3.8 64 bits
+            python: cp38-*
+            arch: x86_64
+          - build: CPython 3.9 64 bits
+            python: cp39-*
+            arch: x86_64
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.8'
+
+      - name: Build wheels
+        uses: joerick/cibuildwheel@v1.11.0
+        env:
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_BUILD: ${{ matrix.python }}
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BEFORE_BUILD: share/ci/scripts/macos/install_docs_env.sh
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+  # ---------------------------------------------------------------------------
+  # Windows
+  # ---------------------------------------------------------------------------
+
+  windows:
+    name: Build wheels on Windows
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        include:
+          # -------------------------------------------------------------------
+          # CPython 32 bits
+          # -------------------------------------------------------------------
+          - build: CPython 3.6 32 bits
+            python: cp36-*
+            arch: x86
+          - build: CPython 3.7 32 bits
+            python: cp37-*
+            arch: x86
+          - build: CPython 3.8 32 bits
+            python: cp38-*
+            arch: x86
+          - build: CPython 3.9 32 bits
+            python: cp39-*
+            arch: x86
+          # -------------------------------------------------------------------
+          # CPython 64 bits
+          # -------------------------------------------------------------------
+          - build: CPython 3.6 64 bits
+            python: cp36-*
+            arch: AMD64
+          - build: CPython 3.7 64 bits
+            python: cp37-*
+            arch: AMD64
+          - build: CPython 3.8 64 bits
+            python: cp38-*
+            arch: AMD64
+          - build: CPython 3.9 64 bits
+            python: cp39-*
+            arch: AMD64
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.8'
+
+      - name: Build wheels
+        uses: joerick/cibuildwheel@v1.11.0
+        env:
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_BUILD: ${{ matrix.python }}
+          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BEFORE_BUILD: bash -c share/ci/scripts/windows/install_docs_env.sh
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+
+  upload_pypi:
+    needs: [linux, macos, windows]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/setup-python@v2
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ OpenColorIO
 [![Analysis Status](https://github.com/AcademySoftwareFoundation/OpenColorIO/workflows/Analysis/badge.svg)](https://github.com/AcademySoftwareFoundation/OpenColorIO/actions?query=workflow%3AAnalysis)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=AcademySoftwareFoundation_OpenColorIO&metric=alert_status)](https://sonarcloud.io/dashboard?id=AcademySoftwareFoundation_OpenColorIO)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2612/badge)](https://bestpractices.coreinfrastructure.org/projects/2612)
+[![Wheels](https://github.com/AcademySoftwareFoundation/OpenColorIO/workflows/Wheels/badge.svg)](https://github.com/AcademySoftwareFoundation/OpenColorIO/actions?query=workflow%3AWheels)
 
 Introduction
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+
+[project]
+requires-python = ">=2.7, >=3.6"
+
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "cmake>=3.12",
+    "ninja",
+    "pybind11",
+    # Documentation requirements
+    "six",
+    "testresources",
+    "recommonmark",
+    "sphinx-press-theme",
+    "sphinx-tabs",
+    "breathe"
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,26 @@
+[metadata]
+author = OpenColorIO Developers
+author_email = ocio-dev@lists.aswf.io
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    Topic :: Software Development :: Libraries :: Python Modules
+    Programming Language :: C++
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: C++
+    Topic :: Software Development :: Libraries :: Python Modules
+description = OpenColorIO (OCIO) is a complete color management solution geared towards motion picture production with an emphasis on visual effects and computer animation.
+license = Copyright Contributors to the OpenColorIO Project.
+long_description = file: README.md, LICENSE
+long_description_content_type = text/markdown
+name = opencolorio
+version = 2.1.0.dev1
+
+[options]
+zip_safe = False

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+#
+# Adapted from: https://github.com/pybind/cmake_example
+#
+
+import os
+import sys
+import subprocess
+
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
+
+# Convert distutils Windows platform specifiers to CMake -A arguments
+PLAT_TO_CMAKE = {
+    "win32": "Win32",
+    "win-amd64": "x64",
+    "win-arm32": "ARM",
+    "win-arm64": "ARM64",
+}
+
+
+# A CMakeExtension needs a sourcedir instead of a file list.
+# The name must be the _single_ output extension from the CMake build.
+# If you need multiple extensions, see scikit-build.
+class CMakeExtension(Extension):
+    def __init__(self, name, sourcedir=""):
+        Extension.__init__(self, name, sources=[])
+        self.sourcedir = os.path.abspath(sourcedir)
+
+
+class CMakeBuild(build_ext):
+    def build_extension(self, ext):
+        extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+
+        # required for auto-detection of auxiliary "native" libs
+        if not extdir.endswith(os.path.sep):
+            extdir += os.path.sep
+
+        cfg = "Debug" if self.debug else "Release"
+
+        # CMake lets you override the generator - we need to check this.
+        # Can be set with Conda-Build, for example.
+        cmake_generator = os.environ.get("CMAKE_GENERATOR", "")
+
+        # Set Python_EXECUTABLE instead if you use PYBIND11_FINDPYTHON
+        cmake_args = [
+            "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={}".format(extdir),
+            "-DPython_EXECUTABLE={}".format(sys.executable),
+            # Not used on MSVC, but no harm
+            "-DCMAKE_BUILD_TYPE={}".format(cfg),
+            "-DBUILD_SHARED_LIBS=OFF",
+            "-DOCIO_BUILD_DOCS=ON",
+            "-DOCIO_BUILD_TESTS=ON",
+            "-DOCIO_BUILD_GPU_TESTS=OFF",
+            # Install pybind11 via pip to avoid issue on Windows where
+            # ExternalProject pybind11 build detect the wrong version
+            "-DOCIO_INSTALL_EXT_PACKAGES=MISSING",
+        ]
+        build_args = []
+
+        if self.compiler.compiler_type != "msvc":
+            # Using Ninja-build since it a) is available as a wheel and b)
+            # multithreads automatically. MSVC would require all variables be
+            # exported for Ninja to pick it up, which is a little tricky to do.
+            # Users can override the generator with CMAKE_GENERATOR in CMake
+            # 3.15+.
+            if not cmake_generator:
+                cmake_args += ["-GNinja"]
+
+        else:
+
+            # Single config generators are handled "normally"
+            single_config = any(x in cmake_generator for x in {"NMake", "Ninja"})
+
+            # CMake allows an arch-in-generator style for backward compatibility
+            contains_arch = any(x in cmake_generator for x in {"ARM", "Win64"})
+
+            # Specify the arch if using MSVC generator, but only if it doesn't
+            # contain a backward-compatibility arch spec already in the
+            # generator name.
+            if not single_config and not contains_arch:
+                cmake_args += ["-A", PLAT_TO_CMAKE[self.plat_name]]
+
+            # Multi-config generators have a different way to specify configs
+            if not single_config:
+                cmake_args += [
+                    "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}".format(cfg.upper(), extdir)
+                ]
+                build_args += ["--config", cfg]
+
+        # Set CMAKE_BUILD_PARALLEL_LEVEL to control the parallel build level
+        # across all generators.
+        if "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:
+            # self.parallel is a Python 3 only way to set parallel jobs by hand
+            # using -j in the build_ext call, not supported by pip or PyPA-build.
+            if hasattr(self, "parallel") and self.parallel:
+                # CMake 3.12+ only.
+                build_args += ["-j{}".format(self.parallel)]
+
+        if not os.path.exists(self.build_temp):
+            os.makedirs(self.build_temp)
+
+        subprocess.check_call(
+            ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp
+        )
+        subprocess.check_call(
+            ["cmake", "--build", "."] + build_args, cwd=self.build_temp
+        )
+
+
+setup(
+    ext_modules=[CMakeExtension("OpenColorIO")],
+    cmdclass={"build_ext": CMakeBuild},
+)

--- a/share/ci/scripts/linux/yum/install_docs_env.sh
+++ b/share/ci/scripts/linux/yum/install_docs_env.sh
@@ -6,5 +6,7 @@ set -ex
 
 HERE=$(dirname $0)
 
+yum install -y sudo
+
 bash $HERE/install_doxygen.sh latest
 sudo pip install -r $HERE/../../../../../docs/requirements.txt

--- a/share/ci/scripts/linux/yum/install_doxygen.sh
+++ b/share/ci/scripts/linux/yum/install_doxygen.sh
@@ -7,7 +7,7 @@ set -ex
 DOXYGEN_VERSION="$1"
 
 if [ "$DOXYGEN_VERSION" == "latest" ]; then
-    sudo yum install doxygen
+    sudo yum install -y doxygen
 else
-    sudo yum install doxygen-${DOXYGEN_VERSION}
+    sudo yum install -y doxygen-${DOXYGEN_VERSION}
 fi

--- a/share/ci/scripts/linux/yum/install_tests_env.sh
+++ b/share/ci/scripts/linux/yum/install_tests_env.sh
@@ -6,4 +6,5 @@ set -ex
 
 HERE=$(dirname $0)
 
+yum install -y sudo
 sudo pip install -r $HERE/../../../../../tests/python/requirements.txt

--- a/share/cmake/modules/FindExtPackages.cmake
+++ b/share/cmake/modules/FindExtPackages.cmake
@@ -52,6 +52,27 @@ if(OCIO_BUILD_APPS)
     find_package(lcms2 2.2 REQUIRED)
 endif()
 
+# NOTE: Performing Python package detection first to allow pybind11 to pick up
+# that instead of potentially chosing another installation.
+if(OCIO_BUILD_PYTHON OR OCIO_BUILD_DOCS)
+
+    # NOTE: We find Python once in the global scope so that it can be checked 
+    # and referenced throughout the project.
+
+    set(_Python_COMPONENTS Interpreter)
+
+    # Support building on manylinux docker images.
+    # https://pybind11.readthedocs.io/en/stable/compiling.html#findpython-mode
+    if(OCIO_BUILD_PYTHON AND ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.18.0")
+        list(APPEND _Python_COMPONENTS Development.Module)
+    elseif(OCIO_BUILD_PYTHON)
+        list(APPEND _Python_COMPONENTS Development)
+    endif()
+
+    # Python
+    find_package(Python REQUIRED COMPONENTS ${_Python_COMPONENTS})
+endif()
+
 if(OCIO_BUILD_PYTHON)
 
     # NOTE: Depending of the compiler version pybind11 2.4.3 does not compile 
@@ -63,18 +84,4 @@ if(OCIO_BUILD_PYTHON)
     # pybind11
     # https://github.com/pybind/pybind11
     find_package(pybind11 2.6.1 REQUIRED)
-endif()
-
-if(OCIO_BUILD_PYTHON OR OCIO_BUILD_DOCS)
-
-    # NOTE: We find Python once in the global scope so that it can be checked 
-    # and referenced throughout the project.
-
-    set(_Python_COMPONENTS Interpreter)
-    if(OCIO_BUILD_PYTHON)
-        list(APPEND _Python_COMPONENTS Development)
-    endif()
-
-    # Python
-    find_package(Python REQUIRED COMPONENTS ${_Python_COMPONENTS})
 endif()

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -108,6 +108,8 @@ set(SOURCES
 	PyViewTransform.cpp
 )
 
+# Reason not to use pybind11_add_module ?
+# https://pybind11.readthedocs.io/en/stable/compiling.html#pybind11-add-module
 add_library(PyOpenColorIO MODULE ${SOURCES})
 
 if(OCIO_BUILD_DOCS)


### PR DESCRIPTION
This address #1362 , adding Python wheel generation using `cibuildwheel`, demo wheels available here https://test.pypi.org/project/opencolorio/, this surely is not the only way, but it looks promising to me.

Current status:
* Build process work on Github Action for all ubuntu, macos, windows platforms, each job building for a specific platform / python interpreter version / architecture. Results are then uploaded to https://test.pypi.org/.
* OpenColorIO is linked statically to the PyOpenColorIO module, to avoid some issues in the wheel repair process seen below.
* The wheels are currently generated only for Python 3.6+, see below for details.

Questions:
* How do we decide when to build and when to publish those wheels. Should those two be invoked on different times, eg. building more or less regularly and publishing only on new tags to master ? Optional pip workflow that just install and test the wheels on supported platforms.
* How do we test the built wheel easily without needing the build tree and ctest ?

Notes:
* Wheel repair does not work for dynamically linked OpenColorIO. The build process generate PyOpenColorIO.so with RPATH that point to the temporary build folder (used by `pip wheel`), `auditwheel` produce wheels with OpenColorIO lib copied into the wheel but don't update the RPATH on the Python module (this fails for both linux and macos). When using `pip wheel --no-clean` the repair process works better fixing the RPATH and point to a subfolder within the wheel where OpenColorIO.so is copied. It looks like there is some lib duplication as it's also on the root wheel folder, and overall size is 3-4 times bigger than statically linked wheel. Why does `pip wheel` override the Python module RPATH to a temporary folder that's deleted at the end of the build process, preventing `auditwheel` to work properly ? What do we do differently from other projects here ? Do we care about dynamic link here at all ?
* manylinux2010 images doesn't build the documentation, failing could be due to the older `doxygen` version, see comment in wheel_workflow.yml. manylinux2014 images don't support Python 2.
* Issue correctly building pybind11 on Windows (CMake ExternalProject), it does not pick the correct Python interpreter and trying to hint it toward the solution didn't work so far. An alternative solution currently used is to simply install it from the setuptools requirements so it will link to the correct python interpreter automatically.
* (https://test.pypi.org/ only) The version number 2.0.0 was used for the first test by mistake, and it seems even removing the project don't free it up again, now using 2.0.0devN for tests. This was also wrong as the wheel are built on the current master branch, so the latest version is now named 2.1.0dev1.