### PR TITLE
Add python source distribution package

### DIFF
--- a/.github/workflows/wheel_workflow.yml
+++ b/.github/workflows/wheel_workflow.yml
@@ -20,7 +20,10 @@ on:
       - v1.*
     paths:
       - .github/workflows/wheel_workflow.yml
+      - MANIFEST.in
       - pyproject.toml
+      - setup.cfg
+      - setup.py
   schedule:
     # Nightly build
     - cron: "0 0 * * *"
@@ -35,7 +38,33 @@ jobs:
   # version), we build on manylinux2014 image, this requires pip >= 19.3.
 
   # ---------------------------------------------------------------------------
-  # Linux
+  # Source Distribution
+  # ---------------------------------------------------------------------------
+
+  sdist:
+    name: Build SDist
+    runs-on: ubuntu-latest
+    Don't run on OCIO forks
+    if: |
+      github.event_name != 'schedule' ||
+      github.repository == 'AcademySoftwareFoundation/OpenColorIO'
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Build SDist
+      run: pipx run build --sdist
+
+    - name: Check metadata
+      run: pipx run twine check dist/*
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: dist/*.tar.gz
+
+  # ---------------------------------------------------------------------------
+  # Linux Wheels
   # ---------------------------------------------------------------------------
 
   linux:
@@ -127,7 +156,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   # ---------------------------------------------------------------------------
-  # macOS
+  # macOS Wheels
   # ---------------------------------------------------------------------------
 
   macos:
@@ -190,7 +219,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   # ---------------------------------------------------------------------------
-  # Windows
+  # Windows Wheels
   # ---------------------------------------------------------------------------
 
   windows:
@@ -260,7 +289,7 @@ jobs:
 
 
   upload_pypi:
-    needs: [linux, macos, windows]
+    needs: [sdist, linux, macos, windows]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:

--- a/.github/workflows/wheel_workflow.yml
+++ b/.github/workflows/wheel_workflow.yml
@@ -44,7 +44,7 @@ jobs:
   sdist:
     name: Build SDist
     runs-on: ubuntu-latest
-    Don't run on OCIO forks
+    # Don't run on OCIO forks
     if: |
       github.event_name != 'schedule' ||
       github.repository == 'AcademySoftwareFoundation/OpenColorIO'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,8 @@
-graft tests/data
-exclude tests/data/CMakeLists.txt
+include LICENSE
+graft docs
+graft ext
+graft include
+graft share
+graft src
+graft tests
+global-include CMakeLists.txt *.cmake *.md


### PR DESCRIPTION
Adding Python source distribution package to be uploaded to PyPI, allowing source install (eg. when a binary wheel for the requested architecture is not available) as discussed in #1573.

I pushed a test PyPI archive to test, available [here](https://test-files.pythonhosted.org/packages/08/8e/3d3028dd1dd2129d2b54a70afb4ef4cfcbab1889882a84b78cbb42ccf73b/opencolorio-2.2.0.dev3.tar.gz). Download and then call pip install on it to test, there is a way to test that directly installing from pip / test.pypi.org but there are security concerns as dependency can be pulled from test PyPI which we can't trust so I won't share the command here.