### PR TITLE
CMake: Fix issue that led to Windows Unicode support still defaulting to off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,9 @@ option(OCIO_BUILD_JAVA "Specify whether to build java bindings" OFF)
 
 option(OCIO_WARNING_AS_ERROR "Set build error level for CI testing" OFF)
 
-option(OCIO_USE_WINDOWS_UNICODE "On Windows only, compile with Unicode support" WIN32)
+if (WIN32)
+    option(OCIO_USE_WINDOWS_UNICODE "Compile with Windows Unicode support" ON)
+endif()
 
 
 ###############################################################################


### PR DESCRIPTION
Follow-up from #1363 

In that PR, a CMake option was introduced called `OCIO_USE_WINDOWS_UNICODE` to allow users to compile either an ANSI-only or Unicode build on Windows. Its default value was set to `WIN32` in an attempt to automatically enable on Windows and disable on other platforms.

It turns out there's a syntax issue here, CMake sets it to the literal string `"WIN32"` rather than the value of the variable `${WIN32}`, and it considers that string literal equivalent to `OFF` at all times.

This could be corrected by simply changing the default value to `${WIN32}` instead of `WIN32`, which I've tested and works correctly, however what I've written in this PR is a wrapping of that CMake option in an `if (WIN32)` and defaulting the option to`ON`. Personally, I prefer this approach because I think the code is more readable and there's no real point for a Windows-only option being visible/available on non-Windows platforms anyway. However, if the former approach is preferred, I can write that in instead.