### PR TITLE
Port from main to RB-2.1 - Adsk Contrib - Remove 'expat' symbols (#1582)

### DIFF
--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -301,13 +301,17 @@ set_target_properties(OpenColorIO PROPERTIES
     PUBLIC_HEADER "${INSTALL_HEADERS}"
 )
 
-if (UNIX AND NOT APPLE)
+if(UNIX AND NOT APPLE)
     # Also hide all the symbols of dependent libraries to prevent clashes if
     # an app using this project is linked against other versions of our
     # dependencies.
     set_property (TARGET OpenColorIO
                   APPEND PROPERTY LINK_FLAGS "-Wl,--exclude-libs,ALL")
-endif ()
+elseif(APPLE)
+    # Hide the expat symbols.
+    set_property (TARGET OpenColorIO
+                  APPEND PROPERTY LINK_FLAGS "-Wl,-hidden-lexpat")
+endif()
 
 if(MSVC AND BUILD_SHARED_LIBS)
     # Install the pdb file if any.

--- a/src/apps/ociochecklut/main.cpp
+++ b/src/apps/ociochecklut/main.cpp
@@ -68,6 +68,7 @@ public:
 #else
     void setGPU(OCIO::ConstGPUProcessorRcPtr)
     {
+        m_verbose = false; // Avoid a warning.
     }
 #endif // OCIO_GPU_ENABLED
 


### PR DESCRIPTION
* Adsk Contrib - Remove 'yaml' symbols

Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

* Improve the symbol control

Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>