### PR TITLE
Port from main to RB-2.1 - Fix support for ARM64 macOS python wheels (#1574)

### DIFF
--- a/.github/workflows/wheel_workflow.yml
+++ b/.github/workflows/wheel_workflow.yml
@@ -52,55 +52,55 @@ jobs:
           # CPython 32 bits
           # -------------------------------------------------------------------
           - build: CPython 3.6 32 bits
-            python: cp36-*
+            python: cp36-manylinux*
             arch: i686
           - build: CPython 3.7 32 bits
-            python: cp37-*
+            python: cp37-manylinux*
             arch: i686
           - build: CPython 3.8 32 bits
-            python: cp38-*
+            python: cp38-manylinux*
             arch: i686
           - build: CPython 3.9 32 bits
-            python: cp39-*
+            python: cp39-manylinux*
             arch: i686
           - build: CPython 3.10 32 bits
-            python: cp310-*
+            python: cp310-manylinux*
             arch: i686
           # -------------------------------------------------------------------
           # CPython 64 bits
           # -------------------------------------------------------------------
           - build: CPython 3.6 64 bits
-            python: cp36-*
+            python: cp36-manylinux*
             arch: x86_64
           - build: CPython 3.7 64 bits
-            python: cp37-*
+            python: cp37-manylinux*
             arch: x86_64
           - build: CPython 3.8 64 bits
-            python: cp38-*
+            python: cp38-manylinux*
             arch: x86_64
           - build: CPython 3.9 64 bits
-            python: cp39-*
+            python: cp39-manylinux*
             arch: x86_64
           - build: CPython 3.10 64 bits
-            python: cp310-*
+            python: cp310-manylinux*
             arch: x86_64
           # -------------------------------------------------------------------
           # CPython ARM 64 bits
           # -------------------------------------------------------------------
           - build: CPython 3.6 ARM 64 bits
-            python: cp36-*
+            python: cp36-manylinux*
             arch: aarch64
           - build: CPython 3.7 ARM 64 bits
-            python: cp37-*
+            python: cp37-manylinux*
             arch: aarch64
           - build: CPython 3.8 ARM 64 bits
-            python: cp38-*
+            python: cp38-manylinux*
             arch: aarch64
           - build: CPython 3.9 ARM 64 bits
-            python: cp39-*
+            python: cp39-manylinux*
             arch: aarch64
           - build: CPython 3.10 ARM 64 bits
-            python: cp310-*
+            python: cp310-manylinux*
             arch: aarch64
 
     steps:
@@ -117,7 +117,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.2
+        uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -163,13 +163,13 @@ jobs:
           # -------------------------------------------------------------------
           - build: CPython 3.8 ARM 64 bits
             python: cp38-*
-            arch: arm64
+            arch: universal2
           - build: CPython 3.9 ARM 64 bits
             python: cp39-*
-            arch: arm64
+            arch: universal2
           - build: CPython 3.10 ARM 64 bits
             python: cp310-*
-            arch: arm64
+            arch: universal2
 
     steps:
       - uses: actions/checkout@v2
@@ -180,7 +180,7 @@ jobs:
           python-version: '3.8'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.2
+        uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ requires = [
     "setuptools>=42",
     "wheel",
     "cmake>=3.12",
-    "ninja",
-    "pybind11>=2.6.1",
+    "ninja; sys_platform != 'win32' and platform_machine != 'arm64'",
     # Documentation requirements
     "six",
     "testresources",

--- a/share/cmake/modules/FindHalf.cmake
+++ b/share/cmake/modules/FindHalf.cmake
@@ -186,8 +186,13 @@ if(NOT Half_FOUND)
         endif()
 
         if(APPLE)
+            string(REPLACE ";" "$<SEMICOLON>" ESCAPED_CMAKE_OSX_ARCHITECTURES "${CMAKE_OSX_ARCHITECTURES}")
+
             set(Half_CMAKE_ARGS
-                ${Half_CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
+                ${Half_CMAKE_ARGS}
+                -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
+                -DCMAKE_OSX_ARCHITECTURES=${ESCAPED_CMAKE_OSX_ARCHITECTURES}
+            )
         endif()
 
         # Hack to let imported target be built from ExternalProject_Add

--- a/share/cmake/modules/FindImath.cmake
+++ b/share/cmake/modules/FindImath.cmake
@@ -184,8 +184,13 @@ if(NOT Imath_FOUND)
         endif()
 
         if(APPLE)
+            string(REPLACE ";" "$<SEMICOLON>" ESCAPED_CMAKE_OSX_ARCHITECTURES "${CMAKE_OSX_ARCHITECTURES}")
+
             set(Imath_CMAKE_ARGS
-                ${Imath_CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
+                ${Imath_CMAKE_ARGS}
+                -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
+                -DCMAKE_OSX_ARCHITECTURES=${ESCAPED_CMAKE_OSX_ARCHITECTURES}
+            )
         endif()
 
         # Hack to let imported target be built from ExternalProject_Add

--- a/share/cmake/modules/Findexpat.cmake
+++ b/share/cmake/modules/Findexpat.cmake
@@ -222,8 +222,13 @@ if(NOT expat_FOUND)
         endif()
 
         if(APPLE)
+            string(REPLACE ";" "$<SEMICOLON>" ESCAPED_CMAKE_OSX_ARCHITECTURES "${CMAKE_OSX_ARCHITECTURES}")
+
             set(EXPAT_CMAKE_ARGS
-                ${EXPAT_CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
+                ${EXPAT_CMAKE_ARGS}
+                -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
+                -DCMAKE_OSX_ARCHITECTURES=${ESCAPED_CMAKE_OSX_ARCHITECTURES}
+            )
         endif()
 
         # Hack to let imported target be built from ExternalProject_Add

--- a/share/cmake/modules/Findlcms2.cmake
+++ b/share/cmake/modules/Findlcms2.cmake
@@ -143,8 +143,13 @@ if(NOT lcms2_FOUND)
         endif()
 
         if(APPLE)
+            string(REPLACE ";" "$<SEMICOLON>" ESCAPED_CMAKE_OSX_ARCHITECTURES "${CMAKE_OSX_ARCHITECTURES}")
+
             set(lcms2_CMAKE_ARGS
-                ${lcms2_CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
+                ${lcms2_CMAKE_ARGS}
+                -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
+                -DCMAKE_OSX_ARCHITECTURES=${ESCAPED_CMAKE_OSX_ARCHITECTURES}
+            )
         endif()
 
         # Hack to let imported target be built from ExternalProject_Add

--- a/share/cmake/modules/Findpybind11.cmake
+++ b/share/cmake/modules/Findpybind11.cmake
@@ -165,6 +165,10 @@ if(NOT pybind11_FOUND)
             -DCMAKE_INSTALL_MESSAGE=${CMAKE_INSTALL_MESSAGE}
             -DCMAKE_INSTALL_PREFIX=${_EXT_DIST_ROOT}
             -DCMAKE_OBJECT_PATH_MAX=${CMAKE_OBJECT_PATH_MAX}
+            # Using FindPython mode (PYBIND11_FINDPYTHON=ON) doesn't seem to
+            # work when building on docker manylinux images where Development
+            # component is not available but is hardcoded in pybind11 script.
+            -DPYTHON_EXECUTABLE=${Python_EXECUTABLE}
             -DPYBIND11_INSTALL=ON
             -DPYBIND11_TEST=OFF
         )
@@ -175,8 +179,13 @@ if(NOT pybind11_FOUND)
         endif()
 
         if(APPLE)
+            string(REPLACE ";" "$<SEMICOLON>" ESCAPED_CMAKE_OSX_ARCHITECTURES "${CMAKE_OSX_ARCHITECTURES}")
+
             set(pybind11_CMAKE_ARGS
-                ${pybind11_CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
+                ${pybind11_CMAKE_ARGS}
+                -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
+                -DCMAKE_OSX_ARCHITECTURES=${ESCAPED_CMAKE_OSX_ARCHITECTURES}
+            )
         endif()
 
         ExternalProject_Add(pybind11_install

--- a/share/cmake/modules/Findpystring.cmake
+++ b/share/cmake/modules/Findpystring.cmake
@@ -103,8 +103,13 @@ if(NOT pystring_FOUND)
         endif()
 
         if(APPLE)
+            string(REPLACE ";" "$<SEMICOLON>" ESCAPED_CMAKE_OSX_ARCHITECTURES "${CMAKE_OSX_ARCHITECTURES}")
+
             set(pystring_CMAKE_ARGS
-                ${pystring_CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
+                ${pystring_CMAKE_ARGS}
+                -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
+                -DCMAKE_OSX_ARCHITECTURES=${ESCAPED_CMAKE_OSX_ARCHITECTURES}
+            )
         endif()
 
         if(NOT BUILD_SHARED_LIBS)

--- a/share/cmake/modules/Findyaml-cpp.cmake
+++ b/share/cmake/modules/Findyaml-cpp.cmake
@@ -192,8 +192,13 @@ if(NOT yaml-cpp_FOUND)
         endif()
 
         if(APPLE)
+            string(REPLACE ";" "$<SEMICOLON>" ESCAPED_CMAKE_OSX_ARCHITECTURES "${CMAKE_OSX_ARCHITECTURES}")
+
             set(yaml-cpp_CMAKE_ARGS
-                ${yaml-cpp_CMAKE_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
+                ${yaml-cpp_CMAKE_ARGS}
+                -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}
+                -DCMAKE_OSX_ARCHITECTURES=${ESCAPED_CMAKE_OSX_ARCHITECTURES}
+            )
         endif()
 
         if(NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
* Fix support for ARM64 macOS python wheels

Signed-off-by: Rémi Achard <remiachard@gmail.com>

* Use $<SEMICOLON> generator expression to escape semicolon

Signed-off-by: Rémi Achard <remiachard@gmail.com>

Co-authored-by: Patrick Hodoul <patrickhodoul@gmail.com>