### PR TITLE
Adsk contrib - Removing library "dev" label for official release 2.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ project(OpenColorIO
     LANGUAGES CXX C)
 
 # "dev", "beta1", rc1", etc or "" for an official release.
-set(OpenColorIO_VERSION_RELEASE_TYPE "dev")
+set(OpenColorIO_VERSION_RELEASE_TYPE "")
 
 
 ###############################################################################


### PR DESCRIPTION
Signed-off-by: Cédrik Fuoco <cedrik.fuoco@autodesk.com>