### PR TITLE
Port from master to RB-2.1 - Fix add_test calls and change temporary file creation. (#1522)

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -122,7 +122,7 @@ jobs:
                 -- -j$(nproc)
         working-directory: _build
       - name: Test
-        run: ctest -V
+        run: ctest -V -C Release
         working-directory: _build
 
   # ---------------------------------------------------------------------------
@@ -174,7 +174,7 @@ jobs:
         run: build-wrapper-linux-x86-64 --out-dir bw_output make clean all
         working-directory: _build
       - name: Test
-        run: ctest -V
+        run: ctest -V -C Release
         working-directory: _build
       - name: Generate code coverage report
         run: share/ci/scripts/linux/run_gcov.sh

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -271,7 +271,7 @@ jobs:
                 -- -j$(nproc)
         working-directory: _build
       - name: Test
-        run: ctest -V
+        run: ctest -V -C ${{ matrix.build-type }}
         working-directory: _build
       - name: Test CMake Consumer
         if: matrix.build-shared == 'ON'
@@ -407,7 +407,7 @@ jobs:
                 -- -j$(sysctl -n hw.ncpu)
         working-directory: _build
       - name: Test
-        run: ctest -V
+        run: ctest -V -C ${{ matrix.build-type }}
         working-directory: _build
       - name: Test CMake Consumer
         if: matrix.build-shared == 'ON'
@@ -549,7 +549,7 @@ jobs:
         shell: bash
         working-directory: _build
       - name: Test
-        run: ctest -V
+        run: ctest -V -C ${{ matrix.build-type }}
         shell: bash
         working-directory: _build
       - name: Test CMake Consumer

--- a/src/OpenColorIO/Platform.cpp
+++ b/src/OpenColorIO/Platform.cpp
@@ -225,7 +225,9 @@ std::string CreateTempFilename(const std::string & filenameExt)
         throw Exception("Could not create a temporary file.");
     }
 
-    filename = tmpFilename;
+    // Note that when a file name is pre-pended with a backslash and no path information, such as \fname21, this 
+    // indicates that the name is valid for the current working directory.
+    filename = tmpFilename[0] == '\\' ? tmpFilename + 1 : tmpFilename;
 
 #else
 

--- a/src/OpenColorIO/Platform.h
+++ b/src/OpenColorIO/Platform.h
@@ -86,6 +86,7 @@ void AlignedFree(void * memBlock);
 // Note: Temporary files should be at some point deleted by the OS (depending of the OS
 //       and various platform specific settings). To be safe, add some code to remove
 //       the file if created.
+// FIXME: Implement a function or class for temporary file creation useable by all tests.
 std::string CreateTempFilename(const std::string & filenameExt);
 
 // Create an input file stream (std::ifstream) using a UTF-8 filename on any platform.

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -66,7 +66,7 @@ function(add_ocio_test NAME SOURCES PRIVATE_INCLUDES)
     set_target_properties(${TEST_BINARY} PROPERTIES
         COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
 
-    add_test(${TEST_NAME} ${TEST_BINARY})
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_BINARY})
 endfunction(add_ocio_test)
 
 # Eventually we will factor out each test into it's own executable

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -50,7 +50,7 @@ target_link_libraries(test_gpu_exec
 		unittest_data
 )
 
-add_test(test_gpu test_gpu_exec)
+add_test(NAME test_gpu COMMAND test_gpu_exec)
 
 # Note: To avoid changing PATH from outside the cmake files.
 if(MSVC AND BUILD_SHARED_LIBS)

--- a/tests/gpu/GPUHelpers.cpp
+++ b/tests/gpu/GPUHelpers.cpp
@@ -34,7 +34,9 @@ std::string createTempFile(const std::string& fileExt, const std::string& fileCo
         throw OCIO::Exception("Could not create a temporary file");
     }
 
-    filename = tmpFilename;
+    // Note that when a file name is pre-pended with a backslash and no path information, such as \fname21, this 
+    // indicates that the name is valid for the current working directory.
+    filename = tmpFilename[0] == '\\' ? tmpFilename + 1 : tmpFilename;
     filename += fileExt;
 
 #else

--- a/tests/gpu/GPUHelpers.h
+++ b/tests/gpu/GPUHelpers.h
@@ -8,7 +8,8 @@
 
 #include <string>
 
-
+// FIXME: Duplicate function implemented in `src/OpenColorIO/Platform.h and cpp`.
+// Implement a function or class for temporary file creation useable by all tests.
 std::string createTempFile(const std::string& fileExt, const std::string& fileContent);
 
 

--- a/tests/osl/CMakeLists.txt
+++ b/tests/osl/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(test_osl_exec
         OpenImageIO::OpenImageIO
 )
 
-add_test(test_osl test_osl_exec)
+add_test(NAME test_osl COMMAND test_osl_exec)
 
 list(APPEND ENVS "OSL_SHADERS_DIR=${OSL_SHADERS_DIR}")
 list(APPEND ENVS "TMP_SHADERS_DIR=${CMAKE_CURRENT_BINARY_DIR}")

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -24,4 +24,4 @@ target_link_libraries(test_utils_exec
 set_target_properties(test_utils_exec PROPERTIES
     COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
 
-add_test(test_utils_exec test_utils_exec)
+add_test(NAME test_utils_exec COMMAND test_utils_exec)


### PR DESCRIPTION
* * Fix add_test in cmake files. This notation allows it to understand that the command portion is a target and to translate it to the proper executable.
* Remove starting backslash if present from temporary filename. A starting backslash mean that it is safe to create it in the current working directory.
* Implement a public TempFile class.
* Change relevant tests to use TempFile class.

Signed-off-by: Patrick Northon <northon_patrick3@yahoo.ca>

* * Revert back changes for TempFile class.
* Add comment on temporary file functions fix.

Signed-off-by: Patrick Northon <northon_patrick3@yahoo.ca>

* Add FIXME comments.

Signed-off-by: Patrick Northon <northon_patrick3@yahoo.ca>

* Add -C flag to ctest commands.

Signed-off-by: Patrick Northon <northon_patrick3@yahoo.ca>

* Add `-C Release` to ctest commands in `analysis_workflow.yml`.

Signed-off-by: Patrick Northon <northon_patrick3@yahoo.ca>

Co-authored-by: Patrick Hodoul <patrick.hodoul@autodesk.com>
Co-authored-by: Rémi Achard <remiachard@gmail.com>