### PR TITLE
Adsk Contrib - Fix the processor creation using a DisplayViewTransform with a no-op look

### DIFF
--- a/tests/cpu/apphelpers/DisplayViewHelpers_tests.cpp
+++ b/tests/cpu/apphelpers/DisplayViewHelpers_tests.cpp
@@ -116,6 +116,7 @@ OCIO_ADD_TEST(DisplayViewHelpers, basic)
                                                            "lin_1", "DISP_1", "VIEW_5",
                                                            OCIO::ConstMatrixTransformRcPtr(),
                                                            OCIO::TRANSFORM_DIR_FORWARD));
+    OCIO_REQUIRE_ASSERT(processor);
 
     OCIO::GroupTransformRcPtr groupTransform;
     OCIO_CHECK_NO_THROW(groupTransform = processor->createGroupTransform());

--- a/tests/testutils/UnitTest.cpp
+++ b/tests/testutils/UnitTest.cpp
@@ -137,7 +137,7 @@ int UnitTestMain(int argc, const char ** argv)
             name.resize(maxCharToDisplay);
         }
 
-        std::cerr << "[" << std::right << std::setw(3)
+        std::cerr << "[" << std::right << std::setw(4)
                   << (index+1) << "/" << numTests << "] ["
                   << std::left << std::setw(maxCharToDisplay+1)
                   << name << "] - "


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

The pull request fixes the creation of a processor for a (display, view) color transformation when the look part exists but that's a no-op as explained in #1457.

The problem was that the original code optimized the list of ops when the look is a no-op leaving a variable (i.e `currentColorSpace`) uninitialized for the inverse computation. The forward computation was right because the variable is initialized before calling `RunLookTokens()`. The solution consists to differ the optimization of the list of ops to the optimization step because the look and its process space are both valid so, let the code adds the list of ops (even an empty one). By doing so, it correctly sets the variable. 

Note that the former code was also removing the process space ops when the look was a no-op. The new code keeps it but the optimization will latter combine the forward and reverse process space computation as highlighted by the second case of the new unit test.
