### PR TITLE
Adsk Contrib - Fix a bug with the Vc++ compilation flags.

### DIFF
--- a/share/cmake/utils/CompilerFlags.cmake
+++ b/share/cmake/utils/CompilerFlags.cmake
@@ -22,10 +22,12 @@ if(USE_MSVC)
         )
     endif()
 
+    # Explicitely specify the default warning level i.e. /W3.
+    # Note: Do not use /Wall (i.e. /W4) which adds 'informational' warnings.
+    set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /W3")
+
     if(OCIO_WARNING_AS_ERROR)
         set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /WX")
-    else()
-        set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /Wall")
     endif()
 
 elseif(USE_CLANG)


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

The MSVC warning level was only enabled when the cmake flag warning as error was off and, the level 4 is inappropriate for existing projects as it contains lot of informational warnings. So, the code fixes the bug, set the warning level to 3 (which is the default one i.e. production quality level), and explains why level 4 is not used.

Note: The level 4 is recommended for new projects; otherwise, it could represent lot of work to fix all these warnings (even for OpenColorIO). Some warnings are related to method automatically inlined or not, structure packing, etc. Refer to the MSVC documentation for details about `/W4` included warnings.