### PR TITLE
Port from main to RB-2.0 - Adsk Contrib - Fix half-domain Lut1D issue for values above HALF_MAX (#1614)

### DIFF
--- a/src/OpenColorIO/ops/lut1d/Lut1DOpCPU.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpCPU.cpp
@@ -534,7 +534,7 @@ IndexPair IndexPair::GetEdgeFloatValues(float fIn)
     const float floatTemp = (float) halfVal;
 
     // Strict comparison required otherwise negative fractions will occur.
-    if (fabs(floatTemp)> fabs(fIn)) 
+    if (fabs(floatTemp) > fabs(fIn)) 
     {
         idxPair.valB = halfVal.bits();
         idxPair.valA = idxPair.valB;
@@ -551,6 +551,8 @@ IndexPair IndexPair::GetEdgeFloatValues(float fIn)
         {
             halfVal =  halfVal.isNegative () ? -HALF_MAX : HALF_MAX;
             idxPair.valB = halfVal.bits();
+            // Necessary to reset fIn too (consider fIn = 65519, it's > HALF_MAX but not Inf).
+            fIn = halfVal;
         }
     }
 


### PR DESCRIPTION

* Fix half-domain Lut1D issue for values above HALF_MAX

Signed-off-by: Doug Walker <doug.walker@autodesk.com>

* Address review comments

Signed-off-by: Doug Walker <doug.walker@autodesk.com>

Co-authored-by: Patrick Hodoul <Patrick.Hodoul@autodesk.com>