### PR TITLE
Minor build and CI fixes

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -96,23 +96,27 @@ jobs:
         if: matrix.build-docs == 'ON'
       - name: Install tests env
         run: share/ci/scripts/linux/yum/install_tests_env.sh
+      - name: Setup ext environment
+        run: |
+          EXT_PATH=/usr/local
+          echo "EXT_PATH=$EXT_PATH" >> $GITHUB_ENV
       - name: Install indirect dependencies
         run: |
           share/ci/scripts/multi/install_pugixml.sh latest
       - name: Install fixed ext package versions
         run: |
-          share/ci/scripts/multi/install_expat.sh 2.4.1
-          share/ci/scripts/multi/install_lcms2.sh 2.2
-          share/ci/scripts/multi/install_yaml-cpp.sh 0.7.0
-          share/ci/scripts/multi/install_pystring.sh 1.1.3
-          share/ci/scripts/multi/install_pybind11.sh 2.6.1
+          share/ci/scripts/multi/install_expat.sh 2.4.1 $EXT_PATH
+          share/ci/scripts/multi/install_lcms2.sh 2.2 $EXT_PATH
+          share/ci/scripts/multi/install_yaml-cpp.sh 0.7.0 $EXT_PATH
+          share/ci/scripts/multi/install_pystring.sh 1.1.3 $EXT_PATH
+          share/ci/scripts/multi/install_pybind11.sh 2.6.1 $EXT_PATH
       - name: Install latest ext package versions
         run: |
-          share/ci/scripts/multi/install_openexr.sh latest
-          share/ci/scripts/multi/install_imath.sh latest
-          share/ci/scripts/multi/install_oiio.sh latest
-          share/ci/scripts/multi/install_osl.sh latest
-          share/ci/scripts/multi/install_openfx.sh latest
+          share/ci/scripts/multi/install_openexr.sh latest $EXT_PATH
+          share/ci/scripts/multi/install_imath.sh latest $EXT_PATH
+          share/ci/scripts/multi/install_oiio.sh latest $EXT_PATH
+          share/ci/scripts/multi/install_osl.sh latest $EXT_PATH
+          share/ci/scripts/multi/install_openfx.sh latest $EXT_PATH
       - name: Create build directories
         run: |
           mkdir _install
@@ -192,25 +196,29 @@ jobs:
         if: matrix.build-docs == 'ON'
       - name: Install tests env
         run: share/ci/scripts/macos/install_tests_env.sh
+      - name: Setup ext environment
+        run: |
+          EXT_PATH=/usr/local
+          echo "EXT_PATH=$EXT_PATH" >> $GITHUB_ENV
       - name: Install indirect dependencies
         run: |
           share/ci/scripts/macos/install_bison.sh latest
           share/ci/scripts/macos/install_boost.sh latest
-          share/ci/scripts/multi/install_pugixml.sh latest
+          share/ci/scripts/multi/install_pugixml.sh latest $EXT_PATH
       - name: Install fixed ext package versions
         run: |
-          share/ci/scripts/multi/install_expat.sh 2.4.1
-          share/ci/scripts/multi/install_lcms2.sh 2.2
-          share/ci/scripts/multi/install_yaml-cpp.sh 0.7.0
-          share/ci/scripts/multi/install_pystring.sh 1.1.3
-          share/ci/scripts/multi/install_pybind11.sh 2.6.1
+          share/ci/scripts/multi/install_expat.sh 2.4.1 $EXT_PATH
+          share/ci/scripts/multi/install_lcms2.sh 2.2 $EXT_PATH
+          share/ci/scripts/multi/install_yaml-cpp.sh 0.7.0 $EXT_PATH
+          share/ci/scripts/multi/install_pystring.sh 1.1.3 $EXT_PATH
+          share/ci/scripts/multi/install_pybind11.sh 2.6.1 $EXT_PATH
       - name: Install latest ext package versions
         run: |
-          share/ci/scripts/multi/install_openexr.sh latest
-          share/ci/scripts/multi/install_imath.sh latest
-          share/ci/scripts/multi/install_oiio.sh latest
-          share/ci/scripts/multi/install_osl.sh latest
-          share/ci/scripts/multi/install_openfx.sh latest
+          share/ci/scripts/multi/install_openexr.sh latest $EXT_PATH
+          share/ci/scripts/multi/install_imath.sh latest $EXT_PATH
+          share/ci/scripts/multi/install_oiio.sh latest $EXT_PATH
+          share/ci/scripts/multi/install_osl.sh latest $EXT_PATH
+          share/ci/scripts/multi/install_openfx.sh latest $EXT_PATH
       - name: Create build directories
         run: |
           mkdir _install

--- a/.github/workflows/wheel_workflow.yml
+++ b/.github/workflows/wheel_workflow.yml
@@ -278,7 +278,7 @@ jobs:
           python-version: '3.8'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.2
+        uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}

--- a/docs/quick_start/installation.rst
+++ b/docs/quick_start/installation.rst
@@ -435,5 +435,13 @@ Note: For other user facing environment variables, see :ref:`using_env_vars`.
 
     When building the OCIO OpenFX plugins, include the installed 
     ``OpenColorIO/lib`` directory (where ``OpenColorIO.ofx.bundle`` is located) 
-    in this path. The path to a shared OpenColorIO lib (*.so, *.dll, *.dylib) 
-    should also be present on ``PATH``.
+    in this path.
+
+    It is recommended to build OFX plugins in static mode 
+    (``BUILD_SHARED_LIBS=OFF``) to avoid any issue loading the OpenColorIO
+    library from the plugin once it has been moved. Otherwise, please make sure
+    the shared OpenColorIO lib (*.so, *.dll, *.dylib) is visible from the
+    plugin by mean of ``PATH``, ``LD_LIBRARY_PATH`` or ``DYLD_LIBRARY_PATH``
+    for Windows, Linux and macOS respectively. For systems that supports it,
+    it is also possible to edit the RPATH of the plugin to add the location of
+    the shared OpenColorIO lib.

--- a/include/OpenColorIO/OpenColorABI.h.in
+++ b/include/OpenColorIO/OpenColorABI.h.in
@@ -47,7 +47,7 @@
 
 // If supported, define OCIOEXPORT, OCIOHIDDEN
 // (used to choose which symbols to export from OpenColorIO)
-#if defined(_WIN32)
+#if defined(_WIN32) || defined(__CYGWIN__)
     // Windows requires you to export from the main library and then import in any others
     // only when compiling a dynamic library (i.e. DLL)
     #ifndef OpenColorIO_SKIP_IMPORTS

--- a/share/cmake/projects/Buildlcms2.cmake
+++ b/share/cmake/projects/Buildlcms2.cmake
@@ -5,6 +5,8 @@ project(lcms2)
 
 cmake_minimum_required(VERSION 3.10)
 
+include(GNUInstallDirs)
+
 include_directories(include)
 
 file(GLOB HEADERS "include/*.h")

--- a/share/cmake/projects/Buildpystring.cmake
+++ b/share/cmake/projects/Buildpystring.cmake
@@ -5,6 +5,8 @@ project(pystring)
 
 cmake_minimum_required(VERSION 3.10)
 
+include(GNUInstallDirs)
+
 set(HEADERS
     pystring.h
 )

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -226,9 +226,9 @@ target_link_libraries(OpenColorIO
         expat::expat
         ${OCIO_HALF_LIB}
         pystring::pystring
-        sampleicc::sampleicc
-        utils::from_chars
-        utils::strings
+        "$<BUILD_INTERFACE:sampleicc::sampleicc>"
+        "$<BUILD_INTERFACE:utils::from_chars>"
+        "$<BUILD_INTERFACE:utils::strings>"
         yaml-cpp
 )
 

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -242,7 +242,7 @@ endif()
 
 if(NOT BUILD_SHARED_LIBS)
     target_compile_definitions(OpenColorIO
-        PRIVATE
+        PUBLIC
             OpenColorIO_SKIP_IMPORTS
     )
 else()

--- a/src/OpenColorIO/FileRules.cpp
+++ b/src/OpenColorIO/FileRules.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstring>
 #include <map>
 #include <regex>
 #include <sstream>

--- a/src/apps/ociobakelut/CMakeLists.txt
+++ b/src/apps/ociobakelut/CMakeLists.txt
@@ -8,13 +8,6 @@ set(SOURCES
 
 add_executable(ociobakelut ${SOURCES})
 
-if(NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(ociobakelut
-        PRIVATE
-            OpenColorIO_SKIP_IMPORTS
-    )
-endif()
-
 if(MSVC)
     set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /wd4996")
 endif()

--- a/src/apps/ociocheck/CMakeLists.txt
+++ b/src/apps/ociocheck/CMakeLists.txt
@@ -7,13 +7,6 @@ set(SOURCES
 
 add_executable(ociocheck ${SOURCES})
 
-if(NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(ociocheck
-        PRIVATE
-        OpenColorIO_SKIP_IMPORTS
-    )
-endif()
-
 if(MSVC)
     set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /wd4996")
 endif()

--- a/src/apps/ociochecklut/CMakeLists.txt
+++ b/src/apps/ociochecklut/CMakeLists.txt
@@ -14,13 +14,6 @@ set(SOURCES
 
 add_executable(ociochecklut ${SOURCES})
 
-if(NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(ociochecklut
-        PRIVATE
-        OpenColorIO_SKIP_IMPORTS
-    )
-endif()
-
 if(MSVC)
     set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /wd4996")
 endif()

--- a/src/apps/ocioconvert/CMakeLists.txt
+++ b/src/apps/ocioconvert/CMakeLists.txt
@@ -14,13 +14,6 @@ set(SOURCES
 
 add_executable(ocioconvert ${SOURCES})
 
-if(NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(ocioconvert
-        PRIVATE
-            OpenColorIO_SKIP_IMPORTS
-    )
-endif()
-
 set_target_properties(ocioconvert PROPERTIES 
     COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
 

--- a/src/apps/ociodisplay/CMakeLists.txt
+++ b/src/apps/ociodisplay/CMakeLists.txt
@@ -12,13 +12,6 @@ set(SOURCES
 
 add_executable(ociodisplay ${SOURCES})
 
-if(NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(ociodisplay
-        PRIVATE
-            OpenColorIO_SKIP_IMPORTS
-    )
-endif()
-
 set(CUSTOM_COMPILE_FLAGS ${PLATFORM_COMPILE_FLAGS})
 if(APPLE)
     # Mute the deprecated warning for some GLUT methods.

--- a/src/apps/ociolutimage/CMakeLists.txt
+++ b/src/apps/ociolutimage/CMakeLists.txt
@@ -7,13 +7,6 @@ set(SOURCES
 
 add_executable(ociolutimage ${SOURCES})
 
-if(NOT BUILD_SHARED_LIBS)
-	target_compile_definitions(ociolutimage
-		PRIVATE
-			OpenColorIO_SKIP_IMPORTS
-	)
-endif()
-
 set_target_properties(ociolutimage PROPERTIES
 	COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
 

--- a/src/apps/ociomakeclf/CMakeLists.txt
+++ b/src/apps/ociomakeclf/CMakeLists.txt
@@ -7,13 +7,6 @@ set(SOURCES
 
 add_executable(ociomakeclf ${SOURCES})
 
-if(NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(ociomakeclf
-        PRIVATE
-        OpenColorIO_SKIP_IMPORTS
-    )
-endif()
-
 if(MSVC)
     set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /wd4996")
 endif()

--- a/src/apps/ocioperf/CMakeLists.txt
+++ b/src/apps/ocioperf/CMakeLists.txt
@@ -7,13 +7,6 @@ set(SOURCES
 
 add_executable(ocioperf ${SOURCES})
 
-if(NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(ocioperf
-        PRIVATE
-            OpenColorIO_SKIP_IMPORTS
-    )
-endif()
-
 set_target_properties(ocioperf PROPERTIES
     COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
 

--- a/src/apps/ociowrite/CMakeLists.txt
+++ b/src/apps/ociowrite/CMakeLists.txt
@@ -7,13 +7,6 @@ set(SOURCES
 
 add_executable(ociowrite ${SOURCES})
 
-if(NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(ociowrite
-        PRIVATE
-            OpenColorIO_SKIP_IMPORTS
-    )
-endif()
-
 set_target_properties(ociowrite PROPERTIES 
     COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
 

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -154,7 +154,7 @@ set_target_properties(PyOpenColorIO
 
 if(NOT BUILD_SHARED_LIBS)
 	target_compile_definitions(PyOpenColorIO
-		PRIVATE
+		PUBLIC
 			OpenColorIO_SKIP_IMPORTS
 	)
 endif()

--- a/src/libutils/oglapphelpers/CMakeLists.txt
+++ b/src/libutils/oglapphelpers/CMakeLists.txt
@@ -37,7 +37,7 @@ set_target_properties(oglapphelpers PROPERTIES OUTPUT_NAME OpenColorIOoglapphelp
 
 if(NOT BUILD_SHARED_LIBS)
     target_compile_definitions(oglapphelpers
-        PRIVATE
+        PUBLIC
             OpenColorIO_SKIP_IMPORTS
     )
 endif()

--- a/src/libutils/oiiohelpers/CMakeLists.txt
+++ b/src/libutils/oiiohelpers/CMakeLists.txt
@@ -11,7 +11,7 @@ set_target_properties(oiiohelpers PROPERTIES OUTPUT_NAME OpenColorIOoiiohelpers)
 
 if(NOT BUILD_SHARED_LIBS)
     target_compile_definitions(oiiohelpers
-        PRIVATE
+        PUBLIC
             OpenColorIO_SKIP_IMPORTS
     )
 endif()

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -8,10 +8,6 @@ function(add_ocio_test NAME SOURCES PRIVATE_INCLUDES)
     set(TEST_BINARY "test_${NAME}_exec")
     set(TEST_NAME "test_${NAME}")
     add_executable(${TEST_BINARY} ${SOURCES})
-    target_compile_definitions(${TEST_BINARY}
-        PRIVATE
-            OpenColorIO_SKIP_IMPORTS
-    )
     target_link_libraries(${TEST_BINARY}
         PRIVATE
             OpenColorIO

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -8,6 +8,10 @@ function(add_ocio_test NAME SOURCES PRIVATE_INCLUDES)
     set(TEST_BINARY "test_${NAME}_exec")
     set(TEST_NAME "test_${NAME}")
     add_executable(${TEST_BINARY} ${SOURCES})
+    target_compile_definitions(${TEST_BINARY}
+        PRIVATE
+            OpenColorIO_SKIP_IMPORTS
+    )
     target_link_libraries(${TEST_BINARY}
         PRIVATE
             OpenColorIO

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -8682,8 +8682,8 @@ OCIO_ADD_TEST(Config, look_fallback)
     // Test that the look fallback syntax works for look with missing file.
     // The fallback syntax allow to specify looks to try in order and use the
     // first valid one. When the syntax "my_look | " is used, the fallback
-    // is empty and there will be no look applied (no-op) if my_look in invalid.
-    // This may happen if my_look rely on a missing environment variable.
+    // is empty and there will be no look applied (no-op) if my_look is invalid.
+    // This may happen if my_look relies on a missing environment variable.
 
     {
         static const std::string CONFIG =

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -8676,3 +8676,63 @@ colorspaces:
         OCIO_CHECK_ASSERT(proc->isNoOp());
     }
 }
+
+OCIO_ADD_TEST(Config, look_fallback)
+{
+    // Test that the look fallback syntax works for look with missing file.
+
+    {
+        static const std::string CONFIG =
+            "ocio_profile_version: 1\n"
+            "\n"
+            "search_path: " + OCIO::GetTestFilesDir() + "\n"
+            "\n"
+            "roles:\n"
+            "  scene_linear: cs\n"
+            "\n"
+            "displays:\n"
+            "  disp1:\n"
+            "    - !<View>\n"
+            "      name: view1\n"
+            "      colorspace: cs\n"
+            "      looks: missing_file_look | \n"
+            "\n"
+            "looks:\n"
+            "  - !<Look>\n"
+            "    name: missing_file_look\n"
+            "    process_space: cs\n"
+            "    transform: !<FileTransform> {src: \"${LOOK_CDL}.cc\"}\n"
+            "\n"
+            "colorspaces:\n"
+            "  - !<ColorSpace>\n"
+            "    name: cs\n"
+            "\n";
+
+        // Check that the look is correctly used when file is present.
+
+        OCIO::Platform::Setenv("LOOK_CDL", "cdl_test1");
+
+        std::istringstream iss;
+        iss.str(CONFIG);
+
+        OCIO::ConstConfigRcPtr config;
+
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(iss));
+        OCIO_CHECK_NO_THROW(config->validate());
+
+        OCIO::ConstProcessorRcPtr proc;
+        OCIO_CHECK_NO_THROW(proc = config->getProcessor("cs", "disp1", "view1", OCIO::TRANSFORM_DIR_FORWARD));
+        OCIO_CHECK_ASSERT(!proc->isNoOp());
+
+        // Now remove the variable pointing to the look file and check that we fallback to a no-op.
+
+        OCIO::Platform::Unsetenv("LOOK_CDL");
+
+        iss.str(CONFIG);
+
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(iss));
+
+        OCIO_CHECK_NO_THROW(proc = config->getProcessor("cs", "disp1", "view1", OCIO::TRANSFORM_DIR_FORWARD));
+        OCIO_CHECK_ASSERT(proc->isNoOp());
+    }
+}

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -8680,6 +8680,10 @@ colorspaces:
 OCIO_ADD_TEST(Config, look_fallback)
 {
     // Test that the look fallback syntax works for look with missing file.
+    // The fallback syntax allow to specify looks to try in order and use the
+    // first valid one. When the syntax "my_look | " is used, the fallback
+    // is empty and there will be no look applied (no-op) if my_look in invalid.
+    // This may happen if my_look rely on a missing environment variable.
 
     {
         static const std::string CONFIG =

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -26,13 +26,6 @@ set(SOURCES
 
 add_executable(test_gpu_exec ${SOURCES})
 
-if(NOT BUILD_SHARED_LIBS)
-	target_compile_definitions(test_gpu_exec
-		PRIVATE
-			OpenColorIO_SKIP_IMPORTS
-	)
-endif()
-
 if(OCIO_USE_SSE)
 	target_compile_definitions(test_gpu_exec
 		PRIVATE

--- a/tests/osl/CMakeLists.txt
+++ b/tests/osl/CMakeLists.txt
@@ -18,13 +18,6 @@ set(SOURCES
 
 add_executable(test_osl_exec ${SOURCES})
 
-if(NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(test_osl_exec
-        PRIVATE
-            OpenColorIO_SKIP_IMPORTS
-    )
-endif()
-
 if(OCIO_USE_SSE)
     target_compile_definitions(test_osl_exec
         PRIVATE

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -10,11 +10,6 @@ set(SOURCES
 
 add_executable(test_utils_exec ${SOURCES})
 
-target_compile_definitions(test_utils_exec
-    PRIVATE
-        OpenColorIO_SKIP_IMPORTS
-)
-
 target_link_libraries(test_utils_exec
     PRIVATE
         utils::strings

--- a/vendor/openfx/CMakeLists.txt
+++ b/vendor/openfx/CMakeLists.txt
@@ -30,13 +30,6 @@ set(RESOURCES
 
 add_library(ofxplugin MODULE ${SOURCES} ${OFXS_SOURCES})
 
-if(NOT BUILD_SHARED_LIBS)
-    target_compile_definitions(ofxplugin
-        PRIVATE
-            OpenColorIO_SKIP_IMPORTS
-    )
-endif()
-
 # Disable known compiler warnings from OpenFX Support Library
 if(MSVC)
     set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /wd4996 /wd4101")


### PR DESCRIPTION
#### Fix the analysis workflow

The install location for built dependencies in the analysis workflow is now explicit in Linux and macOS (Windows already use a custom location). This is because OpenImageIO now started to override the install location to point in the build tree when none is specified, instead of using standard Unix paths.

Currently failing on OpenEXR Windows build, see related issue https://github.com/AcademySoftwareFoundation/openexr/issues/1236

#### Fix issue in static builds on Windows #1581

#### Fix #1593

#### Improve documentation for OFX build #1607 