### PR TITLE
Port from main to RB-2.1 - Adds Metal Shading Language (MSL) Generation support (#1520)

### DIFF
--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -449,6 +449,7 @@ enum GpuLanguage
     LANGUAGE_OSL_1,                 ///< Open Shading Language
     GPU_LANGUAGE_GLSL_ES_1_0,       ///< OpenGL ES Shading Language
     GPU_LANGUAGE_GLSL_ES_3_0,       ///< OpenGL ES Shading Language
+    GPU_LANGUAGE_MSL_2_0            ///< Metal Shading Language
 };
 
 enum EnvironmentMode

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -54,6 +54,7 @@ set(SOURCES
     GPUProcessor.cpp
     GpuShader.cpp
     GpuShaderDesc.cpp
+    GpuShaderClassWrapper.cpp
     GpuShaderUtils.cpp
     HashUtils.cpp
     ImageDesc.cpp

--- a/src/OpenColorIO/GpuShaderClassWrapper.cpp
+++ b/src/OpenColorIO/GpuShaderClassWrapper.cpp
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "GpuShaderClassWrapper.h"
+
+namespace OCIO_NAMESPACE
+{
+
+std::string MetalShaderClassWrapper::generateClassWrapperHeader(GpuShaderText& kw) const
+{
+    if(m_className.empty())
+    {
+        throw Exception("Struct name must include at least 1 character");
+    }
+    if(std::isdigit(m_className[0]))
+    {
+        throw Exception(("Struct name must not start with a digit. Invalid className passed in: " + m_className).c_str());
+    }
+
+    kw.newLine() << "struct " << m_className;
+    kw.newLine() << "{";
+    kw.newLine() << m_className <<"(";
+    kw.indent();
+
+    std::string separator = "";
+    for(const auto& param : m_functionParameters)
+    {
+        kw.newLine() << separator << param.type << " " << param.name;
+        separator = ", ";
+    }
+    kw.dedent();
+    kw.newLine() << ")";
+    kw.newLine() << "{";
+    
+    kw.indent();
+    for(const auto& param : m_functionParameters)
+    {
+        size_t openAngledBracketPos = param.name.find('[');
+        bool isArray = openAngledBracketPos != std::string::npos;
+        if(!isArray)
+            kw.newLine()    << "this->" << param.name  << " = " << param.name  << ";";
+        else
+        {
+            size_t closeAngledBracketPos = param.name.find(']');
+            std::string variableName = param.name.substr(0, openAngledBracketPos);
+            
+            kw.newLine()    << "for(int i = 0; i < "
+                            << param.name.substr(openAngledBracketPos+1, closeAngledBracketPos-openAngledBracketPos-1)
+                            << "; ++i)";
+            kw.indent();
+            kw.newLine()    << "this->" << variableName << "[i] = " << variableName << "[i];";
+            kw.dedent();
+        }
+    }
+    kw.dedent();
+    kw.newLine() <<"}";
+    return kw.string();
+}
+    
+std::string MetalShaderClassWrapper::generateClassWrapperFooter(GpuShaderText& kw, const std::string &ocioFunctionName) const
+{
+    if(m_className.empty())
+    {
+        throw Exception("Struct name must include at least 1 character");
+    }
+    if(std::isdigit(m_className[0]))
+    {
+        throw Exception(("Struct name must not start with a digit. Invalid className passed in: " + m_className).c_str());
+    }
+
+    kw.newLine() << "};";
+    
+    kw.newLine() << kw.float4Keyword() << " " << ocioFunctionName<< "(";
+    std::string texParamOut;
+    
+    kw.indent();
+    std::string separator = "";
+    for(const auto& param : m_functionParameters)
+    {
+        kw.newLine() << separator << param.type << " " << param.name;
+        separator = ", ";
+    }
+    kw.newLine() << separator << kw.float4Keyword() << " inPixel)";
+    kw.dedent();
+    kw.newLine() << "{";
+    kw.indent();
+    kw.newLine() << "return " << m_className << "(";
+
+    kw.indent();
+    separator = "";
+    for(const auto& param : m_functionParameters)
+    {
+        size_t openAngledBracketPos = param.name.find('[');
+        bool isArray = openAngledBracketPos != std::string::npos;
+        
+        if(!isArray)
+            kw.newLine() << separator << param.name;
+        else
+            kw.newLine() << separator << param.name.substr(0, openAngledBracketPos);
+        separator = ", ";
+    }
+    kw.dedent();
+    
+    kw.newLine() << ")." << ocioFunctionName << "(inPixel);";
+    kw.dedent();
+    kw.newLine() << "}";
+    
+    return kw.string();
+}
+
+std::string MetalShaderClassWrapper::getClassWrapperName(const std::string &resourcePrefix, const std::string& functionName)
+{
+    return (resourcePrefix.length() == 0 ? "OCIO_" : resourcePrefix) + functionName;
+}
+
+void MetalShaderClassWrapper::extractFunctionParameters(const std::string& declaration)
+{
+    // We want the caller to always pass 3d luts first with their samplers, and then pass other luts.
+    std::vector<std::tuple<std::string, std::string, std::string>> lut3DTextures;
+    std::vector<std::tuple<std::string, std::string, std::string>> lutTextures;
+    std::vector<std::pair <std::string, std::string             >> uniforms;
+
+    m_functionParameters.clear();
+    
+    std::string lineBuffer;
+    
+    std::istringstream is(declaration);
+    while(!is.eof())
+    {
+        std::getline(is, lineBuffer);
+        
+        if(lineBuffer.empty())
+            continue;
+        
+        size_t i = 0;
+        
+        // Skip spaces
+        while(std::isspace(lineBuffer[i])) ++i;
+        
+        // if the line was all skippable characters
+        if(i >= lineBuffer.size())
+            continue;
+        
+        // if the line is a comment
+        if(lineBuffer[i + 0] == '/' && lineBuffer[i + 1] == '/')
+            continue;
+
+        if(lineBuffer.compare(i, 7, "texture") == 0)
+        {
+            int  textureDim = static_cast<int>(lineBuffer[i+7] - '0');
+            
+            size_t endTextureType = lineBuffer.find('>');
+            std::string textureType = lineBuffer.substr(i, (endTextureType - i + 1));
+            
+            i = endTextureType + 1;
+            while(std::isspace(lineBuffer[i])) ++i;
+            
+            size_t endTextureName = lineBuffer.find_first_of(" \t;", i);
+            std::string textureName = lineBuffer.substr(i, (endTextureName - i));
+
+            std::getline(is, lineBuffer);
+            
+            i = lineBuffer.find("sampler") + 7;
+            while(std::isspace(lineBuffer[i])) ++i;
+            size_t endSamplerName = lineBuffer.find_first_of(" \t;", i);
+            std::string samplerName = lineBuffer.substr(i, endSamplerName - i);
+            
+            if(textureDim == 3)
+                lut3DTextures.emplace_back(textureType, textureName, samplerName);
+            else
+                lutTextures.emplace_back(textureType, textureName, samplerName);
+        }
+        else
+        {
+            size_t endTypeName     = lineBuffer.find_first_of(" \t", i);
+            std::string variableType = lineBuffer.substr(i, (endTypeName - i));
+            
+            i = endTypeName + 1;
+            while(std::isspace(lineBuffer[i])) ++i;
+            
+            size_t endVariableName = lineBuffer.find_first_of(" \t;", i);
+            std::string variableName = lineBuffer.substr(i, (endVariableName - i));
+            uniforms.emplace_back(variableType, variableName);
+        }
+    }
+        
+    for(const auto& lut3D : lut3DTextures)
+    {
+        m_functionParameters.emplace_back(std::get<0>(lut3D).c_str(), std::get<1>(lut3D).c_str());
+        m_functionParameters.emplace_back("sampler", std::get<2>(lut3D).c_str());
+    }
+    
+    for(const auto& lut : lutTextures)
+    {
+        m_functionParameters.emplace_back(std::get<0>(lut).c_str(), std::get<1>(lut).c_str());
+        m_functionParameters.emplace_back("sampler", std::get<2>(lut).c_str());
+    }
+    
+    for(const auto& uniform : uniforms)
+    {
+        m_functionParameters.emplace_back(uniform.first, uniform.second);
+    }
+}
+
+void MetalShaderClassWrapper::prepareClassWrapper(const std::string& resourcePrefix, const std::string& functionName, const std::string& originalHeader)
+{
+    m_functionName = functionName;
+    m_className = getClassWrapperName(resourcePrefix, functionName);
+    extractFunctionParameters(originalHeader);
+}
+
+std::string MetalShaderClassWrapper::getClassWrapperHeader(const std::string& originalHeader)
+{
+    GpuShaderText st(GPU_LANGUAGE_MSL_2_0);
+
+    generateClassWrapperHeader(st);
+    st.newLine();
+    
+    std::string classWrapHeader = "\n// Declaration of class wrapper\n\n";
+    classWrapHeader += st.string();
+    
+    return classWrapHeader + originalHeader;
+}
+
+std::string MetalShaderClassWrapper::getClassWrapperFooter(const std::string& originalFooter)
+{
+    GpuShaderText st(GPU_LANGUAGE_MSL_2_0);
+    
+    st.newLine();
+    generateClassWrapperFooter(st, m_functionName);
+    
+    std::string classWrapFooter = "\n// Close class wrapper\n\n";
+    classWrapFooter += st.string();
+    
+    return originalFooter + classWrapFooter;
+}
+
+std::unique_ptr<GpuShaderClassWrapper> MetalShaderClassWrapper::clone() const
+{
+    std::unique_ptr<MetalShaderClassWrapper> clonedWrapper = std::unique_ptr<MetalShaderClassWrapper>(new MetalShaderClassWrapper);
+    *clonedWrapper = *this;
+    return clonedWrapper;
+}
+
+MetalShaderClassWrapper& MetalShaderClassWrapper::operator=(const MetalShaderClassWrapper& rhs)
+{
+    this->m_className          = rhs.m_className;
+    this->m_functionName       = rhs.m_functionName;
+    this->m_functionParameters = rhs.m_functionParameters;
+    return *this;
+}
+
+} // namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/GpuShaderClassWrapper.h
+++ b/src/OpenColorIO/GpuShaderClassWrapper.h
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#ifndef INCLUDED_OCIO_GPUSHADERCLASSWRAPPER_H
+#define INCLUDED_OCIO_GPUSHADERCLASSWRAPPER_H
+
+#include <sstream>
+#include <utility>
+#include <vector>
+#include <memory>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "GpuShaderUtils.h"
+
+namespace OCIO_NAMESPACE
+{
+
+class GpuShaderClassWrapper
+{
+public:
+    virtual void prepareClassWrapper(const std::string& resourcePrefix,
+                                     const std::string& functionName,
+                                     const std::string& originalHeader) = 0;
+    virtual std::string getClassWrapperHeader(const std::string& originalHeader) = 0;
+    virtual std::string getClassWrapperFooter(const std::string& originalFooter) = 0;
+    
+    virtual std::unique_ptr<GpuShaderClassWrapper> clone() const = 0;
+    
+    virtual ~GpuShaderClassWrapper() = default;
+};
+
+class NullGpuShaderClassWrapper : public GpuShaderClassWrapper
+{
+public:
+    void prepareClassWrapper(const std::string& /*resourcePrefix*/,
+                             const std::string& /*functionName*/,
+                             const std::string& /*originalHeader*/) final {}
+    std::string getClassWrapperHeader(const std::string& originalHeader) final { return originalHeader; }
+    std::string getClassWrapperFooter(const std::string& originalFooter) final { return originalFooter; }
+    
+    std::unique_ptr<GpuShaderClassWrapper> clone() const final
+    {
+        return std::unique_ptr<NullGpuShaderClassWrapper>(new NullGpuShaderClassWrapper());
+    }
+};
+
+class MetalShaderClassWrapper : public GpuShaderClassWrapper
+{
+public:
+    void prepareClassWrapper(const std::string& resourcePrefix,
+                             const std::string& functionName,
+                             const std::string& originalHeader) final;
+    std::string getClassWrapperHeader(const std::string& originalHeader) final;
+    std::string getClassWrapperFooter(const std::string& originalFooter) final;
+    
+    std::unique_ptr<GpuShaderClassWrapper> clone() const final;
+    MetalShaderClassWrapper& operator=(const MetalShaderClassWrapper& rhs);
+    
+private:
+    struct FunctionParam
+    {
+        FunctionParam(const std::string& type, const std::string& name) :
+            type(type),
+            name(name)
+        {
+        }
+
+        std::string type;
+        std::string name;
+    };
+    
+    std::string getClassWrapperName(const std::string &resourcePrefix, const std::string& functionName);
+    void extractFunctionParameters(const std::string& declaration);
+    std::string generateClassWrapperHeader(GpuShaderText& st) const;
+    std::string generateClassWrapperFooter(GpuShaderText& st, const std::string &ocioFunctionName) const;
+    
+    std::string m_className;
+    std::string m_functionName;
+    std::vector<FunctionParam> m_functionParameters;
+};
+
+} // namespace OCIO_NAMESPACE
+
+#endif

--- a/src/OpenColorIO/ParseUtils.cpp
+++ b/src/OpenColorIO/ParseUtils.cpp
@@ -259,14 +259,15 @@ const char * GpuLanguageToString(GpuLanguage language)
 {
     switch(language)
     {
-        case GPU_LANGUAGE_CG: return "cg";
-        case GPU_LANGUAGE_GLSL_1_2:  return "glsl_1.2";
-        case GPU_LANGUAGE_GLSL_1_3:  return "glsl_1.3";
-        case GPU_LANGUAGE_GLSL_4_0:  return "glsl_4.0";
+        case GPU_LANGUAGE_CG:           return "cg";
+        case GPU_LANGUAGE_GLSL_1_2:     return "glsl_1.2";
+        case GPU_LANGUAGE_GLSL_1_3:     return "glsl_1.3";
+        case GPU_LANGUAGE_GLSL_4_0:     return "glsl_4.0";
         case GPU_LANGUAGE_GLSL_ES_1_0:  return "glsl_es_1.0";
         case GPU_LANGUAGE_GLSL_ES_3_0:  return "glsl_es_3.0";
-        case GPU_LANGUAGE_HLSL_DX11: return "hlsl_dx11";
-        case LANGUAGE_OSL_1: return "osl_1";
+        case GPU_LANGUAGE_HLSL_DX11:    return "hlsl_dx11";
+        case GPU_LANGUAGE_MSL_2_0:      return "msl_2";
+        case LANGUAGE_OSL_1:            return "osl_1";
     }
 
     throw Exception("Unsupported GPU shader language.");
@@ -278,13 +279,14 @@ GpuLanguage GpuLanguageFromString(const char * s)
     const std::string str = StringUtils::Lower(p);
 
     if(str == "cg") return GPU_LANGUAGE_CG;
-    else if(str == "glsl_1.2") return GPU_LANGUAGE_GLSL_1_2;
-    else if(str == "glsl_1.3") return GPU_LANGUAGE_GLSL_1_3;
-    else if(str == "glsl_4.0") return GPU_LANGUAGE_GLSL_4_0;
+    else if(str == "glsl_1.2")    return GPU_LANGUAGE_GLSL_1_2;
+    else if(str == "glsl_1.3")    return GPU_LANGUAGE_GLSL_1_3;
+    else if(str == "glsl_4.0")    return GPU_LANGUAGE_GLSL_4_0;
     else if(str == "glsl_es_1.0") return GPU_LANGUAGE_GLSL_ES_1_0;
     else if(str == "glsl_es_3.0") return GPU_LANGUAGE_GLSL_ES_3_0;
-    else if(str == "hlsl_dx11") return GPU_LANGUAGE_HLSL_DX11;
-    else if(str == "osl_1") return LANGUAGE_OSL_1;
+    else if(str == "hlsl_dx11")   return GPU_LANGUAGE_HLSL_DX11;
+    else if(str == "osl_1")       return LANGUAGE_OSL_1;
+    else if(str == "msl_2")       return GPU_LANGUAGE_MSL_2_0;
 
     std::ostringstream oss;
     oss << "Unsupported GPU shader language: '" << p << "'.";

--- a/src/OpenColorIO/ops/gradingrgbcurve/GradingRGBCurveOpGPU.cpp
+++ b/src/OpenColorIO/ops/gradingrgbcurve/GradingRGBCurveOpGPU.cpp
@@ -227,7 +227,7 @@ void AddCurveEvalMethodTextToShaderProgram(GpuShaderCreatorRcPtr & shaderCreator
     }
 
     st.newLine() << "";
-    if (shaderCreator->getLanguage() == LANGUAGE_OSL_1)
+    if (shaderCreator->getLanguage() == LANGUAGE_OSL_1 || shaderCreator->getLanguage() == GPU_LANGUAGE_MSL_2_0)
     {
         st.newLine() << st.floatKeyword() << " " << props.m_eval << "(int curveIdx, float x)";
     }

--- a/src/bindings/python/PyTypes.cpp
+++ b/src/bindings/python/PyTypes.cpp
@@ -520,6 +520,8 @@ void bindPyTypes(py::module & m)
                DOC(PyOpenColorIO, GpuLanguage, GPU_LANGUAGE_GLSL_ES_3_0))
         .value("GPU_LANGUAGE_HLSL_DX11", GPU_LANGUAGE_HLSL_DX11, 
                DOC(PyOpenColorIO, GpuLanguage, GPU_LANGUAGE_HLSL_DX11))
+        .value("GPU_LANGUAGE_MSL_2_0", GPU_LANGUAGE_MSL_2_0,
+               DOC(PyOpenColorIO, GpuLanguage, GPU_LANGUAGE_MSL_2_0))
         .export_values();
 
     py::enum_<EnvironmentMode>(

--- a/src/libutils/oglapphelpers/glsl.cpp
+++ b/src/libutils/oglapphelpers/glsl.cpp
@@ -460,6 +460,7 @@ std::string OpenGLBuilder::getGLSLVersionString()
     case GPU_LANGUAGE_CG:
     case GPU_LANGUAGE_HLSL_DX11:
     case LANGUAGE_OSL_1:
+    case GPU_LANGUAGE_MSL_2_0:
     default:
         // These are all impossible in OpenGL contexts.
         // The shader will be unusable, so let's throw

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -83,6 +83,7 @@ set(SOURCES
     fileformats/xmlutils/XMLWriterUtils.cpp
     GPUProcessor.cpp
     GpuShaderDesc.cpp
+    GpuShaderClassWrapper.cpp
     HashUtils.cpp
     ImageDesc.cpp
     ImagePacking.cpp

--- a/tests/cpu/GpuShader_tests.cpp
+++ b/tests/cpu/GpuShader_tests.cpp
@@ -5,6 +5,7 @@
 #include "GpuShader.cpp"
 
 #include "testutils/UnitTest.h"
+#include "UnitTestUtils.h"
 
 namespace OCIO = OCIO_NAMESPACE;
 
@@ -191,4 +192,1072 @@ OCIO_ADD_TEST(GpuShader, generic_shader)
 
         OCIO_CHECK_EQUAL(fragText, shaderDesc->getShaderText());
     }
+}
+
+OCIO_ADD_TEST(GpuShader, MetalLutTest)
+{
+    static constexpr char sFromSpace[] = "ACEScg";
+    static constexpr char sDiplay[] = "AdobeRGB";
+    static constexpr char sView[] = "raw";
+
+    static constexpr char CONFIG[] = { R"(ocio_profile_version: 2
+environment: {}
+search_path: "./"
+roles:
+  data: Raw
+  default: Raw
+  scene_linear: ACEScg
+
+file_rules:
+  - !<Rule> {name: Default, colorspace: default}
+
+displays:
+  AdobeRGB:
+    - !<View> {name: Raw, colorspace: Raw}
+
+colorspaces:
+  - !<ColorSpace>
+    name: ACEScg
+    to_reference: !<MatrixTransform> {matrix: [ 0.695452241357, 0.140678696470, 0.163869062172, 0, 0.044794563372, 0.859671118456, 0.095534318172, 0, -0.005525882558, 0.004025210306, 1.001500672252, 0, 0, 0, 0, 1 ]}
+  - !<ColorSpace>
+    name: Raw
+    isdata: true)" };
+
+    {
+        std::istringstream iss;
+        iss.str(CONFIG);
+
+        OCIO::ConstConfigRcPtr mOCIOCfg;
+        OCIO_CHECK_NO_THROW(mOCIOCfg = OCIO::Config::CreateFromStream(iss));
+        OCIO_CHECK_NO_THROW(mOCIOCfg->validate());
+
+        OCIO::DisplayViewTransformRcPtr transform = OCIO::DisplayViewTransform::Create();
+        transform->setSrc(sFromSpace);
+        transform->setDisplay(sDiplay);
+        transform->setView(sView);
+        
+        auto processor = mOCIOCfg->getProcessor(transform);
+
+        const unsigned edgelen = 2;
+        auto gpuProcessor = processor->getOptimizedLegacyGPUProcessor(OCIO::OPTIMIZATION_ALL, edgelen);
+    
+        auto shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
+
+        shaderDesc->setFunctionName("Display");
+        shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_MSL_2_0);
+
+        gpuProcessor->extractGpuShaderInfo(shaderDesc);
+        const std::string text = shaderDesc->getShaderText();;
+        static constexpr char expected[] = { R"(
+// Declaration of class wrapper
+
+struct ocioDisplay
+{
+ocioDisplay(
+)
+{
+}
+
+
+// Declaration of the OCIO shader function
+
+float4 Display(float4 inPixel)
+{
+  float4 outColor = inPixel;
+
+  return outColor;
+}
+
+// Close class wrapper
+
+
+};
+float4 Display(
+  float4 inPixel)
+{
+  return ocioDisplay(
+  ).Display(inPixel);
+}
+)" };
+
+        OCIO_CHECK_EQUAL(expected, text);
+    }
+}
+
+OCIO_ADD_TEST(GpuShader, MetalLutTest2)
+{
+    static constexpr char sFromSpace[] = "ACEScg";
+    static constexpr char sDiplay[] = "AdobeRGB";
+    static constexpr char sView[] = "raw";
+
+    static constexpr char CONFIG[] = { R"(ocio_profile_version: 2
+environment: {}
+search_path: "./"
+roles:
+  data: Raw
+  default: Raw
+  scene_linear: ACEScg
+
+file_rules:
+  - !<Rule> {name: Default, colorspace: default}
+
+displays:
+  AdobeRGB:
+    - !<View> {name: Raw, colorspace: Raw}
+
+colorspaces:
+  - !<ColorSpace>
+    name: ACEScg
+    to_reference: !<MatrixTransform> {matrix: [ 0.695452241357, 0.140678696470, 0.163869062172, 0, 0.044794563372, 0.859671118456, 0.095534318172, 0, -0.005525882558, 0.004025210306, 1.001500672252, 0, 0, 0, 0, 1 ]}
+  - !<ColorSpace>
+    name: Raw
+    isdata: true)" };
+
+    {
+        std::istringstream iss;
+        iss.str(CONFIG);
+
+        OCIO::ConstConfigRcPtr mOCIOCfg;
+        OCIO_CHECK_NO_THROW(mOCIOCfg = OCIO::Config::CreateFromStream(iss));
+        OCIO_CHECK_NO_THROW(mOCIOCfg->validate());
+
+        OCIO::DisplayViewTransformRcPtr transform = OCIO::DisplayViewTransform::Create();
+        transform->setSrc(sFromSpace);
+        transform->setDisplay(sDiplay);
+        transform->setView(sView);
+        
+        auto processor = mOCIOCfg->getProcessor(transform);
+
+        auto gpuProcessor = processor->getDefaultGPUProcessor();
+    
+        auto shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
+
+        shaderDesc->setFunctionName("Display");
+        shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_MSL_2_0);
+
+        gpuProcessor->extractGpuShaderInfo(shaderDesc);
+        const std::string text = shaderDesc->getShaderText();
+        static constexpr char expected[] = { R"(
+// Declaration of class wrapper
+
+struct ocioDisplay
+{
+ocioDisplay(
+)
+{
+}
+
+
+// Declaration of the OCIO shader function
+
+float4 Display(float4 inPixel)
+{
+  float4 outColor = inPixel;
+
+  return outColor;
+}
+
+// Close class wrapper
+
+
+};
+float4 Display(
+  float4 inPixel)
+{
+  return ocioDisplay(
+  ).Display(inPixel);
+}
+)" };
+        
+        OCIO_CHECK_EQUAL(expected, text);
+    }
+}
+
+OCIO_ADD_TEST(GpuShader, MetalSupport3)
+{
+    // The unit test validates a single 1D LUT.
+
+    static const std::string CONFIG =
+        "ocio_profile_version: 2\n"
+        "\n"
+        "environment: {ENV1: " + OCIO::GetTestFilesDir() + "}\n"
+        "\n"
+        "search_path: $ENV1\n"
+        "\n"
+        "roles:\n"
+        "  default: cs1\n"
+        "  reference: cs1\n"
+        "\n"
+        "displays:\n"
+        "  disp1:\n"
+        "    - !<View> {name: view1, colorspace: cs2}\n"
+        "\n"
+        "colorspaces:\n"
+        "  - !<ColorSpace>\n"
+        "    name: cs1\n"
+        "\n"
+        "  - !<ColorSpace>\n"
+        "    name: cs2\n"
+        "    from_scene_reference: !<FileTransform> {src: lut1d_green.ctf}\n";
+
+    {
+        std::istringstream iss;
+        iss.str(CONFIG);
+
+        OCIO::ConstConfigRcPtr mOCIOCfg;
+        OCIO_CHECK_NO_THROW(mOCIOCfg = OCIO::Config::CreateFromStream(iss));
+        OCIO_CHECK_NO_THROW(mOCIOCfg->validate());
+
+        OCIO::ColorSpaceTransformRcPtr transform = OCIO::ColorSpaceTransform::Create();
+        transform->setSrc("cs1");
+        transform->setDst("cs2");
+        
+        auto processor = mOCIOCfg->getProcessor(transform);
+        auto gpuProcessor = processor->getOptimizedGPUProcessor(OCIO::OPTIMIZATION_NONE);
+    
+        auto shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
+        shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_MSL_2_0);
+        shaderDesc->setFunctionName("MyMethodName");
+        shaderDesc->setPixelName("myPixelName");
+        
+        gpuProcessor->extractGpuShaderInfo(shaderDesc);
+
+        const std::string text(shaderDesc->getShaderText());
+        static constexpr char expected[] = { R"(
+// Declaration of class wrapper
+
+struct ocioMyMethodName
+{
+ocioMyMethodName(
+  texture1d<float> ocio_lut1d_0
+  , sampler ocio_lut1d_0Sampler
+)
+{
+  this->ocio_lut1d_0 = ocio_lut1d_0;
+  this->ocio_lut1d_0Sampler = ocio_lut1d_0Sampler;
+}
+
+
+// Declaration of all variables
+
+texture1d<float> ocio_lut1d_0;
+sampler ocio_lut1d_0Sampler;
+
+// Declaration of the OCIO shader function
+
+float4 MyMethodName(float4 inPixel)
+{
+  float4 myPixelName = inPixel;
+  
+  // Add LUT 1D processing for ocio_lut1d_0
+  
+  {
+    float3 ocio_lut1d_0_coords = (myPixelName.rgb * float3(31., 31., 31.) + float3(0.5, 0.5, 0.5) ) / float3(32., 32., 32.);
+    myPixelName.r = ocio_lut1d_0.sample(ocio_lut1d_0Sampler, ocio_lut1d_0_coords.r).r;
+    myPixelName.g = ocio_lut1d_0.sample(ocio_lut1d_0Sampler, ocio_lut1d_0_coords.g).g;
+    myPixelName.b = ocio_lut1d_0.sample(ocio_lut1d_0Sampler, ocio_lut1d_0_coords.b).b;
+  }
+
+  return myPixelName;
+}
+
+// Close class wrapper
+
+
+};
+float4 MyMethodName(
+  texture1d<float> ocio_lut1d_0
+  , sampler ocio_lut1d_0Sampler
+  , float4 inPixel)
+{
+  return ocioMyMethodName(
+    ocio_lut1d_0
+    , ocio_lut1d_0Sampler
+  ).MyMethodName(inPixel);
+}
+)" };
+
+        OCIO_CHECK_EQUAL(expected, text);
+    }
+}
+
+OCIO_ADD_TEST(GpuShader, MetalSupport4)
+{
+    // The unit test validates a single 3D LUT.
+
+    static const std::string CONFIG =
+        "ocio_profile_version: 2\n"
+        "\n"
+        "environment: {ENV1: " + OCIO::GetTestFilesDir() + "}\n"
+        "\n"
+        "search_path: $ENV1\n"
+        "\n"
+        "roles:\n"
+        "  default: cs1\n"
+        "  reference: cs1\n"
+        "\n"
+        "displays:\n"
+        "  disp1:\n"
+        "    - !<View> {name: view1, colorspace: cs2}\n"
+        "\n"
+        "colorspaces:\n"
+        "  - !<ColorSpace>\n"
+        "    name: cs1\n"
+        "\n"
+        "  - !<ColorSpace>\n"
+        "    name: cs2\n"
+        "    from_scene_reference: !<FileTransform> {src: lut3d_example_Inv.ctf}\n";
+
+    {
+        std::istringstream iss;
+        iss.str(CONFIG);
+
+        OCIO::ConstConfigRcPtr mOCIOCfg;
+        OCIO_CHECK_NO_THROW(mOCIOCfg = OCIO::Config::CreateFromStream(iss));
+        OCIO_CHECK_NO_THROW(mOCIOCfg->validate());
+
+        OCIO::ColorSpaceTransformRcPtr transform = OCIO::ColorSpaceTransform::Create();
+        transform->setSrc("cs1");
+        transform->setDst("cs2");
+        
+        auto processor = mOCIOCfg->getProcessor(transform);
+        auto gpuProcessor = processor->getOptimizedGPUProcessor(OCIO::OPTIMIZATION_NONE);
+    
+        auto shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
+        shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_MSL_2_0);
+        shaderDesc->setFunctionName("MyMethodName");
+        shaderDesc->setPixelName("myPixelName");
+
+        gpuProcessor->extractGpuShaderInfo(shaderDesc);
+
+        const std::string text(shaderDesc->getShaderText());
+        static constexpr char expected[] = { R"(
+// Declaration of class wrapper
+
+struct ocioMyMethodName
+{
+ocioMyMethodName(
+  texture3d<float> ocio_lut3d_0
+  , sampler ocio_lut3d_0Sampler
+)
+{
+  this->ocio_lut3d_0 = ocio_lut3d_0;
+  this->ocio_lut3d_0Sampler = ocio_lut3d_0Sampler;
+}
+
+
+// Declaration of all variables
+
+texture3d<float> ocio_lut3d_0;
+sampler ocio_lut3d_0Sampler;
+
+// Declaration of the OCIO shader function
+
+float4 MyMethodName(float4 inPixel)
+{
+  float4 myPixelName = inPixel;
+  
+  // Add LUT 3D processing for ocio_lut3d_0
+  
+  float3 ocio_lut3d_0_coords = (myPixelName.zyx * float3(47., 47., 47.) + float3(0.5, 0.5, 0.5)) / float3(48., 48., 48.);
+  myPixelName.rgb = ocio_lut3d_0.sample(ocio_lut3d_0Sampler, ocio_lut3d_0_coords).rgb;
+
+  return myPixelName;
+}
+
+// Close class wrapper
+
+
+};
+float4 MyMethodName(
+  texture3d<float> ocio_lut3d_0
+  , sampler ocio_lut3d_0Sampler
+  , float4 inPixel)
+{
+  return ocioMyMethodName(
+    ocio_lut3d_0
+    , ocio_lut3d_0Sampler
+  ).MyMethodName(inPixel);
+}
+)" };
+        
+        OCIO_CHECK_EQUAL(expected, text);
+    }
+}
+
+OCIO_ADD_TEST(GpuShader, MetalSupport5)
+{
+    // The unit test validates a single 1D LUT needing an helper method.
+
+    static const std::string CONFIG =
+        "ocio_profile_version: 2\n"
+        "\n"
+        "environment: {ENV1: " + OCIO::GetTestFilesDir() + "}\n"
+        "\n"
+        "search_path: $ENV1\n"
+        "\n"
+        "roles:\n"
+        "  default: cs1\n"
+        "  reference: cs1\n"
+        "\n"
+        "displays:\n"
+        "  disp1:\n"
+        "    - !<View> {name: view1, colorspace: cs2}\n"
+        "\n"
+        "colorspaces:\n"
+        "  - !<ColorSpace>\n"
+        "    name: cs1\n"
+        "\n"
+        "  - !<ColorSpace>\n"
+        "    name: cs2\n"
+        "    from_scene_reference: !<FileTransform> {src: clf/lut1d_long.clf}\n";
+
+    {
+        std::istringstream iss;
+        iss.str(CONFIG);
+
+        OCIO::ConstConfigRcPtr mOCIOCfg;
+        OCIO_CHECK_NO_THROW(mOCIOCfg = OCIO::Config::CreateFromStream(iss));
+        OCIO_CHECK_NO_THROW(mOCIOCfg->validate());
+
+        OCIO::ColorSpaceTransformRcPtr transform = OCIO::ColorSpaceTransform::Create();
+        transform->setSrc("cs1");
+        transform->setDst("cs2");
+        
+        auto processor = mOCIOCfg->getProcessor(transform);
+        auto gpuProcessor = processor->getOptimizedGPUProcessor(OCIO::OPTIMIZATION_NONE);
+    
+        auto shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
+        shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_MSL_2_0);
+
+        gpuProcessor->extractGpuShaderInfo(shaderDesc);
+
+        const std::string text(shaderDesc->getShaderText());
+        static constexpr char expected[] = { R"(
+// Declaration of class wrapper
+
+struct ocioOCIOMain
+{
+ocioOCIOMain(
+  texture2d<float> ocio_lut1d_0
+  , sampler ocio_lut1d_0Sampler
+)
+{
+  this->ocio_lut1d_0 = ocio_lut1d_0;
+  this->ocio_lut1d_0Sampler = ocio_lut1d_0Sampler;
+}
+
+
+// Declaration of all variables
+
+texture2d<float> ocio_lut1d_0;
+sampler ocio_lut1d_0Sampler;
+
+// Declaration of all helper methods
+
+float2 ocio_lut1d_0_computePos(float f)
+{
+  float dep = clamp(f, 0.0, 1.0) * 131071.;
+  float2 retVal;
+  retVal.y = float(int(dep / 4095.));
+  retVal.x = dep - retVal.y * 4095.;
+  retVal.x = (retVal.x + 0.5) / 4096.;
+  retVal.y = (retVal.y + 0.5) / 33.;
+  return retVal;
+}
+
+// Declaration of the OCIO shader function
+
+float4 OCIOMain(float4 inPixel)
+{
+  float4 outColor = inPixel;
+  
+  // Add LUT 1D processing for ocio_lut1d_0
+  
+  {
+    outColor.r = ocio_lut1d_0.sample(ocio_lut1d_0Sampler, ocio_lut1d_0_computePos(outColor.r)).r;
+    outColor.g = ocio_lut1d_0.sample(ocio_lut1d_0Sampler, ocio_lut1d_0_computePos(outColor.g)).r;
+    outColor.b = ocio_lut1d_0.sample(ocio_lut1d_0Sampler, ocio_lut1d_0_computePos(outColor.b)).r;
+  }
+
+  return outColor;
+}
+
+// Close class wrapper
+
+
+};
+float4 OCIOMain(
+  texture2d<float> ocio_lut1d_0
+  , sampler ocio_lut1d_0Sampler
+  , float4 inPixel)
+{
+  return ocioOCIOMain(
+    ocio_lut1d_0
+    , ocio_lut1d_0Sampler
+  ).OCIOMain(inPixel);
+}
+)" };
+
+        OCIO_CHECK_EQUAL(expected, text);
+    }
+}
+
+OCIO_ADD_TEST(GpuShader, MetalSupport6)
+{
+    // The unit test validates several arbitrary luts.
+
+    static const std::string CONFIG =
+        "ocio_profile_version: 2\n"
+        "\n"
+        "environment: {ENV1: " + OCIO::GetTestFilesDir() + "}\n"
+        "\n"
+        "search_path: $ENV1\n"
+        "\n"
+        "roles:\n"
+        "  default: cs1\n"
+        "  reference: cs1\n"
+        "\n"
+        "displays:\n"
+        "  disp1:\n"
+        "    - !<View> {name: view1, colorspace: cs2}\n"
+        "\n"
+        "colorspaces:\n"
+        "  - !<ColorSpace>\n"
+        "    name: cs1\n"
+        "\n"
+        "  - !<ColorSpace>\n"
+        "    name: cs2\n"
+        "    from_scene_reference: !<GroupTransform>\n"
+        "      children:\n"
+        "        - !<FileTransform> {src: lut1d_green.ctf}\n"
+        "        - !<FileTransform> {src: lut3d_example_Inv.ctf}\n"
+        "        - !<FileTransform> {src: clf/lut1d_long.clf}\n";
+    {
+        std::istringstream iss;
+        iss.str(CONFIG);
+
+        OCIO::ConstConfigRcPtr mOCIOCfg;
+        OCIO_CHECK_NO_THROW(mOCIOCfg = OCIO::Config::CreateFromStream(iss));
+        OCIO_CHECK_NO_THROW(mOCIOCfg->validate());
+
+        OCIO::ColorSpaceTransformRcPtr transform = OCIO::ColorSpaceTransform::Create();
+        transform->setSrc("cs1");
+        transform->setDst("cs2");
+        
+        auto processor = mOCIOCfg->getProcessor(transform);
+        auto gpuProcessor = processor->getOptimizedGPUProcessor(OCIO::OPTIMIZATION_NONE);
+    
+        auto shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
+        shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_MSL_2_0);
+
+        gpuProcessor->extractGpuShaderInfo(shaderDesc);
+
+        const std::string text(shaderDesc->getShaderText());
+        static constexpr char expected[] = { R"(
+// Declaration of class wrapper
+
+struct ocioOCIOMain
+{
+ocioOCIOMain(
+  texture3d<float> ocio_lut3d_1
+  , sampler ocio_lut3d_1Sampler
+  , texture1d<float> ocio_lut1d_0
+  , sampler ocio_lut1d_0Sampler
+  , texture2d<float> ocio_lut1d_2
+  , sampler ocio_lut1d_2Sampler
+)
+{
+  this->ocio_lut3d_1 = ocio_lut3d_1;
+  this->ocio_lut3d_1Sampler = ocio_lut3d_1Sampler;
+  this->ocio_lut1d_0 = ocio_lut1d_0;
+  this->ocio_lut1d_0Sampler = ocio_lut1d_0Sampler;
+  this->ocio_lut1d_2 = ocio_lut1d_2;
+  this->ocio_lut1d_2Sampler = ocio_lut1d_2Sampler;
+}
+
+
+// Declaration of all variables
+
+texture1d<float> ocio_lut1d_0;
+sampler ocio_lut1d_0Sampler;
+texture3d<float> ocio_lut3d_1;
+sampler ocio_lut3d_1Sampler;
+texture2d<float> ocio_lut1d_2;
+sampler ocio_lut1d_2Sampler;
+
+// Declaration of all helper methods
+
+float2 ocio_lut1d_2_computePos(float f)
+{
+  float dep = clamp(f, 0.0, 1.0) * 131071.;
+  float2 retVal;
+  retVal.y = float(int(dep / 4095.));
+  retVal.x = dep - retVal.y * 4095.;
+  retVal.x = (retVal.x + 0.5) / 4096.;
+  retVal.y = (retVal.y + 0.5) / 33.;
+  return retVal;
+}
+
+// Declaration of the OCIO shader function
+
+float4 OCIOMain(float4 inPixel)
+{
+  float4 outColor = inPixel;
+  
+  // Add LUT 1D processing for ocio_lut1d_0
+  
+  {
+    float3 ocio_lut1d_0_coords = (outColor.rgb * float3(31., 31., 31.) + float3(0.5, 0.5, 0.5) ) / float3(32., 32., 32.);
+    outColor.r = ocio_lut1d_0.sample(ocio_lut1d_0Sampler, ocio_lut1d_0_coords.r).r;
+    outColor.g = ocio_lut1d_0.sample(ocio_lut1d_0Sampler, ocio_lut1d_0_coords.g).g;
+    outColor.b = ocio_lut1d_0.sample(ocio_lut1d_0Sampler, ocio_lut1d_0_coords.b).b;
+  }
+  
+  // Add LUT 3D processing for ocio_lut3d_1
+  
+  float3 ocio_lut3d_1_coords = (outColor.zyx * float3(47., 47., 47.) + float3(0.5, 0.5, 0.5)) / float3(48., 48., 48.);
+  outColor.rgb = ocio_lut3d_1.sample(ocio_lut3d_1Sampler, ocio_lut3d_1_coords).rgb;
+  
+  // Add LUT 1D processing for ocio_lut1d_2
+  
+  {
+    outColor.r = ocio_lut1d_2.sample(ocio_lut1d_2Sampler, ocio_lut1d_2_computePos(outColor.r)).r;
+    outColor.g = ocio_lut1d_2.sample(ocio_lut1d_2Sampler, ocio_lut1d_2_computePos(outColor.g)).r;
+    outColor.b = ocio_lut1d_2.sample(ocio_lut1d_2Sampler, ocio_lut1d_2_computePos(outColor.b)).r;
+  }
+
+  return outColor;
+}
+
+// Close class wrapper
+
+
+};
+float4 OCIOMain(
+  texture3d<float> ocio_lut3d_1
+  , sampler ocio_lut3d_1Sampler
+  , texture1d<float> ocio_lut1d_0
+  , sampler ocio_lut1d_0Sampler
+  , texture2d<float> ocio_lut1d_2
+  , sampler ocio_lut1d_2Sampler
+  , float4 inPixel)
+{
+  return ocioOCIOMain(
+    ocio_lut3d_1
+    , ocio_lut3d_1Sampler
+    , ocio_lut1d_0
+    , ocio_lut1d_0Sampler
+    , ocio_lut1d_2
+    , ocio_lut1d_2Sampler
+  ).OCIOMain(inPixel);
+}
+)" };
+        
+        OCIO_CHECK_EQUAL(expected, text);
+    }
+}
+
+OCIO_ADD_TEST(GpuShader, MetalSupport7)
+{
+    // The unit test validates a single E/C which needs a uniform.
+
+    static const std::string CONFIG =
+        "ocio_profile_version: 2\n"
+        "\n"
+        "search_path: " + OCIO::GetTestFilesDir() + "\n"
+        "\n"
+        "roles:\n"
+        "  default: cs1\n"
+        "  reference: cs1\n"
+        "\n"
+        "displays:\n"
+        "  disp1:\n"
+        "    - !<View> {name: view1, colorspace: cs2}\n"
+        "\n"
+        "colorspaces:\n"
+        "  - !<ColorSpace>\n"
+        "    name: cs1\n"
+        "\n"
+        "  - !<ColorSpace>\n"
+        "    name: cs2\n"
+        "    from_scene_reference:\n"
+        "       !<ExposureContrastTransform> {style: video, contrast: 0.5}\n";
+
+    {
+        std::istringstream iss;
+        iss.str(CONFIG);
+
+        OCIO::ConstConfigRcPtr mOCIOCfg;
+        OCIO_CHECK_NO_THROW(mOCIOCfg = OCIO::Config::CreateFromStream(iss));
+        OCIO_CHECK_NO_THROW(mOCIOCfg->validate());
+
+        OCIO::ColorSpaceTransformRcPtr transform = OCIO::ColorSpaceTransform::Create();
+        transform->setSrc("cs1");
+        transform->setDst("cs2");
+        
+        auto processor = mOCIOCfg->getProcessor(transform);
+        auto gpuProcessor = processor->getOptimizedGPUProcessor(OCIO::OPTIMIZATION_NONE);
+    
+        auto shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
+        shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_MSL_2_0);
+
+        gpuProcessor->extractGpuShaderInfo(shaderDesc);
+
+        const std::string text(shaderDesc->getShaderText());
+        static constexpr char expected[] = { R"(
+// Declaration of class wrapper
+
+struct ocioOCIOMain
+{
+ocioOCIOMain(
+  float ocio_exposure_contrast_exposureVal
+  , float ocio_exposure_contrast_gammaVal
+)
+{
+  this->ocio_exposure_contrast_exposureVal = ocio_exposure_contrast_exposureVal;
+  this->ocio_exposure_contrast_gammaVal = ocio_exposure_contrast_gammaVal;
+}
+
+
+// Declaration of all variables
+
+float ocio_exposure_contrast_exposureVal;
+float ocio_exposure_contrast_gammaVal;
+
+// Declaration of the OCIO shader function
+
+float4 OCIOMain(float4 inPixel)
+{
+  float4 outColor = inPixel;
+  
+  // Add ExposureContrast 'video' processing
+  
+  {
+    float contrastVal = 0.5;
+    float exposure = pow( pow( 2., ocio_exposure_contrast_exposureVal ), 0.54644808743169393);
+    float contrast = max( 0.001, ( contrastVal * ocio_exposure_contrast_gammaVal ) );
+    outColor.rgb = outColor.rgb * exposure;
+    if (contrast != 1.0)
+    {
+      outColor.rgb = pow( max( float3(0., 0., 0.), outColor.rgb / float3(0.39178254652545397, 0.39178254652545397, 0.39178254652545397) ), float3(contrast, contrast, contrast) ) * float3(0.39178254652545397, 0.39178254652545397, 0.39178254652545397);
+    }
+  }
+
+  return outColor;
+}
+
+// Close class wrapper
+
+
+};
+float4 OCIOMain(
+  float ocio_exposure_contrast_exposureVal
+  , float ocio_exposure_contrast_gammaVal
+  , float4 inPixel)
+{
+  return ocioOCIOMain(
+    ocio_exposure_contrast_exposureVal
+    , ocio_exposure_contrast_gammaVal
+  ).OCIOMain(inPixel);
+}
+)"};
+        OCIO_CHECK_EQUAL(expected, text);
+    }
+}
+
+OCIO_ADD_TEST(GpuShader, MetalSupport8)
+{
+    // The unit test validates a single Grading transform.
+
+    static const std::string CONFIG =
+        "ocio_profile_version: 2\n"
+        "\n"
+        "search_path: " + OCIO::GetTestFilesDir() + "\n"
+        "\n"
+        "roles:\n"
+        "  default: cs1\n"
+        "  reference: cs1\n"
+        "\n"
+        "displays:\n"
+        "  disp1:\n"
+        "    - !<View> {name: view1, colorspace: cs2}\n"
+        "\n"
+        "colorspaces:\n"
+        "  - !<ColorSpace>\n"
+        "    name: cs1\n"
+        "\n"
+        "  - !<ColorSpace>\n"
+        "    name: cs2\n"
+        "    from_scene_reference: \n"
+        "       !<GradingRGBCurveTransform>\n"
+        "          style: log\n"
+        "          red: {control_points: [0, 0, 0.5, 0.5, 1, 1.123456]}\n";
+
+    {
+        std::istringstream iss;
+        iss.str(CONFIG);
+
+        OCIO::ConstConfigRcPtr mOCIOCfg;
+        OCIO_CHECK_NO_THROW(mOCIOCfg = OCIO::Config::CreateFromStream(iss));
+        OCIO_CHECK_NO_THROW(mOCIOCfg->validate());
+
+        OCIO::ColorSpaceTransformRcPtr transform = OCIO::ColorSpaceTransform::Create();
+        transform->setSrc("cs1");
+        transform->setDst("cs2");
+        
+        auto processor = mOCIOCfg->getProcessor(transform);
+        auto gpuProcessor = processor->getOptimizedGPUProcessor(OCIO::OPTIMIZATION_NONE);
+    
+        auto shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
+        shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_MSL_2_0);
+
+        gpuProcessor->extractGpuShaderInfo(shaderDesc);
+
+        const std::string text(shaderDesc->getShaderText());
+        static constexpr char expected[] = { R"(
+// Declaration of class wrapper
+
+struct ocioOCIOMain
+{
+ocioOCIOMain(
+)
+{
+}
+
+
+// Declaration of all helper methods
+
+
+const int ocio_grading_rgbcurve_knotsOffsets_0[8] = {0, 5, -1, 0, -1, 0, -1, 0};
+const float ocio_grading_rgbcurve_knots_0[5] = {0., 0.333333343, 0.5, 0.666666508, 1.};
+const int ocio_grading_rgbcurve_coefsOffsets_0[8] = {0, 12, -1, 0, -1, 0, -1, 0};
+const float ocio_grading_rgbcurve_coefs_0[12] = {0.0982520878, 0.393008381, 0.347727984, 0.08693178, 0.934498608, 1., 1.13100278, 1.246912, 0., 0.322416425, 0.5, 0.698159397};
+
+float ocio_grading_rgbcurve_evalBSplineCurve_0(int curveIdx, float x)
+{
+  int knotsOffs = ocio_grading_rgbcurve_knotsOffsets_0[curveIdx * 2];
+  int knotsCnt = ocio_grading_rgbcurve_knotsOffsets_0[curveIdx * 2 + 1];
+  int coefsOffs = ocio_grading_rgbcurve_coefsOffsets_0[curveIdx * 2];
+  int coefsCnt = ocio_grading_rgbcurve_coefsOffsets_0[curveIdx * 2 + 1];
+  int coefsSets = coefsCnt / 3;
+  if (coefsSets == 0)
+  {
+    return x;
+  }
+  float knStart = ocio_grading_rgbcurve_knots_0[knotsOffs];
+  float knEnd = ocio_grading_rgbcurve_knots_0[knotsOffs + knotsCnt - 1];
+  if (x <= knStart)
+  {
+    float B = ocio_grading_rgbcurve_coefs_0[coefsOffs + coefsSets];
+    float C = ocio_grading_rgbcurve_coefs_0[coefsOffs + coefsSets * 2];
+    return (x - knStart) * B + C;
+  }
+  else if (x >= knEnd)
+  {
+    float A = ocio_grading_rgbcurve_coefs_0[coefsOffs + coefsSets - 1];
+    float B = ocio_grading_rgbcurve_coefs_0[coefsOffs + coefsSets * 2 - 1];
+    float C = ocio_grading_rgbcurve_coefs_0[coefsOffs + coefsSets * 3 - 1];
+    float kn = ocio_grading_rgbcurve_knots_0[knotsOffs + knotsCnt - 2];
+    float t = knEnd - kn;
+    float slope = 2. * A * t + B;
+    float offs = ( A * t + B ) * t + C;
+    return (x - knEnd) * slope + offs;
+  }
+  int i = 0;
+  for (i = 0; i < knotsCnt - 2; ++i)
+  {
+    if (x < ocio_grading_rgbcurve_knots_0[knotsOffs + i + 1])
+    {
+      break;
+    }
+  }
+  float A = ocio_grading_rgbcurve_coefs_0[coefsOffs + i];
+  float B = ocio_grading_rgbcurve_coefs_0[coefsOffs + coefsSets + i];
+  float C = ocio_grading_rgbcurve_coefs_0[coefsOffs + coefsSets * 2 + i];
+  float kn = ocio_grading_rgbcurve_knots_0[knotsOffs + i];
+  float t = x - kn;
+  return ( A * t + B ) * t + C;
+}
+
+// Declaration of the OCIO shader function
+
+float4 OCIOMain(float4 inPixel)
+{
+  float4 outColor = inPixel;
+  
+  // Add GradingRGBCurve 'log' forward processing
+  
+  {
+    outColor.rgb.r = ocio_grading_rgbcurve_evalBSplineCurve_0(0, outColor.rgb.r);
+    outColor.rgb.g = ocio_grading_rgbcurve_evalBSplineCurve_0(1, outColor.rgb.g);
+    outColor.rgb.b = ocio_grading_rgbcurve_evalBSplineCurve_0(2, outColor.rgb.b);
+    outColor.rgb.r = ocio_grading_rgbcurve_evalBSplineCurve_0(3, outColor.rgb.r);
+    outColor.rgb.g = ocio_grading_rgbcurve_evalBSplineCurve_0(3, outColor.rgb.g);
+    outColor.rgb.b = ocio_grading_rgbcurve_evalBSplineCurve_0(3, outColor.rgb.b);
+  }
+
+  return outColor;
+}
+
+// Close class wrapper
+
+
+};
+float4 OCIOMain(
+  float4 inPixel)
+{
+  return ocioOCIOMain(
+  ).OCIOMain(inPixel);
+}
+)" };
+        OCIO_CHECK_EQUAL(expected, text);
+    }
+}
+
+OCIO_ADD_TEST(GpuShader, MetalSupport9)
+{
+    // The unit test validates a single Grading transform.
+
+    OCIO::ConfigRcPtr config = OCIO::Config::Create();
+    auto gcta = OCIO::GradingRGBCurveTransform::Create(OCIO::GRADING_LOG);
+    gcta->makeDynamic();
+
+    auto processor = config->getProcessor(gcta);
+    auto gpuProcessor = processor->getOptimizedGPUProcessor(OCIO::OPTIMIZATION_NONE);
+
+    auto shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
+    shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_MSL_2_0);
+
+    gpuProcessor->extractGpuShaderInfo(shaderDesc);
+
+    const std::string text(shaderDesc->getShaderText());
+    static constexpr char expected[] = { R"(
+// Declaration of class wrapper
+
+struct ocioOCIOMain
+{
+ocioOCIOMain(
+  int ocio_grading_rgbcurve_knotsOffsets[8]
+  , float ocio_grading_rgbcurve_knots[60]
+  , int ocio_grading_rgbcurve_coefsOffsets[8]
+  , float ocio_grading_rgbcurve_coefs[180]
+  , bool ocio_grading_rgbcurve_localBypass
+)
+{
+  for(int i = 0; i < 8; ++i)
+    this->ocio_grading_rgbcurve_knotsOffsets[i] = ocio_grading_rgbcurve_knotsOffsets[i];
+  for(int i = 0; i < 60; ++i)
+    this->ocio_grading_rgbcurve_knots[i] = ocio_grading_rgbcurve_knots[i];
+  for(int i = 0; i < 8; ++i)
+    this->ocio_grading_rgbcurve_coefsOffsets[i] = ocio_grading_rgbcurve_coefsOffsets[i];
+  for(int i = 0; i < 180; ++i)
+    this->ocio_grading_rgbcurve_coefs[i] = ocio_grading_rgbcurve_coefs[i];
+  this->ocio_grading_rgbcurve_localBypass = ocio_grading_rgbcurve_localBypass;
+}
+
+
+// Declaration of all variables
+
+int ocio_grading_rgbcurve_knotsOffsets[8];
+float ocio_grading_rgbcurve_knots[60];
+int ocio_grading_rgbcurve_coefsOffsets[8];
+float ocio_grading_rgbcurve_coefs[180];
+bool ocio_grading_rgbcurve_localBypass;
+
+// Declaration of all helper methods
+
+
+float ocio_grading_rgbcurve_evalBSplineCurve(int curveIdx, float x)
+{
+  int knotsOffs = ocio_grading_rgbcurve_knotsOffsets[curveIdx * 2];
+  int knotsCnt = ocio_grading_rgbcurve_knotsOffsets[curveIdx * 2 + 1];
+  int coefsOffs = ocio_grading_rgbcurve_coefsOffsets[curveIdx * 2];
+  int coefsCnt = ocio_grading_rgbcurve_coefsOffsets[curveIdx * 2 + 1];
+  int coefsSets = coefsCnt / 3;
+  if (coefsSets == 0)
+  {
+    return x;
+  }
+  float knStart = ocio_grading_rgbcurve_knots[knotsOffs];
+  float knEnd = ocio_grading_rgbcurve_knots[knotsOffs + knotsCnt - 1];
+  if (x <= knStart)
+  {
+    float B = ocio_grading_rgbcurve_coefs[coefsOffs + coefsSets];
+    float C = ocio_grading_rgbcurve_coefs[coefsOffs + coefsSets * 2];
+    return (x - knStart) * B + C;
+  }
+  else if (x >= knEnd)
+  {
+    float A = ocio_grading_rgbcurve_coefs[coefsOffs + coefsSets - 1];
+    float B = ocio_grading_rgbcurve_coefs[coefsOffs + coefsSets * 2 - 1];
+    float C = ocio_grading_rgbcurve_coefs[coefsOffs + coefsSets * 3 - 1];
+    float kn = ocio_grading_rgbcurve_knots[knotsOffs + knotsCnt - 2];
+    float t = knEnd - kn;
+    float slope = 2. * A * t + B;
+    float offs = ( A * t + B ) * t + C;
+    return (x - knEnd) * slope + offs;
+  }
+  int i = 0;
+  for (i = 0; i < knotsCnt - 2; ++i)
+  {
+    if (x < ocio_grading_rgbcurve_knots[knotsOffs + i + 1])
+    {
+      break;
+    }
+  }
+  float A = ocio_grading_rgbcurve_coefs[coefsOffs + i];
+  float B = ocio_grading_rgbcurve_coefs[coefsOffs + coefsSets + i];
+  float C = ocio_grading_rgbcurve_coefs[coefsOffs + coefsSets * 2 + i];
+  float kn = ocio_grading_rgbcurve_knots[knotsOffs + i];
+  float t = x - kn;
+  return ( A * t + B ) * t + C;
+}
+
+// Declaration of the OCIO shader function
+
+float4 OCIOMain(float4 inPixel)
+{
+  float4 outColor = inPixel;
+  
+  // Add GradingRGBCurve 'log' forward processing
+  
+  {
+    if (!ocio_grading_rgbcurve_localBypass)
+    {
+      outColor.rgb.r = ocio_grading_rgbcurve_evalBSplineCurve(0, outColor.rgb.r);
+      outColor.rgb.g = ocio_grading_rgbcurve_evalBSplineCurve(1, outColor.rgb.g);
+      outColor.rgb.b = ocio_grading_rgbcurve_evalBSplineCurve(2, outColor.rgb.b);
+      outColor.rgb.r = ocio_grading_rgbcurve_evalBSplineCurve(3, outColor.rgb.r);
+      outColor.rgb.g = ocio_grading_rgbcurve_evalBSplineCurve(3, outColor.rgb.g);
+      outColor.rgb.b = ocio_grading_rgbcurve_evalBSplineCurve(3, outColor.rgb.b);
+    }
+  }
+
+  return outColor;
+}
+
+// Close class wrapper
+
+
+};
+float4 OCIOMain(
+  int ocio_grading_rgbcurve_knotsOffsets[8]
+  , float ocio_grading_rgbcurve_knots[60]
+  , int ocio_grading_rgbcurve_coefsOffsets[8]
+  , float ocio_grading_rgbcurve_coefs[180]
+  , bool ocio_grading_rgbcurve_localBypass
+  , float4 inPixel)
+{
+  return ocioOCIOMain(
+    ocio_grading_rgbcurve_knotsOffsets
+    , ocio_grading_rgbcurve_knots
+    , ocio_grading_rgbcurve_coefsOffsets
+    , ocio_grading_rgbcurve_coefs
+    , ocio_grading_rgbcurve_localBypass
+  ).OCIOMain(inPixel);
+}
+)" };
+    
+    OCIO_CHECK_EQUAL(expected, text);
 }

--- a/vendor/aftereffects/vc/vc15/OpenColorIO.vcxproj
+++ b/vendor/aftereffects/vc/vc15/OpenColorIO.vcxproj
@@ -58,6 +58,7 @@
     <ClInclude Include="..\..\..\..\src\OpenColorIO\FileRules.h" />
     <ClInclude Include="..\..\..\..\src\OpenColorIO\GPUProcessor.h" />
     <ClInclude Include="..\..\..\..\src\OpenColorIO\GpuShader.h" />
+    <ClInclude Include="..\..\..\..\src\OpenColorIO\GpuShaderClassWrapper.h" />
     <ClInclude Include="..\..\..\..\src\OpenColorIO\GpuShaderUtils.h" />
     <ClInclude Include="..\..\..\..\src\OpenColorIO\HashUtils.h" />
     <ClInclude Include="..\..\..\..\src\OpenColorIO\ImagePacking.h" />
@@ -218,6 +219,7 @@
     <ClCompile Include="..\..\..\..\src\OpenColorIO\GPUProcessor.cpp" />
     <ClCompile Include="..\..\..\..\src\OpenColorIO\GpuShader.cpp" />
     <ClCompile Include="..\..\..\..\src\OpenColorIO\GpuShaderDesc.cpp" />
+    <ClCompile Include="..\..\..\..\src\OpenColorIO\GpuShaderClassWrapper.cpp" />
     <ClCompile Include="..\..\..\..\src\OpenColorIO\GpuShaderUtils.cpp" />
     <ClCompile Include="..\..\..\..\src\OpenColorIO\HashUtils.cpp" />
     <ClCompile Include="..\..\..\..\src\OpenColorIO\ImageDesc.cpp" />


### PR DESCRIPTION
* * Adds Metal Shading Language (MSL) Generation support

Signed-off-by: Morteza Mostajabodaveh <smostajabodaveh@apple.com>

Co-authored-by: Ingthor Hjalmarsson <ihjalmarsson@apple.com>
Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Fixes warnings triggered due to unused variables.

Signed-off-by: Morteza Mostajabodaveh <smostajabodaveh@apple.com>
Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Fixes compilation error on Mac and Windows:
- vector of const objects causing compiler errors on windows.
- Wrong string was used for Metal language python binding.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Removes class wrapping interface from OpenColorIO interface and move it to implementation
* Adding more tests for metal code path
* Proper generated Metal code indentation
* Fixes a few coding style inconsistencies and unneeded include files

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Remove the unneeded empty line to reset OpenColorIO.h to what it was before the metal change.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * switching from c-like getFunctionParameters function to c++-like one since it is not in the opencolorio interface anymore.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Missing include causing compiler errors on windows

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Fixes and improvements follow up to change that was trying to move metal related code in implementation, and hide them from OCIO interface.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* - remove unused variables.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Adds support for uniform parameters and proper handling of them in metal code.
* Adds two new tests for uniforms and helper functions.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * making declaration parsing more C++-like. Functions like sscanf are problematic when it comes to multiple platform support and may not be safe

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Switching from clf/lut1d_half_domain_raw_half_set.clf  to clf/lut1d_long.clf. Due to decimal number outputting difference between different platforms, some tests were failing.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Moving Metal only functionalities to MetalClassWrappingInterface
* remove unnecessary functions and data types
* code clean up and quality improvement

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Adds support for uniforms that are array
* Removing getTextureKeyword() and getTextureDeclaration() as they are not needed.
* code clean up and quality improvement

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Remove unnecessary changes to GpuShaderUtils_tests.cpp

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Removed unnecessary included files

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Removing unnecessary include

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Apply style improvement suggestions

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * changed from msl_metal to msl_2 so it matches with `GpuLanguageFromString` function.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Move MetalShaderClassWrappingInterface to a separate file and generalise it

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* header files inlcudes clean up

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Still the else path is needed in case we set language from MSL2 to something else.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* [minor] Showing the GpuShaderClassWrapper.h also in the vc15 aftereffect project.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Run ClassWrapper function for all backends. It only produces code in metal shading language code generation case.
operator= for GpuShaderClassWrapper

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* use factory pattern instead of updateClassWrappingInterface

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Replace assignment operator with clone function that is more explicit.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* use Assignment operator instead of setting members in clone member function

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* add include guards.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* make output of MetalShaderClassWrapper::operator= non-const

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

Co-authored-by: Ingthor Hjalmarsson <ihjalmarsson@apple.com>
Co-authored-by: Patrick Hodoul <patrick.hodoul@autodesk.com>
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>