### PR TITLE
Port from main to RB-2.1 - Python 3.10 macOS wheels

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -59,13 +59,13 @@ jobs:
       image: aswf/ci-ocio:${{ matrix.vfx-cy }}
     strategy:
       matrix:
-        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
         include:
           # -------------------------------------------------------------------
           # VFX CY2022 (Python 3.9)
           # -------------------------------------------------------------------
           # Clang, Debug, OpenFX
-          - build: 12
+          - build: 13
             build-type: Debug
             build-shared: 'ON'
             build-docs: 'OFF'
@@ -78,7 +78,7 @@ jobs:
             compiler-desc: Clang 9
             vfx-cy: 2022
           # GCC, no SSE, OpenFX
-          - build: 11
+          - build: 12
             build-type: Release
             build-shared: 'ON'
             build-docs: 'OFF'
@@ -90,15 +90,28 @@ jobs:
             cc-compiler: gcc
             compiler-desc: GCC 9.3.1
             vfx-cy: 2022
-          # GCC, static, docs
-          - build: 10
+          # C++14, GCC, static, docs
+          - build: 11
             build-type: Release
             build-shared: 'OFF'
             build-docs: 'ON'
             build-openfx: 'OFF'
             use-sse: 'ON'
             use-openexr-half: 'OFF'
-            cxx-standard: 17
+            cxx-standard: 14
+            cxx-compiler: g++
+            cc-compiler: gcc
+            compiler-desc: GCC 9.3.1
+            vfx-cy: 2022
+          # C++11, GCC, static
+          - build: 10
+            build-type: Release
+            build-shared: 'OFF'
+            build-docs: 'OFF'
+            build-openfx: 'OFF'
+            use-sse: 'ON'
+            use-openexr-half: 'OFF'
+            cxx-standard: 11
             cxx-compiler: g++
             cc-compiler: gcc
             compiler-desc: GCC 9.3.1
@@ -119,7 +132,7 @@ jobs:
             cc-compiler: clang
             compiler-desc: Clang 9
             vfx-cy: 2021
-          # Clang, static, no SSE, OpenFX
+          # C++14, Clang, static, no SSE, OpenFX
           - build: 8
             build-type: Release
             build-shared: 'OFF'
@@ -127,12 +140,12 @@ jobs:
             build-openfx: 'ON'
             use-sse: 'OFF'
             use-openexr-half: 'ON'
-            cxx-standard: 17
+            cxx-standard: 14
             cxx-compiler: clang++
             cc-compiler: clang
             compiler-desc: Clang 9
             vfx-cy: 2021
-          # GCC, Debug
+          # C++11, GCC, Debug
           - build: 7
             build-type: Debug
             build-shared: 'ON'
@@ -140,7 +153,7 @@ jobs:
             build-openfx: 'OFF'
             use-sse: 'ON'
             use-openexr-half: 'ON'
-            cxx-standard: 17
+            cxx-standard: 11
             cxx-compiler: g++
             cc-compiler: gcc
             compiler-desc: GCC 9.3.1
@@ -148,7 +161,7 @@ jobs:
           # -------------------------------------------------------------------
           # VFX CY2020 (Python 3.7)
           # -------------------------------------------------------------------
-          # Clang, OpenFX
+          # C++14, Clang, OpenFX
           - build: 6
             build-type: Release
             build-shared: 'ON'
@@ -161,7 +174,7 @@ jobs:
             cc-compiler: clang
             compiler-desc: Clang 7
             vfx-cy: 2020
-          # GCC, static, Debug, OpenFX
+          # C++14, GCC, static, Debug, OpenFX
           - build: 5
             build-type: Debug
             build-shared: 'OFF'
@@ -174,7 +187,7 @@ jobs:
             cc-compiler: gcc
             compiler-desc: GCC 6.3.1
             vfx-cy: 2020
-          # GCC, no SSE, docs
+          # C++11, GCC, no SSE, docs
           - build: 4
             build-type: Release
             build-shared: 'ON'
@@ -182,7 +195,7 @@ jobs:
             build-openfx: 'OFF'
             use-sse: 'ON'
             use-openexr-half: 'ON'
-            cxx-standard: 14
+            cxx-standard: 11
             cxx-compiler: g++
             cc-compiler: gcc
             compiler-desc: GCC 6.3.1
@@ -190,7 +203,7 @@ jobs:
           # -------------------------------------------------------------------
           # VFX CY2019 (Python 2.7)
           # -------------------------------------------------------------------
-          # Clang, static
+          # C++11, Clang, static
           - build: 3
             build-type: Release
             build-shared: 'OFF'
@@ -204,7 +217,7 @@ jobs:
             cc-compiler: clang
             compiler-desc: Clang 7
             vfx-cy: 2019
-          # Clang, Debug, no SSE
+          # C++11, Clang, Debug, no SSE
           - build: 2
             build-type: Debug
             build-shared: 'ON'
@@ -218,7 +231,7 @@ jobs:
             cc-compiler: clang
             compiler-desc: Clang 7
             vfx-cy: 2019
-          # GCC, OpenFX
+          # C++11, GCC, OpenFX
           - build: 1
             build-type: Release
             build-shared: 'ON'
@@ -518,6 +531,7 @@ jobs:
         if: matrix.build-docs == 'ON'
       - name: Install tests env
         run: share/ci/scripts/windows/install_tests_env.sh
+        shell: bash
       - name: Create build directories
         run: |
           mkdir _install

--- a/.github/workflows/wheel_workflow.yml
+++ b/.github/workflows/wheel_workflow.yml
@@ -41,6 +41,10 @@ jobs:
   linux:
     name: Build wheels on Linux
     runs-on: ubuntu-latest
+    # Don't run on OCIO forks
+    if: |
+      github.event_name != 'schedule' ||
+      github.repository == 'AcademySoftwareFoundation/OpenColorIO'
     strategy:
       matrix:
         include:
@@ -129,16 +133,13 @@ jobs:
   macos:
     name: Build wheels on macOS
     runs-on: macos-10.15
+    # Don't run on OCIO forks
+    if: |
+      github.event_name != 'schedule' ||
+      github.repository == 'AcademySoftwareFoundation/OpenColorIO'
     strategy:
       matrix:
         include:
-        # Python 3.10 can be enabled when numpy ship the binary wheel (which
-        # we use during tests). Building it within GH produces the following:
-        # RuntimeError: Polyfit sanity test emitted a warning, most likely due
-        # to using a buggy Accelerate backend. If you compiled yourself, see
-        # site.cfg.example for information. Otherwise report this to the vendor
-        # that provided NumPy.
-
           # -------------------------------------------------------------------
           # CPython 64 bits
           # -------------------------------------------------------------------
@@ -154,9 +155,9 @@ jobs:
           - build: CPython 3.9 64 bits
             python: cp39-*
             arch: x86_64
-          # - build: CPython 3.10 64 bits
-          #   python: cp310-*
-          #   arch: x86_64
+          - build: CPython 3.10 64 bits
+            python: cp310-*
+            arch: x86_64
           # -------------------------------------------------------------------
           # CPython ARM 64 bits
           # -------------------------------------------------------------------
@@ -166,9 +167,9 @@ jobs:
           - build: CPython 3.9 ARM 64 bits
             python: cp39-*
             arch: arm64
-          # - build: CPython 3.10 ARM 64 bits
-          #   python: cp310-*
-          #   arch: arm64
+          - build: CPython 3.10 ARM 64 bits
+            python: cp310-*
+            arch: arm64
 
     steps:
       - uses: actions/checkout@v2
@@ -195,6 +196,10 @@ jobs:
   windows:
     name: Build wheels on Windows
     runs-on: windows-2019
+    # Don't run on OCIO forks
+    if: |
+      github.event_name != 'schedule' ||
+      github.repository == 'AcademySoftwareFoundation/OpenColorIO'
     strategy:
       matrix:
         include:


### PR DESCRIPTION
- Disable Wheel build on OCIO forks
- Enable mac OS Python 3.10 wheels

Signed-off-by: Rémi Achard <remiachard@gmail.com>