### PR TITLE
Port from master to RB-2.0 - Write converted image with output colorspace (#1420) (#1500)

### DIFF
--- a/src/apps/ocioconvert/main.cpp
+++ b/src/apps/ocioconvert/main.cpp
@@ -616,6 +616,17 @@ int main(int argc, const char **argv)
             exit(1);
         }
 
+        if (useDisplayView)
+        {
+            OCIO::ConstConfigRcPtr config = OCIO::GetCurrentConfig();
+            outputcolorspace = config->getDisplayViewColorSpaceName(display, view);
+        }
+
+        if (outputcolorspace)
+        {
+            spec.attribute("oiio:ColorSpace", outputcolorspace);
+        }
+
         f->open(outputimage, spec);
 
         if(!f->write_image(spec.format, img.getBuffer()))


### PR DESCRIPTION
* Write converted image with output colorspace (#1420)

Signed-off-by: Bo Zhou <Bo.Schwarzstein@gmail.com>

* Check if outputcolorspace is null and set it as oiio:ColorSpace (#1460)

Signed-off-by: Bo Zhou <Bo.Schwarzstein@gmail.com>

* Call getDisplayViewColorSpaceName to get output colorspace for view mode. #1420

Signed-off-by: Bo Zhou <Bo.Schwarzstein@gmail.com>

Co-authored-by: Patrick Hodoul <patrick.hodoul@autodesk.com>