### PR TITLE
Port from RB-2.0 to master - Hide dependency symbol visibility (#1409)

### DIFF
--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -270,6 +270,14 @@ set_target_properties(OpenColorIO PROPERTIES
     SOVERSION     ${SOVERSION}
 )
 
+if (UNIX AND NOT APPLE)
+    # Also hide all the symbols of dependent libraries to prevent clashes if
+    # an app using this project is linked against other versions of our
+    # dependencies.
+    set_property (TARGET OpenColorIO
+                  APPEND PROPERTY LINK_FLAGS "-Wl,--exclude-libs,ALL")
+endif ()
+
 if(MSVC AND BUILD_SHARED_LIBS)
 	# Install the pdb file if any.
 	install(FILES $<TARGET_PDB_FILE:${PROJECT_NAME}> DESTINATION bin OPTIONAL)


### PR DESCRIPTION
When creating libOpenColorIO.so, we lacked the linker commands that
hide symbol visibility from the dependent libraries, which is
necessary to prevent OCIO from exporting the symbols from Expat and
the other dependencies that OCIO needs to use internally but is not
trying intentionally to expose via its API.

Failing to do this can result in symbol clashes and all sorts of
subtle errors if OCIO is used in an app that also uses and is linked
against a potentially different version of Expat (or any of the other
deps).

Signed-off-by: Larry Gritz <lg@larrygritz.com>