### PR TITLE
Fix install paths regressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ enable_testing()
 
 
 ###############################################################################
+# Provides install directory variables as defined by the GNU Coding Standards.
+include(GNUInstallDirs)
+
+
+###############################################################################
 # Forbid in-source build.
 
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})

--- a/share/cmake/utils/CompilerFlags.cmake
+++ b/share/cmake/utils/CompilerFlags.cmake
@@ -98,8 +98,8 @@ if (UNIX AND NOT CMAKE_SKIP_RPATH)
     # (i.e. a binary loading a dynamic library) and then from the current directory
     # (i.e. dynamic library loading another dynamic library).  
     if (APPLE)
-        set(CMAKE_INSTALL_RPATH "@loader_path/../lib;@loader_path")
+        set(CMAKE_INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR};@loader_path")
     else()
-        set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib;$ORIGIN")
+        set(CMAKE_INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR};$ORIGIN")
     endif()
 endif()

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -173,8 +173,6 @@ if(NOT WIN32)
 
     # Install the pkg-config file.
 
-    include(GNUInstallDirs)
-
     set(prefix ${CMAKE_INSTALL_PREFIX})
     set(exec_prefix "\${prefix}")
     set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")


### PR DESCRIPTION
Fix a regression introduced in #1471.

In some specific situations, like macOS when using system packages for most of the third party dependencies or when using `DOCIO_INSTALL_EXT_PACKAGES=NONE`, there is a possibility of reaching the `src/bindings/python/CMakeLists.txt` without `GNUInstallDirs` included. This patch make sure this module is imported from the root CMakeLists.txt and available for the whole project.

The unit test don't expose the issue, because they are installing some of the external package that have the GNUInstallDirs include in theirs Find*.cmake script.

Note that the analysis nightly script already installs the python binding in the root folder, as can be seen in today logs:
`Set runtime path of "/python3.9/site-packages/PyOpenColorIO.so" to "$ORIGIN/../..:$ORIGIN/../lib:$ORIGIN"`