### PR TITLE
Adsk Contrib - Required interchange roles

### DIFF
--- a/src/OpenColorIO/Logging.cpp
+++ b/src/OpenColorIO/Logging.cpp
@@ -153,6 +153,20 @@ void LogMessage(LoggingLevel level, const char * message)
     }
 }
 
+void LogError(const std::string & text)
+{
+    AutoMutex lock(g_logmutex);
+    InitLogging();
+
+    // Did not add a LOGGING_LEVEL_ERROR since the enum values are part of the user-facing 
+    // documentation and it is therefore difficult to insert an ERROR value since it would 
+    // naturally need to fall between 0 and 1. But there is no need since presumably users 
+    // that want to see warnings would also want to see errors.
+    if(g_logginglevel<LOGGING_LEVEL_WARNING) return;
+
+    LogMessage("[OpenColorIO Error]: ", text);
+}
+
 void LogWarning(const std::string & text)
 {
     AutoMutex lock(g_logmutex);

--- a/src/OpenColorIO/Logging.h
+++ b/src/OpenColorIO/Logging.h
@@ -11,6 +11,7 @@
 
 namespace OCIO_NAMESPACE
 {
+void LogError(const std::string & text);
 void LogWarning(const std::string & text);
 void LogInfo(const std::string & text);
 void LogDebug(const std::string & text);

--- a/src/apps/ociocheck/main.cpp
+++ b/src/apps/ociocheck/main.cpp
@@ -11,14 +11,19 @@
 namespace OCIO = OCIO_NAMESPACE;
 
 #include "apputils/argparse.h"
+#include "apputils/logGuard.h"
+#include "utils/StringUtils.h"
 
 
 const char * DESC_STRING = "\n\n"
-"ociocheck is useful to validate that the specified OCIO configuration\n"
-"is valid, and that all the color transforms are defined.\n"
+"Ociocheck is useful to validate that the specified OCIO configuration\n"
+"is valid, and that all the color transforms are defined and loadable.\n"
 "For example, it is possible that the configuration may reference\n"
-"lookup tables that do not exist. ociocheck will find these cases.\n\n"
-"ociocheck can also be used to clean up formatting on an existing profile\n"
+"lookup tables that do not exist and ociocheck will find these cases.\n"
+"Unlike the config validate method, ociocheck parses all required LUTs.\n"
+"All display/view pairs, color spaces, and named transforms are checked,\n"
+"regardless of whether they are active or inactive.\n\n"
+"Ociocheck can also be used to clean up formatting on an existing profile\n"
 "that has been manually edited, using the '-o' option.\n";
 
 int main(int argc, const char **argv)
@@ -53,7 +58,7 @@ int main(int argc, const char **argv)
 
     try
     {
-        OCIO::ConstConfigRcPtr config;
+        OCIO::ConstConfigRcPtr srcConfig;
 
         std::cout << std::endl;
         std::cout << "OpenColorIO Library Version: " << OCIO::GetVersion() << std::endl;
@@ -63,13 +68,13 @@ int main(int argc, const char **argv)
         {
             std::cout << std::endl;
             std::cout << "Loading " << inputconfig << std::endl;
-            config = OCIO::Config::CreateFromFile(inputconfig.c_str());
+            srcConfig = OCIO::Config::CreateFromFile(inputconfig.c_str());
         }
         else if(OCIO::GetEnvVariable("OCIO"))
         {
             std::cout << std::endl;
             std::cout << "Loading $OCIO " << OCIO::GetEnvVariable("OCIO") << std::endl;
-            config = OCIO::Config::CreateFromEnv();
+            srcConfig = OCIO::Config::CreateFromEnv();
         }
         else
         {
@@ -81,10 +86,10 @@ int main(int argc, const char **argv)
             return 1;
         }
 
-        std::cout << std::endl;
-        std::cout << "** Miscellaneous **" << std::endl;
-        std::cout << "CacheID: " << config->getCacheID() << std::endl;
-        std::cout << "Archivable: " << (config->isArchivable() ? "yes" : "no") << std::endl;
+        // This program calls getProcessor for every color space and display/view in the config,
+        // so turn off the Processor cache.
+        OCIO::ConfigRcPtr config = srcConfig->createEditableCopy();
+        config->setProcessorCacheFlags(OCIO::PROCESSOR_CACHE_OFF);
 
         std::cout << std::endl;
         std::cout << "** General **" << std::endl;
@@ -118,7 +123,7 @@ int main(int argc, const char **argv)
         if (config->getNumDisplays() == 0)
         {
             std::cout << std::endl;
-            std::cout << "Error: At least one (display, view) pair must be defined." << std::endl;
+            std::cout << "ERROR: At least one (display, view) pair must be defined." << std::endl;
             errorcount += 1;
         }
         else
@@ -127,34 +132,77 @@ int main(int argc, const char **argv)
             std::cout << "Default Display: " << config->getDefaultDisplay() << std::endl;
             std::cout << "Default View: " << config->getDefaultView(config->getDefaultDisplay()) << std::endl;
 
+            // It's important that the getProcessor call below always loads the transforms
+            // involved in each display/view pair.  However, if the src color space is a
+            // data space or if the view's colorspace happens to be the same as the src
+            // color space, it will effectively bypass the loading of the transform.
+            // The work-around used here is to create a copy of the config and add a unique
+            // src color space that will definitely allow the Processor to be created.
+
+            OCIO::ConfigRcPtr displayTestConfig = config->createEditableCopy();
+            auto cs = OCIO::ColorSpace::Create(OCIO::REFERENCE_SPACE_SCENE);
+            const std::string srcColorSpace = "ocioCheckTotallyUniqueColorSpaceName";
+            cs->setName(srcColorSpace.c_str());
+            auto ff = OCIO::FixedFunctionTransform::Create(OCIO::FIXED_FUNCTION_ACES_GLOW_10);
+            cs->setTransform(ff, OCIO::COLORSPACE_DIR_TO_REFERENCE);
+            displayTestConfig->addColorSpace(cs);
+
             if (config->getNumColorSpaces() > 0)
             {
                 std::cout << std::endl;
                 std::cout << "** (Display, View) pairs **" << std::endl;
 
-                const char * inputColorSpace = config->getColorSpaceNameByIndex(0);
+                // Iterate over all displays & views (active & inactive).
 
-                for (int idxDisp = 0; idxDisp < config->getNumDisplays(); ++idxDisp)
+                for (int idxDisp = 0; idxDisp < config->getNumDisplaysAll(); ++idxDisp)
                 {
-                    const char * displayName = config->getDisplay(idxDisp);
-                    for (int idxView = 0; idxView < config->getNumViews(displayName); ++idxView)
-                    {
-                        const char * viewName = config->getView(displayName, idxView);
+                    const char * displayName = config->getDisplayAll(idxDisp);
 
+                    // Iterate over shared views.
+                    int numViews = config->getNumViews(OCIO::VIEW_SHARED, displayName);
+                    for (int idxView = 0; idxView < numViews; ++idxView)
+                    {
+                        const char * viewName = config->getView(OCIO::VIEW_SHARED, 
+                                                                displayName, 
+                                                                idxView);
                         try
                         {
                             OCIO::ConstProcessorRcPtr process 
-                                = config->getProcessor(inputColorSpace, 
-                                                       displayName,
-                                                       viewName,
-                                                       OCIO::TRANSFORM_DIR_FORWARD);
+                                = displayTestConfig->getProcessor(srcColorSpace.c_str(), 
+                                                                  displayName,
+                                                                  viewName,
+                                                                  OCIO::TRANSFORM_DIR_FORWARD);
 
                             std::cout << "(" << displayName << ", " << viewName << ")"
                                       << std::endl;
                         }
                         catch(OCIO::Exception & exception)
                         {
-                            std::cerr << "ERROR: " << exception.what() << std::endl;
+                            std::cout << "ERROR: " << exception.what() << std::endl;
+                            errorcount += 1;
+                        }
+                    }
+
+                    // Iterate over display-defined views.
+                    numViews = config->getNumViews(OCIO::VIEW_DISPLAY_DEFINED, displayName);
+                    for (int idxView = 0; idxView < numViews; ++idxView)
+                    {
+                        const char * viewName = config->getView(OCIO::VIEW_DISPLAY_DEFINED, 
+                                                                displayName, idxView);
+                        try
+                        {
+                            OCIO::ConstProcessorRcPtr process 
+                                = displayTestConfig->getProcessor(srcColorSpace.c_str(), 
+                                                                  displayName,
+                                                                  viewName,
+                                                                  OCIO::TRANSFORM_DIR_FORWARD);
+
+                            std::cout << "(" << displayName << ", " << viewName << ")"
+                                      << std::endl;
+                        }
+                        catch(OCIO::Exception & exception)
+                        {
+                            std::cout << "ERROR: " << exception.what() << std::endl;
                             errorcount += 1;
                         }
                     }
@@ -166,181 +214,326 @@ int main(int argc, const char **argv)
             std::cout << std::endl;
             std::cout << "** Roles **" << std::endl;
 
-            std::set<std::string> usedroles;
-            const char * allroles[] = { OCIO::ROLE_DEFAULT, OCIO::ROLE_SCENE_LINEAR,
-                                        OCIO::ROLE_DATA, OCIO::ROLE_REFERENCE,
-                                        OCIO::ROLE_COMPOSITING_LOG, OCIO::ROLE_COLOR_TIMING,
-                                        OCIO::ROLE_COLOR_PICKING,
-                                        OCIO::ROLE_TEXTURE_PAINT, OCIO::ROLE_MATTE_PAINT,
-                                        OCIO::ROLE_RENDERING,
-                                        OCIO::ROLE_INTERCHANGE_SCENE,
-                                        OCIO::ROLE_INTERCHANGE_DISPLAY,
-                                        NULL };
-            int MAXROLES=256;
-            for(int i=0;i<MAXROLES; ++i)
-            {
-                const char * role = allroles[i];
-                if(!role) break;
-                usedroles.insert(role);
+            // All roles defined in OpenColorTypes.h.
+            std::set<std::string> allRolesSet = { 
+                                                    OCIO::ROLE_DEFAULT, 
+                                                    OCIO::ROLE_SCENE_LINEAR,
+                                                    OCIO::ROLE_DATA, 
+                                                    OCIO::ROLE_REFERENCE,
+                                                    OCIO::ROLE_COMPOSITING_LOG, 
+                                                    OCIO::ROLE_COLOR_TIMING,
+                                                    OCIO::ROLE_COLOR_PICKING,
+                                                    OCIO::ROLE_TEXTURE_PAINT, 
+                                                    OCIO::ROLE_MATTE_PAINT,
+                                                    OCIO::ROLE_RENDERING,
+                                                    OCIO::ROLE_INTERCHANGE_SCENE,
+                                                    OCIO::ROLE_INTERCHANGE_DISPLAY
+                                                };
 
+            // Print a list of the config's roles, appending ": user" if they are not one
+            // of the "standard" roles defined in the library.
+            for(int i=0; i<config->getNumRoles(); ++i)
+            {
+                const char * role = config->getRoleName(i);
                 OCIO::ConstColorSpaceRcPtr cs = config->getColorSpace(role);
                 if(cs)
                 {
-                    std::cout << cs->getName() << " (" << role << ")" << std::endl;
+                    if(allRolesSet.find(role) != allRolesSet.end())
+                    {
+                        std::cout << cs->getName() << " (" << role << ")" << std::endl;
+                    }
+                    else
+                    {
+                        std::cout << cs->getName() << " (" << role << ": user)" << std::endl;
+                    }
                 }
                 else
+                {
+                    // Note: The config->validate check below will also fail due to this.
+                    std::cout << "ERROR: SPACE MISSING (" << role << ")" << std::endl;
+                    errorcount += 1;
+                }
+            }
+
+            // Roles that are actually used by the library or important tools/plug-ins.
+            //   Config::validate ensures these are present for 2.2 and later configs,
+            //   but want to warn if they are missing in earlier configs.  No warnings
+            //   are given for other roles since most are not widely used anymore.
+            std::vector<std::string> essentialRoles = {
+                OCIO::ROLE_SCENE_LINEAR,        // LegacyViewingPipeline
+                OCIO::ROLE_COLOR_TIMING,        // LegacyViewingPipeline
+                OCIO::ROLE_COMPOSITING_LOG,     // LogConvert plug-in
+                OCIO::ROLE_INTERCHANGE_SCENE,   // Used by the library
+                OCIO::ROLE_INTERCHANGE_DISPLAY, // Used by the library
+                };
+
+            // Print a warning for any essential roles that are missing.
+            // (Subsequent sections may raise an error.)
+            for(size_t i=0;i<essentialRoles.size(); ++i)
+            {
+                const std::string role = essentialRoles[i];
+                OCIO::ConstColorSpaceRcPtr cs = config->getColorSpace(role.c_str());
+                if(!cs)
                 {
                     std::cout << "WARNING: NOT DEFINED (" << role << ")" << std::endl;
                 }
             }
+        }
 
-            for(int i=0; i<config->getNumRoles(); ++i)
+        {
+            std::cout << std::endl;
+            std::cout << "** ColorSpaces **" << std::endl;
+
+            const int numCS = config->getNumColorSpaces(
+                OCIO::SEARCH_REFERENCE_SPACE_ALL,   // Iterate over scene & display color spaces.
+                OCIO::COLORSPACE_ALL);              // Iterate over active & inactive color spaces.
+
+            for(int i=0; i<numCS; ++i)
             {
-                const char * role = config->getRoleName(i);
-                if(usedroles.find(role) != usedroles.end()) continue;
+                OCIO::ConstColorSpaceRcPtr cs = config->getColorSpace(config->getColorSpaceNameByIndex(
+                    OCIO::SEARCH_REFERENCE_SPACE_ALL,
+                    OCIO::COLORSPACE_ALL,
+                    i));
 
-                OCIO::ConstColorSpaceRcPtr cs = config->getColorSpace(role);
-                if(cs)
+                // Try to load the transform for the to_ref direction -- this will load any LUTs.
+                bool toRefOK = true;
+                std::string toRefErrorText;
+                try
                 {
-                    std::cout << cs->getName() << " (" << role << ": user)" << std::endl;
+                    OCIO::ConstTransformRcPtr t = cs->getTransform(OCIO::COLORSPACE_DIR_TO_REFERENCE);
+                    if(t)
+                    {
+                        OCIO::ConstProcessorRcPtr p = config->getProcessor(t);
+                    }
+                }
+                catch(OCIO::Exception & exception)
+                {
+                    toRefOK = false;
+                    toRefErrorText = exception.what();
+                }
+
+                // Try to load the transform for the from_ref direction -- this will load any LUTs.
+                bool fromRefOK = true;
+                std::string fromRefErrorText;
+                try
+                {
+                    OCIO::ConstTransformRcPtr t = cs->getTransform(OCIO::COLORSPACE_DIR_FROM_REFERENCE);
+                    if(t)
+                    {
+                        OCIO::ConstProcessorRcPtr p = config->getProcessor(t);
+                    }
+                }
+                catch(OCIO::Exception & exception)
+                {
+                    fromRefOK = false;
+                    fromRefErrorText = exception.what();
+                }
+
+                if(!toRefOK || !fromRefOK)
+                {
+                    // There was a problem with one of the color space's transforms.
+                    std::cout << cs->getName();
+                    std::cout << " -- error" << std::endl;
+                    if(!toRefOK)
+                    {
+                        std::cout << "\t" << toRefErrorText << std::endl;
+                    }
+                    if(!fromRefOK)
+                    {
+                        std::cout << "\t" << fromRefErrorText << std::endl;
+                    }
+                    errorcount += 1;
                 }
                 else
                 {
-                    std::cout << "ERROR: NOT DEFINED" << " (" << role << ")" << std::endl;
-                    errorcount += 1;
-                }
-
-            }
-        }
-
-        std::cout << std::endl;
-        std::cout << "** ColorSpaces **" << std::endl;
-        OCIO::ConstColorSpaceRcPtr lin = config->getColorSpace(OCIO::ROLE_SCENE_LINEAR);
-        if(!lin)
-        {
-            std::cout << "Error: scene_linear role must be defined." << std::endl;
-            errorcount += 1;
-        }
-        else
-        {
-            for(int i=0; i<config->getNumColorSpaces(); ++i)
-            {
-                OCIO::ConstColorSpaceRcPtr cs = config->getColorSpace(config->getColorSpaceNameByIndex(i));
-
-                bool convertsToLinear = true;
-                std::string convertsToLinearErrorText;
-
-                bool convertsFromLinear = true;
-                std::string convertsFromLinearErrorText;
-
-                try
-                {
-                    OCIO::ConstProcessorRcPtr p = config->getProcessor(cs, lin);
-                }
-                catch(OCIO::Exception & exception)
-                {
-                    convertsToLinear = false;
-                    convertsToLinearErrorText = exception.what();
-                }
-
-                try
-                {
-                    OCIO::ConstProcessorRcPtr p = config->getProcessor(lin, cs);
-                }
-                catch(OCIO::Exception & exception)
-                {
-                    convertsFromLinear = false;
-                    convertsFromLinearErrorText = exception.what();
-                }
-
-                if(convertsToLinear && convertsFromLinear)
-                {
+                    // The color space's transforms load ok.
                     std::cout << cs->getName() << std::endl;
                 }
-                else if(!convertsToLinear && !convertsFromLinear)
-                {
-                    std::cout << cs->getName();
-                    std::cout << " -- error" << std::endl;
-                    std::cout << "\t" << convertsToLinearErrorText << std::endl;
-                    std::cout << "\t" << convertsFromLinearErrorText << std::endl;
+            }
+        }
 
+        {
+            std::cout << std::endl;
+            std::cout << "** Named Transforms **" << std::endl;
+
+            // Iterate over active & inactive named transforms.
+            const int numNT = config->getNumNamedTransforms(OCIO::NAMEDTRANSFORM_ALL);
+            if(numNT==0)
+            {
+                std::cout << "no named transforms defined" << std::endl;
+            }
+
+            for(int i = 0; i<numNT; ++i)
+            {
+                OCIO::ConstNamedTransformRcPtr nt = config->getNamedTransform(
+                    config->getNamedTransformNameByIndex(OCIO::NAMEDTRANSFORM_ALL, i));
+
+                // Try to load the transform -- this will load any LUTs.
+                bool fwdOK = true;
+                std::string fwdErrorText;
+                try
+                {
+                    OCIO::ConstTransformRcPtr t = nt->getTransform(OCIO::TRANSFORM_DIR_FORWARD);
+                    if(t)
+                    {
+                        OCIO::ConstProcessorRcPtr p = config->getProcessor(t);
+                    }
+                }
+                catch(OCIO::Exception & exception)
+                {
+                    fwdOK = false;
+                    fwdErrorText = exception.what();
+                }
+
+                // Try to load the inverse_transform -- this will load any LUTs.
+                bool invOK = true;
+                std::string invErrorText;
+                try
+                {
+                    OCIO::ConstTransformRcPtr t = nt->getTransform(OCIO::TRANSFORM_DIR_INVERSE);
+                    if(t)
+                    {
+                        OCIO::ConstProcessorRcPtr p = config->getProcessor(t);
+                    }
+                }
+                catch(OCIO::Exception & exception)
+                {
+                    invOK = false;
+                    invErrorText = exception.what();
+                }
+
+                if(!fwdOK || !invOK)
+                {
+                    // There was a problem with one of the named transform's transforms.
+                    std::cout << nt->getName();
+                    std::cout << " -- error" << std::endl;
+                    if(!fwdOK)
+                    {
+                        std::cout << "\t" << fwdErrorText << std::endl;
+                    }
+                    if(!invOK)
+                    {
+                        std::cout << "\t" << invErrorText << std::endl;
+                    }
                     errorcount += 1;
                 }
-                else if(convertsToLinear)
+                else
                 {
-                    std::cout << cs->getName();
-                    std::cout << " -- input only" << std::endl;
-                }
-                else if(convertsFromLinear)
-                {
-                    std::cout << cs->getName();
-                    std::cout << " -- output only" << std::endl;
+                    // The named transform's transforms load ok.
+                    std::cout << nt->getName() << std::endl;
                 }
             }
         }
 
-        std::cout << std::endl;
-        std::cout << "** Looks **" << std::endl;
-        if(config->getNumLooks()>0)
         {
-            for(int i=0; i<config->getNumLooks(); ++i)
-            {
-                std::cout << config->getLookNameByIndex(i) << std::endl;
+            std::cout << std::endl;
+            std::cout << "** Looks **" << std::endl;
 
+            const int numL = config->getNumLooks();
+            if(numL==0)
+            {
+                std::cout << "no looks defined" << std::endl;
+            }
+
+            for(int i=0; i<numL; ++i)
+            {
                 OCIO::ConstLookRcPtr look = config->getLook(config->getLookNameByIndex(i)); 
 
-                OCIO::ConstTransformRcPtr transform = look->getTransform();         
-
-                if(transform)
+                // Try to load the transform -- this will load any LUTs.
+                bool fwdOK = true;
+                std::string fwdErrorText;
+                try
                 {
-                    try
+                    OCIO::ConstTransformRcPtr t = look->getTransform();
+                    if(t)
                     {
-                        OCIO::ConstProcessorRcPtr process = config->getProcessor(transform);
-                        std::cout << "src file found" << std::endl;
-                    }
-                    catch(OCIO::Exception & exception)
-                    {
-                        std::cerr << "ERROR: " << exception.what() << std::endl;
-                        errorcount += 1;
+                        OCIO::ConstProcessorRcPtr p = config->getProcessor(t);
                     }
                 }
-
-                OCIO::ConstTransformRcPtr invTransform = look->getInverseTransform();         
-
-                if(invTransform)
+                catch(OCIO::Exception & exception)
                 {
-                    try
-                    {
-                        OCIO::ConstProcessorRcPtr process = config->getProcessor(invTransform);
-                        std::cout << "src file found" << std::endl;
-                    }
-                    catch(OCIO::Exception & exception)
-                    {
-                        std::cerr << "ERROR: " << exception.what() << std::endl;
-                        errorcount += 1;
-                    }
+                    fwdOK = false;
+                    fwdErrorText = exception.what();
                 }
 
+                // Try to load the inverse transform -- this will load any LUTs.
+                bool invOK = true;
+                std::string invErrorText;
+                try
+                {
+                    OCIO::ConstTransformRcPtr t = look->getInverseTransform();
+                    if(t)
+                    {
+                        OCIO::ConstProcessorRcPtr p = config->getProcessor(t);
+                    }
+                }
+                catch(OCIO::Exception & exception)
+                {
+                    invOK = false;
+                    invErrorText = exception.what();
+                }
+
+                if(!fwdOK || !invOK)
+                {
+                    // There was a problem with one of the look transform's transforms.
+                    std::cout << look->getName();
+                    std::cout << " -- error" << std::endl;
+                    if(!fwdOK)
+                    {
+                        std::cout << "\t" << fwdErrorText << std::endl;
+                    }
+                    if(!invOK)
+                    {
+                        std::cout << "\t" << invErrorText << std::endl;
+                    }
+                    errorcount += 1;
+                }
+                else
+                {
+                    // The look transform's transforms load ok.
+                    std::cout << look->getName() << std::endl;
+                }
             }
         }
-        else
-        {
-            std::cout << "no looks defined" << std::endl;
-        }
+
         std::cout << std::endl;
         std::cout << "** Validation **" << std::endl;
 
+        std::string cacheID;
+        bool isArchivable = false;
         try
         {
+            LogGuard logGuard;
+
             config->validate();
-            std::cout << "passed" << std::endl;
+            cacheID = config->getCacheID();
+            isArchivable = config->isArchivable();
+
+            // Passed if there are no Error level logs.
+            StringUtils::StringVec svec = StringUtils::SplitByLines(logGuard.output());
+            if (!StringUtils::Contain(svec, "[OpenColorIO Error]"))
+            {
+                std::cout << "passed" << std::endl;
+            }
+            else
+            {
+                std::cout << logGuard.output();
+                std::cout << "failed" << std::endl;
+                errorcount += 1;
+            }
         }
         catch(OCIO::Exception & exception)
         {
-            std::cout << "ERROR" << std::endl;
+            std::cout << "ERROR:" << std::endl;
             errorcount += 1;
             std::cout << exception.what() << std::endl;
+            std::cout << "failed" << std::endl;
         }
+
+        std::cout << std::endl;
+        std::cout << "** Miscellaneous **" << std::endl;
+        std::cout << "CacheID: " << cacheID << std::endl;
+        std::cout << "Archivable: " << (isArchivable ? "yes" : "no") << std::endl;
 
         if(!outputconfig.empty())
         {

--- a/src/apputils/CMakeLists.txt
+++ b/src/apputils/CMakeLists.txt
@@ -4,6 +4,7 @@
 set(SOURCES
     argparse.cpp
     strutil.cpp
+    logGuard.cpp
 )
 
 add_library(apputils STATIC ${SOURCES})

--- a/src/apputils/logGuard.cpp
+++ b/src/apputils/logGuard.cpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#include "logGuard.h"
+
+static std::string g_output;
+void CustomLoggingFunction(const char * message)
+{
+    g_output += message;
+}
+
+LogGuard::LogGuard()
+    :   m_logLevel(OCIO::GetLoggingLevel())
+{
+    OCIO::SetLoggingLevel(OCIO::LOGGING_LEVEL_DEBUG);
+    OCIO::SetLoggingFunction(&CustomLoggingFunction);
+}
+
+LogGuard::~LogGuard()
+{
+    OCIO::ResetToDefaultLoggingFunction();
+    OCIO::SetLoggingLevel(m_logLevel);
+    g_output.clear();
+}
+
+const std::string & LogGuard::output() const
+{
+    return g_output;
+}
+
+void LogGuard::clear()
+{
+    g_output.clear();
+}
+
+bool LogGuard::empty() const
+{
+    return g_output.empty();
+}

--- a/src/apputils/logGuard.h
+++ b/src/apputils/logGuard.h
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#ifndef INCLUDED_LOG_GUARD_H
+#define INCLUDED_LOG_GUARD_H
+
+#include <OpenColorIO/OpenColorIO.h>
+namespace OCIO = OCIO_NAMESPACE;
+
+// Trap any log message while preserving the original logging settings.
+// Note that the mechanism is not thread-safe.
+class LogGuard
+{
+public:
+    LogGuard();
+    LogGuard(const LogGuard &) = delete;
+    LogGuard & operator=(const LogGuard &) = delete;
+    ~LogGuard();
+
+    // Return the output message or null.
+    const std::string & output() const;
+
+    void clear();
+    bool empty() const;
+
+private:
+    OCIO::LoggingLevel m_logLevel;
+};
+
+#endif


### PR DESCRIPTION
Hi,

This is a new PR for issue https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1639. This was done to clean up the rebase commits and to fix the DCO error.

--- 

This PR covers the groundwork for issue https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1639. For now, the validation will not reject a version 2.2 config that doesn't have the interchange roles and the other mandatory roles. Instead, it will log a new error message (still warning level) in order for the validation to not fail.

This PR also updates the config file version number to 2.2.

Ociocheck has been refactored a bit and updated with additional checks. See Doug's [comment ](https://opencolorio.slack.com/archives/C3NLV668M/p1665725355036919)on Slack.

Signed-off-by: Cedrik Fuoco <cedrik.fuoco@autodesk.com>