### PR TITLE
Adsk contrib - Remove dev suffix from RB-2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ project(OpenColorIO
     HOMEPAGE_URL https://github.com/AcademySoftwareFoundation/OpenColorIO
     LANGUAGES CXX C)
 
+# "dev", "beta1", rc1", etc or "" for an official release.
+set(OpenColorIO_VERSION_RELEASE_TYPE "")
+
 
 ###############################################################################
 # ctest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,6 @@ project(OpenColorIO
     HOMEPAGE_URL https://github.com/AcademySoftwareFoundation/OpenColorIO
     LANGUAGES CXX C)
 
-# "dev", "beta1", rc1", etc or "" for an official release.
-set(OpenColorIO_VERSION_RELEASE_TYPE "dev")
-
 
 ###############################################################################
 # ctest


### PR DESCRIPTION
Removing dev suffix for 2.0.4 and 2.1.2 patch releases