### PR TITLE
Adsk contrib - Fix issues when building OCIO with MS Visual Studio 2022

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -441,7 +441,7 @@ jobs:
 
   windows:
     name: 'Windows 2019 
-      <MSVC 16.14 
+      <MSVC 16.4
        config=${{ matrix.build-type }}, 
        shared=${{ matrix.build-shared }}, 
        sse=${{ matrix.use-sse }}, 

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -440,8 +440,8 @@ jobs:
   #       Debug build testing with Python bindings and docs enabled.
 
   windows:
-    name: 'Windows 2019 
-      <MSVC 16.4 
+    name: 'Windows 2022 
+      <MSVC 19.31 
        config=${{ matrix.build-type }}, 
        shared=${{ matrix.build-shared }}, 
        sse=${{ matrix.use-sse }}, 
@@ -452,7 +452,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       matrix:
         build: [1, 2, 3, 4, 5, 6]

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -441,7 +441,7 @@ jobs:
 
   windows:
     name: 'Windows 2019 
-      <MSVC 16.4
+      <MSVC 16.4 
        config=${{ matrix.build-type }}, 
        shared=${{ matrix.build-shared }}, 
        sse=${{ matrix.use-sse }}, 

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -440,8 +440,8 @@ jobs:
   #       Debug build testing with Python bindings and docs enabled.
 
   windows:
-    name: 'Windows 2022 
-      <MSVC 19.31 
+    name: 'Windows 2019 
+      <MSVC 16.14 
        config=${{ matrix.build-type }}, 
        shared=${{ matrix.build-shared }}, 
        sse=${{ matrix.use-sse }}, 
@@ -452,7 +452,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: windows-2022
+    runs-on: windows-2019
     strategy:
       matrix:
         build: [1, 2, 3, 4, 5, 6]

--- a/share/cmake/modules/FindExtPackages.cmake
+++ b/share/cmake/modules/FindExtPackages.cmake
@@ -100,7 +100,8 @@ if(OCIO_BUILD_PYTHON OR OCIO_BUILD_DOCS)
     if(OCIO_BUILD_PYTHON)
         # pybind11
         # https://github.com/pybind/pybind11
-        find_package(pybind11 2.6.1 REQUIRED)
+        # pybind11 2.9 fixes issues with MS Visual Studio 2022 (Debug).
+        find_package(pybind11 2.9.2 REQUIRED)
     endif()
 endif()
 

--- a/share/cmake/utils/CheckSupportGL.cmake
+++ b/share/cmake/utils/CheckSupportGL.cmake
@@ -31,7 +31,7 @@ if((OCIO_BUILD_TESTS AND OCIO_BUILD_GPU_TESTS) OR OCIO_BUILD_APPS)
             endif()
         else()
             # Expected variables GLEW_LIBRARIES and GLEW_INCLUDE_DIRS are missing so create
-            # the mandatory one. Note that the cmake bug is now fixed (issue 19662).
+            # the mandatory one.
             if(NOT GLEW_LIBRARIES)
                 set(GLEW_LIBRARIES GLEW::GLEW)
             endif()
@@ -55,7 +55,6 @@ if((OCIO_BUILD_TESTS AND OCIO_BUILD_GPU_TESTS) OR OCIO_BUILD_APPS)
             endif()
             get_target_property(_GLEW_LINK_INTERFACE GLEW::GLEW IMPORTED_LINK_INTERFACE_LIBRARIES_RELEASE) # same for debug and release
             list(APPEND GLEW_LIBRARIES ${_GLEW_LINK_INTERFACE})
-            list(APPEND GLEW_LIBRARY ${_GLEW_LINK_INTERFACE})
             select_library_configurations(GLEW)
             if("${_GLEW_DEFS}" MATCHES "GLEW_STATIC")
                 set(GLEW_STATIC_LIBRARIES ${GLEW_LIBRARIES})

--- a/share/cmake/utils/CheckSupportGL.cmake
+++ b/share/cmake/utils/CheckSupportGL.cmake
@@ -42,7 +42,7 @@ if((OCIO_BUILD_TESTS AND OCIO_BUILD_GPU_TESTS) OR OCIO_BUILD_APPS)
         # See a closed duplicate of 19662: https://gitlab.kitware.com/cmake/cmake/-/issues/20699
         # Ported from vcpkg Glew package - https://github.com/microsoft/vcpkg/blob/master/ports/glew/vcpkg-cmake-wrapper.cmake
         # The following code make sure that GLEW_INCLUDE_DIRS is set correctly.
-        if(GLEW_FOUND AND TARGET GLEW::GLEW AND NOT DEFINED GLEW_INCLUDE_DIRS)
+        if(MSVC AND GLEW_FOUND AND TARGET GLEW::GLEW AND NOT DEFINED GLEW_INCLUDE_DIRS)
             get_target_property(GLEW_INCLUDE_DIRS GLEW::GLEW INTERFACE_INCLUDE_DIRECTORIES)
             set(GLEW_INCLUDE_DIR ${GLEW_INCLUDE_DIRS})
             get_target_property(_GLEW_DEFS GLEW::GLEW INTERFACE_COMPILE_DEFINITIONS)
@@ -55,6 +55,7 @@ if((OCIO_BUILD_TESTS AND OCIO_BUILD_GPU_TESTS) OR OCIO_BUILD_APPS)
             endif()
             get_target_property(_GLEW_LINK_INTERFACE GLEW::GLEW IMPORTED_LINK_INTERFACE_LIBRARIES_RELEASE) # same for debug and release
             list(APPEND GLEW_LIBRARIES ${_GLEW_LINK_INTERFACE})
+            list(APPEND GLEW_LIBRARY ${_GLEW_LINK_INTERFACE})
             select_library_configurations(GLEW)
             if("${_GLEW_DEFS}" MATCHES "GLEW_STATIC")
                 set(GLEW_STATIC_LIBRARIES ${GLEW_LIBRARIES})

--- a/src/apps/ocioconvert/CMakeLists.txt
+++ b/src/apps/ocioconvert/CMakeLists.txt
@@ -17,6 +17,13 @@ add_executable(ocioconvert ${SOURCES})
 set_target_properties(ocioconvert PROPERTIES 
     COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
 
+if (USE_MSVC)
+	# Temporary until fixed in OpenImageIO: Mute some warnings from OpenImageIO farmhash.h
+	# C4267 (level 3)	    'var' : conversion from 'size_t' to 'type', possible loss of data
+	# C4244	(level 3 & 4)	'conversion' conversion from 'type1' to 'type2', possible loss of data
+    target_compile_options(ocioconvert PRIVATE /wd4267 /wd4244)
+endif()
+
 target_link_libraries(ocioconvert
     PRIVATE
         apputils

--- a/src/apps/ociodisplay/CMakeLists.txt
+++ b/src/apps/ociodisplay/CMakeLists.txt
@@ -21,6 +21,13 @@ endif()
 set_target_properties(ociodisplay PROPERTIES 
 	COMPILE_FLAGS "${CUSTOM_COMPILE_FLAGS}")
 
+if (USE_MSVC)
+	# Temporary until fixed in OpenImageIO: Mute some warnings from OpenImageIO farmhash.h
+	# C4267 (level 3)	    'var' : conversion from 'size_t' to 'type', possible loss of data
+	# C4244	(level 3 & 4)	'conversion' conversion from 'type1' to 'type2', possible loss of data
+	target_compile_options(ociodisplay PRIVATE /wd4267 /wd4244)
+endif()
+
 target_include_directories(ociodisplay 
 	SYSTEM
 	PRIVATE

--- a/src/apps/ociolutimage/CMakeLists.txt
+++ b/src/apps/ociolutimage/CMakeLists.txt
@@ -10,6 +10,13 @@ add_executable(ociolutimage ${SOURCES})
 set_target_properties(ociolutimage PROPERTIES
 	COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
 
+if (USE_MSVC)
+	# Temporary until fixed in OpenImageIO: Mute some warnings from OpenImageIO farmhash.h
+	# C4267 (level 3)	    'var' : conversion from 'size_t' to 'type', possible loss of data
+	# C4244	(level 3 & 4)	'conversion' conversion from 'type1' to 'type2', possible loss of data
+	target_compile_options(ociolutimage PRIVATE /wd4267 /wd4244)
+endif()
+
 target_link_libraries(ociolutimage
 	PRIVATE
 		apputils

--- a/src/libutils/oiiohelpers/CMakeLists.txt
+++ b/src/libutils/oiiohelpers/CMakeLists.txt
@@ -20,6 +20,13 @@ set_target_properties(oiiohelpers PROPERTIES
     COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}"
 )
 
+if (USE_MSVC)
+	# Temporary until fixed in OpenImageIO: Mute some warnings from OpenImageIO farmhash.h
+	# C4267 (level 3)	    'var' : conversion from 'size_t' to 'type', possible loss of data
+	# C4244	(level 3 & 4)	'conversion' conversion from 'type1' to 'type2', possible loss of data
+	target_compile_options(oiiohelpers PRIVATE /wd4267 /wd4244)
+endif()
+
 target_include_directories(oiiohelpers
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
All issues were discovered when trying to configure and build OCIO on Windows using Microsoft Visual Studio 2022.

Pybind11 has an issue with Microsoft Visual Studio 2022, FindGlew from CMake has a bug around setting GLEW_INCLUDE_DIRS correctly and OpenImageIO as some warnings that get flagged as error. Since those warning are in the OCIO apps, we decided that I would be ok to ignore them temporarily.

Content overview:

Updating Pybind11 to the latest version as Pybind11 <2.9.0 has issues with Microsoft Visual Studio 2022.
Add fix to make sure that GLEW_INCLUDE_DIRS is set correctly.
Ignoring warnings (C4267 and C4244) temporarily in ociolutimage, ocioconvert and oiiohelpers

Reference issue #1634.

Signed-off-by: Cedrik Fuoco <cedrik.fuoco@autodesk.com>