### PR TITLE
Adsk Contrib - Fix inverse Lut1D optimization issue

### DIFF
--- a/src/OpenColorIO/ops/lut1d/Lut1DOpData.h
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpData.h
@@ -179,6 +179,8 @@ public:
 
     OpDataRcPtr getIdentityReplacement() const override;
 
+    OpDataRcPtr getPairIdentityReplacement(ConstLut1DOpDataRcPtr & lut2) const;
+
     inline const ComponentProperties & getRedProperties() const
     {
         return m_componentProperties[0];


### PR DESCRIPTION
This is a bug-fix to improve how Lut1D pair identities are handled during optimization.  The clamp that is inserted when removing a pair identity now better matches the behavior of the original LUTs rather than being hard-coded to [0,1].  This now handles the case of normal-domain LUTs with extended range values and/or flat regions.

Fixes issue #1737.

Signed-off-by: Doug Walker <doug.walker@autodesk.com>