### PR TITLE
Remove Python wheel workflow running on every pull request

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -47,6 +47,10 @@ jobs:
        sse=${{ matrix.use-sse }}, 
        cxx=${{ matrix.cxx-standard }}, 
        docs=${{ matrix.build-docs }}>'
+    # Avoid duplicated checks when a pull_request is opened from a local branch.
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
     runs-on: ubuntu-latest
     container:
@@ -293,6 +297,10 @@ jobs:
        cxx=${{ matrix.cxx-standard }}, 
        python=${{ matrix.python-version }}, 
        docs=${{ matrix.build-docs }}>'
+    # Avoid duplicated checks when a pull_request is opened from a local branch.
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: macos-10.15
     strategy:
       matrix:
@@ -427,6 +435,10 @@ jobs:
        cxx=${{ matrix.cxx-standard }}, 
        python=${{ matrix.python-version }}, 
        docs=${{ matrix.build-docs }}>'
+    # Avoid duplicated checks when a pull_request is opened from a local branch.
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: windows-2019
     strategy:
       matrix:

--- a/.github/workflows/wheel_workflow.yml
+++ b/.github/workflows/wheel_workflow.yml
@@ -6,15 +6,11 @@ name: Wheel
 
 on:
   push:
-    # Versioned branches and tags are ignored for OCIO <= 1.x.x
-    branches-ignore:
-      - RB-0.*
-      - RB-1.*
-      - gh-pages
-    tags-ignore:
-      - v0.*
-      - v1.*
+    # Workflow run on tags for v2 only.
+    tags:
+      - v2.*
   pull_request:
+    # Workflow run on pull_request only when related files change.
     branches-ignore:
       - RB-0.*
       - RB-1.*
@@ -22,6 +18,12 @@ on:
     tags-ignore:
       - v0.*
       - v1.*
+    paths:
+      - .github/workflows/wheel_workflow.yml
+      - pyproject.toml
+  schedule:
+    # Nightly build
+    - cron: "0 0 * * *"
 
 jobs:
   # Linux jobs run in Docker containers (manylinux), so the latest OS version
@@ -29,18 +31,8 @@ jobs:
   # environment versions to mitigate issues from OS updates, and will require
   # maintenance as OS versions are retired.
   #
-  # Notes:
-  #
-  # Documentation fails to build on manylinux2010, maybe too old
-  # doxygen ? First fail in PyColorSpaceSet for documentation
-  # referencing PyOpenColorIO (eg. __sub__). Consequence is we don't
-  # support python 2.7, alternatively build without docstrings, or
-  # fix the doxygen issue.
-  #
-  # When installing doc environment, Python package are not used as the wheel
-  # is built in it's own isolated environment, hence package are listed again
-  # in pyproject.toml.
-  #
+  # Due to documentation build failing on manylinux2010 (maybe too old doxygen
+  # version), we build on manylinux2014 image, this requires pip >= 19.3.
 
   # ---------------------------------------------------------------------------
   # Linux
@@ -67,6 +59,9 @@ jobs:
           - build: CPython 3.9 32 bits
             python: cp39-*
             arch: i686
+          - build: CPython 3.10 32 bits
+            python: cp310-*
+            arch: i686
           # -------------------------------------------------------------------
           # CPython 64 bits
           # -------------------------------------------------------------------
@@ -82,6 +77,27 @@ jobs:
           - build: CPython 3.9 64 bits
             python: cp39-*
             arch: x86_64
+          - build: CPython 3.10 64 bits
+            python: cp310-*
+            arch: x86_64
+          # -------------------------------------------------------------------
+          # CPython ARM 64 bits
+          # -------------------------------------------------------------------
+          - build: CPython 3.6 ARM 64 bits
+            python: cp36-*
+            arch: aarch64
+          - build: CPython 3.7 ARM 64 bits
+            python: cp37-*
+            arch: aarch64
+          - build: CPython 3.8 ARM 64 bits
+            python: cp38-*
+            arch: aarch64
+          - build: CPython 3.9 ARM 64 bits
+            python: cp39-*
+            arch: aarch64
+          - build: CPython 3.10 ARM 64 bits
+            python: cp310-*
+            arch: aarch64
 
     steps:
       - uses: actions/checkout@v2
@@ -91,17 +107,16 @@ jobs:
         with:
           python-version: '3.8'
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
       - name: Build wheels
-        uses: joerick/cibuildwheel@v1.12.0
+        uses: joerick/cibuildwheel@v2.1.2
         env:
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-          CIBW_BUILD_VERBOSITY: 1
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BEFORE_BUILD: share/ci/scripts/linux/yum/install_docs_env.sh
-          CIBW_TEST_REQUIRES: numpy
-          CIBW_TEST_COMMAND: python -m PyOpenColorIOTests.OpenColorIOTestSuite
 
       - uses: actions/upload-artifact@v2
         with:
@@ -117,6 +132,13 @@ jobs:
     strategy:
       matrix:
         include:
+        # Python 3.10 can be enabled when numpy ship the binary wheel (which
+        # we use during tests). Building it within GH produces the following:
+        # RuntimeError: Polyfit sanity test emitted a warning, most likely due
+        # to using a buggy Accelerate backend. If you compiled yourself, see
+        # site.cfg.example for information. Otherwise report this to the vendor
+        # that provided NumPy.
+
           # -------------------------------------------------------------------
           # CPython 64 bits
           # -------------------------------------------------------------------
@@ -132,6 +154,9 @@ jobs:
           - build: CPython 3.9 64 bits
             python: cp39-*
             arch: x86_64
+          # - build: CPython 3.10 64 bits
+          #   python: cp310-*
+          #   arch: x86_64
           # -------------------------------------------------------------------
           # CPython ARM 64 bits
           # -------------------------------------------------------------------
@@ -141,6 +166,9 @@ jobs:
           - build: CPython 3.9 ARM 64 bits
             python: cp39-*
             arch: arm64
+          # - build: CPython 3.10 ARM 64 bits
+          #   python: cp310-*
+          #   arch: arm64
 
     steps:
       - uses: actions/checkout@v2
@@ -151,14 +179,10 @@ jobs:
           python-version: '3.8'
 
       - name: Build wheels
-        uses: joerick/cibuildwheel@v1.12.0
+        uses: joerick/cibuildwheel@v2.1.2
         env:
-          CIBW_BUILD_VERBOSITY: 1
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BEFORE_BUILD: share/ci/scripts/macos/install_docs_env.sh
-          CIBW_TEST_REQUIRES: numpy
-          CIBW_TEST_COMMAND: python -m PyOpenColorIOTests.OpenColorIOTestSuite
 
       - uses: actions/upload-artifact@v2
         with:
@@ -189,6 +213,9 @@ jobs:
           - build: CPython 3.9 32 bits
             python: cp39-*
             arch: x86
+          - build: CPython 3.10 32 bits
+            python: cp310-*
+            arch: x86
           # -------------------------------------------------------------------
           # CPython 64 bits
           # -------------------------------------------------------------------
@@ -204,6 +231,9 @@ jobs:
           - build: CPython 3.9 64 bits
             python: cp39-*
             arch: AMD64
+          - build: CPython 3.10 64 bits
+            python: cp310-*
+            arch: AMD64
 
     steps:
       - uses: actions/checkout@v2
@@ -214,14 +244,10 @@ jobs:
           python-version: '3.8'
 
       - name: Build wheels
-        uses: joerick/cibuildwheel@v1.12.0
+        uses: joerick/cibuildwheel@v2.1.2
         env:
-          CIBW_BUILD_VERBOSITY: 1
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BEFORE_BUILD: bash -c share/ci/scripts/windows/install_docs_env.sh
-          CIBW_TEST_REQUIRES: numpy
-          CIBW_TEST_COMMAND: python -m PyOpenColorIOTests.OpenColorIOTestSuite
 
       - uses: actions/upload-artifact@v2
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,22 @@ requires = [
     "breathe"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+build-verbosity = "1"
+
+test-command = "python -m PyOpenColorIOTests.OpenColorIOTestSuite"
+test-requires = ["numpy"]
+
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
+manylinux-aarch64-image = "manylinux2014"
+
+[tool.cibuildwheel.linux]
+before-build = "share/ci/scripts/linux/yum/install_docs_env.sh"
+
+[tool.cibuildwheel.macos]
+before-build = "share/ci/scripts/macos/install_docs_env.sh"
+
+[tool.cibuildwheel.windows]
+before-build = "bash -c share/ci/scripts/windows/install_docs_env.sh"

--- a/src/bindings/python/PyGpuShaderDesc.cpp
+++ b/src/bindings/python/PyGpuShaderDesc.cpp
@@ -117,7 +117,7 @@ void bindPyGpuShaderDesc(py::module & m)
                               const py::buffer & values)
             {
                 py::buffer_info info = values.request();
-                ssize_t numChannels;
+                py::ssize_t numChannels;
 
                 switch (channel)
                 {
@@ -252,7 +252,7 @@ void bindPyGpuShaderDesc(py::module & m)
                 const float * values;
                 self.m_shaderDesc->getTextureValues(self.m_index, values);
             
-                ssize_t numChannels;
+                py::ssize_t numChannels;
                 switch (self.m_channel)
                 {
                 case GpuShaderDesc::TEXTURE_RED_CHANNEL:

--- a/src/bindings/python/PyUtils.cpp
+++ b/src/bindings/python/PyUtils.cpp
@@ -23,7 +23,7 @@ const std::vector<std::string> FLOAT_FORMATS = { "e", "f", "d", "g", "Ze", "Zf",
 
 } // namespace
 
-std::string formatCodeToDtypeName(const std::string & format, ssize_t numBits)
+std::string formatCodeToDtypeName(const std::string & format, py::ssize_t numBits)
 {
     std::ostringstream os;
 
@@ -85,7 +85,7 @@ py::dtype bitDepthToDtype(BitDepth bitDepth)
     return py::dtype(name);
 }
 
-ssize_t bitDepthToBytes(BitDepth bitDepth)
+py::ssize_t bitDepthToBytes(BitDepth bitDepth)
 {
     std::string name, err;
 
@@ -179,7 +179,7 @@ void checkBufferType(const py::buffer_info & info, BitDepth bitDepth)
     checkBufferType(info, bitDepthToDtype(bitDepth));
 }
 
-void checkBufferDivisible(const py::buffer_info & info, ssize_t numChannels)
+void checkBufferDivisible(const py::buffer_info & info, py::ssize_t numChannels)
 {
     if (info.size % numChannels != 0)
     {
@@ -190,7 +190,7 @@ void checkBufferDivisible(const py::buffer_info & info, ssize_t numChannels)
     }
 }
 
-void checkBufferSize(const py::buffer_info & info, ssize_t numEntries)
+void checkBufferSize(const py::buffer_info & info, py::ssize_t numEntries)
 {
     if (info.size != numEntries)
     {

--- a/src/bindings/python/PyUtils.h
+++ b/src/bindings/python/PyUtils.h
@@ -61,11 +61,11 @@ private:
 };
 
 // Convert Python buffer protocol format code to NumPy dtype name
-std::string formatCodeToDtypeName(const std::string & format, ssize_t numBits);
+std::string formatCodeToDtypeName(const std::string & format, py::ssize_t numBits);
 // Convert OCIO BitDepth to NumPy dtype
 py::dtype bitDepthToDtype(BitDepth bitDepth);
 // Convert OCIO BitDepth to data type byte count
-ssize_t bitDepthToBytes(BitDepth bitDepth);
+py::ssize_t bitDepthToBytes(BitDepth bitDepth);
 // Convert OCIO ChannelOrdering to channel count
 long chanOrderToNumChannels(ChannelOrdering chanOrder);
 
@@ -79,9 +79,9 @@ void checkBufferType(const py::buffer_info & info, const py::dtype & dt);
 // Throw if Python buffer format is incompatible with an OCIO BitDepth
 void checkBufferType(const py::buffer_info & info, BitDepth bitDepth);
 // Throw if Python buffer size is not divisible by channel count
-void checkBufferDivisible(const py::buffer_info & info, ssize_t numChannels);
+void checkBufferDivisible(const py::buffer_info & info, py::ssize_t numChannels);
 // Throw if Python buffer does not have an exact count of entries
-void checkBufferSize(const py::buffer_info & info, ssize_t numEntries);
+void checkBufferSize(const py::buffer_info & info, py::ssize_t numEntries);
 
 // Calculate 3D grid size from a packed 3D LUT buffer
 unsigned long getBufferLut3DGridSize(const py::buffer_info & info);

--- a/src/bindings/python/transforms/PyLut1DTransform.cpp
+++ b/src/bindings/python/transforms/PyLut1DTransform.cpp
@@ -113,7 +113,7 @@ void bindPyLut1DTransform(py::module & m)
                 py::gil_scoped_acquire acquire;
 
                 return py::array(py::dtype("float32"), 
-                                 { static_cast<ssize_t>(values.size()) },
+                                 { static_cast<py::ssize_t>(values.size()) },
                                  { sizeof(float) },
                                  values.data());
             })

--- a/src/bindings/python/transforms/PyLut3DTransform.cpp
+++ b/src/bindings/python/transforms/PyLut3DTransform.cpp
@@ -128,7 +128,7 @@ void bindPyLut3DTransform(py::module & m)
                 py::gil_scoped_acquire acquire;
 
                 return py::array(py::dtype("float32"), 
-                                 { static_cast<ssize_t>(values.size()) },
+                                 { static_cast<py::ssize_t>(values.size()) },
                                  { sizeof(float) },
                                  values.data());
             })

--- a/tests/python/BuiltinTransformRegistryTest.py
+++ b/tests/python/BuiltinTransformRegistryTest.py
@@ -1,7 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 
-import collections
+try:
+    from collections.abc import Iterable
+except ImportError:
+    # Python 2
+    from collections import Iterable
+
 import unittest
 
 import PyOpenColorIO as OCIO
@@ -30,7 +35,7 @@ class BuiltinTransformRegistryTest(unittest.TestCase):
 
         # Test iterator instance
         iterator = iter(self.REGISTRY)
-        self.assertIsInstance(iterator, collections.Iterable)
+        self.assertIsInstance(iterator, Iterable)
 
         # Iterator size is available
         self.assertEqual(len(iterator), len(self.REGISTRY))
@@ -59,7 +64,7 @@ class BuiltinTransformRegistryTest(unittest.TestCase):
 
         # Test iterator instance
         iterator = self.REGISTRY.getBuiltins()
-        self.assertIsInstance(iterator, collections.Iterable)
+        self.assertIsInstance(iterator, Iterable)
 
         # Iterator size is available
         self.assertEqual(len(iterator), len(self.REGISTRY))


### PR DESCRIPTION
This contains changes to the GH workflows, specifically related to Python wheels plus minor fixes:
* Wheel workflow set to be run nightly, on tags named `v2.*` and on pull request **only** when specifics files are updated, mainly the `wheel_workflow.yml` (this is why wheels check will run for this pull request),
* Adding early support for Python 3.10, this triggered some issues that were fixed related to `collections` Python module updates and the use of raw `ssize_t` failing on MSVC. macOS is not supported currently due to an issue building `numpy` (it could be bypassed by not using it but this will probably solve itself when 3.10 is released and numpy ships wheel for it),
* Adding wheels for Linux ARM 64bits, this takes up to 2hrs per wheel to build instead of the usual 10-20min so it could be removed if we feel it's not needed,
* Avoid duplicated CI workflow checks when a pull_request is opened from a local branch (however, these will still shows as 3 skipped checks in the pull request, one per OS matrix).

I'm planning to look at Analysis nightly build in a subsequent pull request.