### PR TITLE
Propagate Android CMake configuration to external projects

### DIFF
--- a/share/cmake/modules/FindHalf.cmake
+++ b/share/cmake/modules/FindHalf.cmake
@@ -190,6 +190,14 @@ if(NOT Half_FOUND AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
                 ${Half_CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
         endif()
 
+        if (ANDROID)
+            set(Half_CMAKE_ARGS
+                ${Half_CMAKE_ARGS}
+                -DANDROID_PLATFORM=${ANDROID_PLATFORM}
+                -DANDROID_ABI=${ANDROID_ABI}
+                -DANDROID_STL=${ANDROID_STL})
+        endif()
+
         # Hack to let imported target be built from ExternalProject_Add
         file(MAKE_DIRECTORY ${Half_INCLUDE_DIR})
 

--- a/share/cmake/modules/FindImath.cmake
+++ b/share/cmake/modules/FindImath.cmake
@@ -188,6 +188,14 @@ if(NOT Imath_FOUND AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
                 ${Imath_CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
         endif()
 
+        if (ANDROID)
+            set(Imath_CMAKE_ARGS
+                ${Imath_CMAKE_ARGS}
+                -DANDROID_PLATFORM=${ANDROID_PLATFORM}
+                -DANDROID_ABI=${ANDROID_ABI}
+                -DANDROID_STL=${ANDROID_STL})
+        endif()
+
         # Hack to let imported target be built from ExternalProject_Add
         file(MAKE_DIRECTORY ${Imath_INCLUDE_DIR})
 

--- a/share/cmake/modules/Findexpat.cmake
+++ b/share/cmake/modules/Findexpat.cmake
@@ -231,6 +231,14 @@ if(NOT expat_FOUND AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
                 ${EXPAT_CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
         endif()
 
+        if (ANDROID)
+            set(EXPAT_CMAKE_ARGS
+                ${EXPAT_CMAKE_ARGS}
+                -DANDROID_PLATFORM=${ANDROID_PLATFORM}
+                -DANDROID_ABI=${ANDROID_ABI}
+                -DANDROID_STL=${ANDROID_STL})
+        endif()
+
         # Hack to let imported target be built from ExternalProject_Add
         file(MAKE_DIRECTORY ${expat_INCLUDE_DIR})
 

--- a/share/cmake/modules/Findlcms2.cmake
+++ b/share/cmake/modules/Findlcms2.cmake
@@ -150,6 +150,14 @@ if(NOT lcms2_FOUND AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
                 ${lcms2_CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
         endif()
 
+        if (ANDROID)
+            set(lcms2_CMAKE_ARGS
+                ${lcms2_CMAKE_ARGS}
+                -DANDROID_PLATFORM=${ANDROID_PLATFORM}
+                -DANDROID_ABI=${ANDROID_ABI}
+                -DANDROID_STL=${ANDROID_STL})
+        endif()
+
         # Hack to let imported target be built from ExternalProject_Add
         file(MAKE_DIRECTORY ${lcms2_INCLUDE_DIR})
 

--- a/share/cmake/modules/Findpybind11.cmake
+++ b/share/cmake/modules/Findpybind11.cmake
@@ -171,6 +171,14 @@ if(NOT pybind11_FOUND AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
                 ${pybind11_CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
         endif()
 
+        if (ANDROID)
+            set(pybind11_CMAKE_ARGS
+                ${pybind11_CMAKE_ARGS}
+                -DANDROID_PLATFORM=${ANDROID_PLATFORM}
+                -DANDROID_ABI=${ANDROID_ABI}
+                -DANDROID_STL=${ANDROID_STL})
+        endif()
+
         ExternalProject_Add(pybind11_install
             GIT_REPOSITORY "https://github.com/pybind/pybind11.git"
             GIT_TAG "v${pybind11_FIND_VERSION}"

--- a/share/cmake/modules/Findpystring.cmake
+++ b/share/cmake/modules/Findpystring.cmake
@@ -109,6 +109,15 @@ if(NOT pystring_FOUND AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
                 ${pystring_CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
         endif()
 
+
+        if (ANDROID)
+            set(pystring_CMAKE_ARGS
+                ${pystring_CMAKE_ARGS}
+                -DANDROID_PLATFORM=${ANDROID_PLATFORM}
+                -DANDROID_ABI=${ANDROID_ABI}
+                -DANDROID_STL=${ANDROID_STL})
+        endif()
+
         if(NOT BUILD_SHARED_LIBS)
             #TODO: Find a way to merge in the static libs when built with internal pystring
             message(WARNING

--- a/share/cmake/modules/Findyaml-cpp.cmake
+++ b/share/cmake/modules/Findyaml-cpp.cmake
@@ -195,6 +195,15 @@ if(NOT yaml-cpp_FOUND AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
                 ${yaml-cpp_CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
         endif()
 
+
+        if (ANDROID)
+            set(yaml-cpp_CMAKE_ARGS
+                ${yaml-cpp_CMAKE_ARGS}
+                -DANDROID_PLATFORM=${ANDROID_PLATFORM}
+                -DANDROID_ABI=${ANDROID_ABI}
+                -DANDROID_STL=${ANDROID_STL})
+        endif()
+
         if(NOT BUILD_SHARED_LIBS)
             #TODO: Find a way to merge in the static libs when built with internal yamlcpp
             message(WARNING


### PR DESCRIPTION
:wave:

I have been testing OpenColorIO integration in Android for Krita. I found that missing requirements respect the  `CMAKE_TOOLCHAIN_FILE` of its parent project, but no further Android-specific variables are passed. This causes non-ARM builds, e.g. x86, to build OCIO for the specified architecture and its requirements for armv7a, thus failing at the link stage.

This MR fixes this issue by propagating the toolchain file, ABI and STL variables. This commit was sufficient to build a working prototype of color managed Krita (though with a non-fully-functional configuration reading, which I'll file a bug about separately).