### PR TITLE
Increasing version to 2.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 # Project definition.
 
 project(OpenColorIO 
-    VERSION 2.2.0
+    VERSION 2.3.0
     DESCRIPTION "OpenColorIO (OCIO) is a complete color management solution"
     HOMEPAGE_URL https://github.com/AcademySoftwareFoundation/OpenColorIO
     LANGUAGES CXX C)


### PR DESCRIPTION
Since OpenColorIO 2.2 has been released. The version on the main branch has to be incremented.

Signed-off-by: Cédrik Fuoco <cedrik.fuoco@autodesk.com>