### PR TITLE
Adsk Contrib - Fix FixedFunctionTransform::CreateEditableCopy()

### DIFF
--- a/src/OpenColorIO/transforms/FixedFunctionTransform.cpp
+++ b/src/OpenColorIO/transforms/FixedFunctionTransform.cpp
@@ -46,7 +46,21 @@ void FixedFunctionTransformImpl::deleter(FixedFunctionTransform * t)
 
 TransformRcPtr FixedFunctionTransformImpl::createEditableCopy() const
 {
-    TransformRcPtr transform = FixedFunctionTransform::Create(getStyle());
+    TransformRcPtr transform;
+
+    const FixedFunctionOpData::Params & params = data().getParams();
+    if (params.empty())
+    {
+        transform = FixedFunctionTransform::Create(getStyle());
+    }
+    else
+    {
+        // A validation is done when creating the instance so the params are mandatory.
+        const double * values = &params[0];
+        transform = FixedFunctionTransform::Create(getStyle(), values, params.size());
+    }
+
+    // Also copy the Format Metadata if any.
     dynamic_cast<FixedFunctionTransformImpl*>(transform.get())->data() = data();
     return transform;
 }

--- a/tests/cpu/transforms/FixedFunctionTransform_tests.cpp
+++ b/tests/cpu/transforms/FixedFunctionTransform_tests.cpp
@@ -68,3 +68,21 @@ OCIO_ADD_TEST(FixedFunctionTransform, basic)
                          "FIXED_FUNCTION_ACES_GAMUTMAP_07, and "
                          "FIXED_FUNCTION_ACES_GAMUTMAP_13.");
 }
+
+OCIO_ADD_TEST(FixedFunctionTransform, createEditableCopy)
+{
+    OCIO::FixedFunctionTransformRcPtr func;
+
+    // Create an editable copy for fixed transforms without params.
+
+    OCIO_CHECK_NO_THROW(func
+        = OCIO::FixedFunctionTransform::Create(OCIO::FIXED_FUNCTION_ACES_RED_MOD_03));
+    OCIO_CHECK_NO_THROW(func->createEditableCopy());
+
+    // Create an editable copy for fixed transforms with params.
+
+    constexpr double values[1] = { 1. };
+    OCIO_CHECK_NO_THROW(func
+        = OCIO::FixedFunctionTransform::Create(OCIO::FIXED_FUNCTION_REC2100_SURROUND, &values[0], 1));
+    OCIO_CHECK_NO_THROW(func->createEditableCopy());
+}


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

The pull request fixes a major bug with the `FixedFunctionTransform` transform. When using the `FixedFunctionTransform::CreateEditableCopy()` method for a style with mandatory params it was throwing. The problem was that it created a transform with the style only, validating the instance and only after adding the params.

The code now creates an instance with the style and params (when needed) so the validation always succeeds. I've added a unit test to validate the behavior.