### PR TITLE
Port from main to RB-2.0 - Python copy support (#1575) 

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -1328,30 +1328,28 @@ extern OCIOEXPORT std::ostream & operator<< (std::ostream &, const FileRules &);
 
 
 
-
-// TODO: Move to .rst
-//
-// ViewingRules
-// ************
-// Viewing Rules allow config authors to filter the list of views an application should offer
-// based on the color space of an image.   For example, a config may define a large number of
-// views but not all of them may be appropriate for use with all color spaces.  E.g., some views
-// may be intended for use with scene-linear color space encodings and others with video color
-// space encodings.
-// 
-// Each rule has a name key for applications to refer to the rule.  Name values must be unique
-// (using case insensitive comparison). Viewing Rules may also have the following keys:
-//
-// * colorspaces: Either a single colorspace name or a list of names.
-//
-// * encodings: One or more strings to be found in the colorspace's encoding attribute.
-//   Either this attribute or colorspaces must be present, but not both.
-//
-// * custom : Allows arbitrary key / value string pairs, similar to FileRules.
-//
-// Getters and setters are using the rule position, they will throw if the position is not
-// valid.
-
+/**
+ * ViewingRules
+ * 
+ * Viewing Rules allow config authors to filter the list of views an application should offer
+ * based on the color space of an image.  For example, a config may define a large number of
+ * views but not all of them may be appropriate for use with all color spaces.  E.g., some views
+ * may be intended for use with scene-linear color space encodings and others with video color
+ * space encodings.
+ * 
+ * Each rule has a name key for applications to refer to the rule.  Name values must be unique
+ * (using case insensitive comparison). Viewing Rules may also have the following keys:
+ *
+ * * colorspaces: Either a single colorspace name or a list of names.
+ *
+ * * encodings: One or more strings to be found in the colorspace's encoding attribute.
+ *   Either this attribute or colorspaces must be present, but not both.
+ *
+ * * custom : Allows arbitrary key / value string pairs, similar to FileRules.
+ *
+ * Getters and setters are using the rule position, they will throw if the position is not
+ * valid.
+*/
 class OCIOEXPORT ViewingRules
 {
 public:

--- a/src/bindings/python/PyBaker.cpp
+++ b/src/bindings/python/PyBaker.cpp
@@ -72,6 +72,12 @@ Each item is a tuple containing format name and format extension.
              "shaperSize"_a = DEFAULT->getShaperSize(),
              DOC(Baker, Create))
 
+        .def("__deepcopy__", [](const ConstBakerRcPtr & self, py::dict)
+            {
+                return self->createEditableCopy();
+            },
+            "memo"_a)
+
         .def_static("getFormats", []()
             { 
                 return FormatIterator(nullptr); 

--- a/src/bindings/python/PyColorSpace.cpp
+++ b/src/bindings/python/PyColorSpace.cpp
@@ -152,6 +152,12 @@ void bindPyColorSpace(py::module & m)
              "categories"_a = getCategoriesStdVec(DEFAULT),
              DOC(ColorSpace, Create, 2))
 
+        .def("__deepcopy__", [](const ConstColorSpaceRcPtr & self, py::dict)
+            {
+                return self->createEditableCopy();
+            },
+            "memo"_a)
+
         .def("getName", &ColorSpace::getName, 
              DOC(ColorSpace, getName))
         .def("setName", &ColorSpace::setName, "name"_a.none(false), 

--- a/src/bindings/python/PyColorSpaceSet.cpp
+++ b/src/bindings/python/PyColorSpaceSet.cpp
@@ -40,6 +40,12 @@ void bindPyColorSpaceSet(py::module & m)
         .def(py::init(&ColorSpaceSet::Create), 
              DOC(ColorSpaceSet, Create))
 
+        .def("__deepcopy__", [](const ConstColorSpaceSetRcPtr & self, py::dict)
+            {
+                return self->createEditableCopy();
+            },
+            "memo"_a)
+
         .def("__eq__", &ColorSpaceSet::operator==, py::is_operator(), 
              DOC(ColorSpaceSet, operator, eq))
         .def("__ne__", &ColorSpaceSet::operator!=, py::is_operator(), 

--- a/src/bindings/python/PyConfig.cpp
+++ b/src/bindings/python/PyConfig.cpp
@@ -158,6 +158,12 @@ void bindPyConfig(py::module & m)
         .def(py::init(&Config::Create), 
              DOC(Config, Create))
 
+        .def("__deepcopy__", [](const ConstConfigRcPtr & self, py::dict)
+            {
+                return self->createEditableCopy();
+            },
+            "memo"_a)
+
         .def_static("CreateRaw", &Config::CreateRaw, 
                     DOC(Config, CreateRaw))
         .def_static("CreateFromEnv", &Config::CreateFromEnv, 

--- a/src/bindings/python/PyContext.cpp
+++ b/src/bindings/python/PyContext.cpp
@@ -99,7 +99,13 @@ void bindPyContext(py::module & m)
              "searchPaths"_a = getSearchPathsStdVec(DEFAULT),
              "stringVars"_a = getStringVarsStdMap(DEFAULT),
              "environmentMode"_a = DEFAULT->getEnvironmentMode(), 
-             DOC(Context, Create))  
+             DOC(Context, Create))
+
+        .def("__deepcopy__", [](const ConstContextRcPtr & self, py::dict)
+            {
+                return self->createEditableCopy();
+            },
+            "memo"_a)
 
         .def("__iter__", [](ContextRcPtr & self) 
             { 

--- a/src/bindings/python/PyFileRules.cpp
+++ b/src/bindings/python/PyFileRules.cpp
@@ -16,6 +16,12 @@ void bindPyFileRules(py::module & m)
         .def(py::init(&FileRules::Create),
              DOC(FileRules, Create))
 
+        .def("__deepcopy__", [](const ConstFileRulesRcPtr & self, py::dict)
+            {
+                return self->createEditableCopy();
+            },
+            "memo"_a)
+
         .def("getNumEntries", &FileRules::getNumEntries,
              DOC(FileRules, getNumEntries))
         .def("getIndexForRule", &FileRules::getIndexForRule, "ruleName"_a,

--- a/src/bindings/python/PyLook.cpp
+++ b/src/bindings/python/PyLook.cpp
@@ -38,6 +38,12 @@ void bindPyLook(py::module & m)
              "description"_a = DEFAULT->getDescription(), 
              DOC(Look, Create))
 
+        .def("__deepcopy__", [](const ConstLookRcPtr & self, py::dict)
+            {
+                return self->createEditableCopy();
+            },
+            "memo"_a)
+
         .def("getName", &Look::getName, 
              DOC(Look, getName))
         .def("setName", &Look::setName, "name"_a.none(false), 

--- a/src/bindings/python/PyNamedTransform.cpp
+++ b/src/bindings/python/PyNamedTransform.cpp
@@ -118,6 +118,12 @@ void bindPyNamedTransform(py::module & m)
              "categories"_a = getCategoriesStdVec(DEFAULT),
              DOC(NamedTransform, Create))
 
+        .def("__deepcopy__", [](const ConstNamedTransformRcPtr & self, py::dict)
+            {
+                return self->createEditableCopy();
+            },
+            "memo"_a)
+
         .def("getName", &NamedTransform::getName,
              DOC(NamedTransform, getName))
         .def("setName", &NamedTransform::setName, "name"_a.none(false),
@@ -145,7 +151,7 @@ void bindPyNamedTransform(py::module & m)
              DOC(NamedTransform, setDescription))
         .def("getEncoding", &NamedTransform::getEncoding,
              DOC(NamedTransform, getEncoding))
-        .def("setEncoding", &NamedTransform::setEncoding, "encodig"_a.none(false),
+        .def("setEncoding", &NamedTransform::setEncoding, "encoding"_a.none(false),
              DOC(NamedTransform, setEncoding))
 
         // Transform

--- a/src/bindings/python/PyTransform.cpp
+++ b/src/bindings/python/PyTransform.cpp
@@ -13,6 +13,12 @@ void bindPyTransform(py::module & m)
         py::class_<Transform, TransformRcPtr>(
             m.attr("Transform"))
 
+        .def("__deepcopy__", [](const ConstTransformRcPtr & self, py::dict)
+            {
+                return self->createEditableCopy();
+            },
+            "memo"_a)
+
         .def("validate", &Transform::validate,
              DOC(Transform, validate))
         .def("getTransformType", &Transform::getTransformType,

--- a/src/bindings/python/PyViewTransform.cpp
+++ b/src/bindings/python/PyViewTransform.cpp
@@ -85,7 +85,13 @@ void bindPyViewTransform(py::module & m)
              "toReference"_a = DEFAULT->getTransform(VIEWTRANSFORM_DIR_TO_REFERENCE),
              "fromReference"_a = DEFAULT->getTransform(VIEWTRANSFORM_DIR_FROM_REFERENCE),
              "categories"_a = getCategoriesStdVec(DEFAULT),
-             DOC(ViewTransform, Create))  
+             DOC(ViewTransform, Create))
+
+        .def("__deepcopy__", [](const ConstViewTransformRcPtr & self, py::dict)
+            {
+                return self->createEditableCopy();
+            },
+            "memo"_a)
 
         .def("getName", &ViewTransform::getName,
              DOC(ViewTransform, getName))

--- a/src/bindings/python/PyViewingRules.cpp
+++ b/src/bindings/python/PyViewingRules.cpp
@@ -33,7 +33,13 @@ void bindPyViewingRules(py::module & m)
     clsViewingRules
         .def(py::init(&ViewingRules::Create),
              DOC(ViewingRules, Create))
-                    
+
+        .def("__deepcopy__", [](const ConstViewingRulesRcPtr & self, py::dict)
+            {
+                 return self->createEditableCopy();
+            },
+            "memo"_a)
+
         .def("getNumEntries", &ViewingRules::getNumEntries,
              DOC(ViewingRules, getNumEntries))
         .def("getIndexForRule", &ViewingRules::getIndexForRule, "ruleName"_a,

--- a/tests/python/BakerTest.py
+++ b/tests/python/BakerTest.py
@@ -3,7 +3,7 @@
 
 # TODO: Add getFormatMetadata tests.
 
-import unittest, os, sys
+import copy, unittest, os, sys
 import PyOpenColorIO as OCIO
 
 class BakerTest(unittest.TestCase):
@@ -54,6 +54,32 @@ END METADATA
 6.622026 6.622026 6.622026
 
 """
+
+    def test_copy(self):
+        """
+        Test the deepcopy() method.
+        """
+        cfg = OCIO.Config().CreateFromStream(self.SIMPLE_PROFILE)
+
+        bake = OCIO.Baker()
+        bake.setConfig(cfg)
+        bake.setFormat("cinespace")
+        bake.setInputSpace("lnh")
+        bake.setLooks("foo, +bar")
+        bake.setTargetSpace("test")
+        bake.setShaperSize(4)
+        bake.setCubeSize(2)
+
+        other = copy.deepcopy(bake)
+        self.assertFalse(other is bake)
+
+        self.assertEqual(other.getConfig(), bake.getConfig())
+        self.assertEqual(other.getFormat(), bake.getFormat())
+        self.assertEqual(other.getInputSpace(), bake.getInputSpace())
+        self.assertEqual(other.getLooks(), bake.getLooks())
+        self.assertEqual(other.getTargetSpace(), bake.getTargetSpace())
+        self.assertEqual(other.getShaperSize(), bake.getShaperSize())
+        self.assertEqual(other.getCubeSize(), bake.getCubeSize())
 
     def test_interface(self):
         """

--- a/tests/python/ColorSpaceTest.py
+++ b/tests/python/ColorSpaceTest.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 
+import copy
 import unittest
 import os
 import sys
@@ -10,6 +11,7 @@ from UnitTestUtils import SIMPLE_CONFIG, TEST_NAMES, TEST_DESCS, TEST_CATEGORIES
 
 
 class ColorSpaceTest(unittest.TestCase):
+
     def setUp(self):
         self.colorspace = OCIO.ColorSpace()
         self.log_tr = OCIO.LogTransform(10)
@@ -17,6 +19,42 @@ class ColorSpaceTest(unittest.TestCase):
     def tearDown(self):
         self.colorspace = None
         self.log_tr = None
+
+    def test_copy(self):
+        """
+        Test the deepcopy() method.
+        """
+        self.colorspace.setName('colorspace1')
+        self.colorspace.setFamily('family')
+        self.colorspace.setEqualityGroup('group')
+        self.colorspace.setDescription('description')
+        self.colorspace.setBitDepth(OCIO.BIT_DEPTH_UINT8)
+        self.colorspace.setEncoding('encoding')
+        self.colorspace.setIsData(False)
+        self.colorspace.setAllocation(OCIO.ALLOCATION_LG2)
+        self.colorspace.setAllocationVars([-8, 5, 0.00390625])
+        mat = OCIO.MatrixTransform()
+        self.colorspace.setTransform(mat, OCIO.COLORSPACE_DIR_TO_REFERENCE)
+        self.colorspace.setTransform(direction=OCIO.COLORSPACE_DIR_FROM_REFERENCE, transform=mat)
+        self.colorspace.addAlias('alias')
+        self.colorspace.addCategory('cat')
+
+        other = copy.deepcopy(self.colorspace)
+        self.assertFalse(other is self.colorspace)
+
+        self.assertEqual(other.getName(), self.colorspace.getName())
+        self.assertEqual(other.getFamily(), self.colorspace.getFamily())
+        self.assertEqual(other.getEqualityGroup(), self.colorspace.getEqualityGroup())
+        self.assertEqual(other.getDescription(), self.colorspace.getDescription())
+        self.assertEqual(other.getBitDepth(), self.colorspace.getBitDepth())
+        self.assertEqual(other.getEncoding(), self.colorspace.getEncoding())
+        self.assertEqual(other.isData(), self.colorspace.isData())
+        self.assertEqual(other.getAllocation(), self.colorspace.getAllocation())
+        self.assertEqual(other.getAllocationVars(), self.colorspace.getAllocationVars())
+        self.assertTrue(other.getTransform(OCIO.COLORSPACE_DIR_TO_REFERENCE).equals(self.colorspace.getTransform(OCIO.COLORSPACE_DIR_TO_REFERENCE)))
+        self.assertTrue(other.getTransform(OCIO.COLORSPACE_DIR_FROM_REFERENCE).equals(self.colorspace.getTransform(OCIO.COLORSPACE_DIR_FROM_REFERENCE)))
+        self.assertEqual(list(other.getAliases()), list(self.colorspace.getAliases()))
+        self.assertEqual(list(other.getCategories()), list(self.colorspace.getCategories()))
 
     def test_allocation(self):
         """

--- a/tests/python/ConfigTest.py
+++ b/tests/python/ConfigTest.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 
+import copy
 import unittest
 import os
 import sys
@@ -240,6 +241,45 @@ from UnitTestUtils import TEST_DATAFILES_DIR, TEST_NAMES, TEST_DESCS
 #        del _cfg
 
 class ConfigTest(unittest.TestCase):
+
+    def test_copy(self):
+        """
+        Test the deepcopy() method.
+        """
+        cfg = OCIO.Config.CreateRaw()
+        cfg.setMajorVersion(2)
+        cfg.setMinorVersion(1)
+        cfg.setName('test config')
+        cfg.setDescription('test description')
+
+        cfg.addColorSpace(
+            OCIO.ColorSpace(OCIO.REFERENCE_SPACE_DISPLAY,
+                            "display_cs",
+                            toReference=OCIO.CDLTransform(sat=1.5)))
+        cfg.addColorSpace(
+            OCIO.ColorSpace(OCIO.REFERENCE_SPACE_SCENE,
+                            "raw",
+                            isData=True))
+
+        rules = OCIO.FileRules()
+        rules.insertRule(0, 'A', 'raw', '*', 'exr')
+        rules.insertRule(1, 'B', 'display_cs', '*', 'png')
+        cfg.setFileRules(rules)
+
+        other = copy.deepcopy(cfg)
+        self.assertFalse(other is cfg)
+
+        self.assertEqual(other.getMajorVersion(), cfg.getMajorVersion())
+        self.assertEqual(other.getMinorVersion(), cfg.getMinorVersion())
+        self.assertEqual(other.getName(), cfg.getName())
+        self.assertEqual(other.getDescription(), cfg.getDescription())
+        self.assertEqual(list(other.getColorSpaceNames()), list(cfg.getColorSpaceNames()))
+        self.assertEqual(other.getFileRules().getNumEntries(), cfg.getFileRules().getNumEntries())
+
+        # Check that the file rules are not shared between the two config instances.
+        rules.removeRule(0)
+        other.setFileRules(rules)
+        self.assertEqual(other.getFileRules().getNumEntries(), cfg.getFileRules().getNumEntries() - 1)
 
     def test_shared_views(self):
         # Test these Config functions: addSharedView, getSharedViews, removeSharedView.

--- a/tests/python/ConfigTest.py
+++ b/tests/python/ConfigTest.py
@@ -248,7 +248,7 @@ class ConfigTest(unittest.TestCase):
         """
         cfg = OCIO.Config.CreateRaw()
         cfg.setMajorVersion(2)
-        cfg.setMinorVersion(1)
+        cfg.setMinorVersion(0)
         cfg.setName('test config')
         cfg.setDescription('test description')
 

--- a/tests/python/ContextTest.py
+++ b/tests/python/ContextTest.py
@@ -1,10 +1,30 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 
-import unittest, os, sys
+import copy, unittest, os, sys
 import PyOpenColorIO as OCIO
 
 class ContextTest(unittest.TestCase):
+
+    def test_copy(self):
+        """
+        Test the deepcopy() method.
+        """
+        cont = OCIO.Context()
+        cont.setSearchPath('testing123:testing456')
+        cont.setWorkingDir('/dir/123')
+        cont.setEnvironmentMode(OCIO.ENV_ENVIRONMENT_LOAD_PREDEFINED)
+        cont['TeSt'] = 'foobar'
+        cont['Bar'] = 'Foo'
+
+        other = copy.deepcopy(cont)
+        self.assertFalse(other is cont)
+
+        self.assertEqual(other.getCacheID(), cont.getCacheID())
+        self.assertEqual(other.getSearchPath(), cont.getSearchPath())
+        self.assertEqual(other.getWorkingDir(), cont.getWorkingDir())
+        self.assertEqual(other.getEnvironmentMode(), cont.getEnvironmentMode())
+        self.assertEqual(list(other), list(cont))
 
     def test_interface(self):
         """

--- a/tests/python/FileRulesTest.py
+++ b/tests/python/FileRulesTest.py
@@ -1,10 +1,35 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 
-import unittest, os, sys
+import copy, unittest, os, sys
 import PyOpenColorIO as OCIO
 
 class FileRulesTest(unittest.TestCase):
+
+    def test_copy(self):
+        """
+        Test the deepcopy() method.
+        """
+        rules = OCIO.FileRules()
+        rules.insertRule(0, 'test0', 'colorspace', 'pattern', 'ext')
+        rules.setCustomKey(0, 'key1', 'val1')
+        rules.insertRule(1, 'test2', 'colorspace', 'regex')
+        rules.setCustomKey(1, 'key2', 'val2')
+
+        other = copy.deepcopy(rules)
+        self.assertFalse(other is rules)
+
+        self.assertEqual(other.getNumEntries(), rules.getNumEntries())
+        for idx in range(other.getNumEntries()):
+            self.assertEqual(other.getName(idx), rules.getName(idx))
+            self.assertEqual(other.getPattern(idx), rules.getPattern(idx))
+            self.assertEqual(other.getExtension(idx), rules.getExtension(idx))
+            self.assertEqual(other.getRegex(idx), rules.getRegex(idx))
+            self.assertEqual(other.getColorSpace(idx), rules.getColorSpace(idx))
+            self.assertEqual(other.getNumCustomKeys(idx), rules.getNumCustomKeys(idx))
+            for idx_inner in range(other.getNumCustomKeys(idx)):
+                self.assertEqual(other.getCustomKeyName(idx, idx_inner), rules.getCustomKeyName(idx, idx_inner))
+                self.assertEqual(other.getCustomKeyValue(idx, idx_inner), rules.getCustomKeyValue(idx, idx_inner))
 
     def test_default(self):
         """

--- a/tests/python/LookTest.py
+++ b/tests/python/LookTest.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 
+import copy
 import unittest
 import os
 import sys
@@ -18,6 +19,26 @@ class LookTest(unittest.TestCase):
 
     def tearDown(self):
         self.look = None
+
+    def test_copy(self):
+        """
+        Test the deepcopy() method.
+        """
+        self.look.setName('test name')
+        self.look.setProcessSpace('test space')
+        self.look.setDescription('test description')
+        mat = OCIO.MatrixTransform()
+        self.look.setTransform(mat)
+        self.look.setInverseTransform(mat)
+
+        other = copy.deepcopy(self.look)
+        self.assertFalse(other is self.look)
+
+        self.assertEqual(other.getName(), self.look.getName())
+        self.assertEqual(other.getProcessSpace(), self.look.getProcessSpace())
+        self.assertEqual(other.getDescription(), self.look.getDescription())
+        self.assertTrue(other.getTransform().equals(self.look.getTransform()))
+        self.assertTrue(other.getInverseTransform().equals(self.look.getInverseTransform()))
 
     def test_name(self):
         """

--- a/tests/python/NamedTransformTest.py
+++ b/tests/python/NamedTransformTest.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 
+import copy
 import unittest
 
 import PyOpenColorIO as OCIO
@@ -18,6 +19,32 @@ class NamedTransformTest(unittest.TestCase):
 
     def tearDown(self):
         self.named_tr = None
+
+    def test_copy(self):
+        """
+        Test the deepcopy() method.
+        """
+        self.named_tr.setName('test name')
+        self.named_tr.setFamily('test family')
+        self.named_tr.setDescription('test description')
+        self.named_tr.setEncoding('test encoding')
+        mat = OCIO.MatrixTransform()
+        self.named_tr.setTransform(mat, OCIO.TRANSFORM_DIR_FORWARD)
+        self.named_tr.setTransform(direction=OCIO.TRANSFORM_DIR_INVERSE, transform=mat)
+        self.named_tr.addCategory('cat1')
+        self.named_tr.addAlias("alias1")
+
+        other = copy.deepcopy(self.named_tr)
+        self.assertFalse(other is self.named_tr)
+
+        self.assertEqual(other.getName(), self.named_tr.getName())
+        self.assertEqual(other.getFamily(), self.named_tr.getFamily())
+        self.assertEqual(other.getDescription(), self.named_tr.getDescription())
+        self.assertEqual(other.getEncoding(), self.named_tr.getEncoding())
+        self.assertTrue(other.getTransform(OCIO.TRANSFORM_DIR_FORWARD).equals(self.named_tr.getTransform(OCIO.TRANSFORM_DIR_FORWARD)))
+        self.assertTrue(other.getTransform(OCIO.TRANSFORM_DIR_INVERSE).equals(self.named_tr.getTransform(OCIO.TRANSFORM_DIR_INVERSE)))
+        self.assertEqual(list(other.getCategories()), list(self.named_tr.getCategories()))
+        self.assertEqual(list(other.getAliases()), list(self.named_tr.getAliases()))
 
     def test_name(self):
         """

--- a/tests/python/ViewingRulesTest.py
+++ b/tests/python/ViewingRulesTest.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 
+import copy
 import unittest
 import os
 import sys
@@ -15,6 +16,30 @@ class ViewingRulesTest(unittest.TestCase):
 
     def tearDown(self):
         self.rule = None
+
+    def test_copy(self):
+        """
+        Test the deepcopy() method.
+        """
+
+        self.rules.insertRule(0, "rule1")
+        self.rules.insertRule(1, "rule2")
+        self.rules.insertRule(2, "rule3")
+
+        self.rules.addColorSpace(0, "cs1")
+        self.rules.addEncoding(1, "enc1")
+        self.rules.setCustomKey(2, "key1", "value1")
+
+        other = copy.deepcopy(self.rules)
+        self.assertFalse(other is self.rules)
+
+        self.assertEqual(other.getNumEntries(), self.rules.getNumEntries())
+        for idx in range(self.rules.getNumEntries()):
+            self.assertEqual(other.getName(idx), self.rules.getName(idx))
+        self.assertEqual(list(other.getColorSpaces(0)), list(self.rules.getColorSpaces(0)))
+        self.assertEqual(list(other.getEncodings(1)), list(self.rules.getEncodings(1)))
+        self.assertEqual(list(other.getCustomKeyName(2, 0)), list(self.rules.getCustomKeyName(2, 0)))
+        self.assertEqual(list(other.getCustomKeyValue(2, 0)), list(self.rules.getCustomKeyValue(2, 0)))
 
     def test_insert_remove(self):
         """


### PR DESCRIPTION
Signed-off-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>

This PR addresses [#1434](https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1434) adding copy / deepcopy (same implementation) for OCIO objects having C++ createEditableCopy() methods. It also fix the typo reported in [#1540](https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1540).

on behalf of @remia 