### PR TITLE
Adsk contrib - Issue with latest ociocheck

### DIFF
--- a/src/apps/ociocheck/main.cpp
+++ b/src/apps/ociocheck/main.cpp
@@ -513,6 +513,7 @@ int main(int argc, const char **argv)
             StringUtils::StringVec svec = StringUtils::SplitByLines(logGuard.output());
             if (!StringUtils::Contain(svec, "[OpenColorIO Error]"))
             {
+                std::cout << logGuard.output();
                 std::cout << "passed" << std::endl;
             }
             else

--- a/src/apps/ociocheck/main.cpp
+++ b/src/apps/ociocheck/main.cpp
@@ -506,6 +506,8 @@ int main(int argc, const char **argv)
             LogGuard logGuard;
 
             config->validate();
+            std::cout << logGuard.output();
+            
             cacheID = config->getCacheID();
             isArchivable = config->isArchivable();
 
@@ -513,12 +515,10 @@ int main(int argc, const char **argv)
             StringUtils::StringVec svec = StringUtils::SplitByLines(logGuard.output());
             if (!StringUtils::Contain(svec, "[OpenColorIO Error]"))
             {
-                std::cout << logGuard.output();
                 std::cout << "passed" << std::endl;
             }
             else
             {
-                std::cout << logGuard.output();
                 std::cout << "failed" << std::endl;
                 errorcount += 1;
             }


### PR DESCRIPTION
An issue was introduced with the recent changes to ociocheck. The logs (warning, etc) weren't printed at all. The PR is fixing that.