### PR TITLE
chore: update to new cibuildwheel location

### DIFF
--- a/.github/workflows/wheel_workflow.yml
+++ b/.github/workflows/wheel_workflow.yml
@@ -113,7 +113,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: joerick/cibuildwheel@v2.1.2
+        uses: pypa/cibuildwheel@v2.1.2
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -179,7 +179,7 @@ jobs:
           python-version: '3.8'
 
       - name: Build wheels
-        uses: joerick/cibuildwheel@v2.1.2
+        uses: pypa/cibuildwheel@v2.1.2
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -244,7 +244,7 @@ jobs:
           python-version: '3.8'
 
       - name: Build wheels
-        uses: joerick/cibuildwheel@v2.1.2
+        uses: pypa/cibuildwheel@v2.1.2
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}


### PR DESCRIPTION
Cibuildwheel is now part of the PyPA. The old name still works, but this is better, and if you use dependabot, it works better with the correct name.