### PR TITLE
Fix Typo

### DIFF
--- a/src/OpenColorIO/NamedTransform.cpp
+++ b/src/OpenColorIO/NamedTransform.cpp
@@ -240,7 +240,7 @@ std::ostream & operator<< (std::ostream & os, const NamedTransform & t)
 {
     os << "<NamedTransform ";
     const std::string strName{ t.getName() };
-    os << "name=" << strName;
+    os << "name=" << strName << ", ";
     const auto numAliases = t.getNumAliases();
     if (numAliases == 1)
     {


### PR DESCRIPTION
Fix minor typo in NamedTransform.

Example output currently:
```
[...]
Invoked with: kwargs: referenceSpace=<ReferenceSpaceType.REFERENCE_SPACE_DISPLAY: 1>, name='sRGB Display View', description='IEC 61966-2-1:1999 Reference sRGB Display', toReference=<NamedTransform name=Identity Transformalias=
[...]

Note how the toReference line lacks the comma.