### PR TITLE
Allow loading dlls from PATH on windows and python>=3.8

### DIFF
--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -227,9 +227,9 @@ target_compile_definitions(PyOpenColorIO
 )
 
 if(WIN32)
-    set(_Python_VARIANT_PATH "${CMAKE_INSTALL_LIBDIR}/site-packages")
+    set(_Python_VARIANT_PATH "${CMAKE_INSTALL_LIBDIR}/site-packages/PyOpenColorIO")
 else()
-    set(_Python_VARIANT_PATH "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+    set(_Python_VARIANT_PATH "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages/PyOpenColorIO")
 endif()
 
 # Create an internal global variable to access it in another scope but not publicly visible
@@ -239,3 +239,5 @@ set(PYTHON_VARIANT_PATH ${_Python_VARIANT_PATH} CACHE INTERNAL "")
 install(TARGETS PyOpenColorIO
     LIBRARY DESTINATION ${_Python_VARIANT_PATH}
 )
+
+install(FILES __init__.py DESTINATION ${_Python_VARIANT_PATH})

--- a/src/bindings/python/__init__.py
+++ b/src/bindings/python/__init__.py
@@ -1,5 +1,9 @@
 import os, sys, platform
 
+# This works around the python 3.8 change to stop loading DLLs from PATH on Windows.
+# We reproduce the old behaviour by manually tokenizing PATH, checking that the directories exist and are not ".",
+# then add them to the DLL load path.
+# This behviour is only enabled if the environment variable "OIIO_LOAD_DLLS_FROM_PATH" is set to "1" so it is opt-in.
 if sys.version_info >= (3, 8) and platform.system() == "Windows" and os.getenv("OCIO_LOAD_DLLS_FROM_PATH", "0") == "1":
     for path in os.getenv("PATH", "").split(os.pathsep):
         if os.path.exists(path) and path != ".":

--- a/src/bindings/python/__init__.py
+++ b/src/bindings/python/__init__.py
@@ -1,0 +1,11 @@
+import os, sys, platform
+
+if sys.version_info >= (3, 8) and platform.system() == "Windows" and os.getenv("OCIO_LOAD_DLLS_FROM_PATH", "0") == "1":
+    for path in os.getenv("PATH", "").split(os.pathsep):
+        if os.path.exists(path) and path != ".":
+            os.add_dll_directory(path)
+
+from .PyOpenColorIO import *
+
+
+


### PR DESCRIPTION
python 3.8 stopped loading DLLs from PATH, which breaks PyOpenColorIO when it and its dependencies have been built as shared libraries. This PR provides an optional (gated behind an env var) fix to shim the paths in PATH back in using `os.add_dll_directory()`. This is the same approach as taken by USD.