### PR TITLE
A few fixes and proposed changes.

### DIFF
--- a/src/OpenColorIO/Platform.h
+++ b/src/OpenColorIO/Platform.h
@@ -71,7 +71,7 @@ void AlignedFree(void * memBlock);
 // Note: Temporary files should be at some point deleted by the OS (depending of the OS
 //       and various platform specific settings). To be safe, add some code to remove
 //       the file if created.
-std::string CreateTempFilename(const std::string & filenameExt);
+std::string CreateTempFile(const std::string & filenameExt);
 
 }
 

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -60,7 +60,7 @@ function(add_ocio_test NAME SOURCES PRIVATE_INCLUDES)
     set_target_properties(${TEST_BINARY} PROPERTIES
         COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
 
-    add_test(${TEST_NAME} ${TEST_BINARY})
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_BINARY})
 endfunction(add_ocio_test)
 
 # Eventually we will factor out each test into it's own executable

--- a/tests/cpu/Platform_tests.cpp
+++ b/tests/cpu/Platform_tests.cpp
@@ -154,7 +154,17 @@ OCIO_ADD_TEST(Platform, create_temp_filename)
     std::set<std::string> uids;
     for (size_t idx=0; idx<TestMax; ++idx)
     {
-        uids.insert(OCIO::Platform::CreateTempFile(""));
+        struct FGuard
+        {
+            ~FGuard()
+            {
+                std::remove(m_filename.c_str());
+            }
+            
+            std::string m_filename;
+        } file{ OCIO::Platform::CreateTempFile("") };
+        
+        uids.insert(file.m_filename);
     }
 
     // Check that it only generates unique random strings.

--- a/tests/cpu/Platform_tests.cpp
+++ b/tests/cpu/Platform_tests.cpp
@@ -154,7 +154,7 @@ OCIO_ADD_TEST(Platform, create_temp_filename)
     std::set<std::string> uids;
     for (size_t idx=0; idx<TestMax; ++idx)
     {
-        uids.insert(OCIO::Platform::CreateTempFilename(""));
+        uids.insert(OCIO::Platform::CreateTempFile(""));
     }
 
     // Check that it only generates unique random strings.

--- a/tests/cpu/transforms/CDLTransform_tests.cpp
+++ b/tests/cpu/transforms/CDLTransform_tests.cpp
@@ -210,7 +210,7 @@ struct FileGuard
 {
     explicit FileGuard(unsigned lineNo)
     {
-        OCIO_CHECK_NO_THROW_FROM(m_filename = OCIO::Platform::CreateTempFilename(""), lineNo);
+        OCIO_CHECK_NO_THROW_FROM(m_filename = OCIO::Platform::CreateTempFile(""), lineNo);
     }
     ~FileGuard()
     {

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -50,7 +50,7 @@ target_link_libraries(test_gpu_exec
 		unittest_data
 )
 
-add_test(test_gpu test_gpu_exec)
+add_test(NAME test_gpu COMMAND test_gpu_exec)
 
 # Note: To avoid changing PATH from outside the cmake files.
 if(MSVC AND BUILD_SHARED_LIBS)

--- a/tests/osl/CMakeLists.txt
+++ b/tests/osl/CMakeLists.txt
@@ -36,7 +36,7 @@ target_link_libraries(test_osl_exec
         OpenImageIO::OpenImageIO
 )
 
-add_test(test_osl test_osl_exec)
+add_test(NAME test_osl COMMAND test_osl_exec)
 
 set_tests_properties(test_osl PROPERTIES ENVIRONMENT SHADERS_DIR=${OSL_SHADERS_DIR})
 

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -24,4 +24,4 @@ target_link_libraries(test_utils_exec
 set_target_properties(test_utils_exec PROPERTIES
     COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
 
-add_test(test_utils_exec test_utils_exec)
+add_test(NAME test_utils_exec COMMAND test_utils_exec)


### PR DESCRIPTION
* Remove starting backslash if present from temporary filename. A starting backslash mean that it is safe to create it in the current working directory.
* Use mkstemps to generate a temporary file on non-Windows systems. This function will create a temporary file with a randomized name with proper permissions.
* Rename CreateTempFilename to CreateTempFile, since mkstemps will create the file.
* Remove GenerateRandomNumber which is no longer needed.
* Fix add_test in cmake files. This notation allows it to understand that the command portion is a target and translate it to the proper executable.
* Add guard to remove temporary file in create_temp_filename test.