### PR TITLE
Print version on find_package(OpenColorIO CONFIG)

### DIFF
--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -3,3 +3,7 @@
 include(CMakeFindDependencyMacro)
 
 include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
+
+include(FindPackageHandleStandardArgs)
+set(@PROJECT_NAME@_CONFIG ${CMAKE_CURRENT_LIST_FILE})
+find_package_handle_standard_args(@PROJECT_NAME@ CONFIG_MODE)


### PR DESCRIPTION
This is a very short change to enable the standard print when using `find_package(OpenColorIO CONFIG)`.

`-- Found OpenColorIO: .../myinstall/lib/cmake/OpenColorIO/OpenColorIOConfig.cmake (found version "2.2.0")`

Source: https://cmake.org/pipermail/cmake/2018-August/068063.html