### PR TITLE
Adsk contrib - Scripts to facilitate building OCIO on Windows

### DIFF
--- a/docs/quick_start/installation.rst
+++ b/docs/quick_start/installation.rst
@@ -5,31 +5,70 @@
 .. _installation:
 
 Installation
-============
-
-The easy way
 ************
 
-While prebuilt binaries are not yet available for all platforms, OCIO
-is available via several platform's package managers.
+Although OpenColorIO is available through a variety of package managers, please note that the 
+version available through a given package manager may be significantly outdated when compared to 
+the current official OCIO release. Even two years after the introduction of OpenColorIO v2, several 
+package managers continue to install OCIO 1.1.1.
 
-Please note that the package managers are still installing the previous 
-stable release, 1.1.1.  If you want OCIO v2, you currently must build from source.
-See :ref:`building-from-source`.
+.. _Python:
 
+Python
+^^^^^^
 
-Fedora and RHEL
-^^^^^^^^^^^^^^^
+If you only need the Python bindings, the simplest solution is to take advantage of the pre-built 
+wheels in the Python Package Installer (PyPi) `here <https://pypi.org/project/opencolorio>`__. It 
+can be installed by using this command:: 
 
-In Fedora Core 15 and above, the following command will install OpenColorIO::
+    pip install opencolorio
 
-    yum install OpenColorIO
+OpenImageIO
+^^^^^^^^^^^
 
-Providing you are using the `Fedora EPEL repository
-<http://fedoraproject.org/wiki/EPEL>`__ (see the `FAQ for instructions
-<http://fedoraproject.org/wiki/EPEL/FAQ#Using_EPEL>`__), this same
-command will work for RedHat Enterprise Linux 6 and higher (including
-RHEL derivatives such as CentOS 6 and Scientific Linux 6)
+If you only need to apply color conversions to images, please note that OpenImageIO's oiiotool has 
+most of the functionality of the ocioconvert command-line tool (although not everything, such as 
+GPU processing). OpenImageIO is available via several package managers (including brew and vcpkg).
+
+**Homebrew**::
+
+    brew install openimageio
+
+**Vcpkg**::
+
+    vcpkg install openimageio[opencolorio,tools]:x64-windows --recurse
+
+Installing OpenColorIO using existing packages
+**********************************************
+
+Linux
+^^^^^
+
+When it comes to Linux distributions, relatively few of the Linux distribution repositories have been 
+updated to OCIO v2. The **latest Fedora** is one good option as it offers the most 
+recent release of OpenColorIO v2. Information about the package can be found on 
+`fedoraproject website <https://packages.fedoraproject.org/pkgs/OpenColorIO/OpenColorIO/index.html>`__.
+
+For the other distributions, information about which release of OpenColorIO is available can be 
+verified on `pkgs.org <https://pkgs.org/search/?q=OpenColorIO>`__.
+
+**The recommendation is to build OpenColorIO from source**. You may build from source using the 
+instructions below. See :ref:`building-from-source`.
+
+Windows 7 or newer using vcpkg
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Vcpkg can be used to install OpenColorIO on Windows. In order to do that, Vcpkg must be installed 
+by following the `official instructions <https://vcpkg.io/en/getting-started.html>`__. Once Vcpkg 
+is installed, OpenColorIO and some of the tools can be installed with the following command::
+
+    vcpkg install opencolorio[tools]:x64-windows
+
+Note that this package **does not** install ocioconvert, ociodisplay, ociolutimage and the Python 
+bindings.
+
+The three missing tools can be built from source by following the steps in the :ref:`Windows 7 or newer` 
+section while the Python bindings can be install using the pip command in the :ref:`Python` section.
 
 OS X using Homebrew
 ^^^^^^^^^^^^^^^^^^^
@@ -45,10 +84,8 @@ Then simply run the following command to install::
 
     brew install opencolorio
 
-To build with the Python library use this command::
-
-    brew install opencolorio --with-python
-
+Homebrew does not install the Python binding or the command-line tools that depend on OpenImageIO 
+such as ocioconvert, ociodisplay and ociolutimage.
 
 .. _building-from-source:
 
@@ -56,7 +93,7 @@ Building from source
 ********************
 
 Dependencies
-************
+^^^^^^^^^^^^
 
 The basic requirements for building OCIO are the following.  Note that, by
 default, cmake will try to install all of the items labelled with * and so
@@ -74,7 +111,7 @@ it is not necessary to install those items manually:
 Some optional components also depend on:
 
 - \*Little CMS >= 2.2 (for ociobakelut ICC profile baking)
-- \*pybind11 >= 2.6.1 (for the Python bindings)
+- \*pybind11 >= 2.9.2 (for the Python bindings)
 - Python >= 2.7 (for the Python bindings)
 - Python 3.7 or 3.8 (for the docs, with the following PyPi packages)
     - Sphinx
@@ -98,7 +135,7 @@ available for all supported platforms. Use GitBash
 this script on Windows.
 
 Automated Installation
-^^^^^^^^^^^^^^^^^^^^^^
+----------------------
 
 Listed dependencies with a preceeding * can be automatically installed at 
 build time using the ``OCIO_INSTALL_EXT_PACKAGES`` option in your cmake 
@@ -119,7 +156,7 @@ Three ``OCIO_INSTALL_EXT_PACKAGES`` options are available::
   current system.
 
 Existing Install Hints
-^^^^^^^^^^^^^^^^^^^^^^
+----------------------
 
 When using existing system libraries, the following CMake variables can be 
 defined to hint at non-standard install locations and preference of shared
@@ -209,133 +246,44 @@ this::
     $ ls lib/
     libOpenColorIO.a      libOpenColorIO.dylib
 
-.. _windows-build:
+.. _Windows 7 or newer:
 
-Windows Build
-^^^^^^^^^^^^^
+Windows 7 or newer
+^^^^^^^^^^^^^^^^^^
 
-While build environments may vary between user, here is an example batch file
-for compiling on Windows as provided by `@hodoulp <https://github.com/hodoulp>`__::
+While build environments may vary between users, the recommended way to build OCIO from source on 
+Windows is to use the scripts provided in the Windows 
+`share <https://github.com/AcademySoftwareFoundation/OpenColorIO/tree/main/share/dev/windows>`_ 
+section of the OCIO repository. There are two scripts currently available. 
 
-    @echo off
+The first script is called 
+`ocio_deps.bat <https://github.com/AcademySoftwareFoundation/OpenColorIO/tree/main/share/dev/windows/ocio_deps.bat>`_ 
+and it provides some automation to install the most difficult dependencies. Those dependencies are:
 
+- `Vcpkg <https://vcpkg.io/en/index.html>`_
+- OpenImageIO
+- Freeglut
+- Glew
+- Python dependencies for documentation
 
-    REM Grab the repo name, default is ocio
-    set repo_name=ocio
-    if not %1.==. set repo_name=%1
+Run this command to execute the ocio_deps.bat script::
 
+    ocio_deps.bat --vcpkg <path to current vcpkg installation or where it should be installed>
 
-    REM Using cygwin to have Linux cool command line tools
-    set CYGWIN=nodosfilewarning
+The second script is called 
+`ocio.bat <https://github.com/AcademySoftwareFoundation/OpenColorIO/tree/main/share/dev/windows/ocio.bat>`_ 
+and it provide a way to configure and build OCIO from source. Moreover, this script executes the 
+install step of cmake as well as the unit tests. The main use case is the following::
 
-    set CMAKE_PATH=D:\OpenSource\3rdParty\cmake-3.12.2
-    set GLUT_PATH=D:\OpenSource\3rdParty\freeglut-3.0.0-2
-    set GLEW_PATH=D:\OpenSource\3rdParty\glew-1.9.0
-    set PYTHON_PATH=C:\Python27
-
-    REM Add glut & glew dependencies to have GPU unit tests
-    set PATH=%GLEW_PATH%\bin;%GLUT_PATH%\bin;D:\Tools\cygwin64\bin;%CMAKE_PATH%\bin;%PATH%
-
-    REM Add Ninja & jom to speed-up command line build i.e. one is enough
-    set PATH=D:\OpenSource\3rdParty\ninja;D:\OpenSource\3rdParty\jom;%PYTHONPATH%;%PATH%
-
-    call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
-    REM call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvarsall.bat" x64
-
-    set OCIO_PATH=D:\OpenSource\%repo_name%
-
-    D:
-
-    IF NOT EXIST %OCIO_PATH% ( 
-    echo %OCIO_PATH% does not exist
-    exit /b
-    )
-    cd %OCIO_PATH%
+    ocio.bat --b <path to build folder> --i <path to install folder> 
+    --vcpkg <path to vcpkg installation> --ocio <path to ocio repository> --type Release
 
 
-    set CMAKE_BUILD_TYPE=Release
+For more information, please look at each script's documentation::
 
-    echo *******
-    echo *********************************************
-    echo ******* Building %OCIO_PATH%
-    echo **
-    echo **
-    set are_you_sure = Y
-    set /P are_you_sure=Build in %CMAKE_BUILD_TYPE% ([Y]/N)?  
-    if not %are_you_sure%==Y set CMAKE_BUILD_TYPE=Debug
+    ocio.bat --help
 
-
-    set BUILD_PATH=%OCIO_PATH%\build_rls
-    set COMPILED_THIRD_PARTY_HOME=D:/OpenSource/3rdParty/compiled-dist_rls
-    set OCIO_BUILD_PYTHON=1
-
-    if not %CMAKE_BUILD_TYPE%==Release (
-    set BUILD_PATH=%OCIO_PATH%\build_dbg
-    set COMPILED_THIRD_PARTY_HOME=D:/OpenSource/3rdParty/compiled-dist_dbg
-    set OCIO_BUILD_PYTHON=0
-    )
-
-    set INSTALL_PATH=%COMPILED_THIRD_PARTY_HOME%/OpenColorIO-2.0.0
-
-    IF NOT EXIST %BUILD_PATH% ( mkdir %BUILD_PATH% )
-    cd %BUILD_PATH%
-
-    echo **
-    echo **
-
-    REM cmake -G "Visual Studio 14 2015 Win64"
-    REM cmake -G "Visual Studio 15 2017 Win64"
-    REM cmake -G "Ninja"
-    cmake -G "NMake Makefiles JOM" ^
-        -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% ^
-        -DCMAKE_INSTALL_PREFIX=%INSTALL_PATH% ^
-        -DBUILD_SHARED_LIBS=ON ^
-        -DOCIO_BUILD_APPS=ON ^
-        -DOCIO_BUILD_TESTS=ON ^
-        -DOCIO_BUILD_GPU_TESTS=ON ^
-        -DOCIO_BUILD_DOCS=OFF ^
-        -DOCIO_USE_SSE=ON ^
-        -DOCIO_WARNING_AS_ERROR=ON ^
-        -DOCIO_BUILD_PYTHON=%OCIO_BUILD_PYTHON% ^
-        -DPython_LIBRARY=%PYTHON_PATH%\libs\python27.lib ^
-        -DPython_INCLUDE_DIR=%PYTHON_PATH%\include ^
-        -DPython_EXECUTABLE=%PYTHON_PATH%\python.exe ^
-        -DOCIO_BUILD_JAVA=OFF ^
-        -DCMAKE_PREFIX_PATH=%COMPILED_THIRD_PARTY_HOME%\OpenImageIO-1.9.0;%COMPILED_THIRD_PARTY_HOME%/ilmbase-2.2.0 ^
-        %OCIO_PATH%
-
-    REM Add OCIO & OIIO
-    set PATH=%BUILD_PATH%\src\OpenColorIO;%INSTALL_PATH%\bin;%COMPILED_THIRD_PARTY_HOME%\OpenImageIO-1.9.0\bin;%PATH%
-
-
-    REM Find the current branch
-    set GITBRANCH=
-    for /f %%I in ('git.exe rev-parse --abbrev-ref HEAD 2^> NUL') do set GITBRANCH=%%I
-
-    if not "%GITBRANCH%" == ""  prompt $C%GITBRANCH%$F $P$G
-
-    TITLE %repo_name% (%GITBRANCH%)
-
-    echo *******
-    echo *********************************************
-    if not "%GITBRANCH%" == "" echo branch  = %GITBRANCH%
-    echo *
-    echo Mode         = %CMAKE_BUILD_TYPE%
-    echo Build path   = %BUILD_PATH%
-    echo Install path = %INSTALL_PATH%
-    echo *
-    echo compile = jom all
-    echo test    = ctest -V
-    echo doc     = jom doc
-    echo install = jom install
-    echo *********************************************
-    echo *******
-
-You could create a desktop shortcut with the following command:
-    ``%comspec% /k "C:\Users\hodoulp\ocio.bat" ocio``
-
-Also look to the Appveyor config script at the root of repository for an example
-build sequence.
+    ocio_deps.bat --help
 
 .. _enabling-optional-components:
 

--- a/share/dev/windows/README.md
+++ b/share/dev/windows/README.md
@@ -1,0 +1,93 @@
+# Building OCIO on Windows using MS Visual Studio 2022
+
+# Manual steps for installing pre-requisites
+- Install Microsoft Visual Studio
+- Install Python
+- Install CMake
+- Install Doxygen (optional: only for python documentations)
+
+## Microsoft Visual Studio (Desktop development with C++)
+Please use the official Microsoft Visual Studio installer.
+> See https://visualstudio.microsoft.com/downloads/
+
+## Python
+Please use the official Python installer
+> See https://www.python.org/downloads/
+
+**Make sure to check the option to add Python to PATH environment variable while running the installer**
+
+## Cmake
+Please use the official CMake installer.
+> See https://cmake.org/download/
+>
+> Example: https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-windows-x86_64.msi
+
+**Make sure to check the option to add CMake to PATH environment variable while running the installer**
+
+### Doxygen (optional: for editing the documentation)
+Please use the official Doxygen installer.
+> See https://www.doxygen.nl/download.html
+> 
+> Example: https://www.doxygen.nl/files/doxygen-1.9.3-setup.exe
+
+
+# Running the script to install the remaining pre-requisites
+
+## Using ocio_deps.bat
+**ocio_deps.bat** script can be used to verify and install the rest of OCIO dependencies.
+<br/>
+The script can be used to install the following:
+- Vcpkg
+- OpenImageIO
+- FreeGLUT
+- Glew
+- Python documentation dependencies (six, testresources, recommonmark, sphinx-press-theme, sphinx-tabs, and breathe)
+
+Run ocio script and follow the steps.
+```bash
+ocio_deps.bat --vcpkg <path to vcpkg root>
+
+See ocio_deps --help:
+
+Mandatory option:
+--vcpkg        path to an existing vcpkg installation or path where you want to install vcpkg
+```
+
+# Running the script to build and install OCIO
+## Using ocio.bat
+**Ocio.bat** can be used to build and install OCIO.
+```bash
+# Options can be removed by modifying the value inside ocio.bat script.
+# see the top of ocio.bat file
+
+# Produce a release build using the default build and install paths.
+ocio.bat --vcpkg <vcpkg directory> --type Release --ocio <path to OCIO source>
+# Produce a debug build using the default build and install paths.
+ocio.bat --vcpkg <vcpkg directory> --type Debug --ocio <path to OCIO source>
+# Produce a release build using a custom build path (--b) and a custom install paths (--i).
+ocio.bat --vcpkg <vcpkg directory> --type Release --b C:\ocio\__build --i C:\ocio\__install --ocio <path to OCIO source>
+
+See ocio --help:
+
+Mandatory options:
+--vcpkg        path to an existing vcpkg installation
+
+--ocio         path to OCIO source code
+
+Optional options depending on the environment:
+--python       Python installation location
+
+--msvs         path where to find vcvars64.bat from Microsoft Visual Studio
+               Default: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build
+
+--b            build location
+               Default: C:\Users\cfuoco\AppData\Local\Temp\OCIO\build
+
+--i            installation location
+               Default: C:\Users\cfuoco\AppData\Local\Temp\OCIO\install
+
+--type         Release or Debug
+               Default: Release
+--configure    Run cmake configure or not
+               Default: false
+```

--- a/share/dev/windows/ocio.bat
+++ b/share/dev/windows/ocio.bat
@@ -91,15 +91,17 @@ IF NOT EXIST "%OCIO_PATH%" (
     exit /b
 )
 
-where /q python
-if not ErrorLevel 1 (
-    for /f %%p in ('python -c "import os, sys; print(os.path.dirname(sys.executable))"') do SET PYTHON_PATH=%%p
-)
-IF NOT EXIST "%PYTHON_PATH%" ( 
-    echo Could not find Python. Please provide the location for python or modify PYTHON_PATH in this script.
-    rem The double dash are in quote here because otherwise the echo command thow an error.
-    echo "--python <path>"
-    exit /b
+if NOT EXIST "!PYTHON_PATH!\python.exe" ( 
+    where /q python
+    if not ErrorLevel 1 (
+        for /f "tokens=* USEBACKQ" %%p in (`python -c "import os, sys; print(os.path.dirname(sys.executable))"`) do SET PYTHON_PATH=%%p
+    )
+    if NOT EXIST "!PYTHON_PATH!\python.exe" ( 
+        echo Could not find Python. Please provide the location for python or modify PYTHON_PATH in this script.
+        rem The double dash are in quote here because otherwise the echo command thow an error.
+        echo "--python <path>"
+        exit /b
+    )
 )
 
 IF NOT EXIST "%MSVS_PATH%" ( 

--- a/share/dev/windows/ocio.bat
+++ b/share/dev/windows/ocio.bat
@@ -23,7 +23,6 @@ rem Python location
 set PYTHON_PATH=
 
 rem Microsoft Visual Studio path
-rem %programfiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
 set MSVS_PATH=%programfiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build
 
 set DO_CONFIGURE=0
@@ -77,14 +76,14 @@ if NOT "%~1"=="" (
 )
 
 rem Testing the path before cmake
-IF NOT EXIST "%VCPKG_PATH%" ( 
+IF NOT EXIST "!VCPKG_PATH!" ( 
     echo Could not find Vcpkg. Please provide the location for vcpkg or modify VCPKG_PATH in this script.
     rem The double dash are in quote here because otherwise the echo command thow an error.
     echo "--vcpkg <path>"
     exit /b
 )
 
-IF NOT EXIST "%OCIO_PATH%" ( 
+IF NOT EXIST "!OCIO_PATH!" ( 
     echo Could not find OCIO source. Please provide the location for ocio or modify OCIO_PATH in this script.
     rem The double dash are in quote here because otherwise the echo command thow an error.
     echo "--ocio <path>"
@@ -104,7 +103,7 @@ if NOT EXIST "!PYTHON_PATH!\python.exe" (
     )
 )
 
-IF NOT EXIST "%MSVS_PATH%" ( 
+IF NOT EXIST "!MSVS_PATH!" ( 
     echo Could not find MS Visual Studio. Please provide the location for Microsoft Visual Studio vcvars64.bat or modify MSVS_PATH in the script.
     rem The double dash are in quote here because otherwise the echo command thow an error.
     echo "--msvs <path>"
@@ -112,9 +111,9 @@ IF NOT EXIST "%MSVS_PATH%" (
     exit /b
 )
 
-if %CUSTOM_BUILD_PATH%==0 (
+if !CUSTOM_BUILD_PATH!==0 (
     echo.
-    set /p BUILD_PATH_OK=Default build path [%BUILD_PATH%] is used. Is it ok? [y/n]:
+    set /p BUILD_PATH_OK=Default build path [!BUILD_PATH!] is used. Is it ok? [y/n]:
     if !BUILD_PATH_OK!==n (
         echo Please provide the build location.
         rem The double dash are in quote here because otherwise the echo command thow an error.
@@ -123,9 +122,9 @@ if %CUSTOM_BUILD_PATH%==0 (
     )
 )
 
-if %CUSTOM_INSTALL_PATH%==0 (
+if !CUSTOM_INSTALL_PATH!==0 (
     echo.
-    set /p INSTALL_PATH_OK=Default install path [%INSTALL_PATH%] is used. Is it ok? [y/n]:
+    set /p INSTALL_PATH_OK=Default install path [!INSTALL_PATH!] is used. Is it ok? [y/n]:
     if !INSTALL_PATH_OK!==n (
         echo Please provide the install location.
         rem The double dash are in quote here because otherwise the echo command thow an error.
@@ -135,39 +134,39 @@ if %CUSTOM_INSTALL_PATH%==0 (
 )
 
 rem Update build and install variables
-set BUILD_PATH=%BUILD_PATH%\%CMAKE_BUILD_TYPE%
-set INSTALL_PATH=%INSTALL_PATH%\%CMAKE_BUILD_TYPE%
+set BUILD_PATH=!BUILD_PATH!\!CMAKE_BUILD_TYPE!
+set INSTALL_PATH=!INSTALL_PATH!\!CMAKE_BUILD_TYPE!
 
 rem ****************************************************************************************************************
 rem Setting up the environment using MS Visual Studio batch script
-set VCVARS64_PATH="%MSVS_PATH%\vcvars64.bat"
-IF NOT EXIST %VCVARS64_PATH% (
+set VCVARS64_PATH="!MSVS_PATH!\vcvars64.bat"
+IF NOT EXIST !VCVARS64_PATH! (
     rem Checking for vcvars64.bat script.
-    rem %MSVS_PATH% is checked earlier in the script
-    echo VCVARS64_PATH=%VCVARS64_PATH% does not exist
+    rem !MSVS_PATH! is checked earlier in the script
+    echo VCVARS64_PATH=!VCVARS64_PATH! does not exist
     echo Make sure that Microsoft Visual Studio is installed.
     exit /b
 )
 
 rem Checking if it was already previously ran. Some issues might happend when ran multiple time.
 if not defined DevEnvDir (
-    call %VCVARS64_PATH% x64
+    call !VCVARS64_PATH! x64
 )
 
 echo *** Important: Note that the build path should be as small as possible. ***
 echo *** Important: Python documentation generation could failed because of Maximum Path Length Limitation of Windows. ***
 
 rem Freeglut root directory
-set GLUT_ROOT=%VCPKG_PATH%\packages\freeglut_x64-windows
+set GLUT_ROOT=!VCPKG_PATH!\packages\freeglut_x64-windows
 rem Glew root directory
-set GLEW_ROOT=%VCPKG_PATH%\packages\glew_x64-windows
+set GLEW_ROOT=!VCPKG_PATH!\packages\glew_x64-windows
 rem OpenImageIO root directory
-set OPENIMAGEIO_DIR=%VCPKG_PATH%\packages\openimageio_x64-windows
+set OPENIMAGEIO_DIR=!VCPKG_PATH!\packages\openimageio_x64-windows
 
 rem Testing the path before cmake
-echo Checking OCIO_PATH=%OCIO_PATH%...
-IF NOT EXIST "%OCIO_PATH%" ( 
-    echo OCIO_PATH=%OCIO_PATH% does not exist
+echo Checking OCIO_PATH=!OCIO_PATH!...
+IF NOT EXIST "!OCIO_PATH!" ( 
+    echo OCIO_PATH=!OCIO_PATH! does not exist
     exit /b
 )
 echo Checking GLUT_ROOT=%GLUT_ROOT%...
@@ -185,22 +184,22 @@ IF NOT EXIST "%OPENIMAGEIO_DIR%" (
     echo OPENIMAGEIO_DIR=%OPENIMAGEIO_DIR% does not exist
     exit /b
 )
-echo Checking PYTHON_PATH=%PYTHON_PATH%...
-IF NOT EXIST "%PYTHON_PATH%" ( 
-    echo PYTHON_PATH=%PYTHON_PATH% does not exist
+echo Checking PYTHON_PATH="!PYTHON_PATH!"...
+IF NOT EXIST "!PYTHON_PATH!" ( 
+    echo PYTHON_PATH=!PYTHON_PATH! does not exist
     exit /b
 )
 
-if %DO_CONFIGURE%==1 (
+if !DO_CONFIGURE!==1 (
     echo Running CMake...
-    cmake -B "%BUILD_PATH%"^
+    cmake -B "!BUILD_PATH!"^
         -DOCIO_INSTALL_EXT_PACKAGES=ALL^
-        -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%^
-        -DGLEW_ROOT=%GLEW_ROOT%^
-        -DGLUT_ROOT=%GLUT_ROOT%^
-        -DOpenImageIO_ROOT=%OPENIMAGEIO_DIR%^
+        -DCMAKE_BUILD_TYPE=!CMAKE_BUILD_TYPE!^
+        -DGLEW_ROOT="!GLEW_ROOT!"^
+        -DGLUT_ROOT="!GLUT_ROOT!"^
+        -DOpenImageIO_ROOT="!OPENIMAGEIO_DIR!"^
         -DOCIO_BUILD_PYTHON=ON^
-        -DPython_ROOT=%PYTHON_PATH%^
+        -DPython_ROOT="!PYTHON_PATH!"^
         -DBUILD_SHARED_LIBS=ON^
         -DOCIO_BUILD_APPS=ON^
         -DOCIO_BUILD_TESTS=ON^
@@ -209,7 +208,7 @@ if %DO_CONFIGURE%==1 (
         -DOCIO_USE_SSE=ON^
         -DOCIO_WARNING_AS_ERROR=ON^
         -DOCIO_BUILD_JAVA=OFF^
-        %OCIO_PATH%
+        "!OCIO_PATH!"
 
     if not ErrorLevel 1 (
         set CMAKE_CONFIGURE_STATUS=Ok
@@ -221,7 +220,7 @@ if %DO_CONFIGURE%==1 (
 rem Run cmake --build.
 if Not "%CMAKE_CONFIGURE_STATUS%"=="Failed" (
     rem Build OCIO
-    cmake --build %BUILD_PATH% --config %CMAKE_BUILD_TYPE% --parallel %NUMBER_OF_PROCESSORS%)
+    cmake --build !BUILD_PATH! --config !CMAKE_BUILD_TYPE! --parallel %NUMBER_OF_PROCESSORS%)
     if not ErrorLevel 1 (
         set CMAKE_BUILD_STATUS=Ok
     ) else (
@@ -232,7 +231,7 @@ if Not "%CMAKE_CONFIGURE_STATUS%"=="Failed" (
 rem Run cmake --install only if cmake --build was successful.
 if Not "%CMAKE_BUILD_STATUS%"=="Failed" (
     rem Install OCIO
-    cmake --install %BUILD_PATH% --config %CMAKE_BUILD_TYPE% --prefix %INSTALL_PATH%
+    cmake --install !BUILD_PATH! --config !CMAKE_BUILD_TYPE! --prefix !INSTALL_PATH!
     if not ErrorLevel 1 (
         set CMAKE_INSTALL_STATUS=Ok
     ) else (
@@ -244,8 +243,8 @@ rem Run ctest only if cmake --build was successful.
 if Not "%CMAKE_BUILD_STATUS%"=="Failed" (
     rem Run Tests
     rem Need cmake version >= 3.20 for --test-dir argument
-    rem if <= 3.20 --> cd %BUILD_PATH%; ctest -V -C %CMAKE_BUILD_TYPE%
-    ctest -V --test-dir "%BUILD_PATH%" -C %CMAKE_BUILD_TYPE%
+    rem if <= 3.20 --> cd !BUILD_PATH!; ctest -V -C !CMAKE_BUILD_TYPE!
+    ctest -V --test-dir "!BUILD_PATH!" -C !CMAKE_BUILD_TYPE!
     rem Not testing %errorlevel% because ctest returns is not reliable (e.g. returns 0 even when a test fails)
 )
 
@@ -255,7 +254,7 @@ echo **                                                                         
 echo ** Summary                                                                                                  **
 echo **                                                                                                          **
 echo **************************************************************************************************************
-echo.** Source location: %OCIO_PATH%
+echo.** Source location: !OCIO_PATH!
 echo.**
 echo.** Statuses:                                                                                                
 echo.**    Configure: %CMAKE_CONFIGURE_STATUS%                                                                   
@@ -263,9 +262,9 @@ echo.**    Build:     %CMAKE_BUILD_STATUS%
 echo.**    CTest:     See output above summary                                                                          
 echo.**    Install:   %CMAKE_INSTALL_STATUS%                                                                     
 echo.**                                                                                                          
-echo.** Build type:         %CMAKE_BUILD_TYPE%                                                                           
-echo.** Build location:     %BUILD_PATH%                                                                             
-echo.** Install location:   %INSTALL_PATH%                                                                         
+echo.** Build type:         !CMAKE_BUILD_TYPE!                                                                           
+echo.** Build location:     !BUILD_PATH!                                                                             
+echo.** Install location:   !INSTALL_PATH!                                                                         
 echo.**                                                                                                          
 echo **************************************************************************************************************
 

--- a/share/dev/windows/ocio.bat
+++ b/share/dev/windows/ocio.bat
@@ -1,0 +1,311 @@
+@echo OFF
+setlocal enabledelayedexpansion
+
+rem Build type - Release or Debug
+set CMAKE_BUILD_TYPE=Release
+
+rem Vcpkg location
+set VCPKG_PATH=
+rem OpenColorIO source location
+set OCIO_PATH=
+rem OpenColorIO build location
+rem defaut to %TEMP% directory
+set BUILD_PATH=%TEMP%\OCIO\build
+set CUSTOM_BUILD_PATH=0
+rem OpenColorIO install location
+rem default to %TEMP% directory
+set INSTALL_PATH=%TEMP%\OCIO\install
+set CUSTOM_INSTALL_PATH=0
+set BUILD_PATH_OK=n
+set INSTALL_PATH_OK=n
+
+rem Python location
+set PYTHON_PATH=
+
+rem Microsoft Visual Studio path
+rem %programfiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat
+set MSVS_PATH=%programfiles%\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build
+
+set DO_CONFIGURE=0
+
+set CMAKE_CONFIGURE_STATUS=Not executed
+set CMAKE_BUILD_STATUS=Not executed
+set CMAKE_INSTALL_STATUS=Not executed
+
+rem Command line arguments processing
+:args_loop
+if NOT "%~1"=="" (
+    if "%~1"=="--help" (
+        goto :help
+    )
+
+    if "%~1"=="--vcpkg" (
+        set VCPKG_PATH=%~2
+    )
+
+    if "%~1"=="--python" (
+        set PYTHON_PATH=%~2
+    )
+
+    if "%~1"=="--msvs" (
+        set MSVS_PATH=%~2
+    )
+
+    if "%~1"=="--ocio" (
+        set OCIO_PATH=%~2
+    )
+
+    if "%~1"=="--b" (
+        set BUILD_PATH=%~2
+        set CUSTOM_BUILD_PATH=1
+    )
+
+    if "%~1"=="--i" (
+        set INSTALL_PATH=%~2
+        set CUSTOM_INSTALL_PATH=1
+    )
+
+    if "%~1"=="--type" (
+        set CMAKE_BUILD_TYPE=%~2
+    )
+
+    if "%~1"=="--configure" (
+        set DO_CONFIGURE=1
+    )
+    shift
+    goto :args_loop
+)
+
+rem Testing the path before cmake
+IF NOT EXIST "%VCPKG_PATH%" ( 
+    echo Could not find Vcpkg. Please provide the location for vcpkg or modify VCPKG_PATH in this script.
+    rem The double dash are in quote here because otherwise the echo command thow an error.
+    echo "--vcpkg <path>"
+    exit /b
+)
+
+IF NOT EXIST "%OCIO_PATH%" ( 
+    echo Could not find OCIO source. Please provide the location for ocio or modify OCIO_PATH in this script.
+    rem The double dash are in quote here because otherwise the echo command thow an error.
+    echo "--ocio <path>"
+    exit /b
+)
+
+where /q python
+if not ErrorLevel 1 (
+    for /f %%p in ('python -c "import os, sys; print(os.path.dirname(sys.executable))"') do SET PYTHON_PATH=%%p
+)
+IF NOT EXIST "%PYTHON_PATH%" ( 
+    echo Could not find Python. Please provide the location for python or modify PYTHON_PATH in this script.
+    rem The double dash are in quote here because otherwise the echo command thow an error.
+    echo "--python <path>"
+    exit /b
+)
+
+IF NOT EXIST "%MSVS_PATH%" ( 
+    echo Could not find MS Visual Studio. Please provide the location for Microsoft Visual Studio vcvars64.bat or modify MSVS_PATH in the script.
+    rem The double dash are in quote here because otherwise the echo command thow an error.
+    echo "--msvs <path>"
+    echo E.g. C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build
+    exit /b
+)
+
+if %CUSTOM_BUILD_PATH%==0 (
+    echo.
+    set /p BUILD_PATH_OK=Default build path [%BUILD_PATH%] is used. Is it ok? [y/n]:
+    if !BUILD_PATH_OK!==n (
+        echo Please provide the build location.
+        rem The double dash are in quote here because otherwise the echo command thow an error.
+        echo "--b <path>"
+        exit /b
+    )
+)
+
+if %CUSTOM_INSTALL_PATH%==0 (
+    echo.
+    set /p INSTALL_PATH_OK=Default install path [%INSTALL_PATH%] is used. Is it ok? [y/n]:
+    if !INSTALL_PATH_OK!==n (
+        echo Please provide the install location.
+        rem The double dash are in quote here because otherwise the echo command thow an error.
+        echo "--i <path>"
+        exit /b
+    )
+)
+
+rem Update build and install variables
+set BUILD_PATH=%BUILD_PATH%\%CMAKE_BUILD_TYPE%
+set INSTALL_PATH=%INSTALL_PATH%\%CMAKE_BUILD_TYPE%
+
+rem ****************************************************************************************************************
+rem Setting up the environment using MS Visual Studio batch script
+set VCVARS64_PATH="%MSVS_PATH%\vcvars64.bat"
+IF NOT EXIST %VCVARS64_PATH% (
+    rem Checking for vcvars64.bat script.
+    rem %MSVS_PATH% is checked earlier in the script
+    echo VCVARS64_PATH=%VCVARS64_PATH% does not exist
+    echo Make sure that Microsoft Visual Studio is installed.
+    exit /b
+)
+
+rem Checking if it was already previously ran. Some issues might happend when ran multiple time.
+if not defined DevEnvDir (
+    call %VCVARS64_PATH% x64
+)
+
+echo *** Important: Note that the build path should be as small as possible. ***
+echo *** Important: Python documentation generation could failed because of Maximum Path Length Limitation of Windows. ***
+
+rem Freeglut root directory
+set GLUT_ROOT=%VCPKG_PATH%\packages\freeglut_x64-windows
+rem Glew root directory
+set GLEW_ROOT=%VCPKG_PATH%\packages\glew_x64-windows
+rem OpenImageIO root directory
+set OPENIMAGEIO_DIR=%VCPKG_PATH%\packages\openimageio_x64-windows
+
+rem Testing the path before cmake
+echo Checking OCIO_PATH=%OCIO_PATH%...
+IF NOT EXIST "%OCIO_PATH%" ( 
+    echo OCIO_PATH=%OCIO_PATH% does not exist
+    exit /b
+)
+echo Checking GLUT_ROOT=%GLUT_ROOT%...
+IF NOT EXIST "%GLUT_ROOT%" ( 
+    echo GLUT_ROOT=%GLUT_ROOT% does not exist
+    exit /b
+)
+echo Checking GLEW_ROOT=%GLEW_ROOT%...
+IF NOT EXIST "%GLEW_ROOT%" ( 
+    echo GLEW_ROOT=%GLEW_ROOT% does not exist
+    exit /b
+)
+echo Checking OPENIMAGEIO_DIR=%OPENIMAGEIO_DIR%...
+IF NOT EXIST "%OPENIMAGEIO_DIR%" ( 
+    echo OPENIMAGEIO_DIR=%OPENIMAGEIO_DIR% does not exist
+    exit /b
+)
+echo Checking PYTHON_PATH=%PYTHON_PATH%...
+IF NOT EXIST "%PYTHON_PATH%" ( 
+    echo PYTHON_PATH=%PYTHON_PATH% does not exist
+    exit /b
+)
+
+if %DO_CONFIGURE%==1 (
+    echo Running CMake...
+    cmake -B "%BUILD_PATH%"^
+        -DOCIO_INSTALL_EXT_PACKAGES=ALL^
+        -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%^
+        -DGLEW_ROOT=%GLEW_ROOT%^
+        -DGLUT_ROOT=%GLUT_ROOT%^
+        -DOpenImageIO_ROOT=%OPENIMAGEIO_DIR%^
+        -DOCIO_BUILD_PYTHON=ON^
+        -DPython_ROOT=%PYTHON_PATH%^
+        -DBUILD_SHARED_LIBS=ON^
+        -DOCIO_BUILD_APPS=ON^
+        -DOCIO_BUILD_TESTS=ON^
+        -DOCIO_BUILD_GPU_TESTS=ON^
+        -DOCIO_BUILD_DOCS=OFF^
+        -DOCIO_USE_SSE=ON^
+        -DOCIO_WARNING_AS_ERROR=ON^
+        -DOCIO_BUILD_JAVA=OFF^
+        %OCIO_PATH%
+
+    if not ErrorLevel 1 (
+        set CMAKE_CONFIGURE_STATUS=Ok
+    ) else (
+        set CMAKE_CONFIGURE_STATUS=Failed
+    )
+)
+
+rem Run cmake --build.
+if Not "%CMAKE_CONFIGURE_STATUS%"=="Failed" (
+    rem Build OCIO
+    cmake --build %BUILD_PATH% --config %CMAKE_BUILD_TYPE% --parallel %NUMBER_OF_PROCESSORS%)
+    if not ErrorLevel 1 (
+        set CMAKE_BUILD_STATUS=Ok
+    ) else (
+        set CMAKE_BUILD_STATUS=Failed
+    )
+)
+
+rem Run cmake --install only if cmake --build was successful.
+if Not "%CMAKE_BUILD_STATUS%"=="Failed" (
+    rem Install OCIO
+    cmake --install %BUILD_PATH% --config %CMAKE_BUILD_TYPE% --prefix %INSTALL_PATH%
+    if not ErrorLevel 1 (
+        set CMAKE_INSTALL_STATUS=Ok
+    ) else (
+        set CMAKE_INSTALL_STATUS=Failed
+    )
+)
+
+rem Run ctest only if cmake --build was successful.
+if Not "%CMAKE_BUILD_STATUS%"=="Failed" (
+    rem Run Tests
+    rem Need cmake version >= 3.20 for --test-dir argument
+    rem if <= 3.20 --> cd %BUILD_PATH%; ctest -V -C %CMAKE_BUILD_TYPE%
+    ctest -V --test-dir "%BUILD_PATH%" -C %CMAKE_BUILD_TYPE%
+    rem Not testing %errorlevel% because ctest returns is not reliable (e.g. returns 0 even when a test fails)
+)
+
+rem Output summary
+echo **************************************************************************************************************
+echo **                                                                                                          **
+echo ** Summary                                                                                                  **
+echo **                                                                                                          **
+echo **************************************************************************************************************
+echo.** Source location: %OCIO_PATH%
+echo.**
+echo.** Statuses:                                                                                                
+echo.**    Configure: %CMAKE_CONFIGURE_STATUS%                                                                   
+echo.**    Build:     %CMAKE_BUILD_STATUS%                                                                       
+echo.**    CTest:     See output above summary                                                                          
+echo.**    Install:   %CMAKE_INSTALL_STATUS%                                                                     
+echo.**                                                                                                          
+echo.** Build type:         %CMAKE_BUILD_TYPE%                                                                           
+echo.** Build location:     %BUILD_PATH%                                                                             
+echo.** Install location:   %INSTALL_PATH%                                                                         
+echo.**                                                                                                          
+echo **************************************************************************************************************
+
+exit /b 0
+
+:help
+echo.
+echo **************************************************************************************************************
+echo **                                                                                                          **
+echo ** Script to help build and install OCIO                                                                    **
+echo **                                                                                                          **
+echo **************************************************************************************************************
+echo Usage: ocio --vcpkg <path to vcpkg> [OPTIONS]...
+echo.
+echo Please consider modifying the following script variables to reduce the number of options needed:
+echo    VCPKG_PATH
+echo    BUILD_PATH
+echo    INSTALL_PATH
+echo    PYTHON_PATH
+echo    MSVS_PATH
+echo.
+echo Mandatory options:
+echo --vcpkg        path to an existing vcpkg installation
+echo.
+echo --ocio         path to OCIO source code
+echo.
+echo Optional options depending on the environment:
+echo --python       Python installation location
+echo.
+echo --msvs         path where to find vcvars64.bat from Microsoft Visual Studio
+echo                Default: C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build
+echo.
+echo --b            build location
+echo                Default: %TEMP%\OCIO\build
+echo.
+echo --i            installation location
+echo                Default: %TEMP%\OCIO\install
+echo.
+echo --type         Release or Debug
+echo                Default: Release
+echo --configure    Run cmake configure or not
+echo                Default: false
+exit /b 0
+
+endlocal

--- a/share/dev/windows/ocio_deps.bat
+++ b/share/dev/windows/ocio_deps.bat
@@ -1,0 +1,335 @@
+@echo off
+rem install_pkg_managers
+rem Download and install some windows package managers to handle
+rem the installations of OCIO dependencies.
+
+setlocal enabledelayedexpansion
+
+rem Check if x64 or x86
+set isX64=0 && if /I "%PROCESSOR_ARCHITECTURE%"=="AMD64" ( set isX64=1 ) else ( if /I "%PROCESSOR_ARCHITEW6432%"=="AMD64" ( set isX64=1 ) )
+
+set IS_VCPKG_PRESENT=0
+set VCPKG_INTEGRATE=0
+
+set IS_OPENIMAGEIO_PRESENT=0
+set IS_FREEGLUT_PRESENT=0
+set IS_GLEW_PRESENT=0
+
+rem Define flags to indicate if automated install or not.
+set AUTO_VCPKG=n
+set AUTO_OPENIMAGEIO=n
+set AUTO_FREEGLUT=n
+set AUTO_GLEW=n
+
+rem Python documentation related variables
+set AUTO_PYTHON_DEPS=n
+
+rem Skip doxygen (e.g. false positive) and continue the script
+set DOXYGEN_CONTINUE_ANYWAY=n
+
+set %PYTHON_DOCUMENTATION_REQUIREMENTS=..\..\..\docs\requirements.txt
+
+rem Command line arguments processing
+:args_loop
+if NOT "%~1"=="" (
+    if "%~1"=="--vcpkg" (
+        set VCPKG_INSTALL_DIR=%~2
+    )
+
+    if "%~1"=="--help" (
+        goto :help
+    )
+    shift
+    goto :args_loop
+)
+
+if "!VCPKG_INSTALL_DIR!"=="" ( 
+    echo Please provide the location to install vcpkg or modify VCPKG_INSTALL_DIR in this script.
+    rem The double dash are in quote here because otherwise the echo command thow an error.
+    echo "--vcpkg <path>"
+    exit /b
+)
+
+echo Checking for Git...
+where /q git
+if ErrorLevel 1 (
+    echo.
+    echo Please make sure that Git is already installed.
+    echo See https://git-scm.com/download/win
+    echo e.g. https://github.com/git-for-windows/git/releases/download/v2.36.0.windows.1/Git-2.36.0-64-bit.exe
+    echo Do not forget to open a new command prompt after Git installation.
+    exit /b
+)
+
+echo Checking for Python...
+where /q python
+if ErrorLevel 1 (
+    echo.
+    echo Please make sure that Python is already installed.
+    echo See https://www.python.org/downloads/
+    echo e.g. https://www.python.org/ftp/python/3.10.4/python-3.10.4-amd64.exe
+    echo While installing Python, make sure to check "Add PYTHON to path"
+    echo Do not forget to open a new command prompt after Python installation.
+    exit /b
+)
+
+echo Checking for Pip...
+where /q pip
+if ErrorLevel 1 (
+    echo.
+    echo Please make sure that Pip is already installed.
+    echo See https://www.python.org/downloads/
+    echo e.g. https://www.python.org/ftp/python/3.10.4/python-3.10.4-amd64.exe
+    echo While installing Python, make sure to check "Add PYTHON to path"
+    echo Do not forget to open a new command prompt after Python installation.
+    exit /b
+)
+
+IF NOT EXIST "%PYTHON_DOCUMENTATION_REQUIREMENTS%" ( 
+    echo.
+    echo Could not find %PYTHON_DOCUMENTATION_REQUIREMENTS%.
+    exit /b
+)
+
+echo Checking for CMake...
+where /q cmake
+if ErrorLevel 1 (
+    echo.
+    echo Please make sure that CMake is already installed.
+    echo See https://cmake.org/download/
+    echo e.g. https://github.com/Kitware/CMake/releases/download/v3.23.1/cmake-3.23.1-windows-x86_64.msi
+    echo While installing CMake, make sure to check "Add CMake to the system PATH"
+    echo Do not forget to open a new command prompt after CMake installation.
+    exit /b
+)
+
+echo Checking for Microsoft Visual Studio...
+set MSVS=0
+for /d %%a in ("%programfiles%\Microsoft Visual Studio*") do (
+    for /f "tokens=3 delims=\" %%x in ("%%a") do set MSVS=1
+)
+
+if !MSVS!==0 (
+    echo No Microsoft Visual Studio installation was found in !programfiles!.
+    echo For non-standard installation path, please use the following option:
+    rem The double dash are in quote here because otherwise the echo command thow an error. 
+    echo "ocio_deps --vs <path>"
+    exit /b
+)
+
+echo Checking for Vcpkg...
+where /q vcpkg
+set IS_VCPKG_PRESENT=False && if ErrorLevel 1 ( set IS_VCPKG_PRESENT=False ) && if EXIST !VCPKG_INSTALL_DIR!\vcpkg.exe ( set IS_VCPKG_PRESENT=True )
+
+if %IS_VCPKG_PRESENT%==False (
+    echo Vcpkg is needed to install the following OCIO dependencies: openimageio, freeglut and glew.
+    set /p AUTO_VCPKG=Do you want to install Vcpkg in [!VCPKG_INSTALL_DIR!]? [y/n]:
+
+    if !AUTO_VCPKG!==y (
+        echo.
+        echo Installing vcpkg...
+        echo Cloning Vcpkg repository to !VCPKG_INSTALL_DIR!....
+        git clone https://github.com/Microsoft/vcpkg.git !VCPKG_INSTALL_DIR! >nul 2>&1
+        echo Running bootstrap-vcpkg script...
+        call !VCPKG_INSTALL_DIR!\bootstrap-vcpkg.bat >nul 2>&1
+    ) else (
+        echo.
+        echo For Vcpkg, please use the following options:
+        echo 1. Install it through this script by answering [y]es to the question
+        rem The double dash are in quote here because otherwise the echo command thow an error.
+        echo 2. Install it manually and provide the installation location using "--vcpkg <path>" option
+        exit /b
+    )
+)
+
+rem Make sure vcpkg in avaiable in the command prompt environment
+set Path=%Path%;!VCPKG_INSTALL_DIR!
+echo All set! Everything is present to continue....
+
+rem **************************************************************************************
+rem ** OCIO dependencies installation                                                   **
+rem **************************************************************************************
+
+echo.
+echo **************************************************************************************
+echo ** Vcpkg is used to install the following package:                                  **
+echo **    - OpenImageIO                                                                 **
+echo **    - Freeglut                                                                    **
+echo **    - Glew                                                                        **
+echo **************************************************************************************
+
+if %isX64%==1 (
+    IF NOT EXIST "!VCPKG_INSTALL_DIR!\packages\openimageio_x64-windows" ( 
+        set /p AUTO_OPENIMAGEIO=OpenImageIO is needed. Do you want to install it? [y/n]:
+    ) else (
+        echo OpenImageIO is already present. Skipping...
+        set IS_OPENIMAGEIO_PRESENT=1
+    )
+
+    if !AUTO_OPENIMAGEIO!==y (
+        echo.
+        echo **************************************************************************************
+        echo ** Installing OpenImageIO...                                                        **
+        echo **************************************************************************************
+        vcpkg install openimageio:x64-windows
+        set VCPKG_INTEGRATE=1
+        set IS_OPENIMAGEIO_PRESENT=1
+    ) else (
+        if !IS_OPENIMAGEIO_PRESENT!==0 (
+            echo Without OpenImageIO, some part of OCIO will not be built. Please install it with this script or manually.
+            exit /b
+        )
+    )
+
+    IF NOT EXIST "!VCPKG_INSTALL_DIR!\packages\freeglut_x64-windows" ( 
+        set /p AUTO_FREEGLUT=Freeglut is needed. Do you want to install it? [y/n]:
+    ) else (
+        echo Freeglut is already present. Skipping...
+        set IS_FREEGLUT_PRESENT=1
+    )
+
+    if !AUTO_FREEGLUT!==y (
+        echo.
+        echo **************************************************************************************
+        echo ** Installing Freeglut...                                                           **
+        echo **************************************************************************************
+        vcpkg install freeglut:x64-windows
+        set VCPKG_INTEGRATE=1
+        set IS_FREEGLUT_PRESENT=1
+    ) else (
+        if !IS_FREEGLUT_PRESENT!==0 (
+            echo Without Freeglut, some part of OCIO will not be built. Please install it with this script or manually
+            exit /b
+        )
+    )
+
+    IF NOT EXIST "!VCPKG_INSTALL_DIR!\packages\glew_x64-windows" ( 
+        set /p AUTO_GLEW=Glew is needed. Do you want to install it? [y/n]:
+    ) else (
+        echo Glew is already present. Skipping...
+        set IS_GLEW_PRESENT=1
+    )
+
+    if !AUTO_GLEW!==y (
+        echo.
+        echo **************************************************************************************
+        echo ** Installing Glew...                                                               **
+        echo **************************************************************************************
+        vcpkg install glew:x64-windows
+        set VCPKG_INTEGRATE=1
+        set IS_GLEW_PRESENT=1
+    ) else (
+        if !IS_GLEW_PRESENT!==0 (
+            echo Without Glew, some part of OCIO will not be built. Please install it with this script or manually.
+            exit /b
+        )
+        
+    )
+
+    rem Integrate vcpkg with Visual Studio
+    if !VCPKG_INTEGRATE!==1 (
+        echo Running Vcpkg integrate command...
+        vcpkg integrate install >nul 2>&1
+    )
+
+    echo.
+    echo **************************************************************************************
+    echo ** Python pip will be used to install the documentations dependencies               **
+    echo **    six                                                                           **
+    echo **    testresources                                                                 **
+    echo **    recommonmark                                                                  **
+    echo **    sphinx-press-theme                                                           **
+    echo **    sphinx-tabs                                                                   **
+    echo **    breathe                                                                       **
+    echo **************************************************************************************
+    
+    set /p AUTO_PYTHON_DEPS=Do you want to install Python documentations dependencies? [y/n]:
+    if !AUTO_PYTHON_DEPS!==y (
+        echo Checking for Doxygen...
+        if NOT EXIST "%programfiles%\doxygen" (
+            echo.
+            echo Please make sure that Doxygen is already installed.
+            echo See https://www.doxygen.nl/download.html
+            echo e.g. https://www.doxygen.nl/files/doxygen-1.9.3-setup.exe
+            echo Do not forget to open a new command prompt after Doxygen installation.
+
+            set /p DOXYGEN_CONTINUE_ANYWAY=It could be a false positive. Do you want to continue anyway? [y/n]:
+        ) else (
+            set DOXYGEN_CONTINUE_ANYWAY=y
+        )
+
+        if !DOXYGEN_CONTINUE_ANYWAY!==y (
+            echo Installing python documentation dependencies...
+            rem NOTE: Change path based on script location
+            pip install -r %PYTHON_DOCUMENTATION_REQUIREMENTS%
+            where /q python
+            if not ErrorLevel 1 (
+                for /f %%p in ('python -c "import os, sys; print(os.path.dirname(sys.executable))"') do SET PYTHON_PATH=%%p
+            )
+        ) else (
+            exit /b
+        )
+    )
+)
+
+rem Output summary
+echo **************************************************************************************************************
+echo **                                                                                                          **
+echo ** Summary                                                                                                  **
+echo **                                                                                                          **
+echo **************************************************************************************************************
+echo.**
+echo.** Vcpkg location:           !VCPKG_INSTALL_DIR!
+if !IS_OPENIMAGEIO_PRESENT!==1 echo.** OpenImageIO:              !VCPKG_INSTALL_DIR!\packages\openimageio_x64-windows
+if !IS_FREEGLUT_PRESENT!==1 echo.** Freeglut:                 !VCPKG_INSTALL_DIR!\packages\freeglut_x64-windows
+if !IS_GLEW_PRESENT!==1 echo.** Glew:                     !VCPKG_INSTALL_DIR!\packages\glew_x64-windows
+echo.**                                                                                                          
+if Defined PYTHON_PATH (
+    echo.** Python packages location: %PYTHON_PATH%\lib\site-packages
+    echo.**  
+)                                                                                                                                                                              
+echo **************************************************************************************************************
+
+exit /b 0
+
+
+:help
+echo.
+echo **************************************************************************************
+echo ** Verify and install OCIO dependencies                                             **
+echo **                                                                                  **
+echo ** Before running this script, please see the README.md file                        **
+echo ** and manually install the following:                                              **
+echo **    - Git                                                                         **
+echo **    - Python and Pip                                                              **
+echo **    - CMake                                                                       **
+echo **    - Microsoft Visual Studio                                                     **
+echo **                                                                                  **
+echo ** Modifications are needed if Microsoft Visual Studio is not used.                 **
+echo **                                                                                  **
+echo ** Depending on presence and choices, the following could be installed:             **
+echo **    - Vcpkg                                                                       **
+echo **    - OpenImageIO (using Vcpkg)                                                   **
+echo **    - Freeglut (using Vcpkg)                                                      **
+echo **    - Glew (using Vcpkg)                                                          **
+echo **                                                                                  **
+echo **    - Python documentations (optional):                                           **
+echo **          six                                                                     **
+echo **          testresources                                                           **
+echo **          recommonmark                                                            **
+echo **          sphinx-press-theme                                                     **
+echo **          sphinx-tabs                                                             **
+echo **          breathe                                                                 **
+echo **************************************************************************************
+echo.
+echo Usage: ocio_deps --vcpkg <path to vcpkg> [OPTIONS]...
+echo.
+echo Mandatory option:
+echo --vcpkg        path to an existing vcpkg installation
+echo                or path where you want to install vcpkg
+exit /b 0
+
+
+
+
+endlocal


### PR DESCRIPTION
The goal of this PR is to add scripts that makes building OCIO on Windows easier.

- The script ocio_deps.bat can be used to check and install some of the difficult dependencies - such as OpenImageIO, Freeglut and Glew.

- The script ocio.bat can be used to make it easy to run cmake configure, build and install.

Signed-off-by: Cedrik Fuoco <cedrik.fuoco@autodesk.com>