### PR TITLE
Port from master to RB-2.1 - Fixes Unicode paths on Windows (#1363)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,8 @@ option(OCIO_BUILD_JAVA "Specify whether to build java bindings" OFF)
 
 option(OCIO_WARNING_AS_ERROR "Set build error level for CI testing" OFF)
 
+option(OCIO_USE_WINDOWS_UNICODE "On Windows only, compile with Unicode support" WIN32)
+
 
 ###############################################################################
 # Optimization / internal linking preferences

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -280,6 +280,15 @@ if(WIN32)
         PRIVATE
             XML_STATIC
     )
+
+    if (OCIO_USE_WINDOWS_UNICODE)
+        # Add Unicode definitions to use Unicode functions
+        target_compile_definitions(OpenColorIO
+            PRIVATE
+                UNICODE
+                _UNICODE
+        )
+    endif()
 endif()
 
 set_target_properties(OpenColorIO PROPERTIES

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -1117,7 +1117,7 @@ ConstConfigRcPtr Config::CreateFromFile(const char * filename)
         throw ExceptionMissingFile ("The config filepath is missing.");
     }
 
-    std::ifstream istream(filename);
+    std::ifstream istream = Platform::CreateInputFileStream(filename, std::ios_base::in);
     if (istream.fail())
     {
         std::ostringstream os;

--- a/src/OpenColorIO/ContextVariableUtils.cpp
+++ b/src/OpenColorIO/ContextVariableUtils.cpp
@@ -6,6 +6,7 @@
 
 #include "ContextVariableUtils.h"
 #include "utils/StringUtils.h"
+#include "Platform.h"
 
 
 #if defined(__APPLE__) && !defined(__IPHONE__)
@@ -19,6 +20,12 @@ extern char ** environ;
 namespace
 {
 
+#if defined(_WIN32) && defined(UNICODE)
+inline wchar_t ** GetEnviron()
+{
+    return _wenviron;
+}
+#else
 inline char ** GetEnviron()
 {
 #if __IPHONE__
@@ -30,6 +37,7 @@ inline char ** GetEnviron()
     return environ;
 #endif
 }
+#endif
 
 } // anon.
 
@@ -71,11 +79,28 @@ void LoadEnvironment(EnvMap & map, bool update)
 {
     // First, add or update the context variables with existing env. variables.
 
+#if defined(_WIN32) && defined(UNICODE)
+    if (GetEnviron() == NULL) {
+        // If the program starts with "main" instead of "wmain", then wenviron returns NULL until
+        // the first call to either wgetenv or wputenv. Calling wgetenv, even with an empty
+        // variable name, will populate wenviron correctly. We also use wgetenv_s (which requires
+        // a valid size pointer) to suppress safety warnings about wgetenv during the compile.
+        size_t sz;
+        _wgetenv_s(&sz, NULL, 0, L"");
+    }
+
+    for (wchar_t **env = GetEnviron(); *env != NULL; ++env)
+    {
+        // Split environment up into std::map[name] = value.
+
+        const std::string env_str = Platform::Utf16ToUtf8((wchar_t*)*env);
+#else
     for (char **env = GetEnviron(); *env != NULL; ++env)
     {
         // Split environment up into std::map[name] = value.
 
         const std::string env_str = (char*)*env;
+#endif
         const int pos = static_cast<int>(env_str.find_first_of('='));
 
         const std::string name  = env_str.substr(0, pos);

--- a/src/OpenColorIO/Platform.cpp
+++ b/src/OpenColorIO/Platform.cpp
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <codecvt>
+#include <locale>
 #include <random>
 #include <sstream>
+#include <sys/stat.h>
 #include <vector>
 
 #include <OpenColorIO/OpenColorIO.h>
@@ -49,12 +52,36 @@ bool Getenv(const char * name, std::string & value)
         return false;
     }
 
-#ifdef _WIN32
-    if(uint32_t size = GetEnvironmentVariable(name, nullptr, 0))
+#if defined(_WIN32)
+    // Define working strings, converting to UTF-16 if necessary
+#ifdef UNICODE
+    std::wstring name_str = Utf8ToUtf16(name);
+    std::wstring value_str;
+#else
+    std::string name_str = name;
+    std::string value_str;
+#endif
+
+    if(uint32_t size = GetEnvironmentVariable(name_str.c_str(), nullptr, 0))
     {
-        std::vector<char> buffer(size);
-        GetEnvironmentVariable(name, buffer.data(), size);
-        value = std::string(buffer.data());
+        value_str.resize(size);
+
+        GetEnvironmentVariable(name_str.c_str(), &value_str[0], size);
+
+        // GetEnvironmentVariable is designed for raw pointer strings and therefore requires that
+        // the destination buffer be long enough to place a null terminator at the end of it. Since
+        // we're using std::wstrings here, the null terminator is unnecessary (and causes false
+        // negatives in unit tests since the extra character makes it "non-equal" to normally
+        // defined std::wstrings). Therefore, we pop the last character off (the null terminator)
+        // to ensure that the string conforms to expectations.
+        value_str.pop_back();
+
+        // Return value, converting to UTF-8 if necessary
+#ifdef UNICODE
+        value = Utf16ToUtf8(value_str);
+#else
+        value = value_str;
+#endif
         return true;
     }
     else
@@ -81,7 +108,13 @@ void Setenv(const char * name, const std::string & value)
     // exists. To avoid the ambiguity, use Unsetenv() when the env. variable removal if needed.
 
 #ifdef _WIN32
+
+#ifdef UNICODE
+    _wputenv_s(Utf8ToUtf16(name).c_str(), Utf8ToUtf16(value).c_str());
+#else
     _putenv_s(name, value.c_str());
+#endif
+
 #else
     ::setenv(name, value.c_str(), 1);
 #endif
@@ -95,8 +128,14 @@ void Unsetenv(const char * name)
     }
 
 #ifdef _WIN32
+
+#ifdef UNICODE
     // Note that the Windows _putenv_s() removes the env. variable if the value is empty.
+    _wputenv_s(Utf8ToUtf16(name).c_str(), L"");
+#else
     _putenv_s(name, "");
+#endif
+
 #else
     ::unsetenv(name);
 #endif
@@ -201,6 +240,91 @@ std::string CreateTempFilename(const std::string & filenameExt)
     filename += filenameExt;
 
     return filename;
+}
+
+std::ifstream CreateInputFileStream(const char * filename, std::ios_base::openmode mode)
+{
+#if defined(_WIN32) && defined(UNICODE)
+    return std::ifstream(Utf8ToUtf16(filename).c_str(), mode);
+#else
+    return std::ifstream(filename, mode);
+#endif
+}
+
+void OpenInputFileStream(std::ifstream & stream, const char * filename, std::ios_base::openmode mode)
+{
+#if defined(_WIN32) && defined(UNICODE)
+    stream.open(Utf8ToUtf16(filename).c_str(), mode);
+#else
+    stream.open(filename, mode);
+#endif
+}
+
+std::wstring Utf8ToUtf16(const std::string & str)
+{
+    if (str.empty()) {
+        return std::wstring();
+    }
+
+#ifdef _WIN32
+    int sz = MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), NULL, 0);
+    std::wstring wstr(sz, 0);
+    MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), &wstr[0], sz);
+    return wstr;
+#else
+    throw Exception("Only supported by the Windows platform.");
+#endif
+}
+
+std::string Utf16ToUtf8(const std::wstring & wstr)
+{
+    if (wstr.empty()) {
+        return std::string();
+    }
+
+#ifdef _WIN32
+    int sz = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
+    std::string str(sz, 0);
+    WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &str[0], sz, NULL, NULL);
+    return str;
+#else
+    throw Exception("Only supported by the Windows platform.");
+#endif
+}
+
+// Here is the explanation of the stat() method:
+// https://pubs.opengroup.org/onlinepubs/009695299/basedefs/sys/stat.h.html
+// "The st_ino and st_dev fields taken together uniquely identify the file within the system."
+//
+// However there are limitations to the stat() support on some Windows file systems:
+// https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/stat-functions?redirectedfrom=MSDN&view=vs-2019
+// "The inode, and therefore st_ino, has no meaning in the FAT, HPFS, or NTFS file systems."
+
+// That's the default hash method implementation to compute a hash key based on a file content.
+std::string CreateFileContentHash(const std::string &filename)
+{
+#if defined(_WIN32) && defined(UNICODE)
+    struct _stat fileInfo;
+    if (_wstat(Platform::Utf8ToUtf16(filename).c_str(), &fileInfo) == 0)
+#else
+    struct stat fileInfo;
+    if (stat(filename.c_str(), &fileInfo) == 0)
+#endif
+    {
+        // Treat the st_dev (i.e. device) + st_ino (i.e. inode) as a proxy for the contents.
+
+        std::ostringstream fasthash;
+        fasthash << fileInfo.st_dev << ":";
+#ifdef _WIN32
+        // TODO: The hard-linked files are then not correctly supported on Windows platforms.
+        fasthash << std::hash<std::string>{}(filename);
+#else
+        fasthash << fileInfo.st_ino;
+#endif
+        return fasthash.str();
+    }
+
+    return "";
 }
 
 

--- a/src/OpenColorIO/Platform.h
+++ b/src/OpenColorIO/Platform.h
@@ -20,6 +20,7 @@
 #endif // _WIN32
 
 
+#include <fstream>
 #include <string>
 
 
@@ -27,6 +28,20 @@
 #ifdef _WIN32
 
 #define sscanf sscanf_s
+
+// Define std::tstring as a wstring when Unicode is enabled and a regular string otherwise
+namespace std
+{
+#ifdef _UNICODE
+typedef wstring tstring;
+typedef wostringstream tostringstream;
+#define LogDebugT(x) LogDebug(Platform::Utf16ToUtf8(x))
+#else
+typedef string tstring;
+typedef ostringstream tostringstream;
+#define LogDebugT(x) LogDebug(x)
+#endif
+}
 
 #endif // _WIN32
 
@@ -72,6 +87,21 @@ void AlignedFree(void * memBlock);
 //       and various platform specific settings). To be safe, add some code to remove
 //       the file if created.
 std::string CreateTempFilename(const std::string & filenameExt);
+
+// Create an input file stream (std::ifstream) using a UTF-8 filename on any platform.
+std::ifstream CreateInputFileStream(const char * filename, std::ios_base::openmode mode);
+
+// Open an input file stream (std::ifstream) using a UTF-8 filename on any platform.
+void OpenInputFileStream(std::ifstream & stream, const char * filename, std::ios_base::openmode mode);
+
+// Create a unique hash of a file provided as a UTF-8 filename on any platform.
+std::string CreateFileContentHash(const std::string &filename);
+
+// Convert UTF-8 string to UTF-16LE.
+std::wstring Utf8ToUtf16(const std::string & str);
+
+// Convert UTF-16LE string to UTF-8.
+std::string Utf16ToUtf8(const std::wstring & str);
 
 }
 

--- a/src/OpenColorIO/fileformats/FileFormatICC.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatICC.cpp
@@ -541,7 +541,7 @@ FileFormat * CreateFileFormatICC()
 
 std::string GetProfileDescriptionFromICCProfile(const char * ICCProfileFilepath)
 {
-    std::ifstream filestream(ICCProfileFilepath, std::ios_base::binary);
+    std::ifstream filestream = Platform::CreateInputFileStream(ICCProfileFilepath, std::ios_base::binary);
     if (!filestream.good())
     {
         std::ostringstream os;

--- a/src/OpenColorIO/transforms/FileTransform.cpp
+++ b/src/OpenColorIO/transforms/FileTransform.cpp
@@ -546,7 +546,8 @@ void LoadFileUncached(FileFormat * & returnFormat,
         try
         {
             // Open the filePath
-            filestream.open(
+            Platform::OpenInputFileStream(
+                filestream,
                 filepath.c_str(),
                 tryFormat->isBinary()
                     ? std::ios_base::binary : std::ios_base::in);
@@ -618,7 +619,8 @@ void LoadFileUncached(FileFormat * & returnFormat,
         std::ifstream filestream;
         try
         {
-            filestream.open(filepath.c_str(), altFormat->isBinary()
+            Platform::OpenInputFileStream(
+                filestream, filepath.c_str(), altFormat->isBinary()
                 ? std::ios_base::binary : std::ios_base::in);
             if (!filestream.good())
             {

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -53,6 +53,15 @@ function(add_ocio_test NAME SOURCES PRIVATE_INCLUDES)
             PRIVATE
                 XML_STATIC
         )
+
+        if (OCIO_USE_WINDOWS_UNICODE)
+            # Add Unicode definitions to use Unicode functions
+            target_compile_definitions(${TEST_BINARY}
+                PRIVATE
+                    UNICODE
+                    _UNICODE
+            )
+        endif()
     endif(WIN32)
     set_target_properties(${TEST_BINARY} PROPERTIES
         COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")

--- a/tests/cpu/Platform_tests.cpp
+++ b/tests/cpu/Platform_tests.cpp
@@ -17,17 +17,35 @@ OCIO_ADD_TEST(Platform, envVariable)
     // Only validates the public API.
     // Complete validations are done below using the private methods.
 
-    const char * path = OCIO::GetEnvVariable("PATH");
+    const char * path = OCIO::GetEnvVariable(u8"PATH");
     OCIO_CHECK_ASSERT(path && *path);
 
-    OCIO::SetEnvVariable("MY_DUMMY_ENV", "SomeValue");
-    const char * value = OCIO::GetEnvVariable("MY_DUMMY_ENV");
+    OCIO::SetEnvVariable(u8"MY_DUMMY_ENV", u8"SomeValue");
+    const char * value = OCIO::GetEnvVariable(u8"MY_DUMMY_ENV");
     OCIO_CHECK_ASSERT(value && *value);
-    OCIO_CHECK_EQUAL(std::string(value), "SomeValue");
+    OCIO_CHECK_EQUAL(std::string(value), u8"SomeValue");
 
-    OCIO::UnsetEnvVariable("MY_DUMMY_ENV");
-    value = OCIO::GetEnvVariable("MY_DUMMY_ENV");
+#ifdef _WIN32
+    // Assert that we retrieve the correct value from the Windows API too.
+    uint32_t win_env_sz = GetEnvironmentVariable(TEXT("MY_DUMMY_ENV"), NULL, 0);
+    OCIO_CHECK_NE(win_env_sz, 0);
+
+    std::tstring win_env_value(win_env_sz, 0);
+    GetEnvironmentVariable(TEXT("MY_DUMMY_ENV"), &win_env_value[0], win_env_sz);
+    win_env_value.pop_back(); // Remove null terminator that interferes with comparison
+    OCIO_CHECK_ASSERT(win_env_value == TEXT("SomeValue"));
+#endif
+
+    OCIO::UnsetEnvVariable(u8"MY_DUMMY_ENV");
+    value = OCIO::GetEnvVariable(u8"MY_DUMMY_ENV");
     OCIO_CHECK_ASSERT(!value || !*value);
+
+#ifdef _WIN32
+    // Assert that the variable has been unset from the Windows API too, which will result in
+    // GetEnvironmentVariable returning 0 and GetLastError returning ERROR_ENVVAR_NOT_FOUND.
+    OCIO_CHECK_EQUAL(GetEnvironmentVariable(TEXT("MY_DUMMY_ENV"), NULL, 0), 0);
+    OCIO_CHECK_EQUAL(GetLastError(), ERROR_ENVVAR_NOT_FOUND);
+#endif
 }
 
 OCIO_ADD_TEST(Platform, getenv)
@@ -52,6 +70,32 @@ OCIO_ADD_TEST(Platform, getenv)
 
     OCIO_CHECK_ASSERT(OCIO::Platform::Getenv("PATH", env));
     OCIO_CHECK_ASSERT(!env.empty());
+
+#ifdef _WIN32
+    // Assert that all results match in Windows API.
+
+    // Assert this variable doesn't exist, which will result in GetEnvironmentVariable returning
+    // 0 and GetLastError returning ERROR_ENVVAR_NOT_FOUND.
+    OCIO_CHECK_EQUAL(GetEnvironmentVariable(TEXT("NotExistingEnvVariable"), NULL, 0), 0);
+    OCIO_CHECK_EQUAL(GetLastError(), ERROR_ENVVAR_NOT_FOUND);
+
+    // Assert this variable does exist.
+    OCIO_CHECK_NE(GetEnvironmentVariable(TEXT("PATH"), NULL, 0), 0);
+
+    // Create a variable and test that it's retrievable through the Windows API.
+    OCIO::Platform::Setenv(u8"MY_WINDOWS_DUMMY_ENV", u8"SomeValue");
+    uint32_t win_env_sz = GetEnvironmentVariable(TEXT("MY_WINDOWS_DUMMY_ENV"), NULL, 0);
+    OCIO_CHECK_NE(win_env_sz, 0);
+
+    std::tstring win_env_value(win_env_sz, 0);
+    GetEnvironmentVariable(TEXT("MY_WINDOWS_DUMMY_ENV"), &win_env_value[0], win_env_sz);
+    win_env_value.pop_back(); // Remove null terminator that interferes with comparison
+    OCIO_CHECK_ASSERT(win_env_value == TEXT("SomeValue"));
+
+    OCIO::Platform::Unsetenv(u8"MY_WINDOWS_DUMMY_ENV");
+    OCIO_CHECK_EQUAL(GetEnvironmentVariable(TEXT("MY_WINDOWS_DUMMY_ENV"), NULL, 0), 0);
+    OCIO_CHECK_EQUAL(GetLastError(), ERROR_ENVVAR_NOT_FOUND);
+#endif
 }
 
 OCIO_ADD_TEST(Platform, setenv)
@@ -62,61 +106,61 @@ OCIO_ADD_TEST(Platform, setenv)
         Guard() = default;
         ~Guard()
         {
-            OCIO::Platform::Unsetenv("MY_DUMMY_ENV");
-            OCIO::Platform::Unsetenv("MY_WINDOWS_DUMMY_ENV");
+            OCIO::Platform::Unsetenv(u8"MY_DUMMY_ENV");
+            OCIO::Platform::Unsetenv(u8"MY_WINDOWS_DUMMY_ENV");
         }
     } guard;
 
     {
-        OCIO::Platform::Setenv("MY_DUMMY_ENV", "SomeValue");
+        OCIO::Platform::Setenv(u8"MY_DUMMY_ENV", u8"SomeValue");
         std::string env;
-        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv("MY_DUMMY_ENV", env));
+        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv(u8"MY_DUMMY_ENV", env));
         OCIO_CHECK_ASSERT(!env.empty());
 
-        OCIO_CHECK_ASSERT(0==std::strcmp("SomeValue", env.c_str()));
-        OCIO_CHECK_EQUAL(strlen("SomeValue"), env.size());
+        OCIO_CHECK_ASSERT(0==std::strcmp(u8"SomeValue", env.c_str()));
+        OCIO_CHECK_EQUAL(strlen(u8"SomeValue"), env.size());
     }
     {
-        OCIO::Platform::Setenv("MY_DUMMY_ENV", " ");
+        OCIO::Platform::Setenv(u8"MY_DUMMY_ENV", u8" ");
         std::string env;
-        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv("MY_DUMMY_ENV", env));
+        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv(u8"MY_DUMMY_ENV", env));
         OCIO_CHECK_ASSERT(!env.empty());
 
-        OCIO_CHECK_ASSERT(0==std::strcmp(" ", env.c_str()));
-        OCIO_CHECK_EQUAL(std::strlen(" "), env.size());
+        OCIO_CHECK_ASSERT(0==std::strcmp(u8" ", env.c_str()));
+        OCIO_CHECK_EQUAL(std::strlen(u8" "), env.size());
     }
     {
-        OCIO::Platform::Unsetenv("MY_DUMMY_ENV");
+        OCIO::Platform::Unsetenv(u8"MY_DUMMY_ENV");
         std::string env;
-        OCIO_CHECK_ASSERT(!OCIO::Platform::Getenv("MY_DUMMY_ENV", env));
+        OCIO_CHECK_ASSERT(!OCIO::Platform::Getenv(u8"MY_DUMMY_ENV", env));
         OCIO_CHECK_ASSERT(env.empty());
     }
 #ifdef _WIN32
     {
-        SetEnvironmentVariable("MY_WINDOWS_DUMMY_ENV", "1");
+        SetEnvironmentVariable(TEXT("MY_WINDOWS_DUMMY_ENV"), TEXT("1"));
         std::string env;
-        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv("MY_WINDOWS_DUMMY_ENV", env));
-        OCIO_CHECK_EQUAL(env, std::string("1"));
+        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv(u8"MY_WINDOWS_DUMMY_ENV", env));
+        OCIO_CHECK_EQUAL(env, std::string(u8"1"));
     }
     {
-        SetEnvironmentVariable("MY_WINDOWS_DUMMY_ENV", " ");
+        SetEnvironmentVariable(TEXT("MY_WINDOWS_DUMMY_ENV"), TEXT(" "));
         std::string env;
-        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv("MY_WINDOWS_DUMMY_ENV", env));
-        OCIO_CHECK_EQUAL(env, std::string(" "));
+        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv(u8"MY_WINDOWS_DUMMY_ENV", env));
+        OCIO_CHECK_EQUAL(env, std::string(u8" "));
     }
     {
         // Windows SetEnvironmentVariable() sets the env. variable to empty like
         // the Linux ::setenv() in contradiction with the Windows _putenv_s().
 
-        SetEnvironmentVariable("MY_WINDOWS_DUMMY_ENV", "");
+        SetEnvironmentVariable(TEXT("MY_WINDOWS_DUMMY_ENV"), TEXT(""));
         std::string env;
-        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv("MY_WINDOWS_DUMMY_ENV", env));
+        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv(u8"MY_WINDOWS_DUMMY_ENV", env));
         OCIO_CHECK_ASSERT(env.empty());
     }
     {
-        SetEnvironmentVariable("MY_WINDOWS_DUMMY_ENV", nullptr);
+        SetEnvironmentVariable(TEXT("MY_WINDOWS_DUMMY_ENV"), nullptr);
         std::string env;
-        OCIO_CHECK_ASSERT(!OCIO::Platform::Getenv("MY_WINDOWS_DUMMY_ENV", env));
+        OCIO_CHECK_ASSERT(!OCIO::Platform::Getenv(u8"MY_WINDOWS_DUMMY_ENV", env));
         OCIO_CHECK_ASSERT(env.empty());
     }
 #endif
@@ -159,4 +203,27 @@ OCIO_ADD_TEST(Platform, create_temp_filename)
 
     // Check that it only generates unique random strings.
     OCIO_CHECK_EQUAL(uids.size(), TestMax);
+}
+
+OCIO_ADD_TEST(Platform, utf8_utf16_convert)
+{
+#ifdef _WIN32
+    // Define the same string in both UTF-8 and UTF-16LE encoding:
+    // - Hiragana letter KO:        xe3, x81, x93       x3053
+    // - Hiragana letter N:         xe3, x82, x93       x3093
+    // - Hiragana letter NI:        xe3, x81, xab       x306b
+    // - Hiragana letter CHI:       xe3, x81, xa1       x3061
+    // - Hiragana letter HA/WA:     xe3, x81, xaf       x306f
+    std::string utf8_str = "\xe3\x81\x93\xe3\x82\x93\xe3\x81\xab\xe3\x81\xa1\xe3\x81\xaf";
+    std::wstring utf16_str = L"\x3053\x3093\x306b\x3061\x306f";
+
+    // Convert each string to the other encoding and assert that the result matches the other
+    std::string utf16_to_utf8 = OCIO::Platform::Utf16ToUtf8(utf16_str);
+    std::wstring utf8_to_utf16 = OCIO::Platform::Utf8ToUtf16(utf8_str);
+
+    OCIO_CHECK_EQUAL(utf16_to_utf8, utf8_str);
+
+    // wstring can't be sent to cout, so we run an assert
+    OCIO_CHECK_ASSERT(wcscmp(utf8_to_utf16.c_str(), utf16_str.c_str()) == 0);
+#endif
 }

--- a/tests/cpu/UnitTestUtils.h
+++ b/tests/cpu/UnitTestUtils.h
@@ -11,6 +11,7 @@
 
 #include "MathUtils.h"
 #include "Op.h"
+#include "Platform.h"
 #include "pystring/pystring.h"
 
 namespace OCIO_NAMESPACE
@@ -43,7 +44,7 @@ OCIO_SHARED_PTR<LocalCachedFile> LoadTestFile(
 
     // Open the filePath
     std::ifstream filestream;
-    filestream.open(filePath.c_str(), mode);
+    Platform::OpenInputFileStream(filestream, filePath.c_str(), mode);
 
     if (!filestream.is_open())
     {

--- a/vendor/aftereffects/OpenColorIO_AE_Context.cpp
+++ b/vendor/aftereffects/OpenColorIO_AE_Context.cpp
@@ -153,7 +153,7 @@ bool Path::exists() const
     if(path.empty())
         return false;
     
-    std::ifstream f( path.c_str() );
+    std::ifstream f = Platform::CreateInputFileStream( path.c_str() );
     
     return !!f;
 }


### PR DESCRIPTION
* Fixes Unicode paths on Windows

Unlike most other platforms, Windows' Unicode is standardized around
UTF-16, an encoding not compatible with "char *" arrays common in
C/C++. As such, to support Unicode correctly when using Win32 APIs,
strings must be converted to and from UTF-16 and the Unicode
versions of the APIs must be used over the ANSI versions.

This commit introduces the following:

- Utility funcions for converting between UTF-8 and UTF-16LE on all
  platforms:
  - Platform::Utf8ToUtf16
  - Platform::Utf16ToUtf8

- Adds test for these conversion functions to ensure the conversion
  to and from UTF-8 and UTF-16LE is correct.

- Utility wrappers for "std::ifstream" that automatically convert
  to and from UTF-16 so that filenames requiring Unicode encoding
  function correctly:
  - Platform::CreateInputFileStream
  - Platform::OpenInputFileStream

- Moves the file default compute hash function to the Platform
  class (Platform::CreateFileContentHash) and switches to the
  Win32 UTF-16 variant on Windows.

- Adds the "UNICODE" macro before including "Windows.h" which
  ensures all functions called are the Unicode variants instead of
  the default ANSI variants.
  - Implicitly changes functions such as GetEnvironmentVariable and
    SetEnvironmentVariable to their Unicode variants.

- Changes the following environment variable related functions to
  their Win32 Unicode variants on Windows:
  - environ -> _wenviron
  - _putenv_s -> _wputenv_s

- Updates tests using SetEnvironmentVariable to use wide string
  literals since that function has been switched to the Unicode
  variant.

Signed-off-by: itsmattkc <itsmattkc@gmail.com>

* Moved UNICODE and _UNICODE definitions to CMake

Signed-off-by: itsmattkc <34096995+itsmattkc@users.noreply.github.com>

* handle empty strings and use const references

Signed-off-by: itsmattkc <34096995+itsmattkc@users.noreply.github.com>

* only use wenviron when unicode is enabled

Signed-off-by: itsmattkc <itsmattkc@gmail.com>

* add ANSI Win32 version of Getenv

Signed-off-by: itsmattkc <itsmattkc@gmail.com>

* Add CMake option for compiling with Win32 Unicode support

Signed-off-by: itsmattkc <itsmattkc@gmail.com>

* Throw exception if UTF functions are called on non-Windows platforms

Signed-off-by: itsmattkc <itsmattkc@gmail.com>

* Throw OCIO Exception

Signed-off-by: itsmattkc <itsmattkc@gmail.com>

* Don't run UTF-8/16 conversion test on non-Windows

Signed-off-by: itsmattkc <34096995+itsmattkc@users.noreply.github.com>

* Fix CMake error

Signed-off-by: itsmattkc <34096995+itsmattkc@users.noreply.github.com>

* minor CMake adjustment

Signed-off-by: itsmattkc <itsmattkc@gmail.com>

* Clarified CMake option for Win32 unicode

Signed-off-by: itsmattkc <34096995+itsmattkc@users.noreply.github.com>

* minor improvements

Signed-off-by: itsmattkc <34096995+itsmattkc@users.noreply.github.com>

* fix macro in cpu test cmake

Signed-off-by: itsmattkc <34096995+itsmattkc@users.noreply.github.com>