### PR TITLE
Adsk Contrib - Add preliminary support for ACES Metadata Files (AMF)

### DIFF
--- a/src/apps/pyocioamf/README.md
+++ b/src/apps/pyocioamf/README.md
@@ -1,0 +1,32 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the OpenColorIO Project. -->
+
+pyocioamf
+=========
+
+**Work in progress**. Script to convert an ACES Metadata File (AMF) into OCIO's 
+native CTF file format.  The CTF may then be used with any of the other OCIO tools 
+to process pixels.
+
+An example AMF file named ``example.amf`` is provided.  It references the LUT file
+``example_referenced_lut.clf``, which is in the Academy/ASC Common LUT Format (CLF).
+
+Usage
+-----
+
+1. Install dependencies on ``PYTHONPATH``
+2. Run ``python pyocioamf.py example.amf`` (or any other AMF file).
+3. The CTF file will have the same name as the AMF file but with a .ctf extension, in
+this case, ``example.ctf``.
+
+Dependencies
+------------
+
+* PyOpenColorIO
+
+Implementation notes
+--------------------
+
+* Uses a prototype ACES config ``config-aces-reference.yaml`` to interpret the
+  ACES Transform IDs encountered in the AMF file.  This file should be in the
+  same directory as the script.

--- a/src/apps/pyocioamf/config-aces-reference.yaml
+++ b/src/apps/pyocioamf/config-aces-reference.yaml
@@ -1,0 +1,696 @@
+ocio_profile_version: 2.1
+
+environment:
+  {}
+search_path: ""
+strictparsing: true
+luma: [0.2126, 0.7152, 0.0722]
+description: |
+  This is a prototype version of the OCIO v2 "Academy Color Encoding System" (ACES) "Reference Config".
+  
+  It has been enhanced with additional ACES Transform ID strings to facilitate its use as a database of
+  transforms that may be used to implement the color pipeline of an ACES Metadata File (AMF).  However
+  certain Transform IDs are still missing (e.g. Canon and Red IDTs) since they do not currently exist
+  in the Academy aces-dev repository.
+
+roles:
+  aces_interchange: ACES - ACES2065-1
+  cie_xyz_d65_interchange: CIE-XYZ-D65
+  color_timing: ACES - ACEScct
+  compositing_log: ACES - ACEScct
+  data: Utility - Raw
+  default: ACES - ACES2065-1
+  reference: ACES - ACES2065-1
+  rendering: ACES - ACEScg
+  scene_linear: ACES - ACEScg
+
+file_rules:
+  - !<Rule> {name: Default, colorspace: ACES - ACES2065-1}
+
+shared_views:
+  - !<View> {name: Output - SDR Video - ACES 1.0, view_transform: Output - SDR Video - ACES 1.0, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - SDR Video (D60 sim on D65) - ACES 1.0, view_transform: Output - SDR Video (D60 sim on D65) - ACES 1.0, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - SDR Video (P3 lim) - ACES 1.1, view_transform: Output - SDR Video (P3 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - SDR Video (Rec.709 lim) - ACES 1.1, view_transform: Output - SDR Video (Rec.709 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - HDR Video (1000 nits & Rec.2020 lim) - ACES 1.1, view_transform: Output - HDR Video (1000 nits & Rec.2020 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - HDR Video (2000 nits & Rec.2020 lim) - ACES 1.1, view_transform: Output - HDR Video (2000 nits & Rec.2020 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - HDR Video (4000 nits & Rec.2020 lim) - ACES 1.1, view_transform: Output - HDR Video (4000 nits & Rec.2020 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - HDR Video (1000 nits & P3 lim) - ACES 1.1, view_transform: Output - HDR Video (1000 nits & P3 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - HDR Video (2000 nits & P3 lim) - ACES 1.1, view_transform: Output - HDR Video (2000 nits & P3 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - HDR Video (4000 nits & P3 lim) - ACES 1.1, view_transform: Output - HDR Video (4000 nits & P3 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - SDR Cinema - ACES 1.0, view_transform: Output - SDR Cinema - ACES 1.0, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - SDR Cinema (D60 sim on D65) - ACES 1.1, view_transform: Output - SDR Cinema (D60 sim on D65) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - SDR Cinema (Rec.709 lim) - ACES 1.1, view_transform: Output - SDR Cinema (Rec.709 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - SDR Cinema (D60 sim on DCI) - ACES 1.0, view_transform: Output - SDR Cinema (D60 sim on DCI) - ACES 1.0, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - SDR Cinema (D65 sim on DCI) - ACES 1.1, view_transform: Output - SDR Cinema (D65 sim on DCI) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Output - HDR Cinema (108 nits & P3 lim) - ACES 1.1, view_transform: Output - HDR Cinema (108 nits & P3 lim) - ACES 1.1, display_colorspace: <USE_DISPLAY_NAME>}
+  - !<View> {name: Un-tone-mapped, view_transform: Un-tone-mapped, display_colorspace: <USE_DISPLAY_NAME>}
+
+displays:
+  Display - sRGB:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - SDR Video - ACES 1.0, Output - SDR Video (D60 sim on D65) - ACES 1.0, Un-tone-mapped]
+  Display - Rec.1886 / Rec.709 Video:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - SDR Video - ACES 1.0, Output - SDR Video (D60 sim on D65) - ACES 1.0, Un-tone-mapped]
+  Display - Rec.1886 / Rec.2020 Video:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - SDR Video - ACES 1.0, Output - SDR Video (P3 lim) - ACES 1.1, Output - SDR Video (Rec.709 lim) - ACES 1.1, Un-tone-mapped]
+  Display - Rec.2100-HLG:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - HDR Video (1000 nits & Rec.2020 lim) - ACES 1.1, Un-tone-mapped]
+  Display - Rec.2100-PQ:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - HDR Video (1000 nits & Rec.2020 lim) - ACES 1.1, Output - HDR Video (2000 nits & Rec.2020 lim) - ACES 1.1, Output - HDR Video (4000 nits & Rec.2020 lim) - ACES 1.1, Un-tone-mapped]
+  Display - ST2084-P3-D65:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - HDR Video (1000 nits & P3 lim) - ACES 1.1, Output - HDR Video (2000 nits & P3 lim) - ACES 1.1, Output - HDR Video (4000 nits & P3 lim) - ACES 1.1, Output - HDR Cinema (108 nits & P3 lim) - ACES 1.1, Un-tone-mapped]
+  Display - P3-D60:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - SDR Cinema - ACES 1.0, Un-tone-mapped]
+  Display - P3-D65:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - SDR Cinema - ACES 1.0, Output - SDR Cinema (D60 sim on D65) - ACES 1.1, Output - SDR Cinema (Rec.709 lim) - ACES 1.1, Un-tone-mapped]
+  Display - P3-DCI:
+    - !<View> {name: Raw, colorspace: Utility - Raw}
+    - !<Views> [Output - SDR Cinema (D60 sim on DCI) - ACES 1.0, Output - SDR Cinema (D65 sim on DCI) - ACES 1.1, Un-tone-mapped]
+
+active_displays: [Display - sRGB, Display - Rec.1886 / Rec.709 Video, Display - Rec.1886 / Rec.2020 Video, Display - Rec.2100-HLG, Display - Rec.2100-PQ, Display - ST2084-P3-D65, Display - P3-D60, Display - P3-D65, Display - P3-DCI]
+active_views: [Output - SDR Video - ACES 1.0, Output - SDR Video (D60 sim on D65) - ACES 1.0, Output - SDR Video (P3 lim) - ACES 1.1, Output - SDR Video (Rec.709 lim) - ACES 1.1, Output - HDR Video (1000 nits & Rec.2020 lim) - ACES 1.1, Output - HDR Video (2000 nits & Rec.2020 lim) - ACES 1.1, Output - HDR Video (4000 nits & Rec.2020 lim) - ACES 1.1, Output - HDR Video (1000 nits & P3 lim) - ACES 1.1, Output - HDR Video (2000 nits & P3 lim) - ACES 1.1, Output - HDR Video (4000 nits & P3 lim) - ACES 1.1, Output - SDR Cinema - ACES 1.0, Output - SDR Cinema (D60 sim on D65) - ACES 1.1, Output - SDR Cinema (Rec.709 lim) - ACES 1.1, Output - SDR Cinema (D60 sim on DCI) - ACES 1.0, Output - SDR Cinema (D65 sim on DCI) - ACES 1.1, Output - HDR Cinema (108 nits & P3 lim) - ACES 1.1, Raw]
+inactive_colorspaces: [CIE-XYZ-D65]
+
+looks:
+  - !<Look>
+    name: LMT - Blue Light Artifact Fix
+    process_space: ACES - ACES2065-1
+    description: |
+      LMT for desaturating blue hues to reduce clipping artifacts
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:LMT.Academy.BlueLightArtifactFix.a1.1.0
+    transform: !<BuiltinTransform> {style: ACES-LMT - BLUE_LIGHT_ARTIFACT_FIX}
+
+  - !<Look>
+    name: LMT - ACES 1.3 Reference Gamut Compression
+    process_space: ACES - ACES2065-1
+    description: |
+      LMT (applied in ACES2065-1) to compress scene-referred values from common cameras into the AP1 gamut
+
+      # NB: The first id is out of date with aces-dev and should be removed.
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:LMT.Academy.GamutCompress.a1.3.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:LMT.Academy.ReferenceGamutCompress.a1.v1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvLMT.Academy.ReferenceGamutCompress.a1.v1.0
+    transform: !<BuiltinTransform> {style: ACES-LMT - ACES 1.3 Reference Gamut Compression}
+
+
+default_view_transform: Un-tone-mapped
+
+view_transforms:
+  - !<ViewTransform>
+    name: Output - SDR Video - ACES 1.0
+    description: |
+      Component of ACES Output Transforms for SDR D65 video
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.RGBmonitor_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec709_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec2020_100nits_dim.a1.0.3
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-VIDEO_1.0}
+
+  - !<ViewTransform>
+    name: Output - SDR Video (D60 sim on D65) - ACES 1.0
+    description: |
+      Component of ACES Output Transforms for SDR D65 video simulating D60 white
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-VIDEO-D60sim-D65_1.0}
+
+  - !<ViewTransform>
+    name: Output - SDR Video (P3 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for SDR D65 video
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_P3D65limited_100nits_dim.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-VIDEO-P3lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - SDR Video (Rec.709 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for SDR D65 video
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_Rec709limited_100nits_dim.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-VIDEO-REC709lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - HDR Video (1000 nits & Rec.2020 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for 1000 nit HDR D65 video
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-1000nit-15nit-REC2020lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - HDR Video (2000 nits & Rec.2020 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for 2000 nit HDR D65 video
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-2000nit-15nit-REC2020lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - HDR Video (4000 nits & Rec.2020 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for 4000 nit HDR D65 video
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-4000nit-15nit-REC2020lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - HDR Video (1000 nits & P3 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for 1000 nit HDR D65 video
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-1000nit-15nit-P3lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - HDR Video (2000 nits & P3 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for 2000 nit HDR D65 video
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_2000nits_15nits_ST2084.a1.1.0
+      # NB: The 2000 nit inverse doesn't exist yet in aces-dev, which is a bug.
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_2000nits_15nits_ST2084.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-2000nit-15nit-P3lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - HDR Video (4000 nits & P3 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for 4000 nit HDR D65 video
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_4000nits_15nits_ST2084.a1.1.0
+      # NB: The 4000 nit inverse doesn't exist yet in aces-dev, which is a bug.
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_4000nits_15nits_ST2084.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-VIDEO-4000nit-15nit-P3lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - SDR Cinema - ACES 1.0
+    description: |
+      Component of ACES Output Transforms for SDR cinema
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D60_48nits.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_48nits.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D60_48nits.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_48nits.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA_1.0}
+
+  - !<ViewTransform>
+    name: Output - SDR Cinema (D60 sim on D65) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for SDR D65 cinema simulating D60 white
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_D60sim_48nits.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_D60sim_48nits.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA-D60sim-D65_1.1}
+
+  - !<ViewTransform>
+    name: Output - SDR Cinema (Rec.709 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for SDR cinema
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_Rec709limited_48nits.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA-REC709lim_1.1}
+
+  - !<ViewTransform>
+    name: Output - SDR Cinema (D60 sim on DCI) - ACES 1.0
+    description: |
+      Component of ACES Output Transforms for SDR DCI cinema simulating D60 white
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_48nits.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3DCI_48nits.a1.0.3
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA-D60sim-DCI_1.0}
+
+  - !<ViewTransform>
+    name: Output - SDR Cinema (D65 sim on DCI) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for SDR DCI cinema simulating D65 white
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_D65sim_48nits.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3DCI_D65sim_48nits.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - SDR-CINEMA-D65sim-DCI_1.1}
+
+  - !<ViewTransform>
+    name: Output - HDR Cinema (108 nits & P3 lim) - ACES 1.1
+    description: |
+      Component of ACES Output Transforms for 108 nit HDR D65 cinema
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_108nits_7point2nits_ST2084.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_108nits_7point2nits_ST2084.a1.1.0
+    from_scene_reference: !<BuiltinTransform> {style: ACES-OUTPUT - ACES2065-1_to_CIE-XYZ-D65 - HDR-CINEMA-108nit-7.2nit-P3lim_1.1}
+
+  - !<ViewTransform>
+    name: Un-tone-mapped
+    from_scene_reference: !<BuiltinTransform> {style: UTILITY - ACES-AP0_to_CIE-XYZ-D65_BFD}
+
+display_colorspaces:
+  - !<ColorSpace>
+    name: CIE-XYZ-D65
+    family: ""
+    equalitygroup: ""
+    bitdepth: 32f
+    description: The "CIE XYZ (D65)" display connection colorspace.
+    isdata: false
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: Display - sRGB
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert CIE XYZ (D65 white) to sRGB (piecewise EOTF)
+
+      Component of these ACES Output Transforms:
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.RGBmonitor_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.RGBmonitor_D60sim_100nits_dim.a1.0.3
+    isdata: false
+    categories: [file-io]
+    encoding: sdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_sRGB}
+
+  - !<ColorSpace>
+    name: Display - Rec.1886 / Rec.709 Video
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert CIE XYZ (D65 white) to Rec.1886/Rec.709 (HD video)
+
+      Component of these ACES Output Transforms:
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec709_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec709_D60sim_100nits_dim.a1.0.3
+    isdata: false
+    categories: [file-io]
+    encoding: sdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_REC.1886-REC.709}
+
+  - !<ColorSpace>
+    name: Display - Rec.1886 / Rec.2020 Video
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert CIE XYZ (D65 white) to Rec.1886/Rec.2020 (UHD video)
+
+      Component of these ACES Output Transforms:
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_100nits_dim.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_P3D65limited_100nits_dim.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec2020_Rec709limited_100nits_dim.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.Rec2020_100nits_dim.a1.0.3
+    isdata: false
+    categories: [file-io]
+    encoding: sdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_REC.1886-REC.2020}
+
+  - !<ColorSpace>
+    name: Display - Rec.2100-HLG
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert CIE XYZ (D65 white) to Rec.2100-HLG, 1000 nit
+
+      Component of these ACES Output Transforms:
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_1000nits_15nits_HLG.a1.1.0
+    isdata: false
+    categories: [file-io]
+    encoding: hdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_REC.2100-HLG-1000nit}
+
+  - !<ColorSpace>
+    name: Display - Rec.2100-PQ
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert CIE XYZ (D65 white) to Rec.2100-PQ
+
+      Component of these ACES Output Transforms:
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_1000nits_15nits_ST2084.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_2000nits_15nits_ST2084.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.Rec2020_4000nits_15nits_ST2084.a1.1.0
+    isdata: false
+    categories: [file-io]
+    encoding: hdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_REC.2100-PQ}
+
+  - !<ColorSpace>
+    name: Display - ST2084-P3-D65
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert CIE XYZ (D65 white) to ST-2084 (PQ), P3-D65 primaries
+
+      Component of these ACES Output Transforms:
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_108nits_7point2nits_ST2084.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_2000nits_15nits_ST2084.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:RRTODT.Academy.P3D65_4000nits_15nits_ST2084.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_108nits_7point2nits_ST2084.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_1000nits_15nits_ST2084.a1.1.0
+      # NB: The following don't currently exist yet in aces-dev, which is a bug.
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_2000nits_15nits_ST2084.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvRRTODT.Academy.P3D65_4000nits_15nits_ST2084.a1.1.0
+    isdata: false
+    categories: [file-io]
+    encoding: sdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_ST2084-P3-D65}
+
+  - !<ColorSpace>
+    name: Display - P3-D60
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert CIE XYZ (D65 white) to Gamma 2.6, P3-D60 (Bradford adaptation)
+
+      Component of these ACES Output Transforms:
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D60_48nits.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D60_48nits.a1.0.3
+    isdata: false
+    categories: [file-io]
+    encoding: sdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_G2.6-P3-D60-BFD}
+
+  - !<ColorSpace>
+    name: Display - P3-D65
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert CIE XYZ (D65 white) to Gamma 2.6, P3-D65
+
+      Component of these ACES Output Transforms:
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_48nits.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_D60sim_48nits.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D65_Rec709limited_48nits.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_48nits.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3D65_D60sim_48nits.a1.1.0
+    isdata: false
+    categories: [file-io]
+    encoding: sdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_G2.6-P3-D65}
+
+  - !<ColorSpace>
+    name: Display - P3-DCI
+    family: Display
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert CIE XYZ (D65 white) to Gamma 2.6, P3-DCI (DCI white with Bradford adaptation)
+
+      Component of these ACES Output Transforms:
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_48nits.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ODT.Academy.P3DCI_D65sim_48nits.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3DCI_48nits.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:InvODT.Academy.P3DCI_D65sim_48nits.a1.1.0
+    isdata: false
+    categories: [file-io]
+    encoding: sdr-video
+    allocation: uniform
+    from_display_reference: !<BuiltinTransform> {style: DISPLAY - CIE-XYZ-D65_to_G2.6-P3-DCI-BFD}
+
+colorspaces:
+  - !<ColorSpace>
+    name: ACES - ACES2065-1
+    family: ACES
+    equalitygroup: ""
+    bitdepth: 32f
+    description: The "Academy Color Encoding System" reference colorspace.
+    isdata: false
+    encoding: scene-linear
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: Utility - Raw
+    family: Utility
+    equalitygroup: ""
+    bitdepth: 32f
+    description: The utility "Raw" colorspace.
+    isdata: true
+    allocation: uniform
+
+  - !<ColorSpace>
+    name: ACES - ACEScc
+    family: ACES
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert ACEScc to ACES2065-1
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScc_to_ACES.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScc.a1.0.3
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: ACEScc_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: ACES - ACEScct
+    family: ACES
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert ACEScct to ACES2065-1
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScct.a1.0.3
+    isdata: false
+    categories: [file-io, working-space]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: ACEScct_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: ACES - ACEScg
+    family: ACES
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert ACEScg to ACES2065-1
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScg_to_ACES.a1.0.3
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScg.a1.0.3
+    isdata: false
+    categories: [file-io, working-space]
+    encoding: scene-linear
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: ACEScg_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: ACES - ADX10
+    family: ACES
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert ADX10 to ACES2065-1
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ADX10_to_ACES.a1.0.3
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: ADX10_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: ACES - ADX16
+    family: ACES
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert ADX16 to ACES2065-1
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ADX16_to_ACES.a1.0.3
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: ADX16_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - Canon - CLog2 CGamut
+    family: Input/Canon
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert Canon Log 2 Cinema Gamut to ACES2065-1
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog2_CGamut_to_ACES.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_CLog2_CGamut.a1.1.0
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: CANON_CLOG2-CGAMUT_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - Canon - CLog3 CGamut
+    family: Input/Canon
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert Canon Log 3 Cinema Gamut to ACES2065-1
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CLog3_CGamut_to_ACES.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_CLog3_CGamut.a1.1.0
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: CANON_CLOG3-CGAMUT_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - RED - Log3G10 RWG
+    family: Input/RED
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert RED Log3G10 RED Wide Gamut to ACES2065-1
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.Log3G10_RWG_to_ACES.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_Log3G10_RWG.a1.1.0
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: RED_LOG3G10-RWG_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - ARRI - LogC EI800 AWG
+    family: Input/ARRI
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert ARRI ALEXA LogC (EI800) ALEXA Wide Gamut to ACES2065-1
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.LogC_EI800_AWG_to_ACES.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_LogC_EI800_AWG.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI800.a1.v2
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: ARRI_ALEXA-LOGC-EI800-AWG_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - Sony - SLog3 SGamut3
+    family: Input/Sony
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert Sony S-Log3 S-Gamut3 to ACES2065-1
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3_to_ACES.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_SGamut3.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog3_SGamut3.a1.v1
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: SONY_SLOG3-SGAMUT3_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - Sony - SLog3 SGamut3Cine
+    family: Input/Sony
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert Sony S-Log3 S-Gamut3.Cine to ACES2065-1
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_SGamut3Cine_to_ACES.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_SGamut3Cine.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:IDT.Sony.SLog3_SGamut3Cine.a1.v1
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: SONY_SLOG3-SGAMUT3.CINE_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - Sony - SLog3 Venice SGamut3
+    family: Input/Sony
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert Sony S-Log3 S-Gamut3 for the Venice camera to ACES2065-1
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3_to_ACES.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_Venice_SGamut3.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:IDT.Sony.Venice_SLog3_SGamut3.a1.v1
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: SONY_SLOG3-SGAMUT3-VENICE_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - Sony - SLog3 Venice SGamut3Cine
+    family: Input/Sony
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert Sony S-Log3 S-Gamut3.Cine for the Venice camera to ACES2065-1
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.SLog3_Venice_SGamut3Cine_to_ACES.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_SLog3_Venice_SGamut3Cine.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:IDT.Sony.Venice_SLog3_SGamut3Cine.a1.v1
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: SONY_SLOG3-SGAMUT3.CINE-VENICE_to_ACES2065-1}
+
+  - !<ColorSpace>
+    name: Input - Panasonic - VLog VGamut
+    family: Input/Panasonic
+    equalitygroup: ""
+    bitdepth: 32f
+    description: |
+      Convert Panasonic Varicam V-Log V-Gamut to ACES2065-1
+      
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.VLog_VGamut_to_ACES.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_VLog_VGamut.a1.1.0
+      ACEStransformID: urn:ampas:aces:transformId:v1.5:IDT.Panasonic.VLog_VGamut.a1.v1
+    isdata: false
+    categories: [file-io]
+    encoding: log
+    allocation: uniform
+    to_scene_reference: !<BuiltinTransform> {style: PANASONIC_VLOG-VGAMUT_to_ACES2065-1}

--- a/src/apps/pyocioamf/example.amf
+++ b/src/apps/pyocioamf/example.amf
@@ -1,0 +1,72 @@
+<?xml version="1.0" ?>
+<aces:acesMetadataFile version="1.0" xmlns:aces="urn:ampas:aces:amf:v1.0" xmlns:cdl="urn:ASC:CDL:v1.01" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:ampas:aces:amf:v1.0 file:acesMetadataFile.xsd">
+    <aces:amfInfo>
+        <aces:description>Example Movie</aces:description>
+        <aces:dateTime>
+           <aces:creationDateTime>2019-09-19T10:20:00</aces:creationDateTime>
+           <aces:modificationDateTime>2019-11-27T10:20:00Z</aces:modificationDateTime>
+        </aces:dateTime>
+    </aces:amfInfo>
+    <aces:clipId>
+        <aces:clipName>A001A020</aces:clipName>
+        <aces:uuid>urn:uuid:797c7cd8-4eb1-4f67-afce-af2b0a1d0285</aces:uuid>
+    </aces:clipId>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>3</aces:minorVersion>
+                <aces:patchVersion>0</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+
+        <aces:inputTransform applied="false">
+            <aces:description>ARRI.Alexa-v3-logC-EI800.a1.v2</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.ARRI.Alexa-v3-logC-EI800.a1.v2</aces:transformId>
+        </aces:inputTransform>
+
+        <aces:lookTransform applied="false">
+            <aces:description>ACES 1.3 Look - Reference Gamut Compress</aces:description>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:LMT.Academy.ReferenceGamutCompress.a1.v1.0</aces:transformId>
+        </aces:lookTransform>
+
+        <aces:lookTransform applied="false">
+            <aces:description>Shot technical grade ASC CDL</aces:description>
+            <aces:cdlWorkingSpace>
+                <aces:toCdlWorkingSpace>
+                    <aces:description>ACES2065-1 to ACEScct</aces:description>
+                    <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScct.a1.0.3</aces:transformId>
+                </aces:toCdlWorkingSpace>
+                <aces:fromCdlWorkingSpace>
+                    <aces:description>ACEScct to ACES2065-1</aces:description>
+                    <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+                </aces:fromCdlWorkingSpace>
+            </aces:cdlWorkingSpace>
+            <cdl:SOPNode>
+                <cdl:Slope>1.1 1.0 0.9</cdl:Slope>
+                <cdl:Offset>-0.01 0.02 0.00</cdl:Offset>
+                <cdl:Power>1.0 1.0 1.0</cdl:Power>
+            </cdl:SOPNode>
+            <cdl:SatNode>
+                <cdl:Saturation>1.1</cdl:Saturation>
+            </cdl:SatNode>
+        </aces:lookTransform>
+
+        <aces:lookTransform applied="false">
+            <aces:description>Scene Look LUT</aces:description>
+            <aces:file>example_referenced_lut.clf</aces:file>
+        </aces:lookTransform>
+
+        <aces:outputTransform applied="false">
+            <aces:referenceRenderingTransform>
+                <aces:description>ACES 1.0 - RRT</aces:description>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:description>ACES 1.0 Output - Rec709 100 Nits</aces:description>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.Rec709_100nits_dim.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/src/apps/pyocioamf/example_referenced_lut.clf
+++ b/src/apps/pyocioamf/example_referenced_lut.clf
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ProcessList compCLFversion="3" id="$dc4c5600d5d6169d2b007ed2798559f2">
+    <Description>Very small example LMT, converts to ACEScct to apply a small amount of brightening</Description>
+    <InputDescriptor>ACES2065-1</InputDescriptor>
+    <OutputDescriptor>ACES2065-1</OutputDescriptor>
+    <Matrix inBitDepth="32f" outBitDepth="32f">
+        <Array dim="3 3">
+   1.45143931614567   -0.23651074689374  -0.214928569251925
+-0.0765537733960206    1.17622969983357 -0.0996759264375522
+0.00831614842569772 -0.00603244979102103    0.997716301365323
+        </Array>
+    </Matrix>
+    <Log inBitDepth="32f" outBitDepth="32f" style="cameraLinToLog">
+        <LogParams base="2" linSideSlope="1" linSideOffset="0" logSideSlope="0.0570776255707763" logSideOffset="0.554794520547945" linSideBreak="0.0078125" />
+    </Log>
+    <LUT3D inBitDepth="32f" outBitDepth="32f" interpolation="tetrahedral">
+        <Array dim="3 3 3 3">
+ 0.   0.   0. 
+ 0.   0.   0.5125
+ 0.   0.   1. 
+ 0.   0.5125  0. 
+ 0.   0.5125  0.5125
+ 0.   0.5125  1. 
+ 0.   1.   0. 
+ 0.   1.   0.5125
+ 0.   1.   1. 
+ 0.5125  0.   0. 
+ 0.5125  0.   0.5125
+ 0.5125  0.   1. 
+ 0.5125  0.5125  0. 
+ 0.5125  0.5125  0.5125
+ 0.5125  0.5125  1. 
+ 0.5125  1.   0. 
+ 0.5125  1.   0.5125
+ 0.5125  1.   1. 
+ 1.   0.   0. 
+ 1.   0.   0.5125
+ 1.   0.   1. 
+ 1.   0.5125  0. 
+ 1.   0.5125  0.5125
+ 1.   0.5125  1. 
+ 1.   1.   0. 
+ 1.   1.   0.5125
+ 1.   1.   1. 
+        </Array>
+    </LUT3D>
+    <Log inBitDepth="32f" outBitDepth="32f" style="cameraLogToLin">
+        <LogParams base="2" linSideSlope="1" linSideOffset="0" logSideSlope="0.0570776255707763" logSideOffset="0.554794520547945" linSideBreak="0.0078125" />
+    </Log>
+    <Matrix inBitDepth="32f" outBitDepth="32f">
+        <Array dim="3 3">
+  0.695452241357452   0.140678696470294   0.163869062172254
+ 0.0447945633720377   0.859671118456422  0.0955343181715404
+-0.00552588255811354  0.00402521030597866     1.00150067225213
+        </Array>
+    </Matrix>
+</ProcessList>

--- a/src/apps/pyocioamf/pyocioamf.py
+++ b/src/apps/pyocioamf/pyocioamf.py
@@ -1,0 +1,478 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+"""
+Convert an ACES Metadata File (AMF) into an OCIO Color Transform File (CTF).
+
+This is a prototype for AMF support in OCIO.  It utilizes a tweaked version of the OCIO v2
+ACES Reference config as a database of AMF Transform ID strings and accompanying transforms.
+
+Usage: % python pyocioamf.py <AMF_FILE>
+
+The exported CTF file is written to the same directory as the AMF_FILE and has the same
+name, but uses .ctf as the extension.  The CTF file may then be used with any of the
+other OCIO tools such as ocioconvert or ociochecklut to apply the AMF color pipeline.
+"""
+
+import xml.etree.ElementTree as ET
+
+import PyOpenColorIO as ocio
+
+
+# Specify the color space name for ACES2065-1 in the ACES config.
+ACES = 'ACES - ACES2065-1'
+# Setup the namespaces used in the AMF XML file.
+NS = {'aces': 'urn:ampas:aces:amf:v1.0', 'cdl': 'urn:ASC:CDL:v1.01'}
+
+def search_colorspaces(config, aces_id):
+    """ Search the config for the supplied ACES ID, return the color space name. """
+    for cs in config.getColorSpaces():
+        desc = cs.getDescription()
+        if aces_id in desc:
+            return cs.getName()
+    return None
+
+def search_viewtransforms(config, aces_id):
+    """ Search the config for the supplied ACES ID, return the view transform name. """
+    for vt in config.getViewTransforms():
+        desc = vt.getDescription()
+        if aces_id in desc:
+            return vt.getName()
+    return None
+
+def search_looktransforms(config, aces_id):
+    """ Search the config for the supplied ACES ID, return the look name. """
+    for lt in config.getLooks():
+        desc = lt.getDescription()
+        if aces_id in desc:
+            return lt.getName()
+    return None
+
+def must_apply(elem, type):
+    """ Return True if the 'applied' attribute is not already true. """
+    if elem is None:
+        return False
+    if 'applied' in elem.attrib:
+        if elem.attrib['applied'].lower() == 'true': 
+            print('Skipping', type, 'Transform that was already applied')
+            return False
+    return True
+
+def check_lut_path(amf_path, lut_path):
+    """ Validate the LUT path and try to fix it if it's a relative path. """
+    import os.path
+    if not os.path.isfile(lut_path):
+        if os.path.isabs(lut_path):
+            raise ValueError('File transform refers to path that does not exist: ' + lut_path)
+        else:
+            # See if the LUT path is relative to where the AMF file is located.
+            prefix = os.path.dirname(amf_path)
+            abs_path = os.path.join(prefix, lut_path)
+            if os.path.isfile(abs_path):
+                lut_path = abs_path
+            else:
+                raise ValueError('File transform refers to path that does not exist: ' + lut_path)
+
+    # TODO: Try some other techniques to find the referenced file.
+
+    # Return the (possibly corrected) path of the LUT.
+    return lut_path
+
+def name_ctf_output_file(amf_path):
+    """ Return the path to store the resulting CTF file, based on the AMF name. """
+    import os.path
+    prefix, basename = os.path.split(amf_path)
+    fname, ext = os.path.splitext(basename)
+    abs_path = os.path.join(prefix, fname + '.ctf')
+    return abs_path
+
+def write_ctf(grp, config, amf_path, fname, id):
+    """  Take a GroupTransform and some metadata and write a CTF file. """
+
+    fmdg = grp.getFormatMetadata()
+    fmdg.setID(id)
+    desc = 'Color pipeline for source AMF: \n' + amf_path
+    fmdg.addChildElement('Description', desc)
+
+    # Copy entire AMF text into the Info block as documentation.
+    # TODO: This doesn't work since it tries to escape all the angle brackets, making it
+    #       unreadable, but it would be a nice feature if there's a workaround.
+    # try:
+    #     f = open(path, 'r')
+    #     buf = f.read()
+    #     f.close()
+    #     fmdg.addChildElement('Info', buf)
+    #     #fmdi = fmdg.getChildElements()[0]
+    # except:
+    #     raise
+
+    grp.write(formatName="Color Transform Format", config=config, fileName=fname)
+
+    print('\nWrote OCIO CTF file:', fname)
+
+def extract_three_floats(elem):
+    """ Return three floats extracted from the text of the element. """
+    try:
+        vals = elem.text.split()
+        if len(vals) == 3:
+            float_vals = [float(x) for x in vals]
+            if len(float_vals) == 3:
+                return float_vals
+    except:
+        print("There was an error parsing CDL values")
+        raise
+    return None
+
+def parse_cdl(look_elem):
+    """ Return the CDL slope, offset, power, and saturation values from a look element. """
+    slopes = [1., 1., 1.]
+    offsets = [0., 0., 0.]
+    powers = [1., 1., 1.]
+    sat = 1.
+    has_cdl = False
+
+    sop_elem = look_elem.find('./cdl:SOPNode', namespaces=NS)
+    if sop_elem is not None:
+        slope_elem = sop_elem.find('./cdl:Slope', namespaces=NS)
+        if slope_elem is not None:
+            slopes = extract_three_floats(slope_elem)
+        offset_elem = sop_elem.find('./cdl:Offset', namespaces=NS)
+        if offset_elem is not None:
+            offsets = extract_three_floats(offset_elem)
+        power_elem = sop_elem.find('./cdl:Power', namespaces=NS)
+        if power_elem is not None:
+            powers = extract_three_floats(power_elem)
+        has_cdl = True
+
+    sat_elem = look_elem.find('./cdl:SatNode', namespaces=NS)
+    if sat_elem is not None:
+        saturation_elem = sat_elem.find('./cdl:Saturation', namespaces=NS)
+        if saturation_elem is not None:
+            try:
+                sat = float(saturation_elem.text)
+            except:
+                print("There was an error parsing CDL values")
+                raise
+            has_cdl = True
+
+    return has_cdl, slopes, offsets, powers, sat
+
+def load_cdl_working_space_transform(config, base_path, look_elem, is_to_direc):
+    """ Return an OCIO transform for a CDL to/from working space transform. """
+    if is_to_direc:
+        token = 'aces:toCdlWorkingSpace'
+    else:
+        token = 'aces:fromCdlWorkingSpace'
+
+    elem = look_elem.find(token, namespaces=NS)
+    if elem is not None:
+        #
+        # ACES transformId case.
+        #
+        id_elem = elem.find('./aces:transformId', namespaces=NS)
+        if id_elem is not None:
+            aces_id = id_elem.text
+
+            cs_name = search_colorspaces(config, aces_id)
+            if cs_name is not None:
+                if is_to_direc:
+                    print('  Loading To-CDL-Working-Space Transform from ACES2065-1 to', cs_name)
+                    transform = ocio.ColorSpaceTransform(ACES, cs_name, ocio.TRANSFORM_DIR_FORWARD)
+                else:
+                    print('  Loading From-CDL-Working-Space Transform from', cs_name, 'to ACES2065-1')
+                    transform = ocio.ColorSpaceTransform(cs_name, ACES, ocio.TRANSFORM_DIR_FORWARD)
+                return transform
+            else:
+                raise ValueError("Could not find transform for transformId element: " + aces_id)
+        #
+        # External LUT file case.
+        #
+        file_elem = elem.find('./aces:file', namespaces=NS)
+        if file_elem is not None:
+            lut_path = file_elem.text
+            if lut_path is not None:
+                lut_path = check_lut_path(base_path, lut_path)
+                if is_to_direc:
+                    print('  Loading To-CDL-Working-Space Transform file:', lut_path)
+                else:
+                    print('  Loading From-CDL-Working-Space Transform file:', lut_path)
+                transform = ocio.FileTransform(lut_path, '', ocio.INTERP_BEST, ocio.TRANSFORM_DIR_FORWARD)
+                return transform
+    return None
+
+def process_look(config, gt, base_path, look_elem):
+    """ Build a look transform and add it to the supplied OCIO group transform. """
+    if not must_apply(look_elem, 'Look'):
+        return
+    #
+    # LookTransform ACES transformId case.
+    #
+    id_elem = look_elem.find('./aces:transformId', namespaces=NS)
+    if id_elem is not None:
+        aces_id = id_elem.text
+
+        look_name = search_looktransforms(config, aces_id)
+        if look_name is not None:
+            print('Adding Look Transform:', look_name)
+            gt.appendTransform( ocio.LookTransform(ACES, ACES, look_name, False, ocio.TRANSFORM_DIR_FORWARD) )
+            return
+        else:
+            raise ValueError("Could not find transform for transformId element: " + aces_id)
+    #
+    # LookTransform external LUT file case.
+    #
+    file_elem = look_elem.find('./aces:file', namespaces=NS)
+    if file_elem is not None:
+        lut_path = file_elem.text
+        if lut_path is not None:
+            lut_path = check_lut_path(base_path, lut_path)
+            print('Adding Look Transform file:', lut_path)
+
+            # Support CCC ID, if present, to identify which CDL in a CCC file to use.
+            ccc_id = ''
+            ccref_elem = look_elem.find('./cdl:ColorCorrectionRef', namespaces=NS)
+            if ccref_elem is not None:
+                ccc_id = ccref_elem.text
+                print('Using CCC ID:', ccc_id)
+
+            gt.appendTransform( ocio.FileTransform(lut_path, ccc_id, ocio.INTERP_BEST, ocio.TRANSFORM_DIR_FORWARD) )
+            return
+    #
+    # LookTransform ASC CDL case.
+    #
+    has_cdl, slopes, offsets, powers, sat = parse_cdl(look_elem)
+    if has_cdl:
+        ws_elem = look_elem.find('./aces:cdlWorkingSpace', namespaces=NS)
+        if ws_elem is None:
+            print('Adding CDL Transform')
+            gt.appendTransform( ocio.CDLTransform(slopes, offsets, powers, sat) )
+            return
+        #
+        # Attempt to load the working space transforms.
+        #
+        to_transform = load_cdl_working_space_transform(config, base_path, ws_elem, True)
+        from_transform = load_cdl_working_space_transform(config, base_path, ws_elem, False)
+        #
+        # Handle the four possible scenarios of working space transform availability.
+        #
+        if (to_transform is None) and (from_transform is None):
+            print('Adding CDL Transform')
+            gt.appendTransform( ocio.CDLTransform(slopes, offsets, powers, sat) )
+        elif (to_transform is not None) and (from_transform is not None):
+            print('Adding To-CDL-Working-Space Transform')
+            gt.appendTransform(to_transform)
+            print('Adding CDL Transform')
+            gt.appendTransform( ocio.CDLTransform(slopes, offsets, powers, sat) )
+            print('Adding From-CDL-Working-Space Transform')
+            gt.appendTransform(from_transform)
+        elif to_transform is not None:
+            print('Adding To-CDL-Working-Space Transform')
+            gt.appendTransform(to_transform)
+            print('Adding CDL Transform')
+            gt.appendTransform( ocio.CDLTransform(slopes, offsets, powers, sat) )
+            print('  Generating From-CDL-Working-Space Transform')
+            to_transform.setDirection(ocio.TRANSFORM_DIR_INVERSE)
+            print('Adding From-CDL-Working-Space Transform')
+            gt.appendTransform(to_transform)
+        elif from_transform is not None:
+            print('  Generating From-CDL-Working-Space Transform')
+            from_transform.setDirection(ocio.TRANSFORM_DIR_INVERSE)
+            print('Adding To-CDL-Working-Space Transform')
+            gt.appendTransform(from_transform)
+            print('Adding CDL Transform')
+            gt.appendTransform( ocio.CDLTransform(slopes, offsets, powers, sat) )
+            from_transform.setDirection(ocio.TRANSFORM_DIR_FORWARD)
+            print('Adding From-CDL-Working-Space Transform')
+            gt.appendTransform(from_transform)
+
+def build_output_transform_from_id_elem(config, gt, id_elem, msg, transform_dir):
+    """ Add an OCIO transform to the supplied group transform using a transform ID. """
+    aces_id = id_elem.text
+
+    dcs_name = search_colorspaces(config, aces_id)
+    vt_name = search_viewtransforms(config, aces_id)
+
+    if dcs_name is not None and vt_name is not None:
+        print( msg % (dcs_name, vt_name) )
+        gt.appendTransform( ocio.DisplayViewTransform(ACES, dcs_name, vt_name, direction=transform_dir) )
+    else:
+        raise ValueError("Could not process transformId element: " + aces_id)
+
+def load_output_transform(config, gt, base_path, elem, is_inverse):
+    """ Add an OCIO transform to the supplied group transform to implement an ACES Output Transform. """
+    # Setup some variables based on whether it is an Output or Inverse Output Transform.
+    if not is_inverse:
+        transform_dir = ocio.TRANSFORM_DIR_FORWARD
+        ot_transformId_token = './aces:transformId'
+        ot_file_token = './aces:file'
+        odt_token = './aces:outputDeviceTransform'
+        rrt_token = './aces:referenceRenderingTransform'
+        msg = 'Adding Output Transform from ACES2065-1 to display: %s and view: %s'
+        file_msg = 'Adding Output Transform LUT file:'
+    else:
+        transform_dir = ocio.TRANSFORM_DIR_INVERSE
+        ot_transformId_token = './aces:inverseOutputTransform/aces:transformId'
+        ot_file_token = './aces:inverseOutputTransform/aces:file'
+        odt_token = './aces:inverseOutputDeviceTransform'
+        rrt_token = './aces:inverseReferenceRenderingTransform'
+        msg = 'Adding Inverse Output Transform to ACES2065-1 from display %s and view: %s'
+        file_msg = 'Adding Inverse Output Transform LUT file:'
+    #
+    # OutputTransform ACES transformId case.
+    #
+    id_elem = elem.find(ot_transformId_token, namespaces=NS)
+    if id_elem is not None:
+        build_output_transform_from_id_elem(config, gt, id_elem, msg, transform_dir)
+        return
+    #
+    # OutputTransform external LUT file case.
+    #
+    file_elem = elem.find(ot_file_token, namespaces=NS)
+    if file_elem is not None:
+        lut_path = file_elem.text
+        if lut_path is not None:
+            lut_path = check_lut_path(base_path, lut_path)
+            print(file_msg, lut_path)
+            gt.appendTransform( ocio.FileTransform(lut_path, '', ocio.INTERP_BEST, transform_dir) )
+            return
+    #
+    # Handle referenceRenderingTransform + outputDeviceTransform case.
+    #
+    odt_elem = elem.find(odt_token, namespaces=NS)
+    if odt_elem is not None:
+        #
+        # ACES transformId case.
+        #
+        id_elem = odt_elem.find('./aces:transformId', namespaces=NS)
+        if id_elem is not None:
+            build_output_transform_from_id_elem(config, gt, id_elem, msg, transform_dir)
+            return
+            # TODO: Could validate that the referenceRenderingTransform element exists and is
+            # the expected version (although since there is only one, it is not currently used).
+        #
+        # External LUT file case.
+        #
+        file_elem = odt_elem.find('./aces:file', namespaces=NS)
+        if file_elem is not None:
+            odt_path = file_elem.text
+            if odt_path is not None:
+                odt_path = check_lut_path(base_path, odt_path)
+                odt_transform = ocio.FileTransform(odt_path, '', ocio.INTERP_BEST, transform_dir)
+
+                # NB: Only check for an external file for the RRT if the ODT is also a file.
+                rrt_transform = None
+                rrt_elem = elem.find(rrt_token, namespaces=NS)
+                if rrt_elem is not None:
+                    file_elem = rrt_elem.find('./aces:file', namespaces=NS)
+                    if file_elem is not None:
+                        rrt_path = file_elem.text
+                        if rrt_path is not None:
+                            rrt_path = check_lut_path(base_path, rrt_path)
+                            rrt_transform = ocio.FileTransform(rrt_path, '', ocio.INTERP_BEST, transform_dir)
+
+                if is_inverse:
+                    print('Adding Inverse ODT LUT file:', odt_path)
+                    gt.appendTransform( odt_transform )
+                    if rrt_transform is not None:
+                        print('Adding Inverse RRT LUT file:', rrt_path)
+                        gt.appendTransform( rrt_transform )
+                else:
+                    if rrt_transform is not None:
+                        print('Adding RRT LUT file:', rrt_path)
+                        gt.appendTransform( rrt_transform )
+                    print('Adding ODT LUT file:', odt_path)
+                    gt.appendTransform( odt_transform )
+
+def load_input_transform(config, gt, base_path, input_elem):
+    """ Add an OCIO transform to the supplied group transform to implement an ACES Input Transform. """
+    #
+    # InputTransform ACES transformId case.
+    #
+    id_elem = input_elem.find('./aces:transformId', namespaces=NS)
+    if id_elem is not None:
+        aces_id = id_elem.text
+
+        cs_name = search_colorspaces(config, aces_id)
+        if cs_name is not None:
+            print('Adding Input Transform from', cs_name, 'to ACES2065-1')
+            gt.appendTransform( ocio.ColorSpaceTransform(cs_name, ACES, ocio.TRANSFORM_DIR_FORWARD) )
+            return
+        else:
+            raise ValueError("Could not find transform for transformId element: " + aces_id)
+    #
+    # InputTransform external LUT file case.
+    #
+    file_elem = input_elem.find('./aces:file', namespaces=NS)
+    if file_elem is not None:
+        lut_path = file_elem.text
+        if lut_path is not None:
+            lut_path = check_lut_path(base_path, lut_path)
+            print('Adding Input Transform LUT file:', lut_path)
+            gt.appendTransform( ocio.FileTransform(lut_path, '', ocio.INTERP_BEST, ocio.TRANSFORM_DIR_FORWARD) )
+            return
+    #
+    # InputTransform is an inverse OutputTransform case.
+    #
+    load_output_transform(config, gt, base_path, input_elem, is_inverse=True)
+
+def load_aces_ref_config():
+    """ Return an OCIO config object for the ACES reference config required to decode transform IDs. """
+    ACES_REF_CONFIG = 'config-aces-reference.yaml'
+    import os
+    # Get the path to this script, see if the config is in the same directory.
+    file_path = os.path.realpath(__file__)
+    prefix = os.path.dirname(file_path)
+    config_path = os.path.join(prefix, ACES_REF_CONFIG)
+    config = ocio.Config().CreateFromFile(config_path)
+    # TODO: Try other ways of finding the config.
+    return config
+
+def build_ctf(amf_path):
+    """ Build a color pipeline that implements the supplied AMF file and write out a CTF file. """
+    print('\nProcessing file: ', amf_path, '\n')
+
+    # Use Python to parse the AMF XML file and return an Element Tree object.
+    tree = ET.parse(amf_path)
+    root = tree.getroot()
+
+    # Clear the OCIO file cache (helpful if someone is editing files in between running this).
+    ocio.ClearAllCaches()
+
+    # Load the ACES Reference config that will be used to implement any Transform ID strings
+    # encountered in the AMF file.
+    config = load_aces_ref_config()
+
+    # Initialize a group transform to hold the results.
+    gt = ocio.GroupTransform()
+
+    #
+    # Handle the AMF Input Transform.
+    #
+    input_elem = root.find('./aces:pipeline/aces:inputTransform', namespaces=NS)
+    if must_apply(input_elem, 'Input'):
+        load_input_transform(config, gt, amf_path, input_elem)
+    #
+    # Handle all the AMF Look Transforms.
+    #
+    for look_elem in root.findall('./aces:pipeline/aces:lookTransform', namespaces=NS):
+        process_look(config, gt, amf_path, look_elem)
+    #
+    # Handle the AMF Output Transform.
+    #
+    output_elem = root.find('./aces:pipeline/aces:outputTransform', namespaces=NS)
+    if must_apply(output_elem, 'Output'):
+        load_output_transform(config, gt, amf_path, output_elem, is_inverse=False)
+
+    # Print the OCIO transforms in the group transform.
+    print('\n', gt)
+
+    # Write the group transform using OCIO's native file format, CTF.
+    ctf_path = name_ctf_output_file(amf_path)
+    write_ctf(gt, config, amf_path, ctf_path, 'none')
+
+if __name__=='__main__':
+    """ Run the script from the command-line. """
+    import sys
+    if len( sys.argv ) != 2:
+        raise ValueError( "USAGE: python3 amf_to_ocio.py  <AMF_FILE>" )
+    build_ctf( sys.argv[1] )


### PR DESCRIPTION
Adds a prototype Python tool named pyocioamf that converts an ACES Metadata File (AMF) into the OCIO native transform format CTF. It uses a prototype ACES Reference config file that is serving as a database of ACES Transform IDs for interpreting the AMF file. An example AMF file was included as well, since they are not very widely available currently.

This is intended as a preliminary first step to explore how to best support AMF in OCIO.

Signed-off-by: Doug Walker <doug.walker@autodesk.com>