### PR TITLE
Port from master to RB-2.1 - Fix install paths regressions (#1502) 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,11 @@ enable_testing()
 
 
 ###############################################################################
+# Provides install directory variables as defined by the GNU Coding Standards.
+include(GNUInstallDirs)
+
+
+###############################################################################
 # Forbid in-source build.
 
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})

--- a/share/cmake/utils/CompilerFlags.cmake
+++ b/share/cmake/utils/CompilerFlags.cmake
@@ -98,8 +98,8 @@ if (UNIX AND NOT CMAKE_SKIP_RPATH)
     # (i.e. a binary loading a dynamic library) and then from the current directory
     # (i.e. dynamic library loading another dynamic library).  
     if (APPLE)
-        set(CMAKE_INSTALL_RPATH "@loader_path/../lib;@loader_path")
+        set(CMAKE_INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR};@loader_path")
     else()
-        set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib;$ORIGIN")
+        set(CMAKE_INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR};$ORIGIN")
     endif()
 endif()

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -173,8 +173,6 @@ if(NOT WIN32)
 
     # Install the pkg-config file.
 
-    include(GNUInstallDirs)
-
     set(prefix ${CMAKE_INSTALL_PREFIX})
     set(exec_prefix "\${prefix}")
     set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")


### PR DESCRIPTION
* Fix install directory variable for python bindings

Signed-off-by: Rémi Achard <remiachard@gmail.com>

* Remove hardcoded lib prefix in RPATH handling

Signed-off-by: Rémi Achard <remiachard@gmail.com>

Co-authored-by: Patrick Hodoul <patrick.hodoul@autodesk.com>