### PR TITLE
Adsk Contrib - Change default C++ version to 14

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -55,13 +55,13 @@ jobs:
       image: aswf/ci-ocio:${{ matrix.vfx-cy }}
     strategy:
       matrix:
-        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
         include:
           # -------------------------------------------------------------------
           # VFX CY2022 (Python 3.9)
           # -------------------------------------------------------------------
           # Clang, Debug, OpenFX
-          - build: 12
+          - build: 13
             build-type: Debug
             build-shared: 'ON'
             build-docs: 'OFF'
@@ -74,7 +74,7 @@ jobs:
             compiler-desc: Clang 9
             vfx-cy: 2022
           # GCC, no SSE, OpenFX
-          - build: 11
+          - build: 12
             build-type: Release
             build-shared: 'ON'
             build-docs: 'OFF'
@@ -86,15 +86,28 @@ jobs:
             cc-compiler: gcc
             compiler-desc: GCC 9.3.1
             vfx-cy: 2022
-          # GCC, static, docs
-          - build: 10
+          # C++14, GCC, static, docs
+          - build: 11
             build-type: Release
             build-shared: 'OFF'
             build-docs: 'ON'
             build-openfx: 'OFF'
             use-sse: 'ON'
             use-openexr-half: 'OFF'
-            cxx-standard: 17
+            cxx-standard: 14
+            cxx-compiler: g++
+            cc-compiler: gcc
+            compiler-desc: GCC 9.3.1
+            vfx-cy: 2022
+          # C++11 (not supported by OSL & OIIO)
+          - build: 10
+            build-type: Release
+            build-shared: 'OFF'
+            build-docs: 'OFF'
+            build-openfx: 'OFF'
+            use-sse: 'ON'
+            use-openexr-half: 'OFF'
+            cxx-standard: 11
             cxx-compiler: g++
             cc-compiler: gcc
             compiler-desc: GCC 9.3.1
@@ -123,7 +136,7 @@ jobs:
             build-openfx: 'ON'
             use-sse: 'OFF'
             use-openexr-half: 'ON'
-            cxx-standard: 17
+            cxx-standard: 14
             cxx-compiler: clang++
             cc-compiler: clang
             compiler-desc: Clang 9
@@ -136,7 +149,7 @@ jobs:
             build-openfx: 'OFF'
             use-sse: 'ON'
             use-openexr-half: 'ON'
-            cxx-standard: 17
+            cxx-standard: 11
             cxx-compiler: g++
             cc-compiler: gcc
             compiler-desc: GCC 9.3.1
@@ -178,13 +191,13 @@ jobs:
             build-openfx: 'OFF'
             use-sse: 'ON'
             use-openexr-half: 'ON'
-            cxx-standard: 14
+            cxx-standard: 11
             cxx-compiler: g++
             cc-compiler: gcc
             compiler-desc: GCC 6.3.1
             vfx-cy: 2020
           # -------------------------------------------------------------------
-          # VFX CY2019 (Python 2.7)
+          # VFX CY2019 (C++11, Python 2.7)
           # -------------------------------------------------------------------
           # Clang, static
           - build: 3
@@ -318,7 +331,7 @@ jobs:
             use-openexr-half: 'OFF'
             cxx-standard: 11
             python-version: 3.7
-          # Debug, OpenFX
+          # C++11, Debug, OpenFX
           - build: 4
             build-type: Debug
             build-shared: 'ON'
@@ -338,7 +351,7 @@ jobs:
             use-openexr-half: 'ON'
             cxx-standard: 14
             python-version: 3.7
-          # Static, no SSE
+          # C++11, Static, no SSE
           - build: 2
             build-type: Release
             build-shared: 'OFF'
@@ -348,7 +361,7 @@ jobs:
             use-openexr-half: 'OFF'
             cxx-standard: 11
             python-version: 3.7
-          # Python 2.7
+          # C++11, Python 2.7
           - build: 1
             build-type: Release
             build-shared: 'ON'
@@ -452,7 +465,7 @@ jobs:
             use-openexr-half: 'OFF'
             cxx-standard: 11
             python-version: 3.7
-          # Debug
+          # C++11, Debug
           - build: 4
             build-type: Debug
             build-shared: 'ON'
@@ -472,7 +485,7 @@ jobs:
             use-openexr-half: 'ON'
             cxx-standard: 14
             python-version: 3.7
-          # Static, no SSE, OpenFX
+          # C++11, Static, no SSE, OpenFX
           - build: 2
             build-type: Release
             build-shared: 'OFF'
@@ -482,7 +495,7 @@ jobs:
             use-openexr-half: 'OFF'
             cxx-standard: 11
             python-version: 3.7
-          # Python 2.7
+          # C++11, Python 2.7
           - build: 1
             build-type: Release
             build-shared: 'ON'

--- a/share/cmake/utils/CppVersion.cmake
+++ b/share/cmake/utils/CppVersion.cmake
@@ -9,8 +9,8 @@ set(SUPPORTED_CXX_STANDARDS 11 14 17)
 string(REPLACE ";" ", " SUPPORTED_CXX_STANDARDS_STR "${SUPPORTED_CXX_STANDARDS}")
 
 if(NOT DEFINED CMAKE_CXX_STANDARD)
-    message(STATUS "Setting C++ version to '11' as none was specified.")
-    set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard to compile against")
+    message(STATUS "Setting C++ version to '14' as none was specified.")
+    set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard to compile against")
 elseif(NOT CMAKE_CXX_STANDARD IN_LIST SUPPORTED_CXX_STANDARDS)
     message(FATAL_ERROR 
             "CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} is unsupported. Supported standards are: ${SUPPORTED_CXX_STANDARDS_STR}.")

--- a/src/OpenColorIO/ColorSpaceSet.cpp
+++ b/src/OpenColorIO/ColorSpaceSet.cpp
@@ -35,7 +35,7 @@ public:
         return *this;
     }
 
-    bool operator== (const Impl & rhs)
+    bool operator== (const Impl & rhs) const
     {
         if (this == &rhs) return true;
 


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

As discussed at the last [TSC meeting](https://wiki.aswf.io/display/OCIO/2021-09-20), the versions of `OpenImageIO` and `OpenShadingLanguage` libraries for [CY2022](http://vfxplatform.com/) do not anymore support C++11. To avoid problem to occasional contributors and package maintainers, the default C++ version is now 14 (but CI builds still compile 11, 14, 17 to guaranty support).

I also changed a little bit the various CI builds to better cover the three supported C++ versions on all platforms for CY2022 & CY2021.