### PR TITLE
MinGW: Work around lack of strtof_l for locale independent parsing

### DIFF
--- a/src/utils/NumberUtils.h
+++ b/src/utils/NumberUtils.h
@@ -99,7 +99,12 @@ really_inline from_chars_result from_chars(const char *first, const char *last, 
 
     float
 #ifdef _WIN32
+#if defined(__MINGW32__) || defined(__MINGW64__)
+    // MinGW doesn't define strtof_l (clang/gcc) nor strtod_l (gcc)...
+    tempval = static_cast<float>(_strtod_l (first, &endptr, loc.local));
+#else
     tempval = _strtof_l(first, &endptr, loc.local);
+#endif
 #elif __APPLE__
     // On OSX, strtod_l is for some reason drastically faster than strtof_l.
     tempval = static_cast<float>(::strtod_l(first, &endptr, loc.local));


### PR DESCRIPTION
👋 

This PR is to catch a slipup in #1496 I've only found yesterday. MinGW-based compilers lack ucrtbase's definition of `_strtof_l` completely, and `strtod_l` is also missing from GCC, so neither are viable alternatives to achieve locale-independent floating point number parsing.

In this patch, I propose to apply a workaround similar to the one existing for macOS, that covers only this flavor of compilers.