### PR TITLE
Integration - Port some fixes from main to RB-2.1 - Adsk Contrib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ project(OpenColorIO
     LANGUAGES CXX C)
 
 # "dev", "beta1", rc1", etc or "" for an official release.
-set(OpenColorIO_VERSION_RELEASE_TYPE "dev")
+set(OpenColorIO_VERSION_RELEASE_TYPE "")
 
 
 ###############################################################################

--- a/src/OpenColorIO/GpuShaderUtils.cpp
+++ b/src/OpenColorIO/GpuShaderUtils.cpp
@@ -143,9 +143,13 @@ std::string getTexSample(GpuLanguage lang,
     switch (lang)
     {
         case GPU_LANGUAGE_GLSL_1_2:
-        case GPU_LANGUAGE_GLSL_1_3:
         {
             kw << "texture" << N << "D(" << samplerName << ", " << coords << ")";
+            break;
+        }
+        case GPU_LANGUAGE_GLSL_1_3:
+        {
+            kw << "texture(" << samplerName << ", " << coords << ")";
             break;
         }
         case GPU_LANGUAGE_GLSL_ES_1_0:

--- a/src/OpenColorIO/GpuShaderUtils.cpp
+++ b/src/OpenColorIO/GpuShaderUtils.cpp
@@ -1072,8 +1072,10 @@ std::string GpuShaderText::atan2(const std::string & y,
         }
         case GPU_LANGUAGE_HLSL_DX11:
         {
-            // note: operand order is swapped in HLSL
-            kw << "atan2(" << x << ", " << y << ")";
+            // note: Various internet sources claim that the x & y arguments need to be
+            // swapped for HLSL (relative to GLSL).  However, recent testing on Windows
+            // has revealed that the argument order needs to be the same as GLSL.
+            kw << "atan2(" << y << ", " << x << ")";
             break;
         }
         case LANGUAGE_OSL_1:

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpData.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpData.cpp
@@ -280,6 +280,86 @@ OpDataRcPtr Lut1DOpData::getIdentityReplacement() const
     return res;
 }
 
+OpDataRcPtr Lut1DOpData::getPairIdentityReplacement(ConstLut1DOpDataRcPtr & lut2) const
+{
+    OpDataRcPtr res;
+    if (isInputHalfDomain())
+    {
+        // TODO: If a half-domain LUT has a flat spot, it would be more appropriate
+        // to use a Range, since some areas would be clamped in a round-trip.
+        // Currently leaving this a Matrix since it is a potential work-around
+        // for situations where you want a pair identity of LUTs to be totally
+        // removed, even if it omits some clamping at extreme values.
+        res = std::make_shared<MatrixOpData>();
+    }
+    else
+    {
+        // Note that the ops have been finalized by the time this is called,
+        // Therefore, for an inverse Lut1D, it means initializeFromForward() has
+        // been called and so any reversals have been converted to flat regions.
+        // Therefore, the first and last LUT entries are the extreme values and
+        // the ComponentProperties has been initialized, but only for the op
+        // whose direction is INVERSE.
+        const Lut1DOpData * invLut = (m_direction == TRANSFORM_DIR_INVERSE)
+            ? this: lut2.get();
+        const ComponentProperties & redProperties = invLut->getRedProperties();
+        const unsigned long length = invLut->getArray().getLength();
+
+        // If the start or end of the LUT contains a flat region, that will cause
+        // a round-trip to be limited.
+
+        double minValue = 0.;
+        double maxValue = 1.;
+        switch (m_direction)
+        {
+        case TRANSFORM_DIR_FORWARD: // Fwd Lut1D -> Inv Lut1D
+        {
+            // A round-trip in this order will impose at least a clamp to [0,1]
+            // based on what happens entering the first Fwd Lut1D.  However, the
+            // clamping may be to an even narrower range if there are flat regions.
+            //
+            // The flat region limitation is imposed based on the where it falls
+            // relative to the [0,1] input domain.
+
+            // TODO: A RangeOp has one min & max for all channels, whereas a Lut1D may 
+            // have three independent channels.  Potentially could look at all chans
+            // and take the extrema of each?  For now, just using the first channel.
+            const unsigned long minIndex = redProperties.startDomain;
+            const unsigned long maxIndex = redProperties.endDomain;
+
+            minValue = (double)minIndex / (length - 1);
+            maxValue = (double)maxIndex / (length - 1);
+            break;
+        }
+        case TRANSFORM_DIR_INVERSE: // Inv Lut1D -> Fwd Lut1D
+        {
+            // A round-trip in this order will impose a clamp, but it may be to
+            // bounds outside of [0,1] since the Fwd LUT may contain values outside
+            // [0,1] and so the Inv LUT will accept inputs on that extended range.
+            //
+            // The flat region limitation is imposed based on the output range.
+
+            const bool isIncreasing = redProperties.isIncreasing;
+            const unsigned long maxChannels = invLut->getArray().getMaxColorComponents();
+            const unsigned long lastValIndex = (length - 1) * maxChannels;
+            // Note that the array for the invLut has had initializeFromForward()
+            // done and so any reversals have been converted to flat regions and
+            // the extrema are at the beginning & end of the LUT.
+            const Array::Values & lutValues = invLut->getArray().getValues();
+
+            // TODO: Currently only basing this on the red channel.
+            minValue = isIncreasing ? lutValues[0] : lutValues[lastValIndex];
+            maxValue = isIncreasing ? lutValues[lastValIndex] : lutValues[0];
+            break;
+        }
+        }
+
+        res = std::make_shared<RangeOpData>(minValue, maxValue,
+                                            minValue, maxValue);
+    }
+    return res;
+}
+
 void Lut1DOpData::setInputHalfDomain(bool isHalfDomain) noexcept
 {
     m_halfFlags = (isHalfDomain) ?

--- a/src/OpenColorIO/ops/lut1d/Lut1DOpData.h
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOpData.h
@@ -179,6 +179,8 @@ public:
 
     OpDataRcPtr getIdentityReplacement() const override;
 
+    OpDataRcPtr getPairIdentityReplacement(ConstLut1DOpDataRcPtr & lut2) const;
+
     inline const ComponentProperties & getRedProperties() const
     {
         return m_componentProperties[0];

--- a/src/OpenColorIO/transforms/FileTransform.cpp
+++ b/src/OpenColorIO/transforms/FileTransform.cpp
@@ -240,6 +240,16 @@ bool CollectContextVariables(const Config &,
         usedContextVars->addStringVars(ctxFilepath);
     }
 
+    // Check if the CCCID is using a context variable and add it to the context if that's the case.
+    ContextRcPtr ctxCCCID = Context::Create();
+    const char * cccid = tr.getCCCId();
+    std::string resolvedCCCID = context.resolveStringVar(cccid, ctxCCCID);
+    if (0 != strcmp(resolvedCCCID.c_str(), cccid))
+    {
+        foundContextVars = true;
+        usedContextVars->addStringVars(ctxCCCID);
+    }
+
     return foundContextVars;
 }
 

--- a/src/utils/NumberUtils.h
+++ b/src/utils/NumberUtils.h
@@ -99,7 +99,12 @@ really_inline from_chars_result from_chars(const char *first, const char *last, 
 
     float
 #ifdef _WIN32
+#if defined(__MINGW32__) || defined(__MINGW64__)
+    // MinGW doesn't define strtof_l (clang/gcc) nor strtod_l (gcc)...
+    tempval = static_cast<float>(_strtod_l (first, &endptr, loc.local));
+#else
     tempval = _strtof_l(first, &endptr, loc.local);
+#endif
 #elif __APPLE__
     // On OSX, strtod_l is for some reason drastically faster than strtof_l.
     tempval = static_cast<float>(::strtod_l(first, &endptr, loc.local));

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -7610,6 +7610,61 @@ OCIO_ADD_TEST(Config, context_variables_typical_use_cases)
                           cfg->getProcessor(ctx2, "cs1", "cs2").get());
         }
     }
+
+
+    // Case 7 - Context variables in the FileTransform's CCCID.
+    {
+        static const std::string CONFIG = 
+            "ocio_profile_version: 2\n"
+            "\n"
+            "environment:\n"
+            "  CCPREFIX: cc\n"
+            "\n"
+            "search_path: " + OCIO::GetTestFilesDir() + "\n"
+            "\n"
+            "roles:\n"
+            "  default: cs1\n"
+            "\n"
+            "displays:\n"
+            "  disp1:\n"
+            "    - !<View> {name: view1, colorspace: cs2}\n"
+            "\n"
+            "colorspaces:\n"
+            "  - !<ColorSpace>\n"
+            "    name: cs1\n"
+            "\n"
+            "  - !<ColorSpace>\n"
+            "    name: cs2\n"
+            "    from_scene_reference: !<FileTransform> {src: cdl_test1.ccc, cccid: $CCPREFIX00$CCNUM}\n";
+
+        std::istringstream iss;
+        iss.str(CONFIG);
+
+        OCIO::ConfigRcPtr cfg;
+        OCIO_CHECK_NO_THROW(cfg = OCIO::Config::CreateFromStream(iss)->createEditableCopy());
+        OCIO_CHECK_NO_THROW(cfg->validate());
+
+        OCIO::ConstTransformRcPtr ctf = cfg->getColorSpace("cs2")->getTransform(
+            OCIO::COLORSPACE_DIR_FROM_REFERENCE
+        );
+        OCIO_REQUIRE_ASSERT(ctf);
+
+        OCIO::ContextRcPtr ctx = cfg->getCurrentContext()->createEditableCopy();
+        
+        ctx->setStringVar("CCNUM", "01");
+        OCIO::ConstProcessorRcPtr p1 = cfg->getProcessor(ctx, ctf, OCIO::TRANSFORM_DIR_FORWARD);
+        
+        ctx->setStringVar("CCNUM", "02");
+        OCIO::ConstProcessorRcPtr p2 = cfg->getProcessor(ctx, ctf, OCIO::TRANSFORM_DIR_FORWARD);
+
+        ctx->setStringVar("CCNUM", "03");
+        OCIO::ConstProcessorRcPtr p3 = cfg->getProcessor(ctx, ctf, OCIO::TRANSFORM_DIR_FORWARD);
+
+        // All three processors should be different.
+        OCIO_CHECK_NE(p1.get(), p2.get());
+        OCIO_CHECK_NE(p1.get(), p3.get());
+        OCIO_CHECK_NE(p2.get(), p3.get());
+    }
 }
 
 OCIO_ADD_TEST(Config, virtual_display)

--- a/tests/cpu/transforms/FileTransform_tests.cpp
+++ b/tests/cpu/transforms/FileTransform_tests.cpp
@@ -431,4 +431,56 @@ OCIO_ADD_TEST(FileTransform, context_variables)
 
     // A basic check to validate that context variables are correctly used. 
     OCIO_CHECK_NO_THROW(cfg->getProcessor(ctx, file, OCIO::TRANSFORM_DIR_FORWARD));
+
+
+    {
+        // Case 4 - The 'cccid' now contains a context variable
+        static const std::string CONFIG = 
+            "ocio_profile_version: 2\n"
+            "\n"
+            "environment:\n"
+            "  CCPREFIX: cc\n"
+            "  CCNUM: 02\n"
+            "\n"
+            "search_path: " + OCIO::GetTestFilesDir() + "\n"
+            "\n"
+            "roles:\n"
+            "  default: cs1\n"
+            "\n"
+            "displays:\n"
+            "  disp1:\n"
+            "    - !<View> {name: view1, colorspace: cs2}\n"
+            "\n"
+            "colorspaces:\n"
+            "  - !<ColorSpace>\n"
+            "    name: cs1\n"
+            "\n"
+            "  - !<ColorSpace>\n"
+            "    name: cs2\n"
+            "    from_scene_reference: !<FileTransform> {src: cdl_test1.ccc, cccid: $CCPREFIX00$CCNUM}\n";
+
+            std::istringstream iss;
+            iss.str(CONFIG);
+
+            OCIO::ConstConfigRcPtr cfg;
+            OCIO_CHECK_NO_THROW(cfg = OCIO::Config::CreateFromStream(iss));
+            OCIO_CHECK_NO_THROW(cfg->validate());
+
+            ctx = cfg->getCurrentContext()->createEditableCopy();
+            OCIO_CHECK_NO_THROW(ctx->setStringVar("CCNUM", "01"));
+
+            usedContextVars = OCIO::Context::Create(); // New & empty instance.
+            OCIO::ConstTransformRcPtr tr1 = cfg->getColorSpace("cs2")->getTransform(
+                OCIO::COLORSPACE_DIR_FROM_REFERENCE
+            );
+            OCIO::ConstFileTransformRcPtr fTr1 = OCIO::DynamicPtrCast<const OCIO::FileTransform>(tr1);
+            OCIO_CHECK_ASSERT(fTr1);
+            
+            OCIO_CHECK_ASSERT(CollectContextVariables(*cfg, *ctx, *fTr1, usedContextVars));
+            OCIO_CHECK_EQUAL(2, usedContextVars->getNumStringVars());
+            OCIO_CHECK_EQUAL(std::string("CCPREFIX"), usedContextVars->getStringVarNameByIndex(0));
+            OCIO_CHECK_EQUAL(std::string("cc"), usedContextVars->getStringVarByIndex(0));
+            OCIO_CHECK_EQUAL(std::string("CCNUM"), usedContextVars->getStringVarNameByIndex(1));
+            OCIO_CHECK_EQUAL(std::string("01"), usedContextVars->getStringVarByIndex(1));
+    }
 }


### PR DESCRIPTION
**Integration PR**

The first commit is the version release type name to empty. Each subsequent commit was cherry-picked from the main branch.

These commits correspond to the following PRs:
[MinGW: Work around lack of strtof_l for locale independent parsing](https://github.com/AcademySoftwareFoundation/OpenColorIO/pull/1697)
[Adsk contrib - Fix atan2 argument order for HLSL](https://github.com/AcademySoftwareFoundation/OpenColorIO/pull/1712)
[Replace texture2D function with texture for GLSL 1.3](https://github.com/AcademySoftwareFoundation/OpenColorIO/pull/1723)
[Adsk contrib - Processor cache does not detect changes in cccid](https://github.com/AcademySoftwareFoundation/OpenColorIO/pull/1726)
[Adsk Contrib - Fix inverse Lut1D optimization issue](https://github.com/AcademySoftwareFoundation/OpenColorIO/pull/1743)