### PR TITLE
Port from main to RB-2.0 - Adsk Contrib - Fix RGB spline curve inversion when the slope is zero (#1539)

### DIFF
--- a/src/OpenColorIO/ops/gradingrgbcurve/GradingBSplineCurve.cpp
+++ b/src/OpenColorIO/ops/gradingrgbcurve/GradingBSplineCurve.cpp
@@ -192,7 +192,7 @@ void EstimateSlopes(const std::vector<GradingControlPoint> & ctrlPnts, std::vect
     {
         size_t j = i;
         float DL = secantLen[i];
-        while ((j < numCtrlPnts - 2) && (fabs(secantSlope[j + 1] - secantSlope[j]) < 1e-6f))
+        while ((j < numCtrlPnts - 2) && (std::fabs(secantSlope[j + 1] - secantSlope[j]) < 1e-6f))
         {
             DL += secantLen[j + 1];
             j++;
@@ -255,7 +255,7 @@ void FitSpline(const std::vector<GradingControlPoint> & ctrlPnts,
             }
             else
             {
-                if (fabs(aa) > fabs(bb))
+                if (std::fabs(aa) > std::fabs(bb))
                 {
                     ksi = xi_pl1 + aa * del_x / (slopes[i + 1] - slopes[i]);
                 }
@@ -471,7 +471,7 @@ void GradingBSplineCurveImpl::AddShaderEval(GpuShaderText & st,
         st.newLine() << "{";
         st.newLine() << "  float B = " << coefs << "[coefsOffs + coefsSets];";
         st.newLine() << "  float C = " << coefs << "[coefsOffs + coefsSets * 2];";
-        st.newLine() << "  return (x - C) / B + knStart;";
+        st.newLine() << "  return abs(B) < 1e-5 ? knStart : (x - C) / B + knStart;";
         st.newLine() << "}";
 
         st.newLine() << "else if (x >= knEndY)";
@@ -483,7 +483,7 @@ void GradingBSplineCurveImpl::AddShaderEval(GpuShaderText & st,
         st.newLine() << "  float t = knEnd - kn;";
         st.newLine() << "  float slope = 2. * A * t + B;";
         st.newLine() << "  float offs = ( A * t + B ) * t + C;";
-        st.newLine() << "  return (x - offs) / slope + knEnd;";
+        st.newLine() << "  return abs(slope) < 1e-5 ? knEnd : (x - offs) / slope + knEnd;";
         st.newLine() << "}";
 
         // else
@@ -580,7 +580,7 @@ float GradingBSplineCurveImpl::KnotsCoefs::evalCurveRev(int c, float y) const
     {
         const float B = m_coefsArray[coefsOffs + coefsSets];
         const float C = m_coefsArray[coefsOffs + coefsSets * 2];
-        return (y - C) / B + knStart;
+        return std::fabs(B) < 1e-5f ? knStart : (y - C) / B + knStart;
     }
     else if (y >= knEndY)
     {
@@ -591,7 +591,7 @@ float GradingBSplineCurveImpl::KnotsCoefs::evalCurveRev(int c, float y) const
         const float t = knEnd - kn;
         const float slope = 2.f * A * t + B;
         const float offs = (A * t + B) * t + C;
-        return (y - offs) / slope + knEnd;
+        return std::fabs(slope) < 1e-5f ? knEnd : (y - offs) / slope + knEnd;
     }
     else
     {

--- a/tests/cpu/ops/gradingrgbcurve/GradingRGBCurveOpCPU_tests.cpp
+++ b/tests/cpu/ops/gradingrgbcurve/GradingRGBCurveOpCPU_tests.cpp
@@ -176,14 +176,14 @@ OCIO_ADD_TEST(GradingRGBCurveOpCPU, log)
     OCIO_CHECK_NO_THROW(op = OCIO::GetGradingRGBCurveCPURenderer(gcc));
     OCIO_CHECK_ASSERT(op);
 
-    const long num_samples = 2;
+    constexpr long num_samples = 2;
     float res[4 * num_samples]{ 0.f };
 
-    const float input_32f[] = {
+    constexpr float input_32f[] = {
         -0.2f, 0.2f, 0.5f, 0.0f,
          0.8f, 1.0f, 2.0f, 0.5f };
 
-    const float expected_32f[] = {
+    constexpr float expected_32f[] = {
         0.25306581f, 0.35779659f, 0.98416632f, 0.0f,
         1.09451043f, 1.54596428f, 1.78067802f, 0.5f };
 
@@ -219,14 +219,14 @@ OCIO_ADD_TEST(GradingRGBCurveOpCPU, log_partial_identity)
     OCIO_CHECK_NO_THROW(op = OCIO::GetGradingRGBCurveCPURenderer(gcc));
     OCIO_CHECK_ASSERT(op);
 
-    const long num_samples = 2;
+    constexpr long num_samples = 2;
     float res[4 * num_samples]{ 0.f };
 
     float input_32f[] = {
         -0.2f, 0.2f, 0.5f, 0.0f,
          0.8f, 1.0f, 2.0f, 0.5f };
 
-    const float expected_32f[] = {
+    constexpr float expected_32f[] = {
         -0.2f, 0.15779659f, 0.5f, 0.0f,
          0.8f, 1.34596419f, 2.0f, 0.5f };
 
@@ -264,14 +264,14 @@ OCIO_ADD_TEST(GradingRGBCurveOpCPU, monotonic)
     OCIO_CHECK_NO_THROW(op = OCIO::GetGradingRGBCurveCPURenderer(gcc));
     OCIO_CHECK_ASSERT(op);
 
-    const long num_samples = 2;
+    constexpr long num_samples = 2;
     float res[4 * num_samples]{ 0.f };
 
     float input_32f[] = {
         0.8f, 0.2f, 0.5f, 0.0f,
         0.9f, 1.0f, 2.0f, 0.5f };
 
-    const float expected_32f[] = {
+    constexpr float expected_32f[] = {
         0.52230538f, 0.2f, 0.5f, 0.0f,
         0.68079938f, 1.0f, 2.0f, 0.5f };
 
@@ -311,14 +311,14 @@ OCIO_ADD_TEST(GradingRGBCurveOpCPU, lin_bypass)
     OCIO_CHECK_NO_THROW(op = OCIO::GetGradingRGBCurveCPURenderer(gcc));
     OCIO_CHECK_ASSERT(op);
 
-    const long num_samples = 2;
+    constexpr long num_samples = 2;
     float res[4 * num_samples]{ 0.f };
 
     float input_32f[] = {
         -8.f, -3.f, -1.f,  0.0f,
          1.f,  2.5f, 4.0f, 0.5f };
 
-    const float expected_32f[] = {
+    constexpr float expected_32f[] = {
         -8.50508935f, -6.37181915f, -3.01264257f, 0.0f,
          1.95205522f,  4.76796850f,  5.76796850f, 0.5f };
 
@@ -357,14 +357,14 @@ OCIO_ADD_TEST(GradingRGBCurveOpCPU, lin)
     OCIO_CHECK_NO_THROW(op = OCIO::GetGradingRGBCurveCPURenderer(gcc));
     OCIO_CHECK_ASSERT(op);
 
-    const long num_samples = 2;
+    constexpr long num_samples = 2;
     float res[4 * num_samples]{ 0.f };
 
     float input_32f[] = {
         -0.003f, 0.02f, 0.09f, 0.0f,
          0.360f, 1.00f, 3.00f, 0.5f };
 
-    const float expected_32f[] = {
+    constexpr float expected_32f[] = {
         -4.20784139e-03f, 1.26825221e-03f, 2.23983977e-02f, 0.0f,
          6.96706128e-01f, 4.79411018e+00f, 9.95152432e+00f, 0.5f };
 
@@ -410,14 +410,33 @@ OCIO_ADD_TEST(GradingRGBCurveOpCPU, slopes)
     OCIO_CHECK_NO_THROW(op = OCIO::GetGradingRGBCurveCPURenderer(gcc));
     OCIO_CHECK_ASSERT(op);
 
-    const long num_samples = 1;
+    constexpr long num_samples = 2;
     float input_32f[] = {
-        -3.f, -1.f, 1.f, 0.5f };
+        -3.f, -1.f, 1.f, 0.5f,
+        -7.f,  0.f, 7.f, 1.0f };
 
     // Test that the slopes were used (the values are significantly different without slopes).
-    const float expected_32f[] = {
-        -2.92582282f, 0.28069129f, 2.81987724f, 0.5f };
+    constexpr float expected_32f[] = {
+        -2.92582282f, 0.28069129f, 2.81987724f, 0.5f,
+        -4.0f,        1.73250193f, 4.0f,        1.0f };
 
     OCIO_CHECK_NO_THROW(op->apply(input_32f, input_32f, num_samples));
     ValidateImage(expected_32f, input_32f, num_samples, __LINE__);
+
+    // Test in inverse direction.
+
+    float rev_input_32f[] = {
+        -2.92582282f, 0.28069129f, 2.81987724f, 0.5f,
+        -7.0f,        1.73250193f, 7.0f,        1.0f };
+
+    constexpr float rev_expected_32f[] = {
+        -3.f,        -1.f, 1.f,         0.5f,
+        -5.26017743f, 0.f, 4.67381243f, 1.0f };
+
+    gc->setDirection(OCIO::TRANSFORM_DIR_INVERSE);
+
+    OCIO_CHECK_NO_THROW(op = OCIO::GetGradingRGBCurveCPURenderer(gcc));
+    OCIO_CHECK_ASSERT(op);
+    OCIO_CHECK_NO_THROW(op->apply(rev_input_32f, rev_input_32f, num_samples));
+    ValidateImage(rev_expected_32f, rev_input_32f, num_samples, __LINE__);
 }

--- a/tests/gpu/GradingRGBCurveOp_test.cpp
+++ b/tests/gpu/GradingRGBCurveOp_test.cpp
@@ -105,6 +105,68 @@ OCIO_ADD_GPU_TEST(GradingRGBCurve, style_lin_rev_dynamic)
     GradingRGBCurveLin(test, OCIO::TRANSFORM_DIR_INVERSE, true);
 }
 
+void GradingRGBSCurve(OCIOGPUTest & test, OCIO::TransformDirection dir, bool dynamic)
+{
+    // Create an S-curve with 0 slope at each end.
+    auto curve = OCIO::GradingBSplineCurve::Create({
+            {-5.26017743f, -4.f},
+            {-3.75502745f, -3.57868829f},
+            {-2.24987747f, -1.82131329f},
+            {-0.74472749f,  0.68124124f},
+            { 1.06145248f,  2.87457742f},
+            { 2.86763245f,  3.83406206f},
+            { 4.67381243f,  4.f}
+        });
+    float slopes[] = { 0.f,  0.55982688f,  1.77532247f,  1.55f,  0.8787017f,  0.18374463f,  0.f };
+    for (size_t i = 0; i < 7; ++i)
+    {
+        curve->setSlope( i, slopes[i] );
+    }
+
+    OCIO::ConstGradingBSplineCurveRcPtr m = curve;
+    // Adjust scaling to ensure the test vector for the inverse hits the flat areas.
+    auto scaling = OCIO::GradingBSplineCurve::Create({ { -5.f, 0.f }, { 5.f, 1.f } });
+    OCIO::ConstGradingBSplineCurveRcPtr z = scaling;
+    OCIO::ConstGradingRGBCurveRcPtr curves = OCIO::GradingRGBCurve::Create(m, m, m, z);
+
+    auto gc = OCIO::GradingRGBCurveTransform::Create(OCIO::GRADING_LOG);
+    gc->setValue(curves);
+    gc->setDirection(dir);
+    if (dynamic)
+    {
+        gc->makeDynamic();
+    }
+
+    test.setProcessor(gc);
+
+    test.setErrorThreshold(1.5e-4f);
+    test.setExpectedMinimalValue(1.0f);
+    test.setRelativeComparison(true);
+    test.setTestWideRange(true);
+    test.setTestInfinity(false);
+    test.setTestNaN(true);
+}
+
+OCIO_ADD_GPU_TEST(GradingRGBCurve, scurve_fwd)
+{
+    GradingRGBSCurve(test, OCIO::TRANSFORM_DIR_FORWARD, false);
+}
+
+OCIO_ADD_GPU_TEST(GradingRGBCurve, scurve_fwd_dynamic)
+{
+    GradingRGBSCurve(test, OCIO::TRANSFORM_DIR_FORWARD, true);
+}
+
+OCIO_ADD_GPU_TEST(GradingRGBCurve, scurve_rev)
+{
+    GradingRGBSCurve(test, OCIO::TRANSFORM_DIR_INVERSE, false);
+}
+
+OCIO_ADD_GPU_TEST(GradingRGBCurve, scurve_rev_dynamic)
+{
+    GradingRGBSCurve(test, OCIO::TRANSFORM_DIR_INVERSE, true);
+}
+
 namespace
 {
 


### PR DESCRIPTION
* Fix RGBCurve inverse when slope=0

Signed-off-by: Doug Walker <Doug.Walker@autodesk.com>

* Add GPU fix and test

Signed-off-by: Doug Walker <Doug.Walker@autodesk.com>

* Tweak var name

Signed-off-by: Doug Walker <Doug.Walker@autodesk.com>

Co-authored-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>