### PR TITLE
Add support for MinGW

### DIFF
--- a/share/cmake/modules/Findyaml-cpp.cmake
+++ b/share/cmake/modules/Findyaml-cpp.cmake
@@ -60,19 +60,19 @@ if(NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL ALL)
 
         # Lib names to search for
         set(_yaml-cpp_LIB_NAMES yaml-cpp)
-        if(WIN32 AND BUILD_TYPE_DEBUG)
+        if(WIN32 AND BUILD_TYPE_DEBUG AND NOT MINGW)
             # Prefer Debug lib names (Windows only)
             list(INSERT _yaml-cpp_LIB_NAMES 0 yaml-cppd)
         endif()
 
         if(yaml-cpp_STATIC_LIBRARY)
             # Prefer static lib names
-            if(WIN32)
+            if(WIN32 AND NOT MINGW)
                 set(_yaml-cpp_LIB_SUFFIX "md")
             endif()
             set(_yaml-cpp_STATIC_LIB_NAMES 
                 "libyaml-cpp${_yaml-cpp_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}")
-            if(WIN32 AND BUILD_TYPE_DEBUG)
+            if(WIN32 AND BUILD_TYPE_DEBUG AND NOT MINGW)
                 # Prefer static Debug lib names (Windows only)
                 list(INSERT _yaml-cpp_STATIC_LIB_NAMES 0
                     "libyaml-cpp${_yaml-cpp_LIB_SUFFIX}d${CMAKE_STATIC_LIBRARY_SUFFIX}")
@@ -144,7 +144,7 @@ if(NOT yaml-cpp_FOUND)
     #set(yaml-cpp_INCLUDE_DIR "${_EXT_DIST_ROOT}/${CMAKE_INSTALL_INCLUDEDIR}")
 
     # Set the expected library name
-    if(WIN32)
+    if(WIN32 AND NOT MINGW)
         set(_yaml-cpp_LIB_SUFFIX "md")
         if(BUILD_TYPE_DEBUG)
             string(APPEND _yaml-cpp_LIB_SUFFIX "d")

--- a/src/OpenColorIO/Platform.cpp
+++ b/src/OpenColorIO/Platform.cpp
@@ -174,6 +174,12 @@ std::string CreateTempFilename(const std::string & filenameExt)
 
     // Note: Because of security issue, tmpnam could not be used.
 
+    // Note 2: MinGW doesn't define L_tmpnam_s, we need to patch it in.
+    // https://www.mail-archive.com/mingw-w64-public@lists.sourceforge.net/msg17360.html
+#if !defined(L_tmpnam_s)
+#define L_tmpnam_s L_tmpnam
+#endif
+
     char tmpFilename[L_tmpnam_s];
     if(tmpnam_s(tmpFilename))
     {


### PR DESCRIPTION
In these cases the build system doesn't add a suffix to yaml-cpp.

Additionally, the `L_tmpnam_s` define has been added only last year in MinGW. 7.3 (the last official release used by Qt 5) doesn't have it, so let's import the define from the official patch.