### PR TITLE
Adsk Contrib - Update the macOS minimal version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,11 @@ set(CMAKE_WARN_DEPRECATED ON)
 
 
 if(APPLE AND NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
+    # When not specified, use the VFX Reference Platform recommendation.
+    #
     # The value of this variable should be set prior to the first project() command invocation
     # because it may influence configuration of the toolchain and flags.
-    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X deployment version")
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum OS X deployment version")
 endif()
 
 


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

To follow the `CY2022 DRAFT` recommendations from the VFX Reference platform, we need to update the macOS minimal version to `10.15`.

Even if that's the new recommendation it could be in `2.1.1` if time is missing to merge it.