### PR TITLE
Allow choice of specific python release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,9 @@ option(OCIO_BUILD_FROZEN_DOCS "Specify whether to build frozen documentation, ne
 option(OCIO_BUILD_DOCS "Specify whether to build documentation" ${OCIO_BUILD_FROZEN_DOCS})
 
 option(OCIO_BUILD_PYTHON "Specify whether to build python bindings" ON)
+set (OCIO_PYTHON_VERSION "" CACHE STRING
+     "Preferred Python version (if any) in case multiple are available")
+
 option(OCIO_BUILD_JAVA "Specify whether to build java bindings" OFF)
 
 option(OCIO_WARNING_AS_ERROR "Set build error level for CI testing" OFF)

--- a/share/cmake/modules/FindExtPackages.cmake
+++ b/share/cmake/modules/FindExtPackages.cmake
@@ -52,18 +52,8 @@ if(OCIO_BUILD_APPS)
     find_package(lcms2 2.2 REQUIRED)
 endif()
 
-if(OCIO_BUILD_PYTHON)
-
-    # NOTE: Depending of the compiler version pybind11 2.4.3 does not compile 
-    # with C++17 so, if you change the pybind11 version update the code to 
-    # compile pybind11 and dependencies with C++17 or higher i.e. remove the 
-    # cap of C++ version in FindPybind11.cmake and 
-    # src/bindings/python/CMakeLists.txt.
-
-    # pybind11
-    # https://github.com/pybind/pybind11
-    find_package(pybind11 2.6.1 REQUIRED)
-endif()
+set (OCIO_PREFERRED_PYTHON_VERSION "" CACHE STRING
+     "Preferred Python version (if any) in case multiple are available")
 
 if(OCIO_BUILD_PYTHON OR OCIO_BUILD_DOCS)
 
@@ -76,5 +66,12 @@ if(OCIO_BUILD_PYTHON OR OCIO_BUILD_DOCS)
     endif()
 
     # Python
-    find_package(Python REQUIRED COMPONENTS ${_Python_COMPONENTS})
+    find_package(Python ${OCIO_PREFERRED_PYTHON_VERSION} REQUIRED
+                 COMPONENTS ${_Python_COMPONENTS})
+
+    if(OCIO_BUILD_PYTHON)
+        # pybind11
+        # https://github.com/pybind/pybind11
+        find_package(pybind11 2.6.1 REQUIRED)
+    endif()
 endif()

--- a/share/cmake/modules/FindExtPackages.cmake
+++ b/share/cmake/modules/FindExtPackages.cmake
@@ -52,8 +52,9 @@ if(OCIO_BUILD_APPS)
     find_package(lcms2 2.2 REQUIRED)
 endif()
 
-set (OCIO_PREFERRED_PYTHON_VERSION "" CACHE STRING
-     "Preferred Python version (if any) in case multiple are available")
+if (OCIO_PYTHON_VERSION AND NOT OCIO_BUILD_PYTHON)
+    message (WARNING "OCIO_PYTHON_VERSION=${OCIO_PYTHON_VERSION} but OCIO_BUILD_PYTHON is off.")
+endif ()
 
 if(OCIO_BUILD_PYTHON OR OCIO_BUILD_DOCS)
 
@@ -66,7 +67,7 @@ if(OCIO_BUILD_PYTHON OR OCIO_BUILD_DOCS)
     endif()
 
     # Python
-    find_package(Python ${OCIO_PREFERRED_PYTHON_VERSION} REQUIRED
+    find_package(Python ${OCIO_PYTHON_VERSION} REQUIRED
                  COMPONENTS ${_Python_COMPONENTS})
 
     if(OCIO_BUILD_PYTHON)


### PR DESCRIPTION
If you're building on a system with multiple versions of Python available,
it can be very hard to make OCIO build against a specific version. In
particular, https://cmake.org/cmake/help/latest/module/FindPython.html
explains that FindPython looks preferably for version 3 of Python.

This situation doesn't really come up in the CI, because all of the containers
have only one version of python each -- the one you are trying to use.
But often people are building on systems with several versions of Python.

I also removed a comment about pybind11 2.4.3 that no longer seems
relevant since we're asking for 2.6.1 or higher.

Signed-off-by: Larry Gritz <lg@larrygritz.com>