### PR TITLE
Adsk Contrib - Fix the static library name on Windows

### DIFF
--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -196,6 +196,8 @@ if(BUILD_SHARED_LIBS AND WIN32)
         ${OCIO_LIBNAME_SUFFIX}_${OpenColorIO_VERSION_MAJOR}_${OpenColorIO_VERSION_MINOR}
     )
 
+    set(CMAKE_SHARED_LIBRARY_SUFFIX ${OCIO_LIBNAME_SUFFIX}.dll)
+
     # Create the version.rc file for the Windows DLL.
     configure_file(res/version.rc.in ${CMAKE_CURRENT_BINARY_DIR}/version.rc @ONLY)
     set(SOURCES ${SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
@@ -270,7 +272,7 @@ if(WIN32)
 endif()
 
 set_target_properties(OpenColorIO PROPERTIES
-    OUTPUT_NAME   ${PROJECT_NAME}${OCIO_LIBNAME_SUFFIX}
+    OUTPUT_NAME   ${PROJECT_NAME}
     COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}"
     VERSION       ${OpenColorIO_VERSION}
     SOVERSION     ${SOVERSION}


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

The pull request fixes the static library name (when compiling a shared dynamic library i.e. dll) on Windows. The library name must not be versioned (only the shared library name must be).

Refer to #1448 for details.