### PR TITLE
Log OCIO version for debugging purposes

### DIFF
--- a/src/OpenColorIO/Logging.cpp
+++ b/src/OpenColorIO/Logging.cpp
@@ -53,6 +53,12 @@ void InitLogging()
     {
         g_logginglevel = LOGGING_LEVEL_DEFAULT;
     }
+
+    if (g_logginglevel == LOGGING_LEVEL_DEBUG)
+    {
+        std::cerr << "[OpenColorIO Debug]: Using OpenColorIO version: "
+                  << GetVersion() << "\n";
+    }
 }
 
 // That's the default logging function.


### PR DESCRIPTION
While debugging various DCCs OCIO support through `OCIO_LOGGING_LEVEL`, I found that this simple print of the library version could be useful.