### PR TITLE
CheckSupportSSE2: Fix sse flags unexpected propagation

### DIFF
--- a/share/cmake/utils/CheckSupportSSE2.cmake
+++ b/share/cmake/utils/CheckSupportSSE2.cmake
@@ -3,6 +3,8 @@
 
 include(CheckCXXSourceCompiles)
 
+set(_cmake_required_flags_old "${CMAKE_REQUIRED_FLAGS}")
+
 if(NOT CMAKE_SIZE_OF_VOID_P EQUAL 8)
     # As CheckCXXCompilerFlag implicitly uses CMAKE_CXX_FLAGS some custom flags could trigger
     # unrelated warnings causing a detection failure. So, the code disables all warnings to focus
@@ -26,5 +28,8 @@ check_cxx_source_compiles ("
         return (0);
     }"
     HAVE_SSE2)
+
+set(CMAKE_REQUIRED_FLAGS "${_cmake_required_flags_old}")
+unset(_cmake_required_flags_old)
 
 mark_as_advanced(HAVE_SSE2)


### PR DESCRIPTION
Set function will affects all variables in current directory. If sse flags are added in CheckSupportSSE2.cmake, they will remain in Findminizip-ng.cmake which will cause liblzma cannot be detected. This patch keep CMAKE_REQUIRED_FLAGS being changed only in current file scope. This patch has been tested on riscv64.

Signed-off-by: Letu Ren <fantasquex@gmail.com>

This patch fixes build error on riscv64. Cmake output is listed below.
```
-- The CXX compiler identification is GNU 12.2.0
-- The C compiler identification is GNU 12.2.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Setting build type to 'Release' as none was specified.
-- Setting C++ version to '14' as none was specified.
-- Performing Test COMPILER_SUPPORTS_CXX14
-- Performing Test COMPILER_SUPPORTS_CXX14 - Success
-- Found OpenGL: /usr/lib/libOpenGL.so  found components: OpenGL 
-- Found GLEW: /usr/include (found version "2.2.0") 
-- Found GLUT: TRUE  
-- GLVND supported
-- Performing Test HAVE_SSE2
-- Performing Test HAVE_SSE2 - Failed
-- Disabling SSE optimizations, as the target doesn't support them
-- Setting SOVERSION to '2.2' as none was specified.
-- Found expat: /usr/include (found suitable version "2.5.0", minimum required is "2.4.1") 
-- Found yaml-cpp: /usr/lib/libyaml-cpp.so.0.7.0 (found suitable version "0.7.0", minimum required is "0.7.0") 
-- Found pystring: /usr/include (Required is at least version "1.1.3") 
-- Found Imath: /usr/lib/libImath-3_1.so.29.4.0 (found suitable version "3.1.5", minimum required is "3.0") 
-- Found ZLIB: /usr/lib/libz.so (found version "1.2.13") 
-- Found BZip2: /usr/lib/libbz2.so (found version "1.0.8") 
-- Looking for BZ2_bzCompressInit
-- Looking for BZ2_bzCompressInit - not found
-- Looking for lzma_auto_decoder in /usr/lib/liblzma.so
-- Looking for lzma_auto_decoder in /usr/lib/liblzma.so - not found
-- Looking for lzma_easy_encoder in /usr/lib/liblzma.so
-- Looking for lzma_easy_encoder in /usr/lib/liblzma.so - not found
-- Looking for lzma_lzma_preset in /usr/lib/liblzma.so
-- Looking for lzma_lzma_preset in /usr/lib/liblzma.so - not found
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find LibLZMA (missing: LIBLZMA_HAS_AUTO_DECODER
  LIBLZMA_HAS_EASY_ENCODER LIBLZMA_HAS_LZMA_PRESET) (found version "5.2.7")
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake/Modules/FindLibLZMA.cmake:89 (find_package_handle_standard_args)
  /usr/share/cmake/Modules/CMakeFindDependencyMacro.cmake:47 (find_package)
  /usr/lib/cmake/minizip-ng/minizip-ng-config.cmake:39 (find_dependency)
  share/cmake/modules/Findminizip-ng.cmake:21 (find_package)
  share/cmake/modules/FindExtPackages.cmake:51 (find_package)
  CMakeLists.txt:261 (include)


-- Configuring incomplete, errors occurred!
See also "/build/opencolorio/src/OpenColorIO-2.2.0/build/CMakeFiles/CMakeOutput.log".
See also "/build/opencolorio/src/OpenColorIO-2.2.0/build/CMakeFiles/CMakeError.log".
```

CMakeError.log is listed below.
```
Performing C++ SOURCE FILE Test HAVE_SSE2 failed with the following output:
Change Dir: /build/opencolorio/src/OpenColorIO-2.2.0/build/CMakeFiles/CMakeTmp

Run Build Command(s):/usr/bin/ninja cmTC_7ec19 && [1/2] Building CXX object CMakeFiles/cmTC_7ec19.dir/src.cxx.o
FAILED: CMakeFiles/cmTC_7ec19.dir/src.cxx.o 
/usr/bin/c++ -DHAVE_SSE2  -w -msse2 -std=c++14 -o CMakeFiles/cmTC_7ec19.dir/src.cxx.o -c /build/opencolorio/src/OpenColorIO-2.2.0/build/CMakeFiles/CMakeTmp/src.cxx
c++: error: unrecognized command-line option ‘-msse2’
ninja: build stopped: subcommand failed.


Source file was:

    #include <emmintrin.h>
    int main ()
    {
        __m128d a, b;
        double vals[2] = {0};
        a = _mm_loadu_pd (vals);
        b = _mm_add_pd (a,a);
        _mm_storeu_pd (vals,b);
        return (0);
    }
Determining if the BZ2_bzCompressInit exist failed with the following output:
Change Dir: /build/opencolorio/src/OpenColorIO-2.2.0/build/CMakeFiles/CMakeTmp

Run Build Command(s):/usr/bin/ninja cmTC_24eb7 && [1/2] Building C object CMakeFiles/cmTC_24eb7.dir/CheckSymbolExists.c.o
FAILED: CMakeFiles/cmTC_24eb7.dir/CheckSymbolExists.c.o 
/usr/bin/cc   -w -msse2 -o CMakeFiles/cmTC_24eb7.dir/CheckSymbolExists.c.o -c /build/opencolorio/src/OpenColorIO-2.2.0/build/CMakeFiles/CMakeTmp/CheckSymbolExists.c
cc: error: unrecognized command-line option ‘-msse2’
ninja: build stopped: subcommand failed.


File /build/opencolorio/src/OpenColorIO-2.2.0/build/CMakeFiles/CMakeTmp/CheckSymbolExists.c:
/* */
#include <bzlib.h>

int main(int argc, char** argv)
{
  (void)argv;
#ifndef BZ2_bzCompressInit
  return ((int*)(&BZ2_bzCompressInit))[argc];
#else
  (void)argc;
  return 0;
#endif
}
Determining if the function lzma_auto_decoder exists in the /usr/lib/liblzma.so failed with the following output:
Change Dir: /build/opencolorio/src/OpenColorIO-2.2.0/build/CMakeFiles/CMakeTmp

Run Build Command(s):/usr/bin/ninja cmTC_7167f && [1/2] Building C object CMakeFiles/cmTC_7167f.dir/CheckFunctionExists.c.o
FAILED: CMakeFiles/cmTC_7167f.dir/CheckFunctionExists.c.o 
/usr/bin/cc   -DCHECK_FUNCTION_EXISTS=lzma_auto_decoder -w -msse2 -o CMakeFiles/cmTC_7167f.dir/CheckFunctionExists.c.o -c /usr/share/cmake/Modules/CheckFunctionExists.c
cc: error: unrecognized command-line option ‘-msse2’
ninja: build stopped: subcommand failed.



Determining if the function lzma_easy_encoder exists in the /usr/lib/liblzma.so failed with the following output:
Change Dir: /build/opencolorio/src/OpenColorIO-2.2.0/build/CMakeFiles/CMakeTmp

Run Build Command(s):/usr/bin/ninja cmTC_d1708 && [1/2] Building C object CMakeFiles/cmTC_d1708.dir/CheckFunctionExists.c.o
FAILED: CMakeFiles/cmTC_d1708.dir/CheckFunctionExists.c.o 
/usr/bin/cc   -DCHECK_FUNCTION_EXISTS=lzma_easy_encoder -w -msse2 -o CMakeFiles/cmTC_d1708.dir/CheckFunctionExists.c.o -c /usr/share/cmake/Modules/CheckFunctionExists.c
cc: error: unrecognized command-line option ‘-msse2’
ninja: build stopped: subcommand failed.



Determining if the function lzma_lzma_preset exists in the /usr/lib/liblzma.so failed with the following output:
Change Dir: /build/opencolorio/src/OpenColorIO-2.2.0/build/CMakeFiles/CMakeTmp

Run Build Command(s):/usr/bin/ninja cmTC_684ca && [1/2] Building C object CMakeFiles/cmTC_684ca.dir/CheckFunctionExists.c.o
FAILED: CMakeFiles/cmTC_684ca.dir/CheckFunctionExists.c.o 
/usr/bin/cc   -DCHECK_FUNCTION_EXISTS=lzma_lzma_preset -w -msse2 -o CMakeFiles/cmTC_684ca.dir/CheckFunctionExists.c.o -c /usr/share/cmake/Modules/CheckFunctionExists.c
cc: error: unrecognized command-line option ‘-msse2’
ninja: build stopped: subcommand failed.

```