### PR TITLE
Adsk Contrib - Update the CTF & config version support

### DIFF
--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -233,7 +233,7 @@ static constexpr unsigned LastSupportedMajorVersion = OCIO_VERSION_MAJOR;
 
 // For each major version keep the most recent minor.
 static const unsigned int LastSupportedMinorVersion[] = {0, // Version 1
-                                                         0  // Version 2
+                                                         1  // Version 2
                                                          };
 
 } // namespace
@@ -4504,11 +4504,18 @@ void Config::Impl::checkVersionConsistency(ConstTransformRcPtr & transform) cons
 {
     if (transform)
     {
-        if (ConstBuiltinTransformRcPtr ex = DynamicPtrCast<const BuiltinTransform>(transform))
+        if (ConstBuiltinTransformRcPtr blt = DynamicPtrCast<const BuiltinTransform>(transform))
         {
             if (m_majorVersion < 2)
             {
                 throw Exception("Only config version 2 (or higher) can have BuiltinInTransform.");
+            }
+
+            if (m_majorVersion == 2 && m_minorVersion < 1
+                    && 0 == Platform::Strcasecmp(blt->getStyle(), "ACES-LMT - ACES 1.3 Reference Gamut Compression"))
+            {
+                throw Exception("Only config version 2.1 (or higher) can have "
+                                "BuiltinTransform style 'ACES-LMT - ACES 1.3 Reference Gamut Compression'.");
             }
         }
         else if (ConstCDLTransformRcPtr cdl = DynamicPtrCast<const CDLTransform>(transform))
@@ -4516,7 +4523,7 @@ void Config::Impl::checkVersionConsistency(ConstTransformRcPtr & transform) cons
             if (m_majorVersion < 2 && cdl->getStyle() != CDL_TRANSFORM_DEFAULT)
             {
                 throw Exception("Only config version 2 (or higher) can have style for "
-                               "CDLTransform.");
+                                "CDLTransform.");
             }
         }
         else if (DynamicPtrCast<const DisplayViewTransform>(transform))
@@ -4569,12 +4576,18 @@ void Config::Impl::checkVersionConsistency(ConstTransformRcPtr & transform) cons
                 }
             }
         }
-        else if (DynamicPtrCast<const FixedFunctionTransform>(transform))
+        else if (ConstFixedFunctionTransformRcPtr ff = DynamicPtrCast<const FixedFunctionTransform>(transform))
         {
             if (m_majorVersion < 2)
             {
                 throw Exception("Only config version 2 (or higher) can have "
                                 "FixedFunctionTransform.");
+            }
+
+            if (m_majorVersion == 2 && m_minorVersion < 1 && ff->getStyle() == FIXED_FUNCTION_ACES_GAMUT_COMP_13)
+            {
+                throw Exception("Only config version 2.1 (or higher) can have "
+                                "FixedFunctionTransform style 'ACES_GAMUT_COMP_13'.");
             }
         }
         else if (DynamicPtrCast<const GradingPrimaryTransform>(transform))

--- a/src/OpenColorIO/fileformats/ctf/CTFTransform.cpp
+++ b/src/OpenColorIO/fileformats/ctf/CTFTransform.cpp
@@ -245,6 +245,19 @@ CTFVersion GetOpMinimumVersion(const ConstOpDataRcPtr & op)
         break;
     }
     case OpData::FixedFunctionType:
+    {
+        minVersion = CTF_PROCESS_LIST_VERSION_2_0;
+
+        auto ff = OCIO_DYNAMIC_POINTER_CAST<const FixedFunctionOpData>(op);
+        
+        if (ff->getStyle() == FixedFunctionOpData::ACES_GAMUT_COMP_13_FWD 
+                || ff->getStyle() == FixedFunctionOpData::ACES_GAMUT_COMP_13_INV)
+        {
+            minVersion = CTF_PROCESS_LIST_VERSION_2_1;
+        }
+
+        break;
+    }
     case OpData::GradingPrimaryType:
     case OpData::GradingRGBCurveType:
     case OpData::GradingToneType:

--- a/src/OpenColorIO/fileformats/ctf/CTFTransform.h
+++ b/src/OpenColorIO/fileformats/ctf/CTFTransform.h
@@ -109,12 +109,15 @@ static const CTFVersion CTF_PROCESS_LIST_VERSION_1_7 = CTFVersion(1, 7);
 // Version 1.8 2017-10 adds Function op as a valid element in CTF files.
 static const CTFVersion CTF_PROCESS_LIST_VERSION_1_8 = CTFVersion(1, 8);
 
-// TODO: Version 2.0 (TBD) sync with OCIO and incorporate CLF v3 changes.
+// Version 2.0 sync with OCIO and incorporate CLF v3 changes.
 static const CTFVersion CTF_PROCESS_LIST_VERSION_2_0 = CTFVersion(2, 0);
+
+// Version 2.1 2021-08 adds the 'FIXED_FUNCTION_ACES_GAMUT_COMP_13' style to FixedFunctionOp.
+static const CTFVersion CTF_PROCESS_LIST_VERSION_2_1 = CTFVersion(2, 1);
 
 // Add new version before this line
 // and do not forget to update the following line.
-static const CTFVersion CTF_PROCESS_LIST_VERSION = CTF_PROCESS_LIST_VERSION_2_0;
+static const CTFVersion CTF_PROCESS_LIST_VERSION = CTF_PROCESS_LIST_VERSION_2_1;
 
 
 // Version 1.0 initial Autodesk version for InfoElt.

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -361,7 +361,7 @@ OCIO_ADD_TEST(Config, serialize_group_transform)
     config->serialize(os);
 
     std::string PROFILE_OUT =
-    "ocio_profile_version: 2\n"
+    "ocio_profile_version: 2.1\n"
     "\n"
     "environment:\n"
     "  {}\n"
@@ -434,7 +434,7 @@ OCIO_ADD_TEST(Config, serialize_searchpath)
         config->serialize(os);
 
         std::string PROFILE_OUT =
-            "ocio_profile_version: 2\n"
+            "ocio_profile_version: 2.1\n"
             "\n"
             "environment:\n"
             "  {}\n"
@@ -1675,14 +1675,14 @@ OCIO_ADD_TEST(Config, version)
     }
 
     {
-        OCIO_CHECK_THROW_WHAT(config->setVersion(2, 1), OCIO::Exception,
-                              "The minor version 1 is not supported for major version 2. "
-                              "Maximum minor version is 0");
+        OCIO_CHECK_THROW_WHAT(config->setVersion(2, 2), OCIO::Exception,
+                              "The minor version 2 is not supported for major version 2. "
+                              "Maximum minor version is 1");
 
         OCIO_CHECK_NO_THROW(config->setMajorVersion(2));
-        OCIO_CHECK_THROW_WHAT(config->setMinorVersion(1), OCIO::Exception,
-                              "The minor version 1 is not supported for major version 2. "
-                              "Maximum minor version is 0");
+        OCIO_CHECK_THROW_WHAT(config->setMinorVersion(2), OCIO::Exception,
+                              "The minor version 2 is not supported for major version 2. "
+                              "Maximum minor version is 1");
     }
 
     {
@@ -1714,9 +1714,9 @@ OCIO_ADD_TEST(Config, version_validation)
 
     {
         std::istringstream is;
-        is.str("ocio_profile_version: 2.1\n" + SIMPLE_PROFILE_END);
+        is.str("ocio_profile_version: 2.2\n" + SIMPLE_PROFILE_END);
         OCIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(is), OCIO::Exception,
-                              "The minor version 1 is not supported for major version 2");
+                              "The minor version 2 is not supported for major version 2");
     }
 
     {
@@ -1763,6 +1763,12 @@ const std::string PROFILE_V1 =
 
 const std::string PROFILE_V2 =
     "ocio_profile_version: 2\n"
+    "\n"
+    "environment:\n"
+    "  {}\n";
+
+const std::string PROFILE_V21 =
+    "ocio_profile_version: 2.1\n"
     "\n"
     "environment:\n"
     "  {}\n";
@@ -1859,6 +1865,9 @@ const std::string DEFAULT_RULES =
 
 const std::string PROFILE_V2_START = PROFILE_V2 + SIMPLE_PROFILE_A +
                                      DEFAULT_RULES + SIMPLE_PROFILE_B_V2;
+
+const std::string PROFILE_V21_START = PROFILE_V21 + SIMPLE_PROFILE_A +
+                                      DEFAULT_RULES + SIMPLE_PROFILE_B_V2;
 }
 
 OCIO_ADD_TEST(Config, serialize_colorspace_displayview_transforms)
@@ -4359,8 +4368,6 @@ OCIO_ADD_TEST(Config, fixed_function_serialization)
             "        - !<FixedFunctionTransform> {style: ACES_Glow10, direction: inverse}\n"
             "        - !<FixedFunctionTransform> {style: ACES_DarkToDim10}\n"
             "        - !<FixedFunctionTransform> {style: ACES_DarkToDim10, direction: inverse}\n"
-            "        - !<FixedFunctionTransform> {style: ACES_GamutComp13, params: [1.147, 1.264, 1.312, 0.815, 0.803, 0.88, 1.2]}\n"
-            "        - !<FixedFunctionTransform> {style: ACES_GamutComp13, params: [1.147, 1.264, 1.312, 0.815, 0.803, 0.88, 1.2], direction: inverse}\n"
             "        - !<FixedFunctionTransform> {style: REC2100_Surround, params: [0.75]}\n"
             "        - !<FixedFunctionTransform> {style: REC2100_Surround, params: [0.75], direction: inverse}\n"
             "        - !<FixedFunctionTransform> {style: RGB_TO_HSV}\n"
@@ -4392,6 +4399,46 @@ OCIO_ADD_TEST(Config, fixed_function_serialization)
         const std::string strEnd =
             "    from_scene_reference: !<GroupTransform>\n"
             "      children:\n"
+            "        - !<FixedFunctionTransform> {style: ACES_GamutComp13, params: [1.147, 1.264, 1.312, 0.815, 0.803, 0.88, 1.2]}\n"
+            "        - !<FixedFunctionTransform> {style: ACES_GamutComp13, params: [1.147, 1.264, 1.312, 0.815, 0.803, 0.88, 1.2], direction: inverse}\n";
+
+        const std::string str = PROFILE_V21_START + strEnd;
+
+        std::istringstream is;
+        is.str(str);
+
+        OCIO::ConstConfigRcPtr config;
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->validate());
+
+        // Write the config.
+
+        std::stringstream ss;
+        OCIO_CHECK_NO_THROW(ss << *config.get());
+        OCIO_CHECK_EQUAL(ss.str(), str);
+    }
+
+    {
+        const std::string strEnd =
+            "    from_scene_reference: !<GroupTransform>\n"
+            "      children:\n"
+            "        - !<FixedFunctionTransform> {style: ACES_GamutComp13, params: [1.147, 1.264, 1.312, 0.815, 0.803, 0.88, 1.2]}\n"
+            "        - !<FixedFunctionTransform> {style: ACES_GamutComp13, params: [1.147, 1.264, 1.312, 0.815, 0.803, 0.88, 1.2], direction: inverse}\n";
+
+        const std::string str = PROFILE_V2_START + strEnd;
+
+        std::istringstream is;
+        is.str(str);
+
+        OCIO::ConstConfigRcPtr config;
+        OCIO_CHECK_THROW_WHAT(config = OCIO::Config::CreateFromStream(is), OCIO::Exception,
+            "Only config version 2.1 (or higher) can have FixedFunctionTransform style 'ACES_GAMUT_COMP_13'.");
+    }
+
+    {
+        const std::string strEnd =
+            "    from_scene_reference: !<GroupTransform>\n"
+            "      children:\n"
             "        - !<FixedFunctionTransform> {style: ACES_DarkToDim10, params: [0.75]}\n";
 
         const std::string str = PROFILE_V2_START + strEnd;
@@ -4412,6 +4459,22 @@ OCIO_ADD_TEST(Config, fixed_function_serialization)
             "        - !<FixedFunctionTransform> {style: ACES_GamutComp13}\n";
 
         const std::string str = PROFILE_V2_START + strEnd;
+
+        std::istringstream is;
+        is.str(str);
+
+        OCIO::ConstConfigRcPtr config;
+        OCIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(is), OCIO::Exception,
+            "Only config version 2.1 (or higher) can have FixedFunctionTransform style 'ACES_GAMUT_COMP_13'.");
+    }
+
+    {
+        const std::string strEnd =
+            "    from_scene_reference: !<GroupTransform>\n"
+            "      children:\n"
+            "        - !<FixedFunctionTransform> {style: ACES_GamutComp13}\n";
+
+        const std::string str = PROFILE_V21_START + strEnd;
 
         std::istringstream is;
         is.str(str);
@@ -5966,7 +6029,7 @@ OCIO_ADD_TEST(Config, display_view)
 
     std::stringstream os;
     os << *config.get();
-    constexpr char expected[]{ R"(ocio_profile_version: 2
+    constexpr char expected[]{ R"(ocio_profile_version: 2.1
 
 environment:
   {}

--- a/tests/cpu/fileformats/FileFormatCTF_tests.cpp
+++ b/tests/cpu/fileformats/FileFormatCTF_tests.cpp
@@ -6317,7 +6317,7 @@ OCIO_ADD_TEST(CTFTransform, fixed_function_aces_gamut_comp_13_ctf)
     OCIO_CHECK_NO_THROW(WriteGroupCTF(group, outputTransform));
 
     const std::string expected{ R"(<?xml version="1.0" encoding="UTF-8"?>
-<ProcessList version="2" id="UIDFF42">
+<ProcessList version="2.1" id="UIDFF42">
     <FixedFunction inBitDepth="32f" outBitDepth="32f" style="GamutComp13Fwd" params="1.147 1.264 1.312 0.815 0.803 0.88 1.2">
     </FixedFunction>
 </ProcessList>
@@ -6342,7 +6342,7 @@ OCIO_ADD_TEST(CTFTransform, fixed_function_aces_gamut_comp_13_inverse_ctf)
     OCIO_CHECK_NO_THROW(WriteGroupCTF(group, outputTransform));
 
     const std::string expected{ R"(<?xml version="1.0" encoding="UTF-8"?>
-<ProcessList version="2" id="UIDFF42">
+<ProcessList version="2.1" id="UIDFF42">
     <FixedFunction inBitDepth="32f" outBitDepth="32f" style="GamutComp13Rev" params="1.147 1.264 1.312 0.815 0.803 0.88 1.2">
     </FixedFunction>
 </ProcessList>

--- a/tests/cpu/transforms/builtins/BuiltinTransformRegistry_tests.cpp
+++ b/tests/cpu/transforms/builtins/BuiltinTransformRegistry_tests.cpp
@@ -92,9 +92,11 @@ OCIO_ADD_TEST(Builtins, aces)
 
 OCIO_ADD_TEST(Builtins, read_write)
 {
+    // The unit test validates the read/write and the processor creation for all the existing
+    // builtin transforms.
 
     static constexpr char CONFIG_BUILTIN_TRANSFORMS[] {
-R"(ocio_profile_version: 2
+R"(ocio_profile_version: 2.1
 
 environment:
   {}
@@ -142,6 +144,8 @@ colorspaces:
     std::string configStr;
     configStr += CONFIG_BUILTIN_TRANSFORMS;
 
+    // Add all the existing builtin transforms.
+
     const size_t numBuiltins = reg->getNumBuiltins();
     for (size_t idx = 0; idx < numBuiltins; ++idx)
     {
@@ -177,3 +181,83 @@ colorspaces:
         OCIO_CHECK_NO_THROW(processor = config->getProcessor("ref", "test"));
     }
 }
+
+OCIO_ADD_TEST(Builtins, version_1_validation)
+{
+    // The unit test validates that the config reader throws for version 1 configs containing
+    // a builtin transform.
+
+    static constexpr char CONFIG[] {
+R"(ocio_profile_version: 1
+
+search_path: ""
+strictparsing: true
+luma: [0.2126, 0.7152, 0.0722]
+
+roles:
+  default: ref
+
+displays:
+  Disp1:
+    - !<View> {name: View1, colorspace: test}
+
+colorspaces:
+  - !<ColorSpace>
+    name: ref
+
+  - !<ColorSpace>
+    name: test
+    to_reference: !<BuiltinTransform> {style: ACEScct_to_ACES2065-1})" };
+
+    std::istringstream iss;
+    iss.str(CONFIG);
+
+    OCIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(iss),
+                          OCIO::Exception,
+                          "Only config version 2 (or higher) can have BuiltinInTransform.");
+}
+
+OCIO_ADD_TEST(Builtins, version_2_validation)
+{
+    // The unit test validates that the config reader throws for version 2 configs containing
+    // a builtin transform with the style 'ACES-LMT - ACES 1.3 Reference Gamut Compression'.
+
+    static constexpr char CONFIG[] {
+R"(ocio_profile_version: 2
+
+environment:
+  {}
+search_path: ""
+strictparsing: true
+luma: [0.2126, 0.7152, 0.0722]
+
+roles:
+  default: ref
+
+file_rules:
+  - !<Rule> {name: Default, colorspace: default}
+
+displays:
+  Disp1:
+    - !<View> {name: View1, colorspace: test}
+
+active_displays: []
+active_views: []
+
+colorspaces:
+  - !<ColorSpace>
+    name: ref
+
+  - !<ColorSpace>
+    name: test
+    from_scene_reference: !<BuiltinTransform> {style: ACES-LMT - ACES 1.3 Reference Gamut Compression})" };
+
+    std::istringstream iss;
+    iss.str(CONFIG);
+
+    OCIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(iss),
+                          OCIO::Exception,
+                          "Only config version 2.1 (or higher) can have BuiltinTransform style "\
+                          "'ACES-LMT - ACES 1.3 Reference Gamut Compression'.");
+}
+


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

The pull request implements the issue #1429.

The OpenColorIO version 2.1 adds a new `Gamut Compression` algorithm accessible through a fixed function transform and a builtin transform (refer to the pull request #1404 and the issue #1402 for details) so, the config version must now be changed to `2.1`.

A side-effect is also to update the CTF file format version update to handle the new transforms. 