### PR TITLE
Use the fast_float library to parse floating-point numbers

### DIFF
--- a/share/cmake/utils/CompilerFlags.cmake
+++ b/share/cmake/utils/CompilerFlags.cmake
@@ -25,6 +25,10 @@ if(USE_MSVC)
     # Note: Do not use /Wall (i.e. /W4) which adds 'informational' warnings.
     set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /W3")
 
+    # Do enable C4701 (Potentially uninitialized local variable 'name' used), which is level 4.
+    # This is because strtoX-based from_chars leave the value variable unmodified.
+    set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /we4701")
+
     if(OCIO_WARNING_AS_ERROR)
         set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /WX")
     endif()

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -227,6 +227,7 @@ target_link_libraries(OpenColorIO
         ${OCIO_HALF_LIB}
         pystring::pystring
         sampleicc::sampleicc
+        utils::from_chars
         utils::strings
         yaml-cpp
 )

--- a/src/OpenColorIO/ParseUtils.cpp
+++ b/src/OpenColorIO/ParseUtils.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <cmath>
 #include <cstring>
 #include <iostream>
 #include <set>
@@ -11,6 +12,7 @@
 #include "ParseUtils.h"
 #include "Platform.h"
 #include "utils/StringUtils.h"
+#include "utils/NumberUtils.h"
 
 
 namespace OCIO_NAMESPACE
@@ -526,6 +528,7 @@ static constexpr int DOUBLE_DECIMALS = 16;
 std::string FloatToString(float value)
 {
     std::ostringstream pretty;
+    pretty.imbue(std::locale::classic());
     pretty.precision(FLOAT_DECIMALS);
     pretty << value;
     return pretty.str();
@@ -536,6 +539,7 @@ std::string FloatVecToString(const float * fval, unsigned int size)
     if(size<=0) return "";
 
     std::ostringstream pretty;
+    pretty.imbue(std::locale::classic());
     pretty.precision(FLOAT_DECIMALS);
     for(unsigned int i=0; i<size; ++i)
     {
@@ -550,9 +554,9 @@ bool StringToFloat(float * fval, const char * str)
 {
     if(!str) return false;
 
-    std::istringstream inputStringstream(str);
-    float x;
-    if(!(inputStringstream >> x))
+    float x = NAN;
+    const auto result = NumberUtils::from_chars(str, str + strlen(str), x);
+    if (result.ec != std::errc())
     {
         return false;
     }
@@ -567,6 +571,7 @@ bool StringToInt(int * ival, const char * str, bool failIfLeftoverChars)
     if(!ival) return false;
 
     std::istringstream i(str);
+    i.imbue(std::locale::classic());
     char c=0;
     if (!(i >> *ival) || (failIfLeftoverChars && i.get(c))) return false;
     return true;
@@ -575,6 +580,7 @@ bool StringToInt(int * ival, const char * str, bool failIfLeftoverChars)
 std::string DoubleToString(double value)
 {
     std::ostringstream pretty;
+    pretty.imbue(std::locale::classic());
     pretty.precision(DOUBLE_DECIMALS);
     pretty << value;
     return pretty.str();
@@ -585,6 +591,7 @@ std::string DoubleVecToString(const double * val, unsigned int size)
     if (size <= 0) return "";
 
     std::ostringstream pretty;
+    pretty.imbue(std::locale::classic());
     pretty.precision(DOUBLE_DECIMALS);
     for (unsigned int i = 0; i<size; ++i)
     {
@@ -601,9 +608,10 @@ bool StringVecToFloatVec(std::vector<float> &floatArray, const StringUtils::Stri
 
     for(unsigned int i=0; i<lineParts.size(); i++)
     {
-        std::istringstream inputStringstream(lineParts[i]);
-        float x;
-        if(!(inputStringstream >> x))
+        float x = NAN;
+        const char *str = lineParts[i].c_str();
+        const auto result = NumberUtils::from_chars(str, str + lineParts[i].size(), x);
+        if (result.ec != std::errc())
         {
             return false;
         }

--- a/src/OpenColorIO/fileformats/FileFormatHDL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatHDL.cpp
@@ -37,6 +37,7 @@
 #include "ParseUtils.h"
 #include "transforms/FileTransform.h"
 #include "utils/StringUtils.h"
+#include "utils/NumberUtils.h"
 
 
 namespace OCIO_NAMESPACE
@@ -182,16 +183,11 @@ readLuts(std::istream& istream,
         }
         else if(inlut)
         {
-            // StringToFloat was far slower, for 787456 values:
-            // - StringToFloat took 3879 (avg nanoseconds per value)
-            // - stdtod took 169 nanoseconds
-            char* endptr = 0;
-            float v = static_cast<float>(strtod(word.c_str(), &endptr));
+            float v{};
+            const auto result = NumberUtils::from_chars(word.c_str(), word.c_str() + word.size(), v);
 
-            if(!*endptr)
+            if (result.ec == std::errc())
             {
-                // Since each word should contain a single
-                // float value, the pointer should be null
                 lutValues[lutname].push_back(v);
             }
             else

--- a/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
@@ -16,6 +16,7 @@
 #include "pystring/pystring.h"
 #include "transforms/FileTransform.h"
 #include "utils/StringUtils.h"
+#include "utils/NumberUtils.h"
 
 
 /*
@@ -416,19 +417,18 @@ private:
             std::string size_raw = std::string(s, len);
             std::string size_clean = pystring::strip(size_raw, "'\" "); // strip quotes and space
 
-            char* endptr = 0;
-            int size_3d = static_cast<int>(strtol(size_clean.c_str(), &endptr, 10));
+            long int size_3d{};
+            
+            const auto result = NumberUtils::from_chars(size_clean.c_str(), size_clean.c_str() + size_clean.size(), size_3d);
 
-            if (*endptr)
+            if (result.ec != std::errc())
             {
-                // strtol didn't consume entire string, there was
-                // remaining data, thus did not contain a single integer
                 std::ostringstream os;
                 os << "Invalid LUT size value: '" << size_raw;
                 os << "'. Expected quoted integer";
                 pImpl->Throw(os.str().c_str());
             }
-            pImpl->m_lutSize = size_3d;
+            pImpl->m_lutSize = static_cast<int>(size_3d);
         }
         else if (pImpl->m_data)
         {

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -15,3 +15,12 @@ configure_file("Half.h.in" "Half.h" @ONLY)
 set_property(TARGET ${OCIO_HALF_LIB} APPEND PROPERTY
     INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_BINARY_DIR}/.."
 )
+
+# from_chars shim (via strtod_l)
+
+add_library(utils::from_chars INTERFACE IMPORTED GLOBAL)
+
+set_target_properties(utils::from_chars PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/.."
+)
+

--- a/src/utils/NumberUtils.h
+++ b/src/utils/NumberUtils.h
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#ifndef INCLUDED_NUMBERUTILS_H
+#define INCLUDED_NUMBERUTILS_H
+
+#if defined(_MSC_VER)
+#define really_inline __forceinline
+#else
+#define really_inline inline __attribute__((always_inline))
+#endif
+
+#include <cstdlib>
+#include <locale>
+#include <system_error>
+#include <type_traits>
+
+namespace OCIO_NAMESPACE
+{
+namespace NumberUtils
+{
+
+struct Locale
+{
+#ifdef _WIN32
+    Locale() : local(_create_locale(LC_ALL, "C"))
+    {
+    }
+    ~Locale()
+    {
+        _free_locale(local);
+    }
+    _locale_t local;
+#else
+    Locale() : local(newlocale(LC_ALL_MASK, "C", NULL))
+    {
+    }
+    ~Locale()
+    {
+        freelocale(local);
+    }
+    locale_t local;
+#endif
+};
+
+struct from_chars_result
+{
+    const char *ptr;
+    std::errc ec;
+};
+
+static const Locale loc;
+
+really_inline from_chars_result from_chars(const char *first, const char *last, double &value) noexcept
+{
+    errno = 0;
+    if (!first || !last || first == last)
+    {
+        return {first, std::errc::invalid_argument};
+    }
+
+    char * endptr = nullptr;
+
+    double
+#ifdef _WIN32
+    tempval = _strtod_l(first, &endptr, loc.local);
+#else
+    tempval = ::strtod_l(first, &endptr, loc.local);
+#endif
+
+    if (errno != 0)
+    {
+        return {first + (endptr - first), std::errc::result_out_of_range};
+    }
+    else if (endptr == first)
+    {
+        return {first, std::errc::invalid_argument};
+    }
+    else if (endptr <= last)
+    {
+        value = tempval;
+        return {first + (endptr - first), {}};
+    }
+    else
+    {
+        return {first, std::errc::argument_out_of_domain};
+    }
+}
+
+really_inline from_chars_result from_chars(const char *first, const char *last, float &value) noexcept
+{
+    errno = 0;
+    if (!first || !last || first == last)
+    {
+        return {first, std::errc::invalid_argument};
+    }
+
+    char *endptr = nullptr;
+
+    float
+#ifdef _WIN32
+    tempval = _strtof_l(first, &endptr, loc.local);
+#elif __APPLE__
+    // On OSX, strtod_l is for some reason drastically faster than strtof_l.
+    tempval = static_cast<float>(::strtod_l(first, &endptr, loc.local));
+#else
+    tempval = ::strtof_l(first, &endptr, loc.local);
+#endif
+
+    if (errno != 0)
+    {
+        return {first + (endptr - first), std::errc::result_out_of_range};
+    }
+    else if (endptr == first)
+    {
+        return {first, std::errc::invalid_argument};
+    }
+    else if (endptr <= last)
+    {
+        value = tempval;
+        return {first + (endptr - first), {}};
+    }
+    else
+    {
+        return {first, std::errc::argument_out_of_domain};
+    }
+}
+
+really_inline from_chars_result from_chars(const char *first, const char *last, long int &value) noexcept
+{
+    errno = 0;
+    if (!first || !last || first == last)
+    {
+        return {first, std::errc::invalid_argument};
+    }
+
+    char *endptr = nullptr;
+
+    long int
+#ifdef _WIN32
+    tempval = _strtol_l(first, &endptr, 0, loc.local);
+#else
+    tempval = ::strtol_l(first, &endptr, 0, loc.local);
+#endif
+
+    if (errno != 0)
+    {
+        return {first + (endptr - first), std::errc::result_out_of_range};
+    }
+    else if (endptr == first)
+    {
+        return {first, std::errc::invalid_argument};
+    }
+    else if (endptr <= last)
+    {
+        value = tempval;
+        return {first + (endptr - first), {}};
+    }
+    else
+    {
+        return {first, std::errc::argument_out_of_domain};
+    }
+}
+} // namespace NumberUtils
+} // namespace OCIO_NAMESPACE
+#endif // INCLUDED_NUMBERUTILS_H


### PR DESCRIPTION
This MR brings in the amalgamated header of [the fast_float library](https://github.com/fastfloat/fast-float), and applies it to our uses of sscanf with %f. This library is locale-free, and does not incur the performance penalty of using a thread locale RAII class.

I have also included the relevant entries to THIRD_PARTY, and added a succint Readme listing the library version and its source, in the style of sampleicc.

Fixes #297
Fixes #379
Fixes #1322
