### PR TITLE
Port from main to RB-2.1 - Adds Metal Support to ociodisplay and enables running GPU tests with Metal backend (#1538)

### DIFF
--- a/src/OpenColorIO/GpuShaderClassWrapper.h
+++ b/src/OpenColorIO/GpuShaderClassWrapper.h
@@ -61,13 +61,16 @@ private:
     struct FunctionParam
     {
         FunctionParam(const std::string& type, const std::string& name) :
-            type(type),
-            name(name)
+            m_type(type),
+            m_name(name)
         {
+            size_t openAngledBracketPos = name.find('[');
+            m_isArray = openAngledBracketPos != std::string::npos;
         }
 
-        std::string type;
-        std::string name;
+        std::string m_type;
+        std::string m_name;
+        bool m_isArray;
     };
     
     std::string getClassWrapperName(const std::string &resourcePrefix, const std::string& functionName);

--- a/src/OpenColorIO/GpuShaderUtils.cpp
+++ b/src/OpenColorIO/GpuShaderUtils.cpp
@@ -435,6 +435,16 @@ std::string GpuShaderText::declareVarStr(const std::string & name, float v)
     return floatDecl(name) + " = " + getFloatString(v, m_lang);
 }
 
+std::string GpuShaderText::vectorCompareExpression(const std::string& lhs, const std::string& op, const std::string& rhs)
+{
+    std::string ret = lhs + " " + op + " " + rhs;
+    if(m_lang == GPU_LANGUAGE_MSL_2_0)
+    {
+        ret = "any( " + ret + " )";
+    }
+    return ret;
+}
+
 void GpuShaderText::declareVarConst(const std::string & name, bool v)
 {
     newLine() << constKeyword() << declareVarStr(name, v) << ";";

--- a/src/OpenColorIO/GpuShaderUtils.h
+++ b/src/OpenColorIO/GpuShaderUtils.h
@@ -76,6 +76,8 @@ public:
     std::string intKeyword() const;
 
     std::string colorDecl(const std::string& name) const;
+    
+    std::string vectorCompareExpression(const std::string& lhs, const std::string& op, const std::string& rhs);
 
     //
     // Scalar & arrays helper functions.

--- a/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOpGPU.cpp
+++ b/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOpGPU.cpp
@@ -165,7 +165,7 @@ void AddGPLogForwardShader(GpuShaderCreatorRcPtr & shaderCreator,
                  << " + " << props.pivot << ";";
 
     // Not sure if the if helps performance, but it does allow out == in at the default values.
-    st.newLine() << "if ( " << props.gamma << " != " << st.float3Const(1.f) << " )";
+    st.newLine() << "if ( " << st.vectorCompareExpression(props.gamma, "!=", st.float3Const(1.f)) << " )";
     st.newLine() << "{";
     st.indent();
     st.newLine() << st.float3Decl("normalizedOut")
@@ -206,7 +206,7 @@ void AddGPLogInverseShader(GpuShaderCreatorRcPtr & shaderCreator,
     st.newLine() << "}";
 
     // Not sure if the if helps performance, but it does allow out == in at the default values.
-    st.newLine() << "if ( " << props.gamma << " != " << st.float3Const(1.f) << " )";
+    st.newLine() << "if ( " << st.vectorCompareExpression(props.gamma, "!=", st.float3Const(1.f)) << " )";
     st.newLine() << "{";
     st.indent();
     st.newLine() << st.float3Decl("normalizedOut")
@@ -307,7 +307,7 @@ void AddGPLinForwardShader(GpuShaderCreatorRcPtr & shaderCreator,
 
     // Not sure if the if helps performance, but it does allow out == in at the default values.
     // Although note that the log-to-lin in Tone Op also prevents out == in.
-    st.newLine() << "if ( " << props.contrast << " != " << st.float3Const(1.f) << " )";
+    st.newLine() << "if ( " << st.vectorCompareExpression(props.contrast, "!=", st.float3Const(1.f)) << " )";
     st.newLine() << "{";
     st.indent();
 
@@ -345,7 +345,7 @@ void AddGPLinInverseShader(GpuShaderCreatorRcPtr & shaderCreator,
 
     // Not sure if the if helps performance, but it does allow out == in at the default values.
     // Although note that the log-to-lin in Tone Op also prevents out == in.
-    st.newLine() << "if ( " << props.contrast << " != " << st.float3Const(1.f) << " )";
+    st.newLine() << "if ( " << st.vectorCompareExpression(props.contrast, "!=", st.float3Const(1.f)) << " )";
     st.newLine() << "{";
     st.indent();
     // NB: The sign(outColor.rgb) is a vec3, preserving the sign of each channel.
@@ -446,7 +446,7 @@ void AddGPVideoForwardShader(GpuShaderCreatorRcPtr & shaderCreator,
                                << " + " << props.pivotBlack << ";";
 
     // Not sure if the if helps performance, but it does allow out == in at the default values.
-    st.newLine() << "if ( " << props.gamma << " != " << st.float3Const(1.f) << " )";
+    st.newLine() << "if ( " << st.vectorCompareExpression(props.gamma, "!=", st.float3Const(1.f)) << " )";
     st.newLine() << "{";
     st.indent();
     st.newLine() << st.float3Decl("normalizedOut")
@@ -486,7 +486,7 @@ void AddGPVideoInverseShader(GpuShaderCreatorRcPtr & shaderCreator,
     st.newLine() << "}";
 
     // Not sure if the if helps performance, but it does allow out == in at the default values.
-    st.newLine() << "if ( " << props.gamma << " != " << st.float3Const(1.f) << " )";
+    st.newLine() << "if ( " << st.vectorCompareExpression(props.gamma, "!=", st.float3Const(1.f)) << " )";
     st.newLine() << "{";
     st.indent();
     st.newLine() << st.float3Decl("normalizedOut")

--- a/src/libutils/oglapphelpers/CMakeLists.txt
+++ b/src/libutils/oglapphelpers/CMakeLists.txt
@@ -15,6 +15,22 @@ set(INCLUDES
     oglapp.h
 )
 
+if(APPLE)
+
+    list(APPEND SOURCES
+        msl.mm
+        mtltexture.mm
+        metalapp.mm
+    )
+
+    list(APPEND INCLUDES
+        msl.h
+        mtltexture.h
+        metalapp.h
+    )
+
+endif()
+
 add_library(oglapphelpers STATIC ${SOURCES})
 set_target_properties(oglapphelpers PROPERTIES POSITION_INDEPENDENT_CODE ON)
 set_target_properties(oglapphelpers PROPERTIES OUTPUT_NAME OpenColorIOoglapphelpers)
@@ -80,6 +96,16 @@ else()
             ${GLEW_LIBRARIES}
             ${GLUT_LIBRARIES}
         )
+endif()
+
+if(APPLE)
+    target_link_libraries(oglapphelpers
+        PRIVATE
+            "-framework Carbon"
+            "-framework IOKit"
+            "-framework Metal"
+            "-framework CoreVideo"
+    )
 endif()
 
 if(${OCIO_EGL_HEADLESS})

--- a/src/libutils/oglapphelpers/glsl.cpp
+++ b/src/libutils/oglapphelpers/glsl.cpp
@@ -447,6 +447,7 @@ std::string OpenGLBuilder::getGLSLVersionString()
     switch (m_shaderDesc->getLanguage())
     {
     case GPU_LANGUAGE_GLSL_1_2:
+    case GPU_LANGUAGE_MSL_2_0:
         // That's the minimal version supported.
         return "#version 120";
     case GPU_LANGUAGE_GLSL_1_3:
@@ -460,7 +461,6 @@ std::string OpenGLBuilder::getGLSLVersionString()
     case GPU_LANGUAGE_CG:
     case GPU_LANGUAGE_HLSL_DX11:
     case LANGUAGE_OSL_1:
-    case GPU_LANGUAGE_MSL_2_0:
     default:
         // These are all impossible in OpenGL contexts.
         // The shader will be unusable, so let's throw
@@ -468,7 +468,7 @@ std::string OpenGLBuilder::getGLSLVersionString()
     }
 }
 
-unsigned OpenGLBuilder::buildProgram(const std::string & clientShaderProgram)
+unsigned OpenGLBuilder::buildProgram(const std::string & clientShaderProgram, bool standaloneShader)
 {
     const std::string shaderCacheID = m_shaderDesc->getCacheID();
     if(shaderCacheID!=m_shaderCacheID)
@@ -481,7 +481,7 @@ unsigned OpenGLBuilder::buildProgram(const std::string & clientShaderProgram)
 
         std::ostringstream os;
         os  << getGLSLVersionString() << std::endl
-            << m_shaderDesc->getShaderText() << std::endl
+            << (!standaloneShader ? m_shaderDesc->getShaderText() : "") << std::endl
             << clientShaderProgram << std::endl;
 
         if(m_verbose)

--- a/src/libutils/oglapphelpers/glsl.h
+++ b/src/libutils/oglapphelpers/glsl.h
@@ -79,7 +79,7 @@ public:
 
     // Build the complete shader program which includes the OCIO shader program 
     // and the client shader program.
-    unsigned buildProgram(const std::string & clientShaderProgram);
+    unsigned buildProgram(const std::string & clientShaderProgram, bool standaloneShader);
     void useProgram();
     unsigned getProgramHandle();
 

--- a/src/libutils/oglapphelpers/metalapp.h
+++ b/src/libutils/oglapphelpers/metalapp.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#ifndef INCLUDED_OCIO_METALAPP_H
+#define INCLUDED_OCIO_METALAPP_H
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "oglapp.h"
+
+namespace OCIO_NAMESPACE
+{
+
+struct GraphicsContext;
+
+class MetalBuilder;
+typedef OCIO_SHARED_PTR<MetalBuilder> MetalBuilderRcPtr;
+
+class MetalApp;
+typedef OCIO_SHARED_PTR<MetalApp> MetalAppRcPtr;
+
+class MtlTexture;
+typedef OCIO_SHARED_PTR<MtlTexture> MtlTextureRcPtr;
+
+class MetalApp : public ScreenApp
+{
+public:
+    MetalApp() = delete;
+    MetalApp(const MetalApp &) = delete;
+    MetalApp & operator=(const MetalApp &) = delete;
+
+    // Initialize the app with given window name & client rect size.
+    MetalApp(const char * winTitle, int winWidth, int winHeight);
+
+    virtual ~MetalApp();
+
+    void initContext();
+    
+    // Initialize the image.
+    void initImage(int imageWidth, int imageHeight,
+                   Components comp, const float * imageBuffer) override;
+    // Update the image if it changes.
+    void updateImage(const float * imageBuffer) override;
+    
+    // Set the shader code.
+    void setShader(GpuShaderDescRcPtr & shaderDesc) override;
+    
+    // Prepares and binds the OpenGL state used to present metal output texture in GLUT window
+    void     prepareAndBindOpenGLState();
+    
+    // Process the image.
+    void redisplay() override;
+    
+    // Return a pointer of either ScreenApp or HeadlessApp depending on the
+    // OCIO_HEADLESS_ENABLED preprocessor.
+    static MetalAppRcPtr CreateMetalGlApp(const char * winTitle, int winWidth, int winHeight);
+    
+protected:
+    MtlTextureRcPtr m_image { nullptr };
+    MtlTextureRcPtr m_outputImage { nullptr };
+    std::unique_ptr<GraphicsContext> m_context { nullptr };
+
+private:
+    MetalBuilderRcPtr m_metalBuilder;
+    bool m_glStateBound { false };   // OpenGL state for outputing the metal output texture contents is bound
+};
+
+}
+
+#endif // INCLUDED_OCIO_METALAPP_H
+

--- a/src/libutils/oglapphelpers/metalapp.mm
+++ b/src/libutils/oglapphelpers/metalapp.mm
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+
+#include <iostream>
+#include <sstream>
+#include <utility>
+#include <fstream>
+
+#import <Metal/Metal.h>
+#import <AppKit/AppKit.h>
+
+#include <OpenGL/gl.h>
+#include <GLUT/glut.h>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "metalapp.h"
+#include "msl.h"
+#include "glsl.h"
+#include "mtltexture.h"
+
+namespace OCIO_NAMESPACE
+{
+
+struct GraphicsContext
+{
+    GraphicsContext() = delete;
+    GraphicsContext(NSOpenGLContext* glContext, id<MTLDevice> metalDevice)
+    {
+        this->glContext = glContext;
+        this->metalDevice = metalDevice;
+    }
+    ~GraphicsContext()
+    {
+        if(glContext)
+            [glContext release];
+        glContext = nil;
+    }
+    
+    NSOpenGLContext* glContext;
+    id<MTLDevice>    metalDevice;
+};
+
+MetalApp::MetalApp(const char * winTitle, int winWidth, int winHeight)
+    : ScreenApp(winTitle, winWidth, winHeight)
+{
+    initContext();
+}
+
+void MetalApp::initContext()
+{
+    NSOpenGLContext* currentContext = [NSOpenGLContext currentContext];
+    
+    m_context = std::unique_ptr<GraphicsContext>(new GraphicsContext(currentContext, MTLCreateSystemDefaultDevice()));
+}
+
+MetalApp::~MetalApp()
+{
+    m_metalBuilder.reset();
+    m_glStateBound = false;
+}
+
+void MetalApp::initImage(int imgWidth, int imgHeight, Components comp, const float * image)
+{
+    std::vector<float> imageData;
+    if(comp == Components::COMPONENTS_RGB)
+    {
+        RGB_to_RGBA(image, 3 * imgWidth * imgHeight, imageData);
+        image = imageData.data();
+    }
+    
+    setImageDimensions(imgWidth, imgHeight, comp);
+    m_image = std::make_shared<MtlTexture>(m_context->metalDevice, imgWidth, imgHeight, image);
+    m_outputImage = std::make_shared<MtlTexture>(m_context->metalDevice, m_context->glContext, imgWidth, imgHeight, image);
+    m_glStateBound = false;
+}
+
+void MetalApp::updateImage(const float *image)
+{
+    std::vector<float> imageData;
+    if(getImageComponents() == Components::COMPONENTS_RGB)
+    {
+        RGB_to_RGBA(image, 3 * m_image->getWidth() * m_image->getHeight(), imageData);
+        image = imageData.data();
+    }
+    m_image->update(image);
+}
+
+void MetalApp::prepareAndBindOpenGLState()
+{
+    // A dummyShaderDesc is enough.
+    // The builder will only be used to build GL program
+    GpuShaderDescRcPtr dummyShaderDesc = GpuShaderDesc::CreateShaderDesc();
+    m_oglBuilder = OpenGLBuilder::Create(dummyShaderDesc);
+    
+    std::ostringstream main;
+        
+    main <<    std::endl
+            << "uniform sampler2DRect img;" << std::endl
+            << std::endl
+            << "void main()" << std::endl
+            << "{" << std::endl
+            << "    gl_FragColor = texture2DRect(img, gl_TexCoord[0].st * "
+            << "vec2(" << m_outputImage->getWidth() << ", " << m_outputImage->getHeight() << "));"
+            << std::endl
+            << "}" << std::endl;
+    
+    
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_RECTANGLE_EXT, m_outputImage->getGLHandle());
+    
+    // Build the fragment shader program.
+    m_oglBuilder->buildProgram(main.str().c_str(), true);
+
+    // Enable the fragment shader program, and all needed resources.
+    m_oglBuilder->useProgram();
+    
+    // The image texture.
+    glUniform1i(glGetUniformLocation(m_oglBuilder->getProgramHandle(), "img"), 0);
+    
+    m_glStateBound = true;
+}
+
+void MetalApp::setShader(GpuShaderDescRcPtr & shaderDesc)
+{
+    std::ostringstream main;
+    
+    m_metalBuilder = MetalBuilder::Create(shaderDesc);
+    m_metalBuilder->allocateAllTextures(1);
+    
+    if(shaderDesc->getLanguage() == GPU_LANGUAGE_MSL_2_0)
+    {
+        std::ostringstream uniformParams;
+        std::ostringstream params;
+        
+        static constexpr char shaderheader[] = { R"(//Metal Shading Language version 2.0
+#include <metal_stdlib>
+#include <simd/simd.h>
+using namespace metal;
+
+struct VertexOut
+{
+    float4 position [[ position ]];
+    float2 texCoord0;
+};
+        
+vertex VertexOut ColorCorrectionVS(unsigned int vId [[ vertex_id ]])
+{
+    VertexOut vOut;
+    switch(vId)
+    {
+    case 0:
+        vOut.position  = float4(-1.0f, 3.0f, 1.0f, 1.0f);
+        vOut.texCoord0 = float2(0.0f, -1.0f);
+        break;
+    case 1:
+        vOut.position  = float4(3.0f, -1.0f, 1.0f, 1.0f);
+        vOut.texCoord0 = float2(2.0f, 1.0f);
+        break;
+    case 2:
+        vOut.position  = float4(-1.0f, -1.0f, 1.0f, 1.0f);
+        vOut.texCoord0 = float2(0.0f, 1.0f);
+        break;
+    };
+    return vOut;
+})" };
+        
+        main << shaderheader;
+        main << shaderDesc->getShaderText();
+    
+        const std::string uniformDataStructName = "UniformData";
+        const std::string uniformDataInstanceName = "uniformData";
+        
+        auto uniformLenVariableName = [](std::string varName) -> std::string
+        {
+            return varName + "_count";
+        };
+        
+        auto uniformDataAccess = [&uniformDataInstanceName](std::string memberName) -> std::string
+        {
+            return uniformDataInstanceName + "." + memberName;
+        };
+    
+        std::ostringstream uniformData;
+        std::ostringstream uniformBufferBindings;
+        
+        const std::string tab = "    ";
+        std::string separator = "";
+        unsigned int uniformCount = shaderDesc->getNumUniforms();
+        unsigned int uniformIdx = 1;
+        for(unsigned int i = 0; i < uniformCount; ++i)
+        {
+            GpuShaderDesc::UniformData data;
+            const char* uniformName = shaderDesc->getUniform(i, data);
+            std::string spaceSpecifier = ",    constant ";
+            switch(data.m_type)
+            {
+                case UNIFORM_DOUBLE:
+                    uniformData << tab << "float "  << uniformName << ";\n";
+                    uniformParams << separator << uniformDataAccess(uniformName);
+                    break;
+                    
+                case UNIFORM_BOOL:
+                    uniformData << tab << "int "  << uniformName << ";\n";
+                    uniformParams << separator << uniformDataAccess(uniformName);
+                    break;
+                    
+                case UNIFORM_FLOAT3:
+                    uniformData << tab << "float3 "  << uniformName << ";\n";
+                    uniformParams << separator << uniformDataAccess(uniformName);
+                    break;
+                    
+                case UNIFORM_VECTOR_FLOAT:
+                    uniformBufferBindings << spaceSpecifier << "float* "  << uniformName << "[[ buffer(" << std::to_string(uniformIdx++)  << ") ]]\n";
+                    uniformData << tab << "int "  << uniformLenVariableName(uniformName) << ";\n";
+                    uniformParams << separator << uniformName << ", " << uniformDataAccess(uniformLenVariableName(uniformName));
+                    break;
+                    
+                case UNIFORM_VECTOR_INT:
+                    uniformBufferBindings << spaceSpecifier << "int* "  << uniformName << "[[ buffer(" << std::to_string(uniformIdx++)  << ") ]]\n";
+                    uniformData << tab << "int "  << uniformLenVariableName(uniformName) << ";\n";
+                    uniformParams << separator << uniformName << ", " << uniformDataAccess(uniformLenVariableName(uniformName));
+                    break;
+                    
+                case UNIFORM_UNKNOWN:
+                    throw Exception("Unknown Uniform type.");
+                    break;
+            }
+            
+            separator = ", ";
+        }
+        
+        bool needsUniformData = false;
+        if(uniformData.str().size() > 0)
+        {
+            main << "\nstruct " << uniformDataStructName << "\n"
+                 << "{\n"
+                 << uniformData.str()
+                << "};\n";
+            
+            needsUniformData = true;
+        }
+        
+        main << "\n\n\n"
+             <<"fragment float4 ColorCorrectionPS(VertexOut in [[stage_in]], texture2d<float> colorIn [[ texture(0) ]]\n";
+        
+        if(needsUniformData)
+        {
+            main << ",    constant " << uniformDataStructName << "& " << uniformDataInstanceName
+                 << " [[ buffer(0) ]]\n";
+        }
+        
+        if(uniformBufferBindings.str().size() > 0)
+        {
+            main << uniformBufferBindings.str();
+        }
+        
+        separator = "";
+        
+        int tex_slot = 1;
+        for(unsigned int i = 0; i < shaderDesc->getNum3DTextures(); ++i)
+        {
+            const char* textureName;
+            const char* samplerName;
+            unsigned int edgeLen;
+            Interpolation interpolation;
+            
+            shaderDesc->get3DTexture(i, textureName, samplerName, edgeLen, interpolation);
+            
+            main << ",    texture3d<float> "
+                 << textureName
+                 << " [[ texture("
+                 << std::to_string(tex_slot)
+                 << ") ]]\n";
+            
+            main << ",    sampler "
+                 << samplerName
+                 << " [[ sampler("
+                 << std::to_string(tex_slot++)
+                 << ") ]]\n";
+            
+            params << separator
+                   << textureName
+                   << ", "
+                   << samplerName;
+            
+            separator = ", ";
+        }
+        
+        for(unsigned int i = 0; i < shaderDesc->getNumTextures(); ++i)
+        {
+            const char* textureName;
+            const char* samplerName;
+            unsigned int width, height;
+            GpuShaderCreator::TextureType channel;
+            Interpolation interpolation;
+            
+            shaderDesc->getTexture(i, textureName, samplerName, width, height, channel, interpolation);
+            
+            if(height > 1)
+            {
+                main << ",    texture2d<float> ";
+            }
+            else
+            {
+                main << ",    texture1d<float> ";
+            }
+            main << textureName
+                 << " [[ texture("
+                 << std::to_string(tex_slot)
+                 << ") ]]\n";
+            
+            main << ",    sampler "
+                 << samplerName
+                 << " [[ sampler("
+                 << std::to_string(tex_slot++)
+                 << ") ]]\n";
+            
+            params << separator
+                   << textureName
+                   << ", "
+                   << samplerName;
+            
+            separator = ", ";
+        }
+        
+        if(uniformParams.str().size() > 0 || params.str().size() > 0)
+        {
+            separator = ", ";
+        }
+        
+        main << ")"
+                "{\n"
+                "    constexpr sampler s = sampler(address::clamp_to_edge);\n"
+                "    float4 inPixel = colorIn.sample(s, float2(in.texCoord0.x, in.texCoord0.y));\n"
+                "    return "
+             <<  shaderDesc->getFunctionName() << "(" << params.str() << uniformParams.str() << separator << "inPixel);\n"
+             << "}\n";
+        
+        main << std::endl;
+    }
+    else
+    {
+        throw Exception("Metal renderer can only consume MSL shaders");
+    }
+    
+    if(printShader())
+    {
+        std::cout << std::endl;
+        std::cout << "GPU Shader Program:" << std::endl;
+        std::cout << std::endl;
+        std::cout << main.str() << std::endl;
+        std::cout << std::endl;
+    }
+    
+    // Build the fragment shader program.
+    if(m_metalBuilder->buildPipelineStateObject(main.str().c_str()))
+    {
+        m_metalBuilder->applyColorCorrection(m_image->getMetalTextureHandle(),
+                                             m_outputImage->getMetalTextureHandle(),
+                                             m_outputImage->getWidth(),
+                                             m_outputImage->getHeight());
+    }
+}
+
+void MetalApp::redisplay()
+{
+    if(m_metalBuilder)
+    {
+        m_metalBuilder->applyColorCorrection(m_image->getMetalTextureHandle(),
+                                            m_outputImage->getMetalTextureHandle(),
+                                            m_outputImage->getWidth(),
+                                            m_outputImage->getHeight());
+    }
+    
+    if(!m_glStateBound)
+    {
+        prepareAndBindOpenGLState();
+    }
+    
+    ScreenApp::redisplay();
+}
+
+MetalAppRcPtr MetalApp::CreateMetalGlApp(const char * winTitle, int winWidth, int winHeight)
+{
+    return std::make_shared<MetalApp>(winTitle, winWidth, winHeight);
+}
+
+
+} // namespace OCIO_NAMESPACE

--- a/src/libutils/oglapphelpers/msl.h
+++ b/src/libutils/oglapphelpers/msl.h
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#ifndef INCLUDED_OCIO_MSL_H
+#define INCLUDED_OCIO_MSL_H
+
+#include <vector>
+
+#include <OpenColorIO/OpenColorIO.h>
+#import  <Metal/Metal.h>
+
+namespace OCIO_NAMESPACE
+{
+
+class MetalBuilder;
+typedef OCIO_SHARED_PTR<MetalBuilder> MetalBuilderRcPtr;
+
+void RGB_to_RGBA(const float* lutValues, int valueCount, std::vector<float>& float4AdaptedLutValues);
+
+// This is a reference implementation showing how to do the texture upload & allocation,
+// and the program compilation for the GLSL shader language.
+
+class MetalBuilder
+{
+    struct TextureId
+    {
+        std::string         m_textureName;
+        id<MTLTexture>      m_texture;
+        std::string         m_samplerName;
+        id<MTLSamplerState> m_samplerState;
+        MTLTextureType      m_type;
+
+        TextureId(id<MTLTexture>      tex,
+                  const std::string & textureName,
+                  id<MTLSamplerState> samplerState,
+                  const std::string & samplerName,
+                  MTLTextureType type)
+            :   m_textureName(textureName)
+            ,   m_texture(tex)
+            ,   m_samplerName(samplerName)
+            ,   m_samplerState(samplerState)
+            ,   m_type(type)
+        {}
+        
+        ~TextureId()
+        {
+            m_texture = nil;
+            m_samplerState = nil;
+        }
+        
+        void release()
+        {
+            if(m_texture)
+            {
+                [m_texture      release];
+            }
+            m_texture      = nil;
+            
+            if(m_samplerState)
+            {
+                [m_samplerState      release];
+            }
+            m_samplerState = nil;
+        }
+    };
+
+    typedef std::vector<TextureId> TextureIds;
+
+    // Uniform are used for dynamic parameters.
+    class Uniform
+    {
+    public:
+        Uniform(const std::string & name, const GpuShaderDesc::UniformData & data);
+
+    private:
+        Uniform() = delete;
+        std::string m_name;
+        GpuShaderDesc::UniformData m_data;
+    };
+    typedef std::vector<Uniform> Uniforms;
+
+public:
+    // Create an MSL builder using the GPU shader information from a specific processor
+    static MetalBuilderRcPtr Create(const GpuShaderDescRcPtr & gpuShader);
+
+    ~MetalBuilder();
+
+    inline void setVerbose(bool verbose) { m_verbose = verbose; }
+    inline bool isVerbose() const { return m_verbose; }
+
+    // Allocate & upload all the needed textures
+    //  (i.e. the index is the first available index for any kind of textures).
+    void allocateAllTextures(unsigned startIndex);
+
+    // Update all uniforms.
+    void setUniforms(id<MTLRenderCommandEncoder> renderCmdEncoder);
+
+    bool     buildPipelineStateObject(const std::string & clientShaderProgram);
+    void     applyColorCorrection(id<MTLTexture> inputTexturePtr, id<MTLTexture> outputTexturePtr, unsigned int outWidth, unsigned int outHeight);
+
+    // Determine the maximum width value of a texture
+    // depending of the graphic card and its driver.
+    static unsigned GetTextureMaxWidth();
+    
+    id<MTLDevice> getMetalDevice() { return m_device; }
+
+protected:
+    MetalBuilder(const GpuShaderDescRcPtr & gpuShader);
+    
+    // Metal Capturing functions -- used for debugging
+    void triggerProgrammaticCaptureScope();
+    void stopProgrammaticCaptureScope();
+
+    void deleteAllTextures();
+
+    // Critical for declaring primitive data types like float2, float3, ...
+    std::string getMSLHeader();
+
+private:
+    MetalBuilder();
+    MetalBuilder(const MetalBuilder &) = delete;
+    MetalBuilder& operator=(const MetalBuilder &) = delete;
+    
+    void fillUniformBufferData();
+
+    const GpuShaderDescRcPtr m_shaderDesc; // Description of the fragment shader to create
+    
+    id<MTLDevice>              m_device;
+    id<MTLCommandQueue>        m_cmdQueue;
+    id<MTLLibrary>             m_library;
+    id<MTLRenderPipelineState> m_PSO;
+    
+    unsigned m_startIndex;                 // Starting index for texture allocations
+    TextureIds m_textureIds;               // Texture ids of all needed textures
+    std::vector<uint8_t> m_uniformData;    // Uniform buffer Data
+    std::string m_shaderCacheID;           // Current shader program key
+    bool m_verbose;                        // Print shader code to std::cout for debugging purposes
+};
+
+} // namespace OCIO_NAMESPACE
+
+#endif // INCLUDED_OCIO_MSL_H

--- a/src/libutils/oglapphelpers/msl.mm
+++ b/src/libutils/oglapphelpers/msl.mm
@@ -1,0 +1,547 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#include <unordered_map>
+#include <string>
+#include <sstream>
+#include <iostream>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "msl.h"
+#include "mtltexture.h"
+
+#import <Metal/Metal.h>
+
+namespace OCIO_NAMESPACE
+{
+
+void RGB_to_RGBA(const float* lutValues, int valueCount, std::vector<float>& float4AdaptedLutValues)
+{
+    if(valueCount % 3 != 0)
+        throw Exception("Value count should be divisible by 3.");
+    
+    valueCount = valueCount * 4 / 3;
+    if(lutValues != nullptr)
+    {
+        float4AdaptedLutValues.resize(valueCount);
+        const float *rgbLutValuesIt = lutValues;
+        float *rgbaLutValuesIt = float4AdaptedLutValues.data();
+        const float *end = rgbaLutValuesIt + valueCount;
+            
+        while(rgbaLutValuesIt != end) {
+            *rgbaLutValuesIt++ = *rgbLutValuesIt++;
+            *rgbaLutValuesIt++ = *rgbLutValuesIt++;
+            *rgbaLutValuesIt++ = *rgbLutValuesIt++;
+            *rgbaLutValuesIt++ = 1.0f;
+        }
+    }
+}
+
+namespace
+{
+
+id<MTLSamplerState> GetSamplerState(id<MTLDevice> device, Interpolation interpolation)
+{
+    MTLSamplerDescriptor* samplerDesc = [MTLSamplerDescriptor new];
+    
+    if(interpolation==INTERP_NEAREST)
+    {
+        [samplerDesc setMinFilter:MTLSamplerMinMagFilterNearest];
+        [samplerDesc setMagFilter:MTLSamplerMinMagFilterNearest];
+    }
+    else
+    {
+        [samplerDesc setMinFilter:MTLSamplerMinMagFilterLinear];
+        [samplerDesc setMagFilter:MTLSamplerMinMagFilterLinear];
+    }
+
+    [samplerDesc setSAddressMode:MTLSamplerAddressModeClampToEdge];
+    [samplerDesc setTAddressMode:MTLSamplerAddressModeClampToEdge];
+    [samplerDesc setRAddressMode:MTLSamplerAddressModeClampToEdge];
+    
+    id<MTLSamplerState> samplerState = [device newSamplerStateWithDescriptor:samplerDesc];
+    
+    [samplerDesc release];
+    
+    return samplerState;
+}
+
+id<MTLTexture> AllocateTexture3D(id<MTLDevice> device,
+                       unsigned edgelen, const float * lutValues)
+{
+    if(lutValues == nullptr)
+    {
+        throw Exception("Missing texture data");
+    }
+    
+    // MTLPixelFormatRGB32Float not supported on metal. Adapt to MTLPixelFormatRGBA32Float
+    std::vector<float> float4AdaptedLutValues;
+    RGB_to_RGBA(lutValues, 3*edgelen*edgelen*edgelen, float4AdaptedLutValues);
+    
+    MTLTextureDescriptor* texDescriptor = [MTLTextureDescriptor new];
+    
+    [texDescriptor setTextureType:MTLTextureType3D];
+    [texDescriptor setWidth:edgelen];
+    [texDescriptor setHeight:edgelen];
+    [texDescriptor setDepth:edgelen];
+    [texDescriptor setStorageMode:MTLStorageModeManaged];
+    [texDescriptor setPixelFormat:MTLPixelFormatRGBA32Float];
+    [texDescriptor setMipmapLevelCount:1];
+    id<MTLTexture> tex = [device newTextureWithDescriptor:texDescriptor];
+    
+    const void* texData = float4AdaptedLutValues.data();
+    
+    [tex replaceRegion:MTLRegionMake3D(0, 0, 0, edgelen, edgelen, edgelen)
+           mipmapLevel:0
+                 slice:0
+             withBytes:texData
+           bytesPerRow:edgelen * 4 * sizeof(float)
+         bytesPerImage:edgelen * edgelen * 4 * sizeof(float)];
+    
+    [texDescriptor release];
+    
+    return tex;
+}
+
+id<MTLTexture> AllocateTexture2D(id<MTLDevice> device,
+                                 unsigned width, unsigned height,
+                                 GpuShaderDesc::TextureType channel,
+                                 const float * values)
+{
+    if (values == nullptr)
+    {
+        throw Exception("Missing texture data.");
+    }
+    
+    const int channelPerPix = channel == GpuShaderCreator::TEXTURE_RED_CHANNEL ? 1 : 4;
+    std::vector<float> adaptedLutValues;
+    if(channel == GpuShaderDesc::TEXTURE_RED_CHANNEL)
+    {
+        adaptedLutValues.resize(width * height);
+        memcpy(adaptedLutValues.data(), values, width * height * sizeof(float));
+    }
+    else
+    {
+        RGB_to_RGBA(values, 3*width*height, adaptedLutValues);
+    }
+    
+    MTLTextureDescriptor* texDescriptor = [MTLTextureDescriptor new];
+    
+    MTLPixelFormat pixelFormat = channel == GpuShaderDesc::TEXTURE_RED_CHANNEL ? MTLPixelFormatR32Float : MTLPixelFormatRGBA32Float;
+    
+    [texDescriptor setTextureType:height > 1 ? MTLTextureType2D : MTLTextureType1D];
+    [texDescriptor setWidth:width];
+    [texDescriptor setHeight:height];
+    [texDescriptor setDepth:1];
+    [texDescriptor setStorageMode:MTLStorageModeManaged];
+    [texDescriptor setPixelFormat:pixelFormat];
+    [texDescriptor setMipmapLevelCount:1];
+    id<MTLTexture> tex = [device newTextureWithDescriptor:texDescriptor];
+    
+    [tex replaceRegion:MTLRegionMake3D(0, 0, 0, width, height, 1)
+           mipmapLevel:0
+             withBytes:adaptedLutValues.data()
+           bytesPerRow:channelPerPix * width * sizeof(float)];
+    
+    [texDescriptor release];
+    
+    return tex;
+}
+}
+
+//////////////////////////////////////////////////////////
+
+MetalBuilder::Uniform::Uniform(const std::string & name, const GpuShaderDesc::UniformData & data)
+    : m_name(name)
+    , m_data(data)
+{
+}
+
+//////////////////////////////////////////////////////////
+
+MetalBuilderRcPtr MetalBuilder::Create(const GpuShaderDescRcPtr & shaderDesc)
+{
+    return MetalBuilderRcPtr(new MetalBuilder(shaderDesc));
+}
+
+MetalBuilder::MetalBuilder(const GpuShaderDescRcPtr & shaderDesc)
+    :   m_shaderDesc(shaderDesc)
+    ,   m_startIndex(0)
+    ,   m_textureIds{}
+    ,   m_uniformData{}
+    ,   m_verbose(false)
+{
+    m_device = MTLCreateSystemDefaultDevice();
+    m_cmdQueue = [m_device newCommandQueue];
+}
+
+MetalBuilder::~MetalBuilder()
+{
+    if(m_cmdQueue)
+    {
+        [m_cmdQueue release];
+    }
+    m_cmdQueue = nil;
+    
+    if(m_PSO)
+    {
+        [m_PSO release];
+    }
+    m_PSO = nil;
+
+    deleteAllTextures();
+}
+
+void MetalBuilder::allocateAllTextures(unsigned startIndex)
+{
+    deleteAllTextures();
+
+    // This is the first available index for the textures.
+    m_startIndex = startIndex;
+    unsigned currIndex = m_startIndex;
+
+    // Process the 3D LUT first.
+
+    const unsigned maxTexture3D = m_shaderDesc->getNum3DTextures();
+    for(unsigned idx=0; idx<maxTexture3D; ++idx)
+    {
+        // 1. Get the information of the 3D LUT.
+
+        const char * textureName = nullptr;
+        const char * samplerName = nullptr;
+        unsigned edgelen = 0;
+        Interpolation interpolation = INTERP_LINEAR;
+        m_shaderDesc->get3DTexture(idx, textureName, samplerName, edgelen, interpolation);
+
+        if(!textureName || !*textureName
+            || !samplerName || !*samplerName
+            || edgelen==0)
+        {
+            throw Exception("The texture data is corrupted");
+        }
+
+        const float * values = nullptr;
+        m_shaderDesc->get3DTextureValues(idx, values);
+        if(!values)
+        {
+            throw Exception("The texture values are missing");
+        }
+        
+        // 2. Allocate the 3D LUT.
+
+        id<MTLTexture> texture = AllocateTexture3D(m_device, edgelen, values);
+        id<MTLSamplerState> samplerState = GetSamplerState(m_device, interpolation);
+
+        // 3. Keep the texture id & name for the later enabling.
+
+        m_textureIds.push_back(TextureId(texture, textureName, samplerState, samplerName, MTLTextureType3D));
+
+        currIndex++;
+    }
+
+    // Process the 1D LUTs.
+
+    const unsigned maxTexture2D = m_shaderDesc->getNumTextures();
+    for(unsigned idx=0; idx<maxTexture2D; ++idx)
+    {
+        // 1. Get the information of the 1D LUT.
+
+        const char * textureName = nullptr;
+        const char * samplerName = nullptr;
+        unsigned width = 0;
+        unsigned height = 0;
+        GpuShaderDesc::TextureType channel = GpuShaderDesc::TEXTURE_RGB_CHANNEL;
+        Interpolation interpolation = INTERP_LINEAR;
+        m_shaderDesc->getTexture(idx, textureName, samplerName, width, height, channel, interpolation);
+
+        if (!textureName || !*textureName
+            || !samplerName || !*samplerName
+            || width==0)
+        {
+            throw Exception("The texture data is corrupted");
+        }
+
+        const float * values = 0x0;
+        m_shaderDesc->getTextureValues(idx, values);
+        if(!values)
+        {
+            throw Exception("The texture values are missing");
+        }
+
+        // 2. Allocate the 1D LUT (a 2D texture is needed to hold large LUTs).
+        id<MTLTexture> texture = AllocateTexture2D(m_device, width, height, channel, values);
+        id<MTLSamplerState> samplerState = GetSamplerState(m_device, interpolation);
+
+        // 3. Keep the texture id & name for the later enabling.
+
+        MTLTextureType type = (height > 1) ? MTLTextureType2D : MTLTextureType1D;
+        m_textureIds.push_back(TextureId(texture, textureName, samplerState, samplerName, type));
+        currIndex++;
+    }
+}
+
+void MetalBuilder::deleteAllTextures()
+{
+    for(auto& textureId : m_textureIds)
+    {
+        if(textureId.m_texture)
+        {
+            textureId.release();
+        }
+    }
+    m_textureIds.clear();
+}
+
+void MetalBuilder::fillUniformBufferData()
+{
+    m_uniformData.clear();
+    m_uniformData.reserve(1024);
+    const unsigned maxUniforms = m_shaderDesc->getNumUniforms();
+    
+    int alignment = 4;
+    for (unsigned idx = 0; idx < maxUniforms; ++idx)
+    {
+        GpuShaderDesc::UniformData data;
+        m_shaderDesc->getUniform(idx, data);
+        switch(data.m_type)
+        {
+            case UNIFORM_BOOL:
+            {
+                float v = data.m_getBool() == false ? 0.0f : 1.0f;
+                size_t offset = m_uniformData.size();
+                size_t dataSize = sizeof(float);
+                m_uniformData.resize(offset + dataSize);
+                memcpy(&m_uniformData[offset], &v, dataSize);
+                alignment = std::max(alignment, 4);
+            }
+                break;
+
+            case UNIFORM_DOUBLE:
+            {
+                float v = data.m_getDouble();
+                size_t offset = m_uniformData.size();
+                size_t dataSize = sizeof(float);
+                m_uniformData.resize(offset + dataSize);
+                memcpy(&m_uniformData[offset], &v, dataSize);
+                alignment = std::max(alignment, 4);
+            }
+            break;
+
+            case UNIFORM_FLOAT3:
+            {
+                const float* v = data.m_getFloat3().data();
+                size_t offset = m_uniformData.size();
+                size_t dataSize = 3 * sizeof(float);
+                m_uniformData.resize(offset + 4 * sizeof(float));
+                memcpy(&m_uniformData[offset], v, dataSize);
+                alignment = std::max(alignment, 16);
+            }
+            break;
+                
+            case UNIFORM_VECTOR_INT:
+            {
+                const int v = data.m_vectorInt.m_getSize();
+                size_t offset = m_uniformData.size();
+                size_t dataSize = sizeof(int);
+                m_uniformData.resize(offset + dataSize);
+                memcpy(&m_uniformData[offset], &v, dataSize);
+                alignment = std::max(alignment, 4);
+            }
+            break;
+                
+            case UNIFORM_VECTOR_FLOAT:
+            {
+                const int v = data.m_vectorFloat.m_getSize();
+                size_t offset = m_uniformData.size();
+                size_t dataSize = sizeof(int);
+                m_uniformData.resize(offset + dataSize);
+                memcpy(&m_uniformData[offset], &v, dataSize);
+                alignment = std::max(alignment, 4);
+            }
+            break;
+                
+            case UNIFORM_UNKNOWN:
+                throw Exception("Unknown uniform type.");
+        };
+    }
+    
+    m_uniformData.resize(((m_uniformData.size() + alignment - 1) / alignment) * alignment);
+}
+
+void MetalBuilder::setUniforms(id<MTLRenderCommandEncoder> renderCmdEncoder)
+{
+    fillUniformBufferData();
+    if(m_uniformData.size() > 0)
+        [renderCmdEncoder setFragmentBytes:m_uniformData.data() length:m_uniformData.size() atIndex:0];
+    
+    const unsigned maxUniforms = m_shaderDesc->getNumUniforms();
+    
+    int uniformId = 1;
+    for (unsigned idx = 0; idx < maxUniforms; ++idx)
+    {
+        GpuShaderDesc::UniformData data;
+        m_shaderDesc->getUniform(idx, data);
+        switch(data.m_type)
+        {
+            case UNIFORM_BOOL:
+            case UNIFORM_DOUBLE:
+            case UNIFORM_FLOAT3:
+                // Part of uniform data buffer
+            break;
+                
+            case UNIFORM_VECTOR_INT:
+            {
+                int size = data.m_vectorInt.m_getSize();
+                const int dummyInt = 123456789;
+                const int* v = size == 0 ? &dummyInt : data.m_vectorInt.m_getVector();
+                size = size == 0 ? sizeof(int) : size * sizeof(int);
+                [renderCmdEncoder setFragmentBytes:v length:size * sizeof(int) atIndex:uniformId++];
+            }
+            break;
+                
+            case UNIFORM_VECTOR_FLOAT:
+            {
+                int size = data.m_vectorFloat.m_getSize();
+                const float dummyFloat = 123456789.0f;
+                const float* v = size == 0 ? &dummyFloat : data.m_vectorFloat.m_getVector();
+                size = size == 0 ? sizeof(float) : size * sizeof(float);
+                [renderCmdEncoder setFragmentBytes:v length:size atIndex:uniformId++];
+            }
+            break;
+                
+            case UNIFORM_UNKNOWN:
+                throw Exception("Unknown uniform type.");
+        };
+    }
+}
+
+bool MetalBuilder::buildPipelineStateObject(const std::string & clientShaderProgram)
+{
+    NSString* shaderSrc = [NSString stringWithUTF8String:clientShaderProgram.c_str()];
+    
+    NSError* error = nil;
+    MTLCompileOptions* options = [MTLCompileOptions new];
+    [options setLanguageVersion:MTLLanguageVersion2_0];
+    [options setFastMathEnabled:NO];
+    
+    @autoreleasepool
+    {
+        m_library = [[m_device newLibraryWithSource:shaderSrc options:options error:&error] autorelease];
+    
+        id<MTLFunction> vertexShader = [[m_library newFunctionWithName:@"ColorCorrectionVS"] autorelease];
+        id<MTLFunction> pixelShader  = [[m_library newFunctionWithName:@"ColorCorrectionPS"] autorelease];
+    
+        MTLRenderPipelineDescriptor* renderPipelineDesc = [[MTLRenderPipelineDescriptor new] autorelease];
+        [renderPipelineDesc setVertexFunction:vertexShader];
+        [renderPipelineDesc setFragmentFunction:pixelShader];
+        [renderPipelineDesc setVertexDescriptor:nil];
+        [renderPipelineDesc setRasterizationEnabled:YES];
+        [renderPipelineDesc setInputPrimitiveTopology:MTLPrimitiveTopologyClassTriangle];
+        [[renderPipelineDesc colorAttachments][0] setPixelFormat:MTLPixelFormatRGBA32Float];
+        m_PSO = [m_device newRenderPipelineStateWithDescriptor:renderPipelineDesc error:&error];
+    }
+    
+    if(error != nil)
+    {
+        throw Exception("Failed to create pipeline state object. Applying color transformation is not possible.");
+    }
+    
+    return true;
+}
+
+void MetalBuilder::triggerProgrammaticCaptureScope()
+{
+    if (@available(macOS 10.15, *))
+    {
+        MTLCaptureManager* captureManager = [MTLCaptureManager sharedCaptureManager];
+        MTLCaptureDescriptor* captureDescriptor = [[MTLCaptureDescriptor alloc] init];
+        captureDescriptor.captureObject = m_device;
+
+        NSError *error;
+        if (![captureManager startCaptureWithDescriptor:captureDescriptor error:&error])
+        {
+            NSLog(@"Failed to start capture, error %@", error);
+        }
+    }
+    else
+    {
+        NSLog(@"Capturing functionality is only available on MacOS 10.15 and above.");
+    }
+}
+
+void MetalBuilder::stopProgrammaticCaptureScope()
+{
+    if (@available(macOS 10.15, *))
+    {
+        MTLCaptureManager* captureManager = [MTLCaptureManager sharedCaptureManager];
+        [captureManager stopCapture];
+    }
+}
+
+void MetalBuilder::applyColorCorrection(id<MTLTexture> inputTexture, id<MTLTexture> outputTexture, unsigned int outWidth, unsigned int outHeight)
+{
+    static bool captureThisFrame = false;
+    
+    if(captureThisFrame)
+    {
+        triggerProgrammaticCaptureScope();
+    }
+    
+    id<MTLCommandBuffer> cmdBuffer = [m_cmdQueue commandBuffer];
+    
+    MTLRenderPassDescriptor* renderPassDesc = [MTLRenderPassDescriptor new];
+    if (@available(macOS 10.15, *)) {
+        [renderPassDesc setRenderTargetWidth:outWidth];
+        [renderPassDesc setRenderTargetHeight:outHeight];
+    }
+    else
+    {
+        throw Exception("Metal Renderer Only Operates on MacOS 10.15 and above.");
+    }
+    [[renderPassDesc colorAttachments][0] setTexture:outputTexture];
+    [[renderPassDesc colorAttachments][0] setLoadAction:MTLLoadActionClear];
+    [[renderPassDesc colorAttachments][0] setStoreAction:MTLStoreActionStore];
+    
+    id<MTLRenderCommandEncoder> renderCmdEncoder = [cmdBuffer renderCommandEncoderWithDescriptor:renderPassDesc];
+    
+    [renderCmdEncoder setRenderPipelineState:m_PSO];
+    
+    [renderCmdEncoder setFragmentTexture:inputTexture atIndex:0];
+    
+    setUniforms(renderCmdEncoder);
+    
+    const size_t max = m_textureIds.size();
+    for (size_t idx=0; idx<max; ++idx)
+    {
+        const TextureId& data = m_textureIds[idx];
+        [renderCmdEncoder setFragmentTexture:data.m_texture atIndex:(m_startIndex + idx)];
+        [renderCmdEncoder setFragmentSamplerState:data.m_samplerState atIndex:(m_startIndex + idx)];
+    }
+    
+    [renderCmdEncoder drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:3];
+    
+    [renderCmdEncoder endEncoding];
+    [cmdBuffer commit];
+    [cmdBuffer waitUntilCompleted];
+    
+    [renderPassDesc release];
+    
+    if(captureThisFrame)
+    {
+        stopProgrammaticCaptureScope();
+    }
+}
+
+unsigned MetalBuilder::GetTextureMaxWidth()
+{
+    id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+    if ([device supportsFeatureSet:MTLFeatureSet_macOS_GPUFamily1_v1] ||
+        [device supportsFeatureSet:MTLFeatureSet_macOS_GPUFamily1_v2])
+    {
+        return 8192;
+    }
+    return 16384;
+}
+
+} // namespace OCIO_NAMESPACE

--- a/src/libutils/oglapphelpers/mtltexture.h
+++ b/src/libutils/oglapphelpers/mtltexture.h
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#ifndef INCLUDED_OCIO_MTLTEXTURE_H
+#define INCLUDED_OCIO_MTLTEXTURE_H
+
+#include <vector>
+#include <OpenGL/gl.h>
+
+#import  <AppKit/AppKit.h>
+#import  <Metal/Metal.h>
+#import  <CoreVideo/CVPixelBuffer.h>
+#import  <CoreVideo/CVOpenGLTextureCache.h>
+#import  <CoreVideo/CVMetalTextureCache.h>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+namespace OCIO_NAMESPACE
+{
+
+typedef struct {
+    int                 cvPixelFormat;
+    MTLPixelFormat      mtlFormat;
+    GLuint              glInternalFormat;
+    GLuint              glFormat;
+    GLuint              glType;
+} GLMetalTextureFormatInfo;
+
+class MtlTexture
+{
+public:
+    MtlTexture() = delete;
+    MtlTexture(const MtlTexture&) = delete;
+    MtlTexture & operator=(const MtlTexture&) = delete;
+    
+    int         getWidth()       const { return m_width;  }
+    int         getHeight()      const { return m_height; }
+    uint64_t    getGLHandle()    const
+    {
+        if(!m_openGLContext)
+        {
+            throw Exception("There is no valid OpenGL Context for this texture");
+        }
+        return m_texID;
+    }
+    
+    ~MtlTexture();
+    
+    MtlTexture(id<MTLDevice> device, uint32_t width, uint32_t height, const float* image);
+    MtlTexture(id<MTLDevice> device, NSOpenGLContext* glContext, uint32_t width, uint32_t height, const float* image);
+    void update(const float* image);
+    id<MTLTexture> getMetalTextureHandle() const { return m_metalTexture; }
+    std::vector<float> readTexture() const;
+    
+private:
+    void createGLTexture();
+    void createMetalTexture();
+    
+    id<MTLDevice>                   m_device;
+    NSOpenGLContext*                m_openGLContext;
+    
+    int                             m_width;
+    int                             m_height;
+    
+    unsigned int                    m_texID;
+    id<MTLTexture>                  m_metalTexture;
+    
+    const GLMetalTextureFormatInfo* m_formatInfo;
+    CVPixelBufferRef                m_CVPixelBuffer;
+    CVMetalTextureRef               m_CVMTLTexture;
+
+    CVOpenGLTextureCacheRef         m_CVGLTextureCache;
+    CVOpenGLTextureRef              m_CVGLTexture;
+    CGLPixelFormatObj               m_CGLPixelFormat;
+
+    // Metal
+    CVMetalTextureCacheRef          m_CVMTLTextureCache;
+};
+
+
+} // namespace OCIO_NAMESPACE
+
+#endif // INCLUDED_OCIO_MTLTEXTURE_H
+

--- a/src/libutils/oglapphelpers/mtltexture.mm
+++ b/src/libutils/oglapphelpers/mtltexture.mm
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#include <vector>
+
+#include "msl.h"
+#include "mtltexture.h"
+
+
+namespace OCIO_NAMESPACE
+{
+
+// Table of equivalent formats across CoreVideo, Metal, and OpenGL
+static const GLMetalTextureFormatInfo GLMetalInteropFormatTable[] =
+{
+    // Core Video Pixel Format,Metal Pixel Format, GL internalformat, GL format, GL type
+    { kCVPixelFormatType_32BGRA, MTLPixelFormatBGRA8Unorm,                 GL_RGBA,
+      GL_BGRA_EXT,               GL_UNSIGNED_INT_8_8_8_8_REV },
+    { kCVPixelFormatType_ARGB2101010LEPacked, MTLPixelFormatBGR10A2Unorm, GL_RGB10_A2,
+      GL_BGRA,                   GL_UNSIGNED_INT_2_10_10_10_REV },
+    { kCVPixelFormatType_32BGRA, MTLPixelFormatBGRA8Unorm_sRGB,           GL_SRGB8_ALPHA8,
+      GL_BGRA,                   GL_UNSIGNED_INT_8_8_8_8_REV },
+    { kCVPixelFormatType_64RGBAHalf, MTLPixelFormatRGBA16Float,           GL_RGBA,
+      GL_RGBA,                   GL_HALF_FLOAT },
+    { kCVPixelFormatType_128RGBAFloat, MTLPixelFormatRGBA32Float,         GL_RGBA,
+      GL_RGBA,                   GL_FLOAT},
+};
+
+const GLMetalTextureFormatInfo* textureFormatInfoFromMetalPixelFormat(MTLPixelFormat pixelFormat)
+{
+    const int numInteropFormats =
+        sizeof(GLMetalInteropFormatTable) / sizeof(GLMetalInteropFormatTable[0]);
+    for(int i = 0; i < numInteropFormats; i++) {
+        if(pixelFormat == GLMetalInteropFormatTable[i].mtlFormat)
+        {
+            return &GLMetalInteropFormatTable[i];
+        }
+    }
+    return NULL;
+}
+
+MtlTexture::MtlTexture(id<MTLDevice> device, uint32_t width, uint32_t height, const float* image)
+    : m_width(width), m_height(height)
+{
+    m_device = device;
+    m_openGLContext = nullptr;
+    MTLTextureDescriptor* texDescriptor = [MTLTextureDescriptor new];
+ 
+    const int channelPerPix = 4;
+    MTLPixelFormat pixelFormat = MTLPixelFormatRGBA32Float;
+    
+    [texDescriptor setWidth:width];
+    [texDescriptor setHeight:height];
+    [texDescriptor setDepth:1];
+    [texDescriptor setStorageMode:MTLStorageModeManaged];
+    [texDescriptor setPixelFormat:pixelFormat];
+    [texDescriptor setMipmapLevelCount:1];
+    m_metalTexture = [device newTextureWithDescriptor:texDescriptor];
+    
+    if(image)
+    {
+        [m_metalTexture replaceRegion:MTLRegionMake3D(0, 0, 0, width, height, 1)
+                          mipmapLevel:0
+                            withBytes:image
+                          bytesPerRow:channelPerPix * width * sizeof(float)];
+    }
+    
+    [texDescriptor release];
+}
+
+MtlTexture::MtlTexture(id<MTLDevice> device,
+                       NSOpenGLContext* glContext,
+                       uint32_t width, uint32_t height,
+                       const float* image) : m_width(width), m_height(height)
+{
+    NSDictionary* cvBufferProperties = @{
+        (__bridge NSString*)kCVPixelBufferOpenGLCompatibilityKey : @YES,
+        (__bridge NSString*)kCVPixelBufferMetalCompatibilityKey : @YES,
+    };
+
+    m_device = device;
+    m_openGLContext = glContext;
+    
+    m_formatInfo = textureFormatInfoFromMetalPixelFormat(MTLPixelFormatRGBA32Float);
+    
+    CVReturn cvret = CVPixelBufferCreate(kCFAllocatorDefault,
+                            m_width, m_height,
+                            m_formatInfo->cvPixelFormat,
+                            (__bridge CFDictionaryRef)cvBufferProperties,
+                            &m_CVPixelBuffer);
+    
+    if(cvret != kCVReturnSuccess)
+    {
+        throw Exception("Cannot create Pixel Buffer");
+    }
+    
+    m_CGLPixelFormat = m_openGLContext.pixelFormat.CGLPixelFormatObj;
+    
+    createGLTexture();
+    createMetalTexture();
+    
+    if(image != nullptr)
+    {
+        update(image);
+    }
+}
+
+void MtlTexture::createGLTexture()
+{
+    CVReturn cvret;
+    // Create an OpenGL CoreVideo texture cache from the pixel buffer.
+    cvret  = CVOpenGLTextureCacheCreate(
+                    kCFAllocatorDefault,
+                    nil,
+                    m_openGLContext.CGLContextObj,
+                    m_CGLPixelFormat,
+                    nil,
+                    &m_CVGLTextureCache);
+    
+    if(cvret != kCVReturnSuccess)
+    {
+        throw Exception("Failed to create OpenGL Texture Cache");
+    }
+    
+    // Create a CVPixelBuffer-backed OpenGL texture image from the texture cache.
+    cvret = CVOpenGLTextureCacheCreateTextureFromImage(
+                    kCFAllocatorDefault,
+                    m_CVGLTextureCache,
+                    m_CVPixelBuffer,
+                    nil,
+                    &m_CVGLTexture);
+    
+    if(cvret != kCVReturnSuccess)
+    {
+        throw Exception("Failed to create OpenGL Texture From Image");
+    }
+    
+    // Get an OpenGL texture name from the CVPixelBuffer-backed OpenGL texture image.
+    m_texID = CVOpenGLTextureGetName(m_CVGLTexture);
+}
+
+void MtlTexture::createMetalTexture()
+{
+    CVReturn cvret;
+    // Create a Metal Core Video texture cache from the pixel buffer.
+    cvret = CVMetalTextureCacheCreate(
+                    kCFAllocatorDefault,
+                    nil,
+                    m_device,
+                    nil,
+                    &m_CVMTLTextureCache);
+
+    if(cvret != kCVReturnSuccess)
+    {
+        throw Exception("Failed to create Metal texture cache");
+    }
+    
+    // Create a CoreVideo pixel buffer backed Metal texture image from the texture cache
+    cvret = CVMetalTextureCacheCreateTextureFromImage(
+                    kCFAllocatorDefault,
+                    m_CVMTLTextureCache,
+                    m_CVPixelBuffer, nil,
+                    m_formatInfo->mtlFormat,
+                    m_width, m_height,
+                    0,
+                    &m_CVMTLTexture);
+    
+    if(cvret != kCVReturnSuccess)
+    {
+        throw Exception("Failed to create CoreVideo Metal texture from image");
+    }
+    
+    // Get a Metal texture using the CoreVideo Metal texture reference.
+    m_metalTexture = CVMetalTextureGetTexture(m_CVMTLTexture);
+    
+    if(!m_metalTexture)
+    {
+        throw Exception("Failed to create Metal texture CoreVideo Metal Texture");
+    }
+}
+
+void MtlTexture::update(const float* image)
+{
+    [m_metalTexture replaceRegion:MTLRegionMake2D(0, 0, m_width, m_height)
+                      mipmapLevel:0
+                        withBytes:image
+                      bytesPerRow:m_width * 4 * sizeof(float)];
+}
+
+std::vector<float> MtlTexture::readTexture() const
+{
+    CVPixelBufferLockBaseAddress(m_CVPixelBuffer, 0);
+    size_t dataSize = CVPixelBufferGetDataSize(m_CVPixelBuffer);
+    float* data = (float*)CVPixelBufferGetBaseAddress(m_CVPixelBuffer);//(m_CVPixelBuffer, 0);
+    std::vector<float> img(4 * m_width * m_height);
+    if((img.size()*sizeof(float)) < dataSize)
+    {
+        throw Exception("CPU-side vector is not large enough to read the texture back.");
+    }
+    memcpy(img.data(), data, dataSize);
+    CVPixelBufferUnlockBaseAddress(m_CVPixelBuffer, 0);
+    return img;
+}
+
+MtlTexture::~MtlTexture()
+{
+    if(m_openGLContext)
+        [m_openGLContext release];
+}
+
+}

--- a/src/libutils/oglapphelpers/oglapp.cpp
+++ b/src/libutils/oglapphelpers/oglapp.cpp
@@ -43,7 +43,7 @@ OglApp::~OglApp()
     m_oglBuilder.reset();
 }
 
-void OglApp::initImage(int imgWidth, int imgHeight, Components comp, const float * image)
+void OglApp::setImageDimensions(int imgWidth, int imgHeight, Components comp)
 {
     m_imageWidth = imgWidth;
     m_imageHeight = imgHeight;
@@ -52,7 +52,12 @@ void OglApp::initImage(int imgWidth, int imgHeight, Components comp, const float
     {
         m_imageAspect = (float)m_imageWidth / (float)m_imageHeight;
     }
+}
 
+void OglApp::initImage(int imgWidth, int imgHeight, Components comp, const float * image)
+{
+    setImageDimensions(imgWidth, imgHeight, comp);
+    
     glGenTextures(1, &m_imageTexID);
     glActiveTexture(GL_TEXTURE0);
     updateImage(image);
@@ -210,7 +215,7 @@ void OglApp::setShader(GpuShaderDescRcPtr & shaderDesc)
          << "}" << std::endl;
 
     // Build the fragment shader program.
-    m_oglBuilder->buildProgram(main.str().c_str());
+    m_oglBuilder->buildProgram(main.str().c_str(), false);
 
     // Enable the fragment shader program, and all needed resources.
     m_oglBuilder->useProgram();

--- a/src/libutils/oglapphelpers/oglapp.h
+++ b/src/libutils/oglapphelpers/oglapp.h
@@ -87,16 +87,16 @@ public:
     };
 
     // Initialize the image.
-    void initImage(int imageWidth, int imageHeight,
-                   Components comp, const float * imageBuffer);
+    virtual void initImage(int imageWidth, int imageHeight,
+                           Components comp, const float * imageBuffer);
     // Update the image if it changes.
-    void updateImage(const float * imageBuffer);
+    virtual void updateImage(const float * imageBuffer);
 
     // Create GL frame and rendering buffers. Needed if readImage will be used.
     void createGLBuffers();
 
     // Set the shader code.
-    void setShader(GpuShaderDescRcPtr & shaderDesc);
+    virtual void setShader(GpuShaderDescRcPtr & shaderDesc);
 
     // Update the size of the buffer of the OpenGL viewport that will be used to process the image
     // (it does not modify the UI).  To be called at least one time. Use image size if we want to
@@ -110,7 +110,7 @@ public:
 
     // Read the image from the rendering buffer. It is not meant to be used by interactive
     // applications used to display the image.
-    void readImage(float * imageBuffer);
+    virtual void readImage(float * imageBuffer);
 
     // Helper to print GL info.
     void virtual printGLInfo() const noexcept;
@@ -130,7 +130,14 @@ protected:
 
     // Initialize the OpenGL engine, and set up GLEW if needed.
     void setupCommon();
+    
+    void setImageDimensions(int imgWidth, int imgHeight, Components comp);
+    Components getImageComponents() const { return m_components; }
 
+    bool printShader() const { return m_printShader; }
+    
+    OpenGLBuilderRcPtr m_oglBuilder;
+    
 private:
     // Keep track of the original image ratio.
     float m_imageAspect{ 1.0f };
@@ -146,8 +153,6 @@ private:
     int m_imageHeight{ 0 };
     Components m_components{ COMPONENTS_RGBA };
     unsigned int m_imageTexID;
-
-    OpenGLBuilderRcPtr m_oglBuilder;
 };
 
 class ScreenApp: public OglApp

--- a/tests/cpu/GpuShader_tests.cpp
+++ b/tests/cpu/GpuShader_tests.cpp
@@ -1138,21 +1138,49 @@ OCIO_ADD_TEST(GpuShader, MetalSupport9)
 struct ocioOCIOMain
 {
 ocioOCIOMain(
-  int ocio_grading_rgbcurve_knotsOffsets[8]
-  , float ocio_grading_rgbcurve_knots[60]
-  , int ocio_grading_rgbcurve_coefsOffsets[8]
-  , float ocio_grading_rgbcurve_coefs[180]
+  constant int ocio_grading_rgbcurve_knotsOffsets[8]
+  , int ocio_grading_rgbcurve_knotsOffsets_count
+  , constant float ocio_grading_rgbcurve_knots[60]
+  , int ocio_grading_rgbcurve_knots_count
+  , constant int ocio_grading_rgbcurve_coefsOffsets[8]
+  , int ocio_grading_rgbcurve_coefsOffsets_count
+  , constant float ocio_grading_rgbcurve_coefs[180]
+  , int ocio_grading_rgbcurve_coefs_count
   , bool ocio_grading_rgbcurve_localBypass
 )
 {
-  for(int i = 0; i < 8; ++i)
+  for(int i = 0; i < ocio_grading_rgbcurve_knotsOffsets_count; ++i)
+  {
     this->ocio_grading_rgbcurve_knotsOffsets[i] = ocio_grading_rgbcurve_knotsOffsets[i];
-  for(int i = 0; i < 60; ++i)
+  }
+  for(int i = ocio_grading_rgbcurve_knotsOffsets_count; i < 8; ++i)
+  {
+    this->ocio_grading_rgbcurve_knotsOffsets[i] = 0;
+  }
+  for(int i = 0; i < ocio_grading_rgbcurve_knots_count; ++i)
+  {
     this->ocio_grading_rgbcurve_knots[i] = ocio_grading_rgbcurve_knots[i];
-  for(int i = 0; i < 8; ++i)
+  }
+  for(int i = ocio_grading_rgbcurve_knots_count; i < 60; ++i)
+  {
+    this->ocio_grading_rgbcurve_knots[i] = 0;
+  }
+  for(int i = 0; i < ocio_grading_rgbcurve_coefsOffsets_count; ++i)
+  {
     this->ocio_grading_rgbcurve_coefsOffsets[i] = ocio_grading_rgbcurve_coefsOffsets[i];
-  for(int i = 0; i < 180; ++i)
+  }
+  for(int i = ocio_grading_rgbcurve_coefsOffsets_count; i < 8; ++i)
+  {
+    this->ocio_grading_rgbcurve_coefsOffsets[i] = 0;
+  }
+  for(int i = 0; i < ocio_grading_rgbcurve_coefs_count; ++i)
+  {
     this->ocio_grading_rgbcurve_coefs[i] = ocio_grading_rgbcurve_coefs[i];
+  }
+  for(int i = ocio_grading_rgbcurve_coefs_count; i < 180; ++i)
+  {
+    this->ocio_grading_rgbcurve_coefs[i] = 0;
+  }
   this->ocio_grading_rgbcurve_localBypass = ocio_grading_rgbcurve_localBypass;
 }
 
@@ -1242,18 +1270,26 @@ float4 OCIOMain(float4 inPixel)
 
 };
 float4 OCIOMain(
-  int ocio_grading_rgbcurve_knotsOffsets[8]
-  , float ocio_grading_rgbcurve_knots[60]
-  , int ocio_grading_rgbcurve_coefsOffsets[8]
-  , float ocio_grading_rgbcurve_coefs[180]
+  constant int ocio_grading_rgbcurve_knotsOffsets[8]
+  , int ocio_grading_rgbcurve_knotsOffsets_count
+  , constant float ocio_grading_rgbcurve_knots[60]
+  , int ocio_grading_rgbcurve_knots_count
+  , constant int ocio_grading_rgbcurve_coefsOffsets[8]
+  , int ocio_grading_rgbcurve_coefsOffsets_count
+  , constant float ocio_grading_rgbcurve_coefs[180]
+  , int ocio_grading_rgbcurve_coefs_count
   , bool ocio_grading_rgbcurve_localBypass
   , float4 inPixel)
 {
   return ocioOCIOMain(
     ocio_grading_rgbcurve_knotsOffsets
+    , ocio_grading_rgbcurve_knotsOffsets_count
     , ocio_grading_rgbcurve_knots
+    , ocio_grading_rgbcurve_knots_count
     , ocio_grading_rgbcurve_coefsOffsets
+    , ocio_grading_rgbcurve_coefsOffsets_count
     , ocio_grading_rgbcurve_coefs
+    , ocio_grading_rgbcurve_coefs_count
     , ocio_grading_rgbcurve_localBypass
   ).OCIOMain(inPixel);
 }

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -51,6 +51,9 @@ target_link_libraries(test_gpu_exec
 )
 
 add_test(NAME test_gpu COMMAND test_gpu_exec)
+if(APPLE)
+	add_test(NAME test_metal COMMAND test_gpu_exec -metal)
+endif()
 
 # Note: To avoid changing PATH from outside the cmake files.
 if(MSVC AND BUILD_SHARED_LIBS)

--- a/tests/gpu/GPUUnitTest.cpp
+++ b/tests/gpu/GPUUnitTest.cpp
@@ -16,6 +16,9 @@
 
 #include "GPUUnitTest.h"
 #include "oglapp.h"
+#if __APPLE__
+#include "metalapp.h"
+#endif
 
 namespace OCIO = OCIO_NAMESPACE;
 
@@ -161,7 +164,7 @@ OCIO::GpuShaderDescRcPtr & OCIOGPUTest::getShaderDesc()
     if (!m_shaderDesc)
     {
         m_shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
-        m_shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_GLSL_1_2);
+        m_shaderDesc->setLanguage(m_gpuShadingLanguage);
         m_shaderDesc->setPixelName("myPixel");
     }
     return m_shaderDesc;
@@ -225,8 +228,13 @@ namespace
             // It means to generate the input values.
 
             const bool testWideRange = test->getTestWideRange();
+#if __APPLE__ && __aarch64__
+            const bool testNaN = false;
+            const bool testInfinity = false;
+#else
             const bool testNaN = test->getTestNaN();
             const bool testInfinity = test->getTestInfinity();
+#endif
 
             const float min = testWideRange ? -1.0f : 0.0f;
             const float max = testWideRange ? +2.0f : 1.0f;
@@ -322,7 +330,7 @@ namespace
 
         OCIO::ConstProcessorRcPtr & processor = test->getProcessor();
         OCIO::GpuShaderDescRcPtr & shaderDesc = test->getShaderDesc();
-
+        
         OCIO::ConstGPUProcessorRcPtr gpu;
         if (test->isLegacyShader())
         {
@@ -501,13 +509,31 @@ namespace
     }
 };
 
-int main(int, char **)
+int main(int argc, char ** argv)
 {
-    // Step 1: Initialize the OpenGL engine.
+    // Step 1: Initialize the graphic library engines.
     OCIO::OglAppRcPtr app;
+    
+    bool useMetalRenderer = false;
+    for(int i = 0; i < argc; ++i)
+    {
+        if(strcmp(argv[i], "-metal") == 0)
+        {
+            useMetalRenderer = true;
+        }
+    }
     try
     {
-        app = OCIO::OglApp::CreateOglApp("GPU tests", 10, 10);
+#if __APPLE__
+        if(useMetalRenderer)
+        {
+            app = OCIO::MetalApp::CreateMetalGlApp("GPU tests - Metal", 10, 10);
+        }
+        else
+#endif
+        {
+            app = OCIO::OglApp::CreateOglApp("GPU tests", 10, 10);
+        }
     }
     catch (const OCIO::Exception & e)
     {
@@ -538,6 +564,13 @@ int main(int, char **)
         const unsigned curr_failures = failures;
 
         OCIOGPUTestRcPtr test = tests[idx];
+        
+        test->setShadingLanguage(
+#if __APPLE__
+            useMetalRenderer ?
+            OCIO::GPU_LANGUAGE_MSL_2_0 :
+#endif
+            OCIO::GPU_LANGUAGE_GLSL_1_2);
 
         bool enabledTest = true;
         try

--- a/tests/gpu/GPUUnitTest.h
+++ b/tests/gpu/GPUUnitTest.h
@@ -52,6 +52,11 @@ class OCIOGPUTest
         void setProcessor(OCIO_NAMESPACE::TransformRcPtr transform);
 
         void setProcessor(OCIO_NAMESPACE::ConstProcessorRcPtr processor);
+    
+        void setShadingLanguage(OCIO_NAMESPACE::GpuLanguage gpuShadingLanguage)
+        {
+            m_gpuShadingLanguage = gpuShadingLanguage;
+        }
 
         inline OCIO_NAMESPACE::ConstProcessorRcPtr & getProcessor() { return m_processor; }
         OCIO_NAMESPACE::GpuShaderDescRcPtr & getShaderDesc();
@@ -156,6 +161,7 @@ class OCIOGPUTest
         bool m_legacyShader{ false };
         unsigned m_legacyShaderLutEdge{ 32 };
         CustomValues m_values;
+        OCIO_NAMESPACE::GpuLanguage m_gpuShadingLanguage;
 
         std::vector<RetestSetupCallback> m_retests;
 


### PR DESCRIPTION
* * Adds Metal Shading Language (MSL) Generation support

Signed-off-by: Morteza Mostajabodaveh <smostajabodaveh@apple.com>

Co-authored-by: Ingthor Hjalmarsson <ihjalmarsson@apple.com>
Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Fixes warnings triggered due to unused variables.

Signed-off-by: Morteza Mostajabodaveh <smostajabodaveh@apple.com>
Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Fixes compilation error on Mac and Windows:
- vector of const objects causing compiler errors on windows.
- Wrong string was used for Metal language python binding.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Removes class wrapping interface from OpenColorIO interface and move it to implementation
* Adding more tests for metal code path
* Proper generated Metal code indentation
* Fixes a few coding style inconsistencies and unneeded include files

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Remove the unneeded empty line to reset OpenColorIO.h to what it was before the metal change.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * switching from c-like getFunctionParameters function to c++-like one since it is not in the opencolorio interface anymore.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Missing include causing compiler errors on windows

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Fixes and improvements follow up to change that was trying to move metal related code in implementation, and hide them from OCIO interface.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* - remove unused variables.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Adds support for uniform parameters and proper handling of them in metal code.
* Adds two new tests for uniforms and helper functions.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * making declaration parsing more C++-like. Functions like sscanf are problematic when it comes to multiple platform support and may not be safe

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Switching from clf/lut1d_half_domain_raw_half_set.clf  to clf/lut1d_long.clf. Due to decimal number outputting difference between different platforms, some tests were failing.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Moving Metal only functionalities to MetalClassWrappingInterface
* remove unnecessary functions and data types
* code clean up and quality improvement

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Adds support for uniforms that are array
* Removing getTextureKeyword() and getTextureDeclaration() as they are not needed.
* code clean up and quality improvement

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Remove unnecessary changes to GpuShaderUtils_tests.cpp

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Removed unnecessary included files

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Removing unnecessary include

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * Apply style improvement suggestions

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* * changed from msl_metal to msl_2 so it matches with `GpuLanguageFromString` function.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Move MetalShaderClassWrappingInterface to a separate file and generalise it

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* header files inlcudes clean up

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Still the else path is needed in case we set language from MSL2 to something else.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* [minor] Showing the GpuShaderClassWrapper.h also in the vc15 aftereffect project.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Run ClassWrapper function for all backends. It only produces code in metal shading language code generation case.
operator= for GpuShaderClassWrapper

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* use factory pattern instead of updateClassWrappingInterface

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Replace assignment operator with clone function that is more explicit.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* use Assignment operator instead of setting members in clone member function

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* add include guards.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* make output of MetalShaderClassWrapper::operator= non-const

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Update default branch name (#1532)

Signed-off-by: Michael Dolan <michdolan@gmail.com>

Co-authored-by: Patrick Hodoul <patrick.hodoul@autodesk.com>
Signed-off-by: Morteza Mostajab <smostajabodaveh@apple.com>

* Adsk Contrib - Default to C++14 and remove OIIO from ocioperf (#1516)

* Adsk Contrib - Default to C++14 and remove OIIO from ocioperf

Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

* Fix cmake breaks

Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

* Fix bit-depths

Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

* Fix Linux build break

Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

* Improve the image generation

Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

* Improve the image generation

Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>
Signed-off-by: Morteza Mostajab <smostajabodaveh@apple.com>

* Add metal rendering support to ociodisplay

Signed-off-by: Morteza Mostajab <smostajabodaveh@apple.com>

* Adds support for metal only input texture

Signed-off-by: Morteza Mostajab <smostajabodaveh@apple.com>

* Returning correct value for maximum texture width

Signed-off-by: Morteza Mostajab <smostajabodaveh@apple.com>

* Add GPU rendering tests for metal renderer
Fixes incorrect shader generation code for arrays in uniform buffer
Adds support for vector comparison in Metal

Signed-off-by: Morteza Mostajab <smostajabodaveh@apple.com>

* Fixes failing test_cpu_exec test
Fixes compilation error on Linux, older clang compiler
Makes the app working on x64 Macs

Signed-off-by: Morteza Mostajab <smostajabodaveh@apple.com>

* Add support for test that apply color correction multiple times with different setups
replaces asserts with exception
Disables fast math to get more accurate results

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Matching the uniform buffer size elements for array of ints and float to fix two gpu tests

Signed-off-by: Morteza Mostajab <smostajabodaveh@apple.com>

* enables -gpuinfo to print shader

Signed-off-by: Morteza Mostajab <smostajabodaveh@apple.com>

* Revert "Matching the uniform buffer size elements for array of ints and float to fix two gpu tests"

This reverts commit c1695e20b336c54c618a541cc47311a61399457b.

Signed-off-by: Morteza Mostajab <smostajabodaveh@apple.com>

* Enables uniform data binding for metal without touching OCIO interface

Signed-off-by: Morteza Mostajab <smostajabodaveh@apple.com>

* set dummy buffers for the vectors that are empty.

Signed-off-by: Morteza Mostajab <smostajabodaveh@apple.com>

* Update metal test to reflect latest changes in metal shader generator

Signed-off-by: Morteza Mostajab <smostajabodaveh@apple.com>

* Improving coding style
Adds metal gpu unit tests to the one executing

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Updating the test so it reflects latest code changes.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* sets the opengl state even when no valid ocio config is loaded.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Handles metal resources lifecycles correctly. Fixes the crash on transform change.

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Applying improvements to code and minor fixes

Signed-off-by: Morteza Mostajab <smostajabodaveh@Apple.com>

* Disable testing NaN and Infinity on Apple Silicon that causes test failures and precision errors

Signed-off-by: Morteza Mostajab <smostajabodaveh@apple.com>

* make the condition for disabling NaN and INFs more accurate.

Signed-off-by: Morteza Mostajab <smostajabodaveh@apple.com>

* Improving code quality
Fixing possible texture mem leaks

Signed-off-by: Morteza Mostajab <smostajabodaveh@apple.com>

Co-authored-by: Ingthor Hjalmarsson <ihjalmarsson@apple.com>
Co-authored-by: Patrick Hodoul <patrick.hodoul@autodesk.com>
Co-authored-by: Michael Dolan <michdolan@gmail.com>
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>