### PR TITLE
Adsk Contrib - Better manage Imath dependency

### DIFF
--- a/share/cmake/modules/FindOpenImageIO.cmake
+++ b/share/cmake/modules/FindOpenImageIO.cmake
@@ -59,6 +59,10 @@ find_library ( OPENIMAGEIO_LIBRARY
                NAMES OpenImageIO${OIIO_LIBNAME_SUFFIX}
                HINTS ${OPENIMAGEIO_ROOT_DIR}
                PATH_SUFFIXES lib64 lib )
+find_library ( OPENIMAGEIO_UTIL_LIBRARY
+               NAMES OpenImageIO${OIIO_LIBNAME_SUFFIX}_Util
+               HINTS ${OPENIMAGEIO_ROOT_DIR}
+               PATH_SUFFIXES lib64 lib )
 find_path ( OPENIMAGEIO_INCLUDE_DIR
             NAMES OpenImageIO/imageio.h
             HINTS ${OPENIMAGEIO_ROOT_DIR} )
@@ -112,6 +116,13 @@ if (OpenImageIO_FOUND)
 
         set_property(TARGET OpenImageIO::OpenImageIO APPEND PROPERTY
             IMPORTED_LOCATION "${OPENIMAGEIO_LIBRARIES}")
+    endif ()
+
+    if (NOT TARGET OpenImageIO::OpenImageIO_Util AND EXISTS "${OPENIMAGEIO_UTIL_LIBRARY}")
+        add_library(OpenImageIO::OpenImageIO_Util UNKNOWN IMPORTED)
+        set_target_properties(OpenImageIO::OpenImageIO_Util PROPERTIES
+            IMPORTED_LOCATION "${OPENIMAGEIO_UTIL_LIBRARY}")
+        target_link_libraries(OpenImageIO::OpenImageIO INTERFACE OpenImageIO::OpenImageIO_Util)
     endif ()
 
     if (NOT TARGET OpenImageIO::oiiotool AND EXISTS "${OIIOTOOL_BIN}")

--- a/share/cmake/modules/FindOpenImageIO.cmake
+++ b/share/cmake/modules/FindOpenImageIO.cmake
@@ -60,7 +60,7 @@ find_library ( OPENIMAGEIO_LIBRARY
                HINTS ${OPENIMAGEIO_ROOT_DIR}
                PATH_SUFFIXES lib64 lib )
 find_library ( OPENIMAGEIO_UTIL_LIBRARY
-               NAMES OpenImageIO${OIIO_LIBNAME_SUFFIX}_Util
+               NAMES OpenImageIO_Util${OIIO_LIBNAME_SUFFIX}
                HINTS ${OPENIMAGEIO_ROOT_DIR}
                PATH_SUFFIXES lib64 lib )
 find_path ( OPENIMAGEIO_INCLUDE_DIR

--- a/src/apps/ocioconvert/CMakeLists.txt
+++ b/src/apps/ocioconvert/CMakeLists.txt
@@ -27,7 +27,6 @@ set_target_properties(ocioconvert PROPERTIES
 target_link_libraries(ocioconvert
     PRIVATE
         apputils
-        ${OCIO_HALF_LIB}
         ${OCIO_GL_LIB}
         oiiohelpers
         OpenColorIO

--- a/src/apps/ocioconvert/main.cpp
+++ b/src/apps/ocioconvert/main.cpp
@@ -13,6 +13,16 @@ namespace OCIO = OCIO_NAMESPACE;
 
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/typedesc.h>
+
+// Take the half.h the same way OpenImageIO takes it i.e. do not use the Imath/OpenEXR one from
+// OpenColorIO to avoid version clashes between OpenColorIO & OpenImageIO libraries. For example,
+// OpenColorIO uses Imath 3.1.x but OpenImageIO (from the system) is using Imath 3.0.x which
+// breaks the OpenColorIO compilation.
+#if (OIIO_VERSION >= 20200)
+#   include <OpenImageIO/Imath.h>
+#else
+#   include <OpenEXR/half.h>
+#endif
 #if (OIIO_VERSION < 10100)
 namespace OIIO = OIIO_NAMESPACE;
 #endif
@@ -24,7 +34,6 @@ namespace OIIO = OIIO_NAMESPACE;
 #endif // OCIO_GPU_ENABLED
 
 #include "oiiohelpers.h"
-#include "utils/Half.h"
 
 
 // Array of non OpenColorIO arguments.

--- a/src/apps/ocioperf/CMakeLists.txt
+++ b/src/apps/ocioperf/CMakeLists.txt
@@ -20,7 +20,6 @@ set_target_properties(ocioperf PROPERTIES
 target_link_libraries(ocioperf
     PRIVATE
         apputils
-        ${OCIO_HALF_LIB}
         oiiohelpers
         OpenColorIO
         OpenImageIO::OpenImageIO

--- a/src/apps/ocioperf/main.cpp
+++ b/src/apps/ocioperf/main.cpp
@@ -12,7 +12,6 @@ namespace OIIO = OIIO_NAMESPACE;
 
 #include "apputils/argparse.h"
 #include "oiiohelpers.h"
-#include "utils/Half.h"
 #include "utils/StringUtils.h"
 
 

--- a/src/libutils/oiiohelpers/CMakeLists.txt
+++ b/src/libutils/oiiohelpers/CMakeLists.txt
@@ -31,7 +31,6 @@ target_link_libraries(oiiohelpers
 
     PRIVATE
         OpenColorIO
-        ${OCIO_HALF_LIB}
         utils::strings
 )
 

--- a/src/libutils/oiiohelpers/oiiohelpers.cpp
+++ b/src/libutils/oiiohelpers/oiiohelpers.cpp
@@ -6,7 +6,6 @@
 
 
 #include "oiiohelpers.h"
-#include "utils/Half.h"
 #include "utils/StringUtils.h"
 
 


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

Using `Imath` in the library could sometime conflict with the `Imath` from `OpenImageIO`. When you try on ubuntu 20.04 using the system `OpenImageIO` the compilation of `OpenColorIO` fails because of symbol clashes on `Imath` (i.e. 3.1.x from OpenColorIO 2.1.x vs. 3.0.x expected by OpenImageIO 2.1.x).

The pull request changes the code to use the OpenImageIO one for apps using OpenImageIO. I also removed some useless `Imath` dependencies.