### PR TITLE
Adsk Contrib - Fix half-domain Lut1D issue for values above HALF_MAX

### DIFF
--- a/src/OpenColorIO/ops/lut1d/Lut1DOpCPU.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpCPU.cpp
@@ -527,7 +527,7 @@ IndexPair IndexPair::GetEdgeFloatValues(float fIn)
     const float floatTemp = (float) halfVal;
 
     // Strict comparison required otherwise negative fractions will occur.
-    if (fabs(floatTemp)> fabs(fIn)) 
+    if (fabs(floatTemp) > fabs(fIn)) 
     {
         idxPair.valB = halfVal.bits();
         idxPair.valA = idxPair.valB;
@@ -544,6 +544,8 @@ IndexPair IndexPair::GetEdgeFloatValues(float fIn)
         {
             halfVal =  halfVal.isNegative () ? -HALF_MAX : HALF_MAX;
             idxPair.valB = halfVal.bits();
+            // Necessary to reset fIn too (consider fIn = 65519, it's > HALF_MAX but not Inf).
+            fIn = halfVal;
         }
     }
 

--- a/tests/cpu/ops/lut1d/Lut1DOpCPU_tests.cpp
+++ b/tests/cpu/ops/lut1d/Lut1DOpCPU_tests.cpp
@@ -1266,8 +1266,7 @@ OCIO_ADD_TEST(Lut1DRenderer, lut_1d_hd_above_half_max)
     OCIO::PackedImageDesc dstImgDesc((void*)&outImage[0], 2, 1, 4);
     cpuFwd->apply(srcImgDesc, dstImgDesc);
 
-    const float rtol = 1e-5f;
-
+    static const float rtol = 1e-5f;
     OCIO_CHECK_CLOSE(outImage[0], 0.7785763f, rtol);
     OCIO_CHECK_CLOSE(outImage[1], 0.7785763f, rtol);
     OCIO_CHECK_CLOSE(outImage[2], 0.7785763f, rtol);

--- a/tests/cpu/ops/lut1d/Lut1DOpCPU_tests.cpp
+++ b/tests/cpu/ops/lut1d/Lut1DOpCPU_tests.cpp
@@ -1238,6 +1238,47 @@ OCIO_ADD_TEST(Lut1DRenderer, lut_1d_special_values)
     OCIO_CHECK_EQUAL(outImage[7], 1.0f);
 }
 
+OCIO_ADD_TEST(Lut1DRenderer, lut_1d_hd_above_half_max)
+{
+    // Test the processing of half-domain Lut1D for float input values that are greater than
+    // HALF_MAX but round down to HALF_MAX.  These are the values 65504 < x < 65520.
+    // In other words, half(65519) rounds down to 65504 and half(65520) rounds up to Inf.
+    // There was a bug where these values were not processed correctly.
+
+    OCIO::ConfigRcPtr config = OCIO::Config::Create();
+
+    const std::string ctfLUT("lut1d_hd_16f_16i_1chan.ctf");
+    OCIO::FileTransformRcPtr fileTransform = OCIO::CreateFileTransform(ctfLUT);
+
+    OCIO::ConstProcessorRcPtr proc;
+    OCIO_CHECK_NO_THROW(proc = config->getProcessor(fileTransform));
+
+    OCIO::ConstCPUProcessorRcPtr cpuFwd;
+    OCIO_CHECK_NO_THROW(cpuFwd = proc->getDefaultCPUProcessor());
+
+    float inImage[] = {
+        65505.0f,  65519.0f,  65520.0f, 0.0f,
+       -65505.0f, -65519.0f, -65520.0f, 1.0f
+    };
+
+    std::vector<float> outImage(2 * 4, -12.345f);
+    OCIO::PackedImageDesc srcImgDesc((void*)&inImage[0], 2, 1, 4);
+    OCIO::PackedImageDesc dstImgDesc((void*)&outImage[0], 2, 1, 4);
+    cpuFwd->apply(srcImgDesc, dstImgDesc);
+
+    const float rtol = 1e-5f;
+
+    OCIO_CHECK_CLOSE(outImage[0], 0.7785763f, rtol);
+    OCIO_CHECK_CLOSE(outImage[1], 0.7785763f, rtol);
+    OCIO_CHECK_CLOSE(outImage[2], 0.7785763f, rtol);
+    OCIO_CHECK_EQUAL(outImage[3], 0.0f);
+
+    OCIO_CHECK_CLOSE(outImage[4], 0.f, rtol);
+    OCIO_CHECK_CLOSE(outImage[5], 0.f, rtol);
+    OCIO_CHECK_CLOSE(outImage[6], 0.f, rtol);
+    OCIO_CHECK_EQUAL(outImage[7], 1.0f);
+}
+
 namespace
 {
 constexpr OCIO::OptimizationFlags DefaultNoLutInvFast =


### PR DESCRIPTION
This fixes an issue where float values greater than HALF_MAX but which don't round to Infinity (in other words, values between 65505 and 65519) were returning NaN. (This did not affect the GPU, only CPU.)

If this issue was encountered when inverting a normal domain Lut1D, and a work-around is needed before receiving this fix, turn off the OPTIMIZATION_LUT_INV_FAST optimization flag. For example, to use the default settings but turn off this flag, set the environment variable as follows:
export OCIO_OPTIMIZATION_FLAGS=230440899