### PR TITLE
Fixes C++20 compilation errors and warnings

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -3087,8 +3087,6 @@ public:
      */
     struct UniformData
     {
-        UniformData() = default;
-        UniformData(const UniformData & data) = default;
         UniformDataType m_type{ UNIFORM_UNKNOWN };
         DoubleGetter m_getDouble{};
         BoolGetter m_getBool{};

--- a/include/OpenColorIO/OpenColorTransforms.h
+++ b/include/OpenColorIO/OpenColorTransforms.h
@@ -433,7 +433,6 @@ extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const DisplayViewTra
 struct OCIOEXPORT GradingRGBM
 {
     GradingRGBM() = default;
-    GradingRGBM(const GradingRGBM &) = default;
     GradingRGBM(double red, double green, double blue, double master)
         : m_red(red)
         , m_green(green)
@@ -460,7 +459,6 @@ extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const GradingRGBM &)
 struct OCIOEXPORT GradingPrimary
 {
     GradingPrimary() = delete;
-    GradingPrimary(const GradingPrimary &) = default;
     explicit GradingPrimary(GradingStyle style)
         : m_pivot(style == GRADING_LOG ? -0.2 : 0.18)
         , m_clampBlack(NoClampBlack())
@@ -496,7 +494,6 @@ extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const GradingPrimary
 struct OCIOEXPORT GradingControlPoint
 {
     GradingControlPoint() = default;
-    GradingControlPoint(const GradingControlPoint &) = default;
     GradingControlPoint(float x, float y) : m_x(x), m_y(y) {}
     float m_x{ 0.f };
     float m_y{ 0.f };
@@ -574,7 +571,6 @@ extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const GradingRGBCurv
 struct OCIOEXPORT GradingRGBMSW
 {
     GradingRGBMSW() = default;
-    GradingRGBMSW(const GradingRGBMSW &) = default;
     GradingRGBMSW(double red, double green, double blue, double master, double start, double width)
         : m_red   (red)
         , m_green (green)
@@ -612,7 +608,6 @@ extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const GradingRGBMSW 
 struct OCIOEXPORT GradingTone
 {
     GradingTone() = delete;
-    GradingTone(const GradingTone &) = default;
     explicit GradingTone(GradingStyle style)
         : m_blacks(style == GRADING_LIN ? GradingRGBMSW(0., 4.) :
                   (style == GRADING_LOG ? GradingRGBMSW(0.4, 0.4) :

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: C++
 description = OpenColorIO (OCIO) is a complete color management solution geared towards motion picture production with an emphasis on visual effects and computer animation.

--- a/share/cmake/utils/CppVersion.cmake
+++ b/share/cmake/utils/CppVersion.cmake
@@ -12,7 +12,7 @@ if(NOT DEFINED CMAKE_CXX_STANDARD)
     message(STATUS "Setting C++ version to '14' as none was specified.")
     set(CMAKE_CXX_STANDARD 14 CACHE STRING "C++ standard to compile against")
 elseif(NOT CMAKE_CXX_STANDARD IN_LIST SUPPORTED_CXX_STANDARDS)
-    message(FATAL_ERROR 
+    message(WARNING
             "CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD} is unsupported. Supported standards are: ${SUPPORTED_CXX_STANDARDS_STR}.")
 endif()
 

--- a/src/OpenColorIO/Op.cpp
+++ b/src/OpenColorIO/Op.cpp
@@ -63,7 +63,7 @@ void OpData::getSimplerReplacement(OpDataVec & /* ops */) const
 {
 }
 
-bool OpData::operator==(const OpData & other) const
+bool OpData::equals(const OpData & other) const
 {
     if (this == &other) return true;
 
@@ -89,6 +89,11 @@ const std::string & OpData::getName() const
 void OpData::setName(const std::string & name)
 {
     return m_metadata.setName(name.c_str());
+}
+
+bool operator==(const OpData & lhs, const OpData & rhs)
+{
+    return lhs.equals(rhs);
 }
 
 const char * GetTypeName(OpData::Type type)
@@ -593,4 +598,3 @@ void CreateOpVecFromOpData(OpRcPtrVec & ops,
 }
 
 } // namespace OCIO_NAMESPACE
-

--- a/src/OpenColorIO/Op.h
+++ b/src/OpenColorIO/Op.h
@@ -152,8 +152,7 @@ public:
     // returns true if the op's output does not combine input channels
     virtual bool hasChannelCrosstalk() const = 0;
 
-    virtual bool operator==(const OpData & other) const;
-    bool operator!=(const OpData & other) const = delete;
+    virtual bool equals(const OpData & other) const;
 
     // This should yield a string of not unreasonable length.
     virtual std::string getCacheID() const = 0;
@@ -168,6 +167,8 @@ protected:
 private:
     FormatMetadataImpl m_metadata;
 };
+
+bool operator==(const OpData & lhs, const OpData & rhs);
 
 const char * GetTypeName(OpData::Type type);
 

--- a/src/OpenColorIO/md5/md5.cpp
+++ b/src/OpenColorIO/md5/md5.cpp
@@ -55,6 +55,7 @@
 
 #include "md5.h"
 #include <cstring>
+#include <cstdint>
 
 
 namespace OCIO_NAMESPACE
@@ -168,7 +169,7 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 	     * On little-endian machines, we can process properly aligned
 	     * data without copying it.
 	     */
-	    if (!((data - (const md5_byte_t *)0) & 3)) {
+	    if (((uintptr_t)data & 3) == 0) {
 		/* data are properly aligned */
 		X = (const md5_word_t *)data;
 	    } else {

--- a/src/OpenColorIO/ops/cdl/CDLOpData.cpp
+++ b/src/OpenColorIO/ops/cdl/CDLOpData.cpp
@@ -158,9 +158,9 @@ CDLOpDataRcPtr CDLOpData::clone() const
     return std::make_shared<CDLOpData>(*this);
 }
 
-bool CDLOpData::operator==(const OpData& other) const
+bool CDLOpData::equals(const OpData& other) const
 {
-    if (!OpData::operator==(other)) return false;
+    if (!OpData::equals(other)) return false;
 
     const CDLOpData* cdl = static_cast<const CDLOpData*>(&other);
 
@@ -510,5 +510,9 @@ std::string CDLOpData::getCacheID() const
     return cacheIDStream.str();
 }
 
-} // namespace OCIO_NAMESPACE
+bool operator==(const CDLOpData & lhs, const CDLOpData & rhs)
+{
+    return lhs.equals(rhs);
+}
 
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/cdl/CDLOpData.h
+++ b/src/OpenColorIO/ops/cdl/CDLOpData.h
@@ -121,7 +121,7 @@ public:
 
     CDLOpDataRcPtr clone() const;
 
-    bool operator==(const OpData& other) const override;
+    bool equals(const OpData& other) const override;
 
     Type getType() const override { return CDLType; }
 
@@ -183,6 +183,8 @@ private:
     ChannelParams m_powerParams;   // Power parameters for RGB channels
     double        m_saturation;    // Saturation parameter
 };
+
+bool operator==(const CDLOpData & lhs, const CDLOpData & rhs);
 
 } // namespace OCIO_NAMESPACE
 

--- a/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpData.cpp
+++ b/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpData.cpp
@@ -278,9 +278,9 @@ std::string ExposureContrastOpData::getCacheID() const
     return cacheIDStream.str();
 }
 
-bool ExposureContrastOpData::operator==(const OpData & other) const
+bool ExposureContrastOpData::equals(const OpData & other) const
 {
-    if (!OpData::operator==(other)) return false;
+    if (!OpData::equals(other)) return false;
 
     const ExposureContrastOpData * ec = static_cast<const ExposureContrastOpData *>(&other);
 
@@ -455,5 +455,9 @@ void ExposureContrastOpData::setDirection(TransformDirection dir) noexcept
     }
 }
 
-} // namespace OCIO_NAMESPACE
+bool operator==(const ExposureContrastOpData & lhs, const ExposureContrastOpData & rhs)
+{
+    return lhs.equals(rhs);
+}
 
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpData.h
+++ b/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpData.h
@@ -161,7 +161,7 @@ public:
 
     std::string getCacheID() const override;
 
-    bool operator==(const OpData & other) const override;
+    bool equals(const OpData & other) const override;
 
     bool hasDynamicProperty(DynamicPropertyType type) const;
 
@@ -222,6 +222,8 @@ private:
     double m_logExposureStep = LOGEXPOSURESTEP_DEFAULT;
     double m_logMidGray = LOGMIDGRAY_DEFAULT;
 };
+
+bool operator==(const ExposureContrastOpData & lhs, const ExposureContrastOpData & rhs);
 
 } // namespace OCIO_NAMESPACE
 

--- a/src/OpenColorIO/ops/fixedfunction/FixedFunctionOpData.cpp
+++ b/src/OpenColorIO/ops/fixedfunction/FixedFunctionOpData.cpp
@@ -640,9 +640,9 @@ void FixedFunctionOpData::setDirection(TransformDirection dir) noexcept
     }
 }
 
-bool FixedFunctionOpData::operator==(const OpData & other) const
+bool FixedFunctionOpData::equals(const OpData & other) const
 {
-    if (!OpData::operator==(other)) return false;
+    if (!OpData::equals(other)) return false;
 
     const FixedFunctionOpData* fop = static_cast<const FixedFunctionOpData*>(&other);
 
@@ -669,6 +669,11 @@ std::string FixedFunctionOpData::getCacheID() const
     }
 
     return cacheIDStream.str();
+}
+
+bool operator==(const FixedFunctionOpData & lhs, const FixedFunctionOpData & rhs)
+{
+    return lhs.equals(rhs);
 }
 
 } // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/fixedfunction/FixedFunctionOpData.h
+++ b/src/OpenColorIO/ops/fixedfunction/FixedFunctionOpData.h
@@ -88,7 +88,7 @@ public:
     void setParams(const Params & params) { m_params = params; }
     const Params & getParams() const { return m_params; }
 
-    bool operator==(const OpData & other) const override;
+    bool equals(const OpData & other) const override;
 
 protected:
     void invert() noexcept;
@@ -97,6 +97,8 @@ private:
     Style m_style;
     Params m_params;
 };
+
+bool operator==(const FixedFunctionOpData & lhs, const FixedFunctionOpData & rhs);
 
 } // namespace OCIO_NAMESPACE
 

--- a/src/OpenColorIO/ops/gamma/GammaOpData.cpp
+++ b/src/OpenColorIO/ops/gamma/GammaOpData.cpp
@@ -777,9 +777,9 @@ GammaOpDataRcPtr GammaOpData::compose(const GammaOpData & B) const
     return outOp;
 }
 
-bool GammaOpData::operator==(const OpData & other) const
+bool GammaOpData::equals(const OpData & other) const
 {
-    if(!OpData::operator==(other)) return false;
+    if(!OpData::equals(other)) return false;
 
     const GammaOpData* gop = static_cast<const GammaOpData*>(&other);
 
@@ -859,5 +859,9 @@ void GammaOpData::invert() noexcept
     setStyle(invStyle);
 }
 
-} // namespace OCIO_NAMESPACE
+bool operator==(const GammaOpData & lhs, const GammaOpData & rhs)
+{
+    return lhs.equals(rhs);
+}
 
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/gamma/GammaOpData.h
+++ b/src/OpenColorIO/ops/gamma/GammaOpData.h
@@ -141,7 +141,7 @@ public:
 
     virtual void validateParameters() const;
 
-    bool operator==(const OpData& other) const override;
+    bool equals(const OpData& other) const override;
 
     std::string getCacheID() const override;
 
@@ -164,7 +164,8 @@ private:
     Params m_alphaParams;
 };
 
-} // namespace OCIO_NAMESPACE
+bool operator==(const GammaOpData & lhs, const GammaOpData & rhs);
 
+} // namespace OCIO_NAMESPACE
 
 #endif

--- a/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOpData.cpp
+++ b/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOpData.cpp
@@ -246,9 +246,9 @@ void GradingPrimaryOpData::removeDynamicProperty() noexcept
     m_value->makeNonDynamic();
 }
 
-bool GradingPrimaryOpData::operator==(const OpData & other) const
+bool GradingPrimaryOpData::equals(const OpData & other) const
 {
-    if (!OpData::operator==(other)) return false;
+    if (!OpData::equals(other)) return false;
 
     const GradingPrimaryOpData* rop = static_cast<const GradingPrimaryOpData*>(&other);
 
@@ -262,5 +262,9 @@ bool GradingPrimaryOpData::operator==(const OpData & other) const
     return true;
 }
 
+bool operator==(const GradingPrimaryOpData & lhs, const GradingPrimaryOpData & rhs)
+{
+    return lhs.equals(rhs);
+}
 
 } // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOpData.h
+++ b/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOpData.h
@@ -65,12 +65,14 @@ public:
         return m_value;
     }
 
-    bool operator==(const OpData & other) const override;
+    bool equals(const OpData & other) const override;
 
 private:
     GradingStyle                           m_style;
     DynamicPropertyGradingPrimaryImplRcPtr m_value;
 };
+
+bool operator==(const GradingPrimaryOpData & lhs, const GradingPrimaryOpData & rhs);
 
 } // namespace OCIO_NAMESPACE
 

--- a/src/OpenColorIO/ops/gradingrgbcurve/GradingRGBCurveOpData.cpp
+++ b/src/OpenColorIO/ops/gradingrgbcurve/GradingRGBCurveOpData.cpp
@@ -210,9 +210,9 @@ void GradingRGBCurveOpData::removeDynamicProperty() noexcept
     m_value->makeNonDynamic();
 }
 
-bool GradingRGBCurveOpData::operator==(const OpData & other) const
+bool GradingRGBCurveOpData::equals(const OpData & other) const
 {
-    if (!OpData::operator==(other)) return false;
+    if (!OpData::equals(other)) return false;
 
     const GradingRGBCurveOpData* rop = static_cast<const GradingRGBCurveOpData*>(&other);
 
@@ -227,5 +227,9 @@ bool GradingRGBCurveOpData::operator==(const OpData & other) const
     return true;
 }
 
-} // namespace OCIO_NAMESPACE
+bool operator==(const GradingRGBCurveOpData & lhs, const GradingRGBCurveOpData & rhs)
+{
+    return lhs.equals(rhs);
+}
 
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/gradingrgbcurve/GradingRGBCurveOpData.h
+++ b/src/OpenColorIO/ops/gradingrgbcurve/GradingRGBCurveOpData.h
@@ -76,7 +76,7 @@ public:
         return m_value;
     }
 
-    bool operator==(const OpData & other) const override;
+    bool equals(const OpData & other) const override;
 
 private:
     GradingStyle                            m_style;
@@ -85,7 +85,7 @@ private:
     TransformDirection                      m_direction{ TRANSFORM_DIR_FORWARD };
 };
 
-
+bool operator==(const GradingRGBCurveOpData & lhs, const GradingRGBCurveOpData & rhs);
 
 } // namespace OCIO_NAMESPACE
 

--- a/src/OpenColorIO/ops/gradingtone/GradingToneOpData.cpp
+++ b/src/OpenColorIO/ops/gradingtone/GradingToneOpData.cpp
@@ -167,9 +167,9 @@ void GradingToneOpData::removeDynamicProperty() noexcept
     m_value->makeNonDynamic();
 }
 
-bool GradingToneOpData::operator==(const OpData & other) const
+bool GradingToneOpData::equals(const OpData & other) const
 {
-    if (!OpData::operator==(other)) return false;
+    if (!OpData::equals(other)) return false;
 
     const GradingToneOpData* rop = static_cast<const GradingToneOpData*>(&other);
 
@@ -183,6 +183,10 @@ bool GradingToneOpData::operator==(const OpData & other) const
     return true;
 }
 
+bool operator==(const GradingToneOpData & lhs, const GradingToneOpData & rhs)
+{
+    return lhs.equals(rhs);
+}
+
 
 } // namespace OCIO_NAMESPACE
-

--- a/src/OpenColorIO/ops/gradingtone/GradingToneOpData.h
+++ b/src/OpenColorIO/ops/gradingtone/GradingToneOpData.h
@@ -69,13 +69,15 @@ public:
         return m_value;
     }
 
-    bool operator==(const OpData & other) const override;
+    bool equals(const OpData & other) const override;
 
 private:
     GradingStyle                        m_style;
     DynamicPropertyGradingToneImplRcPtr m_value;
     TransformDirection                  m_direction{ TRANSFORM_DIR_FORWARD };
 };
+
+bool operator==(const GradingToneOpData & lhs, const GradingToneOpData & rhs);
 
 } // namespace OCIO_NAMESPACE
 

--- a/src/OpenColorIO/ops/log/LogOpData.cpp
+++ b/src/OpenColorIO/ops/log/LogOpData.cpp
@@ -324,9 +324,9 @@ std::string LogOpData::getCacheID() const
     return cacheIDStream.str();
 }
 
-bool LogOpData::operator==(const OpData& other) const
+bool LogOpData::equals(const OpData& other) const
 {
-    if (!OpData::operator==(other)) return false;
+    if (!OpData::equals(other)) return false;
 
     const LogOpData* log = static_cast<const LogOpData*>(&other);
 
@@ -490,5 +490,9 @@ bool LogOpData::isCamera() const
     return m_redParams.size() > 4;
 }
 
-} // namespace OCIO_NAMESPACE
+bool operator==(const LogOpData & lhs, const LogOpData & rhs)
+{
+    return lhs.equals(rhs);
+}
 
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/log/LogOpData.h
+++ b/src/OpenColorIO/ops/log/LogOpData.h
@@ -77,7 +77,7 @@ public:
 
     std::string getCacheID() const override;
 
-    bool operator==(const OpData& other) const override;
+    bool equals(const OpData& other) const override;
 
     LogOpDataRcPtr clone() const;
 
@@ -153,6 +153,8 @@ private:
 
     TransformDirection m_direction = TRANSFORM_DIR_FORWARD;
 };
+
+bool operator==(const LogOpData & lhs, const LogOpData & rhs);
 
 } // namespace OCIO_NAMESPACE
 

--- a/src/OpenColorIO/ops/log/LogOpGPU.cpp
+++ b/src/OpenColorIO/ops/log/LogOpGPU.cpp
@@ -245,7 +245,7 @@ void AddCameraLinToLogShader(GpuShaderCreatorRcPtr & shaderCreator,
                              ConstLogOpDataRcPtr & logData)
 {
     // if in <= linBreak
-    //  out = linearSlope × in + linearOffset 
+    //  out = linearSlope * in + linearOffset
     // else
     //  out = ( logSlope * log( base, max( minValue, (in*linSlope + linOffset) ) ) + logOffset )
 

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpData.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpData.cpp
@@ -454,9 +454,9 @@ bool Lut1DOpData::haveEqualBasics(const Lut1DOpData & other) const
            m_array     == other.m_array;
 }
 
-bool Lut1DOpData::operator==(const OpData & other) const
+bool Lut1DOpData::equals(const OpData & other) const
 {
-    if (!OpData::operator==(other)) return false;
+    if (!OpData::equals(other)) return false;
 
     const Lut1DOpData* lop = static_cast<const Lut1DOpData*>(&other);
 
@@ -1038,5 +1038,9 @@ void Lut1DOpData::initializeFromForward()
     }
 }
 
-} // namespace OCIO_NAMESPACE
+bool operator==(const Lut1DOpData & lhs, const Lut1DOpData & rhs)
+{
+    return lhs.equals(rhs);
+}
 
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpData.h
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpData.h
@@ -175,7 +175,7 @@ public:
     // lookup rather than interpolation.
     bool mayLookup(BitDepth incomingDepth) const;
 
-    bool operator==(const OpData & other) const override;
+    bool equals(const OpData & other) const override;
 
     OpDataRcPtr getIdentityReplacement() const override;
 
@@ -264,6 +264,8 @@ private:
     // Used by MakeFastLut1DFromInverse and for saving to CLF/CTF.
     BitDepth m_fileOutBitDepth = BIT_DEPTH_UNKNOWN;
 };
+
+bool operator==(const Lut1DOpData & lhs, const Lut1DOpData & rhs);
 
 // Make a forward Lut1DOpData that approximates the exact inverse
 // Lut1DOpData to be used for the fast rendering style.

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpData.cpp
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpData.cpp
@@ -423,9 +423,9 @@ bool Lut3DOpData::haveEqualBasics(const Lut3DOpData & other) const
     return (m_array == other.m_array);
 }
 
-bool Lut3DOpData::operator==(const OpData & other) const
+bool Lut3DOpData::equals(const OpData & other) const
 {
-    if (!OpData::operator==(other)) return false;
+    if (!OpData::equals(other)) return false;
 
     const Lut3DOpData* lop = static_cast<const Lut3DOpData*>(&other);
 
@@ -495,5 +495,9 @@ void Lut3DOpData::scale(float scale)
     getArray().scale(scale);
 }
 
-} // namespace OCIO_NAMESPACE
+bool operator==(const Lut3DOpData & lhs, const Lut3DOpData & rhs)
+{
+    return lhs.equals(rhs);
+}
 
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpData.h
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpData.h
@@ -81,7 +81,7 @@ public:
 
     Lut3DOpDataRcPtr inverse() const;
 
-    bool operator==(const OpData& other) const override;
+    bool equals(const OpData& other) const override;
 
     std::string getCacheID() const override;
 
@@ -136,6 +136,8 @@ private:
     BitDepth m_fileOutBitDepth = BIT_DEPTH_UNKNOWN;
 
 };
+
+bool operator==(const Lut3DOpData & lhs, const Lut3DOpData & rhs);
 
 // Make a forward Lut3DOpData that approximates the exact inverse Lut3DOpData
 // to be used for the fast rendering style.

--- a/src/OpenColorIO/ops/matrix/MatrixOpData.cpp
+++ b/src/OpenColorIO/ops/matrix/MatrixOpData.cpp
@@ -783,9 +783,9 @@ void MatrixOpData::cleanUp(double offsetScale)
     }
 }
 
-bool MatrixOpData::operator==(const OpData & other) const
+bool MatrixOpData::equals(const OpData & other) const
 {
-    if (!OpData::operator==(other)) return false;
+    if (!OpData::equals(other)) return false;
 
     const MatrixOpData* mop = static_cast<const MatrixOpData*>(&other);
 
@@ -873,5 +873,9 @@ void MatrixOpData::scale(double inScale, double outScale)
     m_offsets.scale(outScale);
 }
 
-} // namespace OCIO_NAMESPACE
+bool operator==(const MatrixOpData & lhs, const MatrixOpData & rhs)
+{
+    return lhs.equals(rhs);
+}
 
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/matrix/MatrixOpData.h
+++ b/src/OpenColorIO/ops/matrix/MatrixOpData.h
@@ -214,7 +214,7 @@ public:
     // Used by composition to remove small errors.
     void cleanUp(double offsetScale);
 
-    bool operator==(const OpData & other) const override;
+    bool equals(const OpData & other) const override;
 
     TransformDirection getDirection() const noexcept { return m_direction; }
     void setDirection(TransformDirection dir) noexcept;
@@ -241,6 +241,9 @@ private:
 
     TransformDirection m_direction{ TRANSFORM_DIR_FORWARD };
 };
+
+bool operator==(const MatrixOpData & lhs, const MatrixOpData & rhs);
+
 } // namespace OCIO_NAMESPACE
 
 #endif

--- a/src/OpenColorIO/ops/range/RangeOpData.cpp
+++ b/src/OpenColorIO/ops/range/RangeOpData.cpp
@@ -512,10 +512,10 @@ MatrixOpDataRcPtr RangeOpData::convertToMatrix() const
     return mtx;
 }
 
-bool RangeOpData::operator==(const OpData & other) const
+bool RangeOpData::equals(const OpData & other) const
 {
     // NB: FormatMetadata and fileIn/OutDepths are ignored.
-    if (!OpData::operator==(other)) return false;
+    if (!OpData::equals(other)) return false;
 
     const RangeOpData* rop = static_cast<const RangeOpData*>(&other);
 
@@ -620,5 +620,9 @@ void RangeOpData::normalize()
     }
 }
 
-} // namespace OCIO_NAMESPACE
+bool operator==(const RangeOpData & lhs, const RangeOpData & rhs)
+{
+    return lhs.equals(rhs);
+}
 
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/range/RangeOpData.h
+++ b/src/OpenColorIO/ops/range/RangeOpData.h
@@ -140,7 +140,7 @@ public:
     // Create a MatrixOp that is equivalent to the Range except does not clamp.
     MatrixOpDataRcPtr convertToMatrix() const;
 
-    bool operator==(const OpData& other) const override;
+    bool equals(const OpData& other) const override;
 
     RangeOpDataRcPtr getAsForward() const;
 
@@ -176,6 +176,8 @@ private:
 
     TransformDirection m_direction{ TRANSFORM_DIR_FORWARD };
 };
+
+bool operator==(const RangeOpData & lhs, const RangeOpData & rhs);
 
 } // namespace OCIO_NAMESPACE
 

--- a/src/OpenColorIO/ops/reference/ReferenceOpData.cpp
+++ b/src/OpenColorIO/ops/reference/ReferenceOpData.cpp
@@ -39,9 +39,9 @@ bool ReferenceOpData::hasChannelCrosstalk() const
     return true;
 }
 
-bool ReferenceOpData::operator==(const OpData& other) const
+bool ReferenceOpData::equals(const OpData& other) const
 {
-    if (!OpData::operator==(other)) return false;
+    if (!OpData::equals(other)) return false;
 
     const ReferenceOpData* rop = static_cast<const ReferenceOpData*>(&other);
 
@@ -65,5 +65,9 @@ std::string ReferenceOpData::getCacheID() const
                     "not have a corresponding Op");
 }
 
-} // namespace OCIO_NAMESPACE
+bool operator==(const ReferenceOpData & lhs, const ReferenceOpData & rhs)
+{
+    return lhs.equals(rhs);
+}
 
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/ops/reference/ReferenceOpData.h
+++ b/src/OpenColorIO/ops/reference/ReferenceOpData.h
@@ -42,7 +42,7 @@ public:
 
     bool hasChannelCrosstalk() const override;
 
-    bool operator==(const OpData& other) const override;
+    bool equals(const OpData& other) const override;
 
     std::string getCacheID() const override;
 
@@ -92,8 +92,8 @@ private:
     TransformDirection m_direction = TRANSFORM_DIR_FORWARD;
 };
 
+bool operator==(const ReferenceOpData & lhs, const ReferenceOpData & rhs);
 
 } // namespace OCIO_NAMESPACE
-
 
 #endif

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -4939,7 +4939,7 @@ OCIO_ADD_TEST(Config, add_color_space)
 
     const std::string str
         = PROFILE_V2_START
-            + u8"    from_scene_reference: !<MatrixTransform> {offset: [-1, -2, -3, -4]}\n";
+            + U8("    from_scene_reference: !<MatrixTransform> {offset: [-1, -2, -3, -4]}\n");
 
     std::istringstream is;
     is.str(str);
@@ -4951,15 +4951,15 @@ OCIO_ADD_TEST(Config, add_color_space)
 
     OCIO::ColorSpaceRcPtr cs;
     OCIO_CHECK_NO_THROW(cs = OCIO::ColorSpace::Create());
-    cs->setName(u8"astéroïde");                           // Color space name with accents.
-    cs->setDescription(u8"é À Â Ç É È ç -- $ € 円 £ 元"); // Some accents and some money symbols.
+    cs->setName(U8("astéroïde"));                           // Color space name with accents.
+    cs->setDescription(U8("é À Â Ç É È ç -- $ € 円 £ 元")); // Some accents and some money symbols.
 
     OCIO::FixedFunctionTransformRcPtr tr;
     OCIO_CHECK_NO_THROW(tr = OCIO::FixedFunctionTransform::Create(OCIO::FIXED_FUNCTION_ACES_RED_MOD_03));
 
     OCIO_CHECK_NO_THROW(cs->setTransform(tr, OCIO::COLORSPACE_DIR_TO_REFERENCE));
 
-    constexpr char csName[] = u8"astéroïde";
+    const char * csName = U8("astéroïde");
 
     OCIO_CHECK_EQUAL(config->getIndexForColorSpace(csName), -1);
     OCIO_CHECK_NO_THROW(config->addColorSpace(cs));
@@ -4967,16 +4967,16 @@ OCIO_ADD_TEST(Config, add_color_space)
 
     const std::string res 
         = str
-        + u8"\n"
-        + u8"  - !<ColorSpace>\n"
-        + u8"    name: " + csName + u8"\n"
-        + u8"    family: \"\"\n"
-        + u8"    equalitygroup: \"\"\n"
-        + u8"    bitdepth: unknown\n"
-        + u8"    description: é À Â Ç É È ç -- $ € 円 £ 元\n"
-        + u8"    isdata: false\n"
-        + u8"    allocation: uniform\n"
-        + u8"    to_scene_reference: !<FixedFunctionTransform> {style: ACES_RedMod03}\n";
+        + U8("\n")
+        + U8("  - !<ColorSpace>\n")
+        + U8("    name: ") + csName + U8("\n")
+        + U8("    family: \"\"\n")
+        + U8("    equalitygroup: \"\"\n")
+        + U8("    bitdepth: unknown\n")
+        + U8("    description: é À Â Ç É È ç -- $ € 円 £ 元\n")
+        + U8("    isdata: false\n")
+        + U8("    allocation: uniform\n")
+        + U8("    to_scene_reference: !<FixedFunctionTransform> {style: ACES_RedMod03}\n");
 
     std::stringstream ss;
     OCIO_CHECK_NO_THROW(ss << *config.get());

--- a/tests/cpu/FileRules_tests.cpp
+++ b/tests/cpu/FileRules_tests.cpp
@@ -432,11 +432,11 @@ OCIO_ADD_TEST(FileRules, config_rule_u8)
     auto fr = configRaw->getFileRules();
     auto fileRules = fr->createEditableCopy();
     OCIO_REQUIRE_EQUAL(fileRules->getNumEntries(), 1);
-    OCIO_CHECK_NO_THROW(fileRules->insertRule(0, u8"éÀÂÇÉÈç$€", "raw", "*", "a"));
+    OCIO_CHECK_NO_THROW(fileRules->insertRule(0, U8("éÀÂÇÉÈç$€"), "raw", "*", "a"));
     OCIO_REQUIRE_EQUAL(fileRules->getNumEntries(), 2);
-    OCIO_CHECK_NO_THROW(fileRules->setCustomKey(0, u8"key£", u8"val€"));
-    OCIO_CHECK_EQUAL(std::string(fileRules->getCustomKeyName(0, 0)), u8"key£");
-    OCIO_CHECK_EQUAL(std::string(fileRules->getCustomKeyValue(0, 0)), u8"val€");
+    OCIO_CHECK_NO_THROW(fileRules->setCustomKey(0, U8("key£"), U8("val€")));
+    OCIO_CHECK_EQUAL(std::string(fileRules->getCustomKeyName(0, 0)), U8("key£"));
+    OCIO_CHECK_EQUAL(std::string(fileRules->getCustomKeyValue(0, 0)), U8("val€"));
 
     auto config = configRaw->createEditableCopy();
     config->setFileRules(fileRules);
@@ -453,11 +453,11 @@ OCIO_ADD_TEST(FileRules, config_rule_u8)
 
     OCIO_REQUIRE_EQUAL(rules_reloaded->getNumEntries(), 2);
 
-    OCIO_CHECK_EQUAL(std::string(fileRules->getName(0)), u8"éÀÂÇÉÈç$€");
+    OCIO_CHECK_EQUAL(std::string(fileRules->getName(0)), U8("éÀÂÇÉÈç$€"));
 
     OCIO_REQUIRE_EQUAL(rules_reloaded->getNumCustomKeys(0), 1);
-    OCIO_CHECK_EQUAL(std::string(fileRules->getCustomKeyName(0, 0)), u8"key£");
-    OCIO_CHECK_EQUAL(std::string(fileRules->getCustomKeyValue(0, 0)), u8"val€");
+    OCIO_CHECK_EQUAL(std::string(fileRules->getCustomKeyName(0, 0)), U8("key£"));
+    OCIO_CHECK_EQUAL(std::string(fileRules->getCustomKeyValue(0, 0)), U8("val€"));
 }
 
 namespace

--- a/tests/cpu/Platform_tests.cpp
+++ b/tests/cpu/Platform_tests.cpp
@@ -8,6 +8,7 @@
 #include "Platform.cpp"
 
 #include "testutils/UnitTest.h"
+#include "UnitTestUtils.h"
 
 namespace OCIO = OCIO_NAMESPACE;
 
@@ -17,13 +18,13 @@ OCIO_ADD_TEST(Platform, envVariable)
     // Only validates the public API.
     // Complete validations are done below using the private methods.
 
-    const char * path = OCIO::GetEnvVariable(u8"PATH");
+    const char * path = OCIO::GetEnvVariable(U8("PATH"));
     OCIO_CHECK_ASSERT(path && *path);
 
-    OCIO::SetEnvVariable(u8"MY_DUMMY_ENV", u8"SomeValue");
-    const char * value = OCIO::GetEnvVariable(u8"MY_DUMMY_ENV");
+    OCIO::SetEnvVariable(U8("MY_DUMMY_ENV"), U8("SomeValue"));
+    const char * value = OCIO::GetEnvVariable(U8("MY_DUMMY_ENV"));
     OCIO_CHECK_ASSERT(value && *value);
-    OCIO_CHECK_EQUAL(std::string(value), u8"SomeValue");
+    OCIO_CHECK_EQUAL(std::string(value), U8("SomeValue"));
 
 #ifdef _WIN32
     // Assert that we retrieve the correct value from the Windows API too.
@@ -36,8 +37,8 @@ OCIO_ADD_TEST(Platform, envVariable)
     OCIO_CHECK_ASSERT(win_env_value == TEXT("SomeValue"));
 #endif
 
-    OCIO::UnsetEnvVariable(u8"MY_DUMMY_ENV");
-    value = OCIO::GetEnvVariable(u8"MY_DUMMY_ENV");
+    OCIO::UnsetEnvVariable(U8("MY_DUMMY_ENV"));
+    value = OCIO::GetEnvVariable(U8("MY_DUMMY_ENV"));
     OCIO_CHECK_ASSERT(!value || !*value);
 
 #ifdef _WIN32
@@ -106,47 +107,47 @@ OCIO_ADD_TEST(Platform, setenv)
         Guard() = default;
         ~Guard()
         {
-            OCIO::Platform::Unsetenv(u8"MY_DUMMY_ENV");
-            OCIO::Platform::Unsetenv(u8"MY_WINDOWS_DUMMY_ENV");
+            OCIO::Platform::Unsetenv(U8("MY_DUMMY_ENV"));
+            OCIO::Platform::Unsetenv(U8("MY_WINDOWS_DUMMY_ENV"));
         }
     } guard;
 
     {
-        OCIO::Platform::Setenv(u8"MY_DUMMY_ENV", u8"SomeValue");
+        OCIO::Platform::Setenv(U8("MY_DUMMY_ENV"), U8("SomeValue"));
         std::string env;
-        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv(u8"MY_DUMMY_ENV", env));
+        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv(U8("MY_DUMMY_ENV"), env));
         OCIO_CHECK_ASSERT(!env.empty());
 
-        OCIO_CHECK_ASSERT(0==std::strcmp(u8"SomeValue", env.c_str()));
-        OCIO_CHECK_EQUAL(strlen(u8"SomeValue"), env.size());
+        OCIO_CHECK_ASSERT(0==std::strcmp(U8("SomeValue"), env.c_str()));
+        OCIO_CHECK_EQUAL(strlen(U8("SomeValue")), env.size());
     }
     {
-        OCIO::Platform::Setenv(u8"MY_DUMMY_ENV", u8" ");
+        OCIO::Platform::Setenv(U8("MY_DUMMY_ENV"), U8(" "));
         std::string env;
-        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv(u8"MY_DUMMY_ENV", env));
+        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv(U8("MY_DUMMY_ENV"), env));
         OCIO_CHECK_ASSERT(!env.empty());
 
-        OCIO_CHECK_ASSERT(0==std::strcmp(u8" ", env.c_str()));
-        OCIO_CHECK_EQUAL(std::strlen(u8" "), env.size());
+        OCIO_CHECK_ASSERT(0==std::strcmp(U8(" "), env.c_str()));
+        OCIO_CHECK_EQUAL(std::strlen(U8(" ")), env.size());
     }
     {
-        OCIO::Platform::Unsetenv(u8"MY_DUMMY_ENV");
+        OCIO::Platform::Unsetenv(U8("MY_DUMMY_ENV"));
         std::string env;
-        OCIO_CHECK_ASSERT(!OCIO::Platform::Getenv(u8"MY_DUMMY_ENV", env));
+        OCIO_CHECK_ASSERT(!OCIO::Platform::Getenv(U8("MY_DUMMY_ENV"), env));
         OCIO_CHECK_ASSERT(env.empty());
     }
 #ifdef _WIN32
     {
         SetEnvironmentVariable(TEXT("MY_WINDOWS_DUMMY_ENV"), TEXT("1"));
         std::string env;
-        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv(u8"MY_WINDOWS_DUMMY_ENV", env));
-        OCIO_CHECK_EQUAL(env, std::string(u8"1"));
+        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv(U8("MY_WINDOWS_DUMMY_ENV"), env));
+        OCIO_CHECK_EQUAL(env, std::string(U8("1")));
     }
     {
         SetEnvironmentVariable(TEXT("MY_WINDOWS_DUMMY_ENV"), TEXT(" "));
         std::string env;
-        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv(u8"MY_WINDOWS_DUMMY_ENV", env));
-        OCIO_CHECK_EQUAL(env, std::string(u8" "));
+        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv(U8("MY_WINDOWS_DUMMY_ENV"), env));
+        OCIO_CHECK_EQUAL(env, std::string(U8(" ")));
     }
     {
         // Windows SetEnvironmentVariable() sets the env. variable to empty like
@@ -154,13 +155,13 @@ OCIO_ADD_TEST(Platform, setenv)
 
         SetEnvironmentVariable(TEXT("MY_WINDOWS_DUMMY_ENV"), TEXT(""));
         std::string env;
-        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv(u8"MY_WINDOWS_DUMMY_ENV", env));
+        OCIO_CHECK_ASSERT(OCIO::Platform::Getenv(U8("MY_WINDOWS_DUMMY_ENV"), env));
         OCIO_CHECK_ASSERT(env.empty());
     }
     {
         SetEnvironmentVariable(TEXT("MY_WINDOWS_DUMMY_ENV"), nullptr);
         std::string env;
-        OCIO_CHECK_ASSERT(!OCIO::Platform::Getenv(u8"MY_WINDOWS_DUMMY_ENV", env));
+        OCIO_CHECK_ASSERT(!OCIO::Platform::Getenv(U8("MY_WINDOWS_DUMMY_ENV"), env));
         OCIO_CHECK_ASSERT(env.empty());
     }
 #endif

--- a/tests/cpu/UnitTestUtils.h
+++ b/tests/cpu/UnitTestUtils.h
@@ -7,6 +7,12 @@
 
 #include <fstream>
 
+#ifdef __has_include
+# if __has_include(<version>)
+#   include <version>
+# endif
+#endif
+
 #include <OpenColorIO/OpenColorIO.h>
 
 #include "MathUtils.h"

--- a/tests/cpu/UnitTestUtils.h
+++ b/tests/cpu/UnitTestUtils.h
@@ -85,6 +85,16 @@ inline bool EqualWithSafeRelError(T value,
         / div) <= eps;
 }
 
+// C++20 introduces new strongly typed, UTF-8 based, char8_t and u8string types
+// which are not implicitly convertible to char and std::string respectively.
+// Here we simply choose to ignore these new types for unit tests while the
+// core API is not explicitly compatible with such types.
+// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1423r2.html
+#if defined(__cpp_lib_char8_t)
+#   define U8(x) reinterpret_cast<const char *>(u8##x)
+#else
+#   define U8(x) u8##x
+#endif
 
 }
 // namespace OCIO_NAMESPACE


### PR DESCRIPTION
This was tested on macOS Apple Clang 13.0 (and brew Clang 13.0), I plan to add it on the analysis CI once #1515 is merged (if it doesn't break dependency build).