### PR TITLE
Add support for OpenGL ES as a shading language

### DIFF
--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -445,6 +445,8 @@ enum GpuLanguage
     GPU_LANGUAGE_GLSL_1_2,          ///< OpenGL Shading Language
     GPU_LANGUAGE_GLSL_1_3,          ///< OpenGL Shading Language
     GPU_LANGUAGE_GLSL_4_0,          ///< OpenGL Shading Language
+    GPU_LANGUAGE_GLSL_ES_1_0,       ///< OpenGL ES Shading Language
+    GPU_LANGUAGE_GLSL_ES_3_0,       ///< OpenGL ES Shading Language
     GPU_LANGUAGE_HLSL_DX11,         ///< DirectX Shading Language
     LANGUAGE_OSL_1                  ///< Open Shading Language                
 };

--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -445,10 +445,10 @@ enum GpuLanguage
     GPU_LANGUAGE_GLSL_1_2,          ///< OpenGL Shading Language
     GPU_LANGUAGE_GLSL_1_3,          ///< OpenGL Shading Language
     GPU_LANGUAGE_GLSL_4_0,          ///< OpenGL Shading Language
+    GPU_LANGUAGE_HLSL_DX11,         ///< DirectX Shading Language
+    LANGUAGE_OSL_1,                 ///< Open Shading Language
     GPU_LANGUAGE_GLSL_ES_1_0,       ///< OpenGL ES Shading Language
     GPU_LANGUAGE_GLSL_ES_3_0,       ///< OpenGL ES Shading Language
-    GPU_LANGUAGE_HLSL_DX11,         ///< DirectX Shading Language
-    LANGUAGE_OSL_1                  ///< Open Shading Language                
 };
 
 enum EnvironmentMode

--- a/src/OpenColorIO/GpuShaderUtils.cpp
+++ b/src/OpenColorIO/GpuShaderUtils.cpp
@@ -44,6 +44,8 @@ std::string getVecKeyword(GpuLanguage lang)
         case GPU_LANGUAGE_GLSL_1_2:
         case GPU_LANGUAGE_GLSL_1_3:
         case GPU_LANGUAGE_GLSL_4_0:
+        case GPU_LANGUAGE_GLSL_ES_1_0:
+        case GPU_LANGUAGE_GLSL_ES_3_0:
         {
             kw << "vec" << N;
             break;
@@ -85,6 +87,8 @@ void getTexDecl(GpuLanguage lang,
         case GPU_LANGUAGE_GLSL_1_3:
         case GPU_LANGUAGE_CG:
         case GPU_LANGUAGE_GLSL_4_0:
+        case GPU_LANGUAGE_GLSL_ES_1_0:
+        case GPU_LANGUAGE_GLSL_ES_3_0:
         {
             textureDecl = "";
 
@@ -132,6 +136,15 @@ std::string getTexSample(GpuLanguage lang,
             kw << "texture" << N << "D(" << samplerName << ", " << coords << ")";
             break;
         }
+        case GPU_LANGUAGE_GLSL_ES_1_0:
+        {
+            if (N == 1) {
+                throw Exception("1D textures are unsupported by OpenGL ES.");
+            }
+
+            kw << "texture" << N << "D(" << samplerName << ", " << coords << ")";
+            break;
+        }
         case GPU_LANGUAGE_CG:
         {
             kw << "tex" << N << "D(" << samplerName << ", " << coords << ")";
@@ -144,6 +157,15 @@ std::string getTexSample(GpuLanguage lang,
         }
         case GPU_LANGUAGE_GLSL_4_0:
         {
+            kw << "texture(" << samplerName << ", " << coords << ")";
+            break;
+        }
+        case GPU_LANGUAGE_GLSL_ES_3_0:
+        {
+            if (N == 1) {
+                throw Exception("1D textures are unsupported by OpenGL ES.");
+            }
+
             kw << "texture(" << samplerName << ", " << coords << ")";
             break;
         }
@@ -299,6 +321,8 @@ std::string GpuShaderText::floatKeywordConst() const
         case GPU_LANGUAGE_GLSL_1_2:
         case GPU_LANGUAGE_GLSL_1_3:
         case GPU_LANGUAGE_GLSL_4_0:
+        case GPU_LANGUAGE_GLSL_ES_1_0:
+        case GPU_LANGUAGE_GLSL_ES_3_0:
         case GPU_LANGUAGE_HLSL_DX11:
         {
             str += "const";
@@ -404,6 +428,8 @@ void GpuShaderText::declareFloatArrayConst(const std::string & name, int size, c
         case GPU_LANGUAGE_GLSL_1_2:
         case GPU_LANGUAGE_GLSL_1_3:
         case GPU_LANGUAGE_GLSL_4_0:
+        case GPU_LANGUAGE_GLSL_ES_1_0:
+        case GPU_LANGUAGE_GLSL_ES_3_0:
         {
             nl << floatKeywordConst() << " " << name << "[" << size << "] = ";
             nl << floatKeyword() << "[" << size << "](";
@@ -455,6 +481,8 @@ void GpuShaderText::declareIntArrayConst(const std::string & name, int size, con
         case GPU_LANGUAGE_GLSL_1_2:
         case GPU_LANGUAGE_GLSL_1_3:
         case GPU_LANGUAGE_GLSL_4_0:
+        case GPU_LANGUAGE_GLSL_ES_1_0:
+        case GPU_LANGUAGE_GLSL_ES_3_0:
         {
             nl << "const " << intKeyword() << " " << name << "[" << size << "] = "
                << intKeyword() << "[" << size << "](";
@@ -798,6 +826,8 @@ std::string matrix4Mul(const T * m4x4, const std::string & vecName, GpuLanguage 
         case GPU_LANGUAGE_GLSL_1_2:
         case GPU_LANGUAGE_GLSL_1_3:
         case GPU_LANGUAGE_GLSL_4_0:
+        case GPU_LANGUAGE_GLSL_ES_1_0:
+        case GPU_LANGUAGE_GLSL_ES_3_0:
         {
             // OpenGL shader program requests a transposed matrix
             kw << "mat4(" 
@@ -858,6 +888,8 @@ std::string GpuShaderText::lerp(const std::string & x,
         case GPU_LANGUAGE_GLSL_1_2:
         case GPU_LANGUAGE_GLSL_1_3:
         case GPU_LANGUAGE_GLSL_4_0:
+        case GPU_LANGUAGE_GLSL_ES_1_0:
+        case GPU_LANGUAGE_GLSL_ES_3_0:
         {
             kw << "mix(" << x << ", " << y << ", " << a << ")";
             break;
@@ -886,6 +918,8 @@ std::string GpuShaderText::float3GreaterThan(const std::string & a,
         case GPU_LANGUAGE_GLSL_1_2:
         case GPU_LANGUAGE_GLSL_1_3:
         case GPU_LANGUAGE_GLSL_4_0:
+        case GPU_LANGUAGE_GLSL_ES_1_0:
+        case GPU_LANGUAGE_GLSL_ES_3_0:
         case GPU_LANGUAGE_CG:
         {
             kw << float3Keyword() << "(greaterThan( " << a << ", " << b << "))";
@@ -918,6 +952,8 @@ std::string GpuShaderText::float4GreaterThan(const std::string & a,
         case GPU_LANGUAGE_GLSL_1_2:
         case GPU_LANGUAGE_GLSL_1_3:
         case GPU_LANGUAGE_GLSL_4_0:
+        case GPU_LANGUAGE_GLSL_ES_1_0:
+        case GPU_LANGUAGE_GLSL_ES_3_0:
         case GPU_LANGUAGE_CG:
         {
             kw << float4Keyword() << "(greaterThan( " << a << ", " << b << "))";
@@ -960,6 +996,8 @@ std::string GpuShaderText::atan2(const std::string & y,
         case GPU_LANGUAGE_GLSL_1_2:
         case GPU_LANGUAGE_GLSL_1_3:
         case GPU_LANGUAGE_GLSL_4_0:
+        case GPU_LANGUAGE_GLSL_ES_1_0:
+        case GPU_LANGUAGE_GLSL_ES_3_0:
         {
             // note: "atan" not "atan2"
             kw << "atan(" << y << ", " << x << ")";
@@ -990,6 +1028,8 @@ std::string GpuShaderText::sign(const std::string & v) const
         case GPU_LANGUAGE_GLSL_1_2:
         case GPU_LANGUAGE_GLSL_1_3:
         case GPU_LANGUAGE_GLSL_4_0:
+        case GPU_LANGUAGE_GLSL_ES_1_0:
+        case GPU_LANGUAGE_GLSL_ES_3_0:
         case GPU_LANGUAGE_HLSL_DX11:
         {
             kw << "sign(" << v << ");";

--- a/src/OpenColorIO/ParseUtils.cpp
+++ b/src/OpenColorIO/ParseUtils.cpp
@@ -261,6 +261,8 @@ const char * GpuLanguageToString(GpuLanguage language)
         case GPU_LANGUAGE_GLSL_1_2:  return "glsl_1.2";
         case GPU_LANGUAGE_GLSL_1_3:  return "glsl_1.3";
         case GPU_LANGUAGE_GLSL_4_0:  return "glsl_4.0";
+        case GPU_LANGUAGE_GLSL_ES_1_0:  return "glsl_es_1.0";
+        case GPU_LANGUAGE_GLSL_ES_3_0:  return "glsl_es_3.0";
         case GPU_LANGUAGE_HLSL_DX11: return "hlsl_dx11";
         case LANGUAGE_OSL_1: return "osl_1";
     }
@@ -277,6 +279,8 @@ GpuLanguage GpuLanguageFromString(const char * s)
     else if(str == "glsl_1.2") return GPU_LANGUAGE_GLSL_1_2;
     else if(str == "glsl_1.3") return GPU_LANGUAGE_GLSL_1_3;
     else if(str == "glsl_4.0") return GPU_LANGUAGE_GLSL_4_0;
+    else if(str == "glsl_es_1.0") return GPU_LANGUAGE_GLSL_ES_1_0;
+    else if(str == "glsl_es_3.0") return GPU_LANGUAGE_GLSL_ES_3_0;
     else if(str == "hlsl_dx11") return GPU_LANGUAGE_HLSL_DX11;
     else if(str == "osl_1") return LANGUAGE_OSL_1;
 

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpGPU.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpGPU.cpp
@@ -201,9 +201,12 @@ void GetLut1DGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
 
     // Add the LUT code to the OCIO shader program.
 
-    if (height > 1 || lutData->isInputHalfDomain())
+    if (height > 1 || lutData->isInputHalfDomain()
+        || shaderCreator->getLanguage() == GPU_LANGUAGE_GLSL_ES_1_0
+        || shaderCreator->getLanguage() == GPU_LANGUAGE_GLSL_ES_3_0)
     {
-        // In case the 1D LUT length exceeds the 1D texture maximum length
+        // In case the 1D LUT length exceeds the 1D texture maximum length,
+        // or the language doesn't support 1D textures,
         // a 2D texture is used.
 
         {
@@ -321,7 +324,9 @@ void GetLut1DGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
         ss.newLine() << "";
     }
 
-    if (height > 1 || lutData->isInputHalfDomain())
+    if (height > 1 || lutData->isInputHalfDomain()
+        || shaderCreator->getLanguage() == GPU_LANGUAGE_GLSL_ES_1_0
+        || shaderCreator->getLanguage() == GPU_LANGUAGE_GLSL_ES_3_0)
     {
         const std::string str = name + "_computePos(" + shaderCreator->getPixelName();
 

--- a/src/bindings/python/PyTypes.cpp
+++ b/src/bindings/python/PyTypes.cpp
@@ -514,6 +514,10 @@ void bindPyTypes(py::module & m)
                DOC(PyOpenColorIO, GpuLanguage, GPU_LANGUAGE_GLSL_1_3))
         .value("GPU_LANGUAGE_GLSL_4_0", GPU_LANGUAGE_GLSL_4_0, 
                DOC(PyOpenColorIO, GpuLanguage, GPU_LANGUAGE_GLSL_4_0))
+        .value("GPU_LANGUAGE_GLSL_ES_1_0", GPU_LANGUAGE_GLSL_ES_1_0, 
+               DOC(PyOpenColorIO, GpuLanguage, GPU_LANGUAGE_GLSL_ES_1_0))
+        .value("GPU_LANGUAGE_GLSL_ES_3_0", GPU_LANGUAGE_GLSL_ES_3_0, 
+               DOC(PyOpenColorIO, GpuLanguage, GPU_LANGUAGE_GLSL_ES_3_0))
         .value("GPU_LANGUAGE_HLSL_DX11", GPU_LANGUAGE_HLSL_DX11, 
                DOC(PyOpenColorIO, GpuLanguage, GPU_LANGUAGE_HLSL_DX11))
         .export_values();

--- a/src/libutils/oglapphelpers/glsl.cpp
+++ b/src/libutils/oglapphelpers/glsl.cpp
@@ -444,25 +444,27 @@ void OpenGLBuilder::useAllUniforms()
 
 std::string OpenGLBuilder::getGLSLVersionString()
 {
-    if (m_shaderDesc->getLanguage() == GPU_LANGUAGE_GLSL_1_3)
+    switch (m_shaderDesc->getLanguage())
     {
+    case GPU_LANGUAGE_GLSL_1_2:
+        // That's the minimal version supported.
+        return "#version 120";
+    case GPU_LANGUAGE_GLSL_1_3:
         return "#version 130";
-    }
-    else if (m_shaderDesc->getLanguage() == GPU_LANGUAGE_GLSL_4_0)
-    {
+    case GPU_LANGUAGE_GLSL_4_0:
         return "#version 400 core";
-    }
-    else if (m_shaderDesc->getLanguage() == GPU_LANGUAGE_GLSL_ES_1_0)
-    {
+    case GPU_LANGUAGE_GLSL_ES_1_0:
         return "#version 100";
-    }
-    else if (m_shaderDesc->getLanguage() == GPU_LANGUAGE_GLSL_ES_3_0)
-    {
+    case GPU_LANGUAGE_GLSL_ES_3_0:
         return "#version 300 es";
+    case GPU_LANGUAGE_CG:
+    case GPU_LANGUAGE_HLSL_DX11:
+    case LANGUAGE_OSL_1:
+    default:
+        // These are all impossible in OpenGL contexts.
+        // The shader will be unusable, so let's throw
+        throw Exception("Invalid shader language for OpenGLBuilder");
     }
-
-    // That's the minimal version supported.
-    return "#version 120";
 }
 
 unsigned OpenGLBuilder::buildProgram(const std::string & clientShaderProgram)

--- a/src/libutils/oglapphelpers/glsl.cpp
+++ b/src/libutils/oglapphelpers/glsl.cpp
@@ -452,6 +452,14 @@ std::string OpenGLBuilder::getGLSLVersionString()
     {
         return "#version 400 core";
     }
+    else if (m_shaderDesc->getLanguage() == GPU_LANGUAGE_GLSL_ES_1_0)
+    {
+        return "#version 100";
+    }
+    else if (m_shaderDesc->getLanguage() == GPU_LANGUAGE_GLSL_ES_3_0)
+    {
+        return "#version 300 es";
+    }
 
     // That's the minimal version supported.
     return "#version 120";


### PR DESCRIPTION
This commit adds two new entries to `GpuLanguage`,
`GPU_LANGUAGE_GLSL_ES_1_0` and `GPU_LANGUAGE_GLSL_ES_3_0`.

The only meaningful differences w.r.t. stock OpenGL are:

- the 1D texture optimization isn't applied to ES, as they are not
  supported at all;

- the texture<N>D() calls are replaced in GLSL ES 3 by a call to
  texture().

Fixes #1486
