### PR TITLE
Adsk Contrib Ocio cmake improvements

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -291,12 +291,35 @@ jobs:
       - name: Test
         run: ctest -V -C ${{ matrix.build-type }}
         working-directory: _build
-      # The test is valid for both build-shared=ON and build-shared=OFF.
-      - name: Test CMake Consumer
+      - name: Store absolute build path
+        run: |
+          echo "ocio_build_path=$(pwd)" >> $GITHUB_ENV
+      - name: Test CMake Consumer with shared OCIO
+        if: matrix.build-shared == 'ON'
         run: |
           cmake . \
                 -DCMAKE_PREFIX_PATH=../../../_install \
                 -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
+          cmake --build . \
+                --config ${{ matrix.build-type }}
+          ./consumer
+        working-directory: _build/tests/cmake-consumer-dist
+      - name: Test CMake Consumer with static OCIO
+        if: matrix.build-shared == 'OFF'
+        # yaml-cpp_VERSION need to be provided since there is no way to find the version in the
+        # header files. 
+        # Pystring is different because Findpystring does not require pystring_VERSION to be present.
+        run: |
+          cmake . \
+                -DCMAKE_PREFIX_PATH=../../../_install \
+                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
+                -Dexpat_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -DImath_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -Dpystring_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -Dyaml-cpp_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -Dyaml-cpp_VERSION=0.7.0
+                -DZLIB_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -Dminizip-ng_ROOT=${{ env.ocio_build_path }}/ext/dist
           cmake --build . \
                 --config ${{ matrix.build-type }}
           ./consumer
@@ -428,12 +451,35 @@ jobs:
       - name: Test
         run: ctest -V -C ${{ matrix.build-type }}
         working-directory: _build
-      # The test is valid for both build-shared=ON and build-shared=OFF.
-      - name: Test CMake Consumer
+      - name: Store absolute build path
+        run: |
+          echo "ocio_build_path=$(pwd)" >> $GITHUB_ENV
+      - name: Test CMake Consumer with shared OCIO
+        if: matrix.build-shared == 'ON'
         run: |
           cmake . \
                 -DCMAKE_PREFIX_PATH=../../../_install \
                 -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
+          cmake --build . \
+                --config ${{ matrix.build-type }}
+          ./consumer
+        working-directory: _build/tests/cmake-consumer-dist
+      - name: Test CMake Consumer with static OCIO
+        if: matrix.build-shared == 'OFF'
+        # yaml-cpp_VERSION need to be provided since there is no way to find the version in the
+        # header files. 
+        # Pystring is different because Findpystring does not require pystring_VERSION to be present.        
+        run: |
+          cmake . \
+                -DCMAKE_PREFIX_PATH=../../../_install \
+                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
+                -Dexpat_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -DImath_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -Dpystring_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -Dyaml-cpp_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -Dyaml-cpp_VERSION=0.7.0
+                -DZLIB_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -Dminizip-ng_ROOT=${{ env.ocio_build_path }}/ext/dist
           cmake --build . \
                 --config ${{ matrix.build-type }}
           ./consumer
@@ -573,12 +619,38 @@ jobs:
         run: ctest -V -C ${{ matrix.build-type }}
         shell: bash
         working-directory: _build
-      # The test is valid for both build-shared=ON and build-shared=OFF.
-      - name: Test CMake Consumer
+      - name: Store absolute build path
+        run: |
+          echo "ocio_build_path=$(pwd)" >> $GITHUB_ENV
+        shell: bash
+      - name: Test CMake Consumer with shared OCIO
+        if: matrix.build-shared == 'ON'
         run: |
           cmake . \
                 -DCMAKE_PREFIX_PATH=../../../_install \
                 -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
+          cmake --build . \
+                --config ${{ matrix.build-type }}
+          export PATH=../../../_install/bin:$PATH
+          ./${{ matrix.build-type }}/consumer
+        shell: bash
+        working-directory: _build/tests/cmake-consumer-dist
+      - name: Test CMake Consumer with static OCIO
+        if: matrix.build-shared == 'OFF'
+        # yaml-cpp_VERSION need to be provided since there is no way to find the version in the
+        # header files. 
+        # Pystring is different because Findpystring does not require pystring_VERSION to be present.
+        run: |
+          cmake . \
+                -DCMAKE_PREFIX_PATH=../../../_install \
+                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
+                -Dexpat_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -DImath_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -Dpystring_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -Dyaml-cpp_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -Dyaml-cpp_VERSION=0.7.0
+                -DZLIB_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -Dminizip-ng_ROOT=${{ env.ocio_build_path }}/ext/dist
           cmake --build . \
                 --config ${{ matrix.build-type }}
           export PATH=../../../_install/bin:$PATH

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -287,13 +287,11 @@ jobs:
                 --target install \
                 --config ${{ matrix.build-type }} \
                 -- -j$(nproc)
+          echo "ocio_build_path=$(pwd)" >> $GITHUB_ENV
         working-directory: _build
       - name: Test
         run: ctest -V -C ${{ matrix.build-type }}
         working-directory: _build
-      - name: Store absolute build path
-        run: |
-          echo "ocio_build_path=$(pwd)" >> $GITHUB_ENV
       - name: Test CMake Consumer with shared OCIO
         if: matrix.build-shared == 'ON'
         run: |
@@ -306,19 +304,18 @@ jobs:
         working-directory: _build/tests/cmake-consumer-dist
       - name: Test CMake Consumer with static OCIO
         if: matrix.build-shared == 'OFF'
-        # yaml-cpp_VERSION need to be provided since there is no way to find the version in the
-        # header files. 
-        # Pystring is different because Findpystring does not require pystring_VERSION to be present.
+        # The yaml-cpp_VERSION is set below because Findyaml-cpp.cmake needs it but is unable to 
+        # extract it from the headers, like the other modules.
         run: |
           cmake . \
                 -DCMAKE_PREFIX_PATH=../../../_install \
-                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
-                -Dexpat_ROOT=${{ env.ocio_build_path }}/ext/dist
-                -DImath_ROOT=${{ env.ocio_build_path }}/ext/dist
-                -Dpystring_ROOT=${{ env.ocio_build_path }}/ext/dist
-                -Dyaml-cpp_ROOT=${{ env.ocio_build_path }}/ext/dist
-                -Dyaml-cpp_VERSION=0.7.0
-                -DZLIB_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+                -Dexpat_ROOT=${{ env.ocio_build_path }}/ext/dist \
+                -DImath_ROOT=${{ env.ocio_build_path }}/ext/dist \
+                -Dpystring_ROOT=${{ env.ocio_build_path }}/ext/dist \
+                -Dyaml-cpp_ROOT=${{ env.ocio_build_path }}/ext/dist \
+                -Dyaml-cpp_VERSION=0.7.0 \
+                -DZLIB_ROOT=${{ env.ocio_build_path }}/ext/dist \
                 -Dminizip-ng_ROOT=${{ env.ocio_build_path }}/ext/dist
           cmake --build . \
                 --config ${{ matrix.build-type }}
@@ -447,13 +444,11 @@ jobs:
                 --target install \
                 --config ${{ matrix.build-type }} \
                 -- -j$(sysctl -n hw.ncpu)
+          echo "ocio_build_path=$(pwd)" >> $GITHUB_ENV
         working-directory: _build
       - name: Test
         run: ctest -V -C ${{ matrix.build-type }}
         working-directory: _build
-      - name: Store absolute build path
-        run: |
-          echo "ocio_build_path=$(pwd)" >> $GITHUB_ENV
       - name: Test CMake Consumer with shared OCIO
         if: matrix.build-shared == 'ON'
         run: |
@@ -466,19 +461,18 @@ jobs:
         working-directory: _build/tests/cmake-consumer-dist
       - name: Test CMake Consumer with static OCIO
         if: matrix.build-shared == 'OFF'
-        # yaml-cpp_VERSION need to be provided since there is no way to find the version in the
-        # header files. 
-        # Pystring is different because Findpystring does not require pystring_VERSION to be present.        
+        # The yaml-cpp_VERSION is set below because Findyaml-cpp.cmake needs it but is unable to 
+        # extract it from the headers, like the other modules.       
         run: |
           cmake . \
                 -DCMAKE_PREFIX_PATH=../../../_install \
-                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
-                -Dexpat_ROOT=${{ env.ocio_build_path }}/ext/dist
-                -DImath_ROOT=${{ env.ocio_build_path }}/ext/dist
-                -Dpystring_ROOT=${{ env.ocio_build_path }}/ext/dist
-                -Dyaml-cpp_ROOT=${{ env.ocio_build_path }}/ext/dist
-                -Dyaml-cpp_VERSION=0.7.0
-                -DZLIB_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+                -Dexpat_ROOT=${{ env.ocio_build_path }}/ext/dist \
+                -DImath_ROOT=${{ env.ocio_build_path }}/ext/dist \
+                -Dpystring_ROOT=${{ env.ocio_build_path }}/ext/dist \
+                -Dyaml-cpp_ROOT=${{ env.ocio_build_path }}/ext/dist \
+                -Dyaml-cpp_VERSION=0.7.0 \
+                -DZLIB_ROOT=${{ env.ocio_build_path }}/ext/dist \
                 -Dminizip-ng_ROOT=${{ env.ocio_build_path }}/ext/dist
           cmake --build . \
                 --config ${{ matrix.build-type }}
@@ -613,15 +607,13 @@ jobs:
           cmake --build . \
                 --target install \
                 --config ${{ matrix.build-type }}
+          echo "ocio_build_path=$(pwd)" >> $GITHUB_ENV
         shell: bash
         working-directory: _build
       - name: Test
         run: ctest -V -C ${{ matrix.build-type }}
         shell: bash
         working-directory: _build
-      - name: Store absolute build path
-        run: |
-          echo "ocio_build_path=$(pwd)" >> $GITHUB_ENV
         shell: bash
       - name: Test CMake Consumer with shared OCIO
         if: matrix.build-shared == 'ON'
@@ -637,19 +629,18 @@ jobs:
         working-directory: _build/tests/cmake-consumer-dist
       - name: Test CMake Consumer with static OCIO
         if: matrix.build-shared == 'OFF'
-        # yaml-cpp_VERSION need to be provided since there is no way to find the version in the
-        # header files. 
-        # Pystring is different because Findpystring does not require pystring_VERSION to be present.
+        # The yaml-cpp_VERSION is set below because Findyaml-cpp.cmake needs it but is unable to 
+        # extract it from the headers, like the other modules.
         run: |
           cmake . \
                 -DCMAKE_PREFIX_PATH=../../../_install \
-                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
-                -Dexpat_ROOT=${{ env.ocio_build_path }}/ext/dist
-                -DImath_ROOT=${{ env.ocio_build_path }}/ext/dist
-                -Dpystring_ROOT=${{ env.ocio_build_path }}/ext/dist
-                -Dyaml-cpp_ROOT=${{ env.ocio_build_path }}/ext/dist
-                -Dyaml-cpp_VERSION=0.7.0
-                -DZLIB_ROOT=${{ env.ocio_build_path }}/ext/dist
+                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
+                -Dexpat_ROOT=${{ env.ocio_build_path }}/ext/dist \
+                -DImath_ROOT=${{ env.ocio_build_path }}/ext/dist \
+                -Dpystring_ROOT=${{ env.ocio_build_path }}/ext/dist \
+                -Dyaml-cpp_ROOT=${{ env.ocio_build_path }}/ext/dist \
+                -Dyaml-cpp_VERSION=0.7.0 \
+                -DZLIB_ROOT=${{ env.ocio_build_path }}/ext/dist \
                 -Dminizip-ng_ROOT=${{ env.ocio_build_path }}/ext/dist
           cmake --build . \
                 --config ${{ matrix.build-type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,8 @@ set(OCIO_TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets.cmake")
 set(OCIO_VERSION_CONFIG "${CMAKE_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
 set(OCIO_PROJECT_CONFIG "${CMAKE_BINARY_DIR}/${PROJECT_NAME}Config.cmake")
 set(OCIO_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-set(OCIO_CUSTOM_FIND_MODULE_DIR "${CMAKE_INSTALL_PREFIX}/cmake")
+set(OCIO_CUSTOM_FIND_MODULE_DIR "${CMAKE_INSTALL_PREFIX}/share/cmake/modules")
+set(OCIO_CUSTOM_MACROS_MODULE_DIR "${CMAKE_INSTALL_PREFIX}/share/cmake/macros")
 
 # Version fetched from the top level project()
 write_basic_package_version_file(
@@ -331,17 +332,25 @@ install(
     FILE ${OCIO_TARGETS_EXPORT_NAME}
 )
 
-# Install custom Find modules.
-install(FILES
-    ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findexpat.cmake
-    ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/FindImath.cmake
-    ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findpystring.cmake
-    ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findminizip.cmake
-    ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findminizip-ng.cmake
-    ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findzlib.cmake
-    ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findyaml-cpp.cmake
-    DESTINATION ${OCIO_CUSTOM_FIND_MODULE_DIR}
-)
+if (NOT BUILD_SHARED_LIBS)
+    # Install custom macros used in the find modules.
+    install(FILES
+        ${CMAKE_CURRENT_LIST_DIR}/share/cmake/macros/VersionUtils.cmake
+        DESTINATION ${OCIO_CUSTOM_MACROS_MODULE_DIR}
+    )
+
+    # Install custom Find modules.
+    install(FILES
+        ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findexpat.cmake
+        ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/FindImath.cmake
+        ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findpystring.cmake
+        ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findminizip.cmake
+        ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findminizip-ng.cmake
+        ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findzlib.cmake
+        ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findyaml-cpp.cmake
+        DESTINATION ${OCIO_CUSTOM_FIND_MODULE_DIR}
+    )
+endif()
 
 install(
     FILES "${OCIO_PROJECT_CONFIG}" "${OCIO_VERSION_CONFIG}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,8 +308,8 @@ set(OCIO_TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets.cmake")
 set(OCIO_VERSION_CONFIG "${CMAKE_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake")
 set(OCIO_PROJECT_CONFIG "${CMAKE_BINARY_DIR}/${PROJECT_NAME}Config.cmake")
 set(OCIO_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-set(OCIO_CUSTOM_FIND_MODULE_DIR "${CMAKE_INSTALL_PREFIX}/share/cmake/modules")
-set(OCIO_CUSTOM_MACROS_MODULE_DIR "${CMAKE_INSTALL_PREFIX}/share/cmake/macros")
+set(OCIO_CUSTOM_FIND_MODULE_DIR "${CMAKE_INSTALL_PREFIX}/share/OpenColorIO/cmake/modules")
+set(OCIO_CUSTOM_MACROS_MODULE_DIR "${CMAKE_INSTALL_PREFIX}/share/OpenColorIO/cmake/macros")
 
 # Version fetched from the top level project()
 write_basic_package_version_file(
@@ -346,7 +346,6 @@ if (NOT BUILD_SHARED_LIBS)
         ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findpystring.cmake
         ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findminizip.cmake
         ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findminizip-ng.cmake
-        ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findzlib.cmake
         ${CMAKE_CURRENT_LIST_DIR}/share/cmake/modules/Findyaml-cpp.cmake
         DESTINATION ${OCIO_CUSTOM_FIND_MODULE_DIR}
     )

--- a/share/cmake/modules/FindExtPackages.cmake
+++ b/share/cmake/modules/FindExtPackages.cmake
@@ -41,10 +41,33 @@ find_package(pystring 1.1.3 REQUIRED)
 set(_Imath_ExternalProject_VERSION "3.1.5")
 find_package(Imath 3.0 REQUIRED)
 
-# ZLIB
-# https://github.com/madler/zlib
-set(_zlib_ExternalProject_VERSION "1.2.12")
-find_package(zlib 1.2.11 REQUIRED)
+###############################################################################
+### ZLIB (https://github.com/madler/zlib)
+###############################################################################
+set(_ZLIB_FIND_VERSION "1.2.11")
+set(_ZLIB_ExternalProject_VERSION ${_ZLIB_FIND_VERSION})
+
+if(NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL ALL)
+    # ZLIB_USE_STATIC_LIBS is supported only from CMake 3.24+.
+    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0") 
+        if (ZLIB_STATIC_LIBRARY)
+            set(ZLIB_USE_STATIC_LIBS "${ZLIB_STATIC_LIBRARY}")
+        endif()
+    endif()
+
+    set(_ZLIB_REQUIRED REQUIRED)
+    # Override REQUIRED if package can be installed
+    if(OCIO_INSTALL_EXT_PACKAGES STREQUAL MISSING)
+        set(_ZLIB_REQUIRED "")
+    endif()
+
+    find_package(ZLIB ${_ZLIB_FIND_VERSION} ${_ZLIB_REQUIRED})
+endif()
+
+if(NOT ZLIB_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
+    include(InstallZLIB)
+endif()
+###############################################################################
 
 # minizip-ng
 # https://github.com/zlib-ng/minizip-ng

--- a/share/cmake/modules/FindExtPackages.cmake
+++ b/share/cmake/modules/FindExtPackages.cmake
@@ -43,6 +43,11 @@ find_package(Imath 3.0 REQUIRED)
 
 ###############################################################################
 ### ZLIB (https://github.com/madler/zlib)
+###
+### Since OCIO is using CMake's FindZLIB, it supports the same output variables
+### and the same variables that can be overridden.
+###
+### See https://cmake.org/cmake/help/latest/module/FindZLIB.html
 ###############################################################################
 set(_ZLIB_FIND_VERSION "1.2.11")
 set(_ZLIB_ExternalProject_VERSION ${_ZLIB_FIND_VERSION})

--- a/share/cmake/modules/FindImath.cmake
+++ b/share/cmake/modules/FindImath.cmake
@@ -131,7 +131,7 @@ endif()
 ###############################################################################
 ### Install package from source ###
 
-if(NOT Imath_FOUND AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
+if(NOT Imath_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
     include(ExternalProject)
     include(GNUInstallDirs)
 

--- a/share/cmake/modules/FindOpenEXR.cmake
+++ b/share/cmake/modules/FindOpenEXR.cmake
@@ -89,13 +89,14 @@ if(NOT OpenEXR_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACK
     set(_EXT_BUILD_ROOT "${CMAKE_BINARY_DIR}/ext/build")
 
     # Required dependency
-    # OCIO custom module to find ZLIB. (Findzlib)
-    find_package(zlib)
     if(NOT ZLIB_FOUND)
-        message(STATUS "ZLib is required to build OpenEXR.")
-        return()
+        find_package(ZLIB)
+        if(NOT ZLIB_FOUND)
+            message(STATUS "ZLib is required to build OpenEXR.")
+            return()
+        endif()
     endif()
-
+    
     find_package(Threads)
     if(NOT Threads_FOUND)
         message(STATUS "Threads is required to build OpenEXR.")

--- a/share/cmake/modules/FindOpenEXR.cmake
+++ b/share/cmake/modules/FindOpenEXR.cmake
@@ -81,7 +81,7 @@ macro(set_target_location target_name)
     endif()
 endmacro()
 
-if(NOT OpenEXR_FOUND AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
+if(NOT OpenEXR_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
     include(ExternalProject)
     include(GNUInstallDirs)
 

--- a/share/cmake/modules/Findexpat.cmake
+++ b/share/cmake/modules/Findexpat.cmake
@@ -162,7 +162,7 @@ endif()
 ###############################################################################
 ### Install package from source ###
 
-if(NOT expat_FOUND AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
+if(NOT expat_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
     include(ExternalProject)
     include(GNUInstallDirs)
 

--- a/share/cmake/modules/Findlcms2.cmake
+++ b/share/cmake/modules/Findlcms2.cmake
@@ -97,7 +97,7 @@ endif()
 ###############################################################################
 ### Install package from source ###
 
-if(NOT lcms2_FOUND AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
+if(NOT lcms2_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
     include(ExternalProject)
 
     set(_EXT_DIST_ROOT "${CMAKE_BINARY_DIR}/ext/dist")

--- a/share/cmake/modules/Findminizip-ng.cmake
+++ b/share/cmake/modules/Findminizip-ng.cmake
@@ -189,7 +189,7 @@ if(NOT minizip_FOUND AND NOT TARGET MINIZIP::minizip)
 
     ###############################################################################
     ### Install package from source ###
-    if(NOT minizip-ng_FOUND AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
+    if(NOT minizip-ng_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
         include(ExternalProject)
         include(GNUInstallDirs)
 

--- a/share/cmake/modules/Findopenfx.cmake
+++ b/share/cmake/modules/Findopenfx.cmake
@@ -58,7 +58,7 @@ endif()
 ###############################################################################
 ### Install package from source ###
 
-if(NOT openfx_FOUND AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
+if(NOT openfx_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
     include(ExternalProject)
     include(GNUInstallDirs)
 

--- a/share/cmake/modules/Findpybind11.cmake
+++ b/share/cmake/modules/Findpybind11.cmake
@@ -134,7 +134,7 @@ endif()
 ###############################################################################
 ### Install package from source ###
 
-if(NOT pybind11_FOUND AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
+if(NOT pybind11_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
     include(ExternalProject)
     include(GNUInstallDirs)
 

--- a/share/cmake/modules/Findpystring.cmake
+++ b/share/cmake/modules/Findpystring.cmake
@@ -66,7 +66,7 @@ endif()
 ###############################################################################
 ### Install package from source ###
 
-if(NOT pystring_FOUND AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
+if(NOT pystring_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
     include(ExternalProject)
 
     set(_EXT_DIST_ROOT "${CMAKE_BINARY_DIR}/ext/dist")

--- a/share/cmake/modules/Findyaml-cpp.cmake
+++ b/share/cmake/modules/Findyaml-cpp.cmake
@@ -130,7 +130,7 @@ endif()
 ###############################################################################
 ### Install package from source ###
 
-if(NOT yaml-cpp_FOUND AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
+if(NOT yaml-cpp_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
     include(ExternalProject)
     include(GNUInstallDirs)
 

--- a/share/cmake/modules/Findzlib.cmake
+++ b/share/cmake/modules/Findzlib.cmake
@@ -107,7 +107,7 @@ endif()
 
 ###############################################################################
 ### Install package from source ###
-if(NOT ZLIB_FOUND AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
+if(NOT ZLIB_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
     include(ExternalProject)
     include(GNUInstallDirs)
 

--- a/share/cmake/modules/Findzlib.cmake
+++ b/share/cmake/modules/Findzlib.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 #
-# Locate or install zlib
+# Locate or install ZLIB
 # 
 # **********************************************************************
 # Note that this is a wrapper around the CMake ZLIB find module.
@@ -39,10 +39,12 @@ if(NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL ALL)
     endif()
 
     # ZLIB_USE_STATIC_LIBS is supported only from CMake 3.24+.
-    if (ZLIB_STATIC_LIBRARY)
-        set(ZLIB_USE_STATIC_LIBS "${ZLIB_STATIC_LIBRARY}")
-    elseif(zlib_STATIC_LIBRARY)
-        set(ZLIB_USE_STATIC_LIBS "${zlib_STATIC_LIBRARY}")
+    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0") 
+        if (ZLIB_STATIC_LIBRARY)
+            set(ZLIB_USE_STATIC_LIBS "${ZLIB_STATIC_LIBRARY}")
+        elseif(zlib_STATIC_LIBRARY)
+            set(ZLIB_USE_STATIC_LIBS "${zlib_STATIC_LIBRARY}")
+        endif()
     endif()
 
     # Forcing CMake to use its own find module called FindZLIB.cmake.
@@ -59,20 +61,21 @@ if(NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL ALL)
     set(CMAKE_MODULE_PATH ${_ZLIB__CMAKE_MODULE_PATH_OLD_})
 
     if (ZLIB_FOUND)
-        # CMake find modules sets ZLIB_LIBRARIES and ZLIB_INCLUDE_DIRS.
-        
+        # Right now, OCIO custom find modules uses the following standard: 
+        # <pkg_name>_LIBRARY and <pkg_name>_INCLUDE_DIR
+        # But CMake's FindZLIB sets ZLIB_LIBRARIES and ZLIB_INCLUDE_DIRS.
+
+        # Set ZLIB_LIBRARY if it is not set already.
         if(ZLIB_LIBRARIES AND NOT ZLIB_LIBRARY)
-            # Set ZLIB_LIBRARY to match the others OCIO's custom find modules.
             set(ZLIB_LIBRARY "${ZLIB_LIBRARIES}")
         endif()
 
+        # Set ZLIB_INCLUDE_DIR if it is not set already.
         if(ZLIB_INCLUDE_DIRS AND NOT ZLIB_INCLUDE_DIR)
-            # Set ZLIB_LIBRARY to match the others OCIO's custom find modules.
             set(ZLIB_INCLUDE_DIR "${ZLIB_INCLUDE_DIRS}")
         endif()
         
         # CMake FindZLIB uses ZLIB_VERSION_STRING for CMake < 3.26. 
-        # CMake 3.26 will update that variable to ZLIB_VERSION.
         if (ZLIB_VERSION_STRING)
             set(ZLIB_VERSION "${ZLIB_VERSION_STRING}")
         endif()

--- a/share/cmake/modules/InstallZLIB.cmake
+++ b/share/cmake/modules/InstallZLIB.cmake
@@ -3,6 +3,9 @@
 #
 # Install ZLIB
 #
+# Except for the variable ZLIB_VERSION_STRING, OCIO sets the same variables as the 
+# CMake's FindZLIB when installing ZLIB manually.
+#
 # Variables defined by this module:
 #   ZLIB_FOUND          - If FALSE, do not try to link to zlib
 #   ZLIB_LIBRARIES      - ZLIB library to link to

--- a/share/cmake/modules/InstallZLIB.cmake
+++ b/share/cmake/modules/InstallZLIB.cmake
@@ -1,14 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 #
-# Locate or install ZLIB
-# 
-# **********************************************************************
-# Note that this is a wrapper around the CMake ZLIB find module.
-# This find module DOES NOT output any variables with lowercase "zlib".
-# 
-# Treat this module as if it was FindZLIB.cmake. 
-# **********************************************************************
+# Install ZLIB
 #
 # Variables defined by this module:
 #   ZLIB_FOUND          - If FALSE, do not try to link to zlib
@@ -17,96 +10,23 @@
 #   ZLIB_VERSION        - The version of the library
 #
 # Targets defined by this module:
-#   ZLIB::ZLIB - IMPORTED target, if found
+#   ZLIB::ZLIB          - Properties:
+#                         IMPORTED_LOCATION ${ZLIB_LIBRARIES}
+#                         INTERFACE_INCLUDE_DIRECTORIES ${ZLIB_INCLUDE_DIRS}
 #
 ###############################################################################
-### Try to find package ###
-
-if(NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL ALL)
-    # Update ZLIB_ROOT if zlib_ROOT was set.
-    if (zlib_ROOT)
-        set(ZLIB_ROOT "${zlib_ROOT}")
-    endif()
-
-    # Update ZLIB_LIBRARY if zlib_LIBRARY was set. 
-    if (zlib_LIBRARY)
-        set(ZLIB_LIBRARY "${zlib_LIBRARY}")
-    endif()
-
-    # Update ZLIB_INCLUDE_DIR if zlib_INCLUDE_DIR was set. 
-    if (zlib_INCLUDE_DIR)
-        set(ZLIB_INCLUDE_DIR "${zlib_INCLUDE_DIR}")
-    endif()
-
-    # ZLIB_USE_STATIC_LIBS is supported only from CMake 3.24+.
-    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0") 
-        if (ZLIB_STATIC_LIBRARY)
-            set(ZLIB_USE_STATIC_LIBS "${ZLIB_STATIC_LIBRARY}")
-        elseif(zlib_STATIC_LIBRARY)
-            set(ZLIB_USE_STATIC_LIBS "${zlib_STATIC_LIBRARY}")
-        endif()
-    endif()
-
-    # Forcing CMake to use its own find module called FindZLIB.cmake.
-    # Save old value of CMAKE_MODULE_PATH 
-    set(_ZLIB__CMAKE_MODULE_PATH_OLD_ ${CMAKE_MODULE_PATH})
-    # Force find_package to use CMAKE module and not custom modules.
-    set(CMAKE_MODULE_PATH "${CMAKE_ROOT}/Modules") 
-
-    # Use CMake FindZLIB module. (ZLIB in capital letters is important)
-    # FindZLIB supports ZLIB_ROOT, ZLIB_LIBRARIES and ZLIB_INCLUDE_DIRS.
-    find_package(ZLIB ${zlib_FIND_VERSION} QUIET)
-
-    # Restore CMAKE_MODULE_PATH
-    set(CMAKE_MODULE_PATH ${_ZLIB__CMAKE_MODULE_PATH_OLD_})
-
-    if (ZLIB_FOUND)
-        # Right now, OCIO custom find modules uses the following standard: 
-        # <pkg_name>_LIBRARY and <pkg_name>_INCLUDE_DIR
-        # But CMake's FindZLIB sets ZLIB_LIBRARIES and ZLIB_INCLUDE_DIRS.
-
-        # Set ZLIB_LIBRARY if it is not set already.
-        if(ZLIB_LIBRARIES AND NOT ZLIB_LIBRARY)
-            set(ZLIB_LIBRARY "${ZLIB_LIBRARIES}")
-        endif()
-
-        # Set ZLIB_INCLUDE_DIR if it is not set already.
-        if(ZLIB_INCLUDE_DIRS AND NOT ZLIB_INCLUDE_DIR)
-            set(ZLIB_INCLUDE_DIR "${ZLIB_INCLUDE_DIRS}")
-        endif()
-        
-        # CMake FindZLIB uses ZLIB_VERSION_STRING for CMake < 3.26. 
-        if (ZLIB_VERSION_STRING)
-            set(ZLIB_VERSION "${ZLIB_VERSION_STRING}")
-        endif()
-    endif()
-
-    # Override REQUIRED if package can be installed
-    if(OCIO_INSTALL_EXT_PACKAGES STREQUAL MISSING)
-        set(zlib_FIND_REQUIRED FALSE)
-        set(ZLIB_FIND_REQUIRED FALSE)
-    endif()
-
-    include(FindPackageHandleStandardArgs)
-    find_package_handle_standard_args(zlib
-        REQUIRED_VARS
-            ZLIB_LIBRARY
-            ZLIB_INCLUDE_DIR
-        VERSION_VAR
-            ZLIB_VERSION
-    )
-endif()
 
 ###############################################################################
 ### Create target
-
+###############################################################################
 if(NOT TARGET ZLIB::ZLIB)
     add_library(ZLIB::ZLIB UNKNOWN IMPORTED GLOBAL)
     set(_ZLIB_TARGET_CREATE TRUE)
 endif()
 
 ###############################################################################
-### Install package from source ###
+### Install package from source
+###############################################################################
 if(NOT ZLIB_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL NONE)
     include(ExternalProject)
     include(GNUInstallDirs)
@@ -127,8 +47,9 @@ if(NOT ZLIB_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAGE
     if(_ZLIB_ExternalProject_VERSION)
         set(ZLIB_VERSION ${_ZLIB_ExternalProject_VERSION})
     else()
-        set(ZLIB_VERSION ${zlib_FIND_VERSION})
+        set(ZLIB_VERSION ${ZLIB_FIND_VERSION})
     endif()
+
     set(ZLIB_INCLUDE_DIRS "${_EXT_DIST_ROOT}/${CMAKE_INSTALL_INCLUDEDIR}")
 
     # Windows need the "d" suffix at the end.
@@ -217,9 +138,10 @@ if(NOT ZLIB_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAGE
     message(STATUS "Installing ZLIB: ${ZLIB_LIBRARIES} (version \"${ZLIB_VERSION}\")")
 endif()
 
+
 ###############################################################################
 ### Configure target ###
-
+###############################################################################
 if(_ZLIB_TARGET_CREATE)
     set_target_properties(ZLIB::ZLIB PROPERTIES
         IMPORTED_LOCATION ${ZLIB_LIBRARIES}

--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -2,52 +2,55 @@
 
 include(CMakeFindDependencyMacro)
 
-# Get the install directory.
-set(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}")
-# Get the install directory. Since the current file is under 
-# <install directory>/lib/cmake/OpenColorIO going back three directory.
-foreach(i RANGE 1 3)
-    get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
-    if(_IMPORT_PREFIX STREQUAL "/")
-      set(_IMPORT_PREFIX "")
-      break()
+if (NOT @BUILD_SHARED_LIBS@)
+    # Get the install directory.
+    set(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}")
+    # Get the install directory. Since the current file is under 
+    # <install directory>/lib/cmake/OpenColorIO going back three directory.
+    foreach(i RANGE 1 3)
+        get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+        if(_IMPORT_PREFIX STREQUAL "/")
+        set(_IMPORT_PREFIX "")
+        break()
+        endif()
+    endforeach()
+
+    # Append OCIO custom find module path.
+    list(APPEND CMAKE_MODULE_PATH "${_IMPORT_PREFIX}/share/cmake/modules")
+    list(APPEND CMAKE_MODULE_PATH "${_IMPORT_PREFIX}/share/cmake/macros")
+
+    ########################
+    # Required dependencies 
+    ########################
+
+    if (NOT expat::expat)
+        find_dependency(expat @expat_VERSION@)
     endif()
-endforeach()
 
-# Append OCIO custom find module path.
-list(APPEND CMAKE_MODULE_PATH "${_IMPORT_PREFIX}/cmake")
+    if (NOT Imath::Imath)
+        find_dependency(Imath @Imath_VERSION@)
+    endif()
 
-########################
-# Required dependencies 
-########################
+    if (NOT pystring::pystring)
+        find_dependency(pystring @pystring_VERSION@)
+    endif()
 
-if (NOT expat::expat)
-    find_dependency(expat @expat_VERSION@)
+    if (NOT yaml-cpp)
+        find_dependency(yaml-cpp @yaml-cpp_VERSION@)
+    endif()
+
+    # CMake has a zlib find module, but OCIO is using its own find module for zlib. (Findzlib.cmake)
+    if (NOT ZLIB::ZLIB)
+        find_dependency(zlib @ZLIB_VERSION@)
+    endif()
+
+    if (NOT MINIZIP::minizip-ng)
+        find_dependency(minizip-ng @minizip-ng_VERSION@)
+    endif()
+
+    # Remove OCIO custom find module path.
+    list(REMOVE_AT CMAKE_MODULE_PATH -1)
 endif()
-
-if (NOT Imath::Imath)
-    find_dependency(Imath @Imath_VERSION@)
-endif()
-
-if (NOT pystring::pystring)
-    find_dependency(pystring @pystring_VERSION@)
-endif()
-
-if (NOT yaml-cpp)
-    find_dependency(yaml-cpp @yaml-cpp_VERSION@)
-endif()
-
-# CMake has a zlib find module, but OCIO is using its own find module for zlib. (Findzlib.cmake)
-if (NOT ZLIB::ZLIB)
-    find_dependency(zlib @ZLIB_VERSION@)
-endif()
-
-if (NOT MINIZIP::minizip-ng)
-    find_dependency(minizip-ng @minizip-ng_VERSION@)
-endif()
-
-# Remove OCIO custom find module path.
-list(REMOVE_AT CMAKE_MODULE_PATH -1)
 
 include(${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake)
 

--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -16,8 +16,8 @@ if (NOT @BUILD_SHARED_LIBS@)
     endforeach()
 
     # Append OCIO custom find module path.
-    list(APPEND CMAKE_MODULE_PATH "${_IMPORT_PREFIX}/share/cmake/modules")
-    list(APPEND CMAKE_MODULE_PATH "${_IMPORT_PREFIX}/share/cmake/macros")
+    list(APPEND CMAKE_MODULE_PATH "${_IMPORT_PREFIX}/share/OpenColorIO/cmake/modules")
+    list(APPEND CMAKE_MODULE_PATH "${_IMPORT_PREFIX}/share/OpenColorIO/cmake/macros")
 
     ########################
     # Required dependencies 
@@ -39,9 +39,15 @@ if (NOT @BUILD_SHARED_LIBS@)
         find_dependency(yaml-cpp @yaml-cpp_VERSION@)
     endif()
 
-    # CMake has a zlib find module, but OCIO is using its own find module for zlib. (Findzlib.cmake)
     if (NOT ZLIB::ZLIB)
-        find_dependency(zlib @ZLIB_VERSION@)
+        # ZLIB_VERSION is available starting CMake 3.26+.
+        # ZLIB_VERSION_STRING is still available for backward compatibility.
+        # See https://cmake.org/cmake/help/git-stage/module/FindZLIB.html
+        if (@ZLIB_VERSION@)
+            find_dependency(ZLIB @ZLIB_VERSION@)
+        else()
+            find_dependency(ZLIB @ZLIB_VERSION_STRING@)
+        endif()
     endif()
 
     if (NOT MINIZIP::minizip-ng)


### PR DESCRIPTION
This PR covers a series of improvements for the build process of OCIO.

This PR is **fixing** the following **opened issues**:
- [Build failing on CMake < 3.18 when using external OpenEXR #1719](https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1719)
- [Missing library dependencies when building static libs #169](https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1698)

It might also help with this issue : [centos7 static build - lib missing symbols from pystring, expat, cpp-yaml #1453](https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1453)
I wasn't able to reproduce the issue. It'll need to be re-tested.

**Improvements:**
- Added a cmake-consumer test when building OCIO as a static library.
- Added a general warning when building OCIO as a static library instead of per package.
- Fixed issues with OCIO package configuration file (config.cmake.in)
- OCIO is now sharing its custom Find modules to be used with OCIO package configuration file.
- Split our custom Findzlib in order to use the CMake's FindZLIB module instead.
- Improvement to minizip-ng's find module.
