### PR TITLE
WIP: add high-precision GPU trilinear interpolation for 3D LUTs

### DIFF
--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -619,6 +619,13 @@ enum OptimizationFlags : unsigned long
      */
     OPTIMIZATION_NO_DYNAMIC_PROPERTIES           = 0x10000000,
 
+    /**
+     * For GPU processor, use native trilinear interpolation for 3D LUTs.  This is faster,
+     * but on many GPUs also lower precision.  With low-resolution LUTs, LUTs with large
+     * extents, or LUTs applied in a linear color space this can sometimes cause color banding.
+     */
+    OPTIMIZATION_NATIVE_GPU_TRILINEAR            = 0x20000000,
+
     /// Apply all possible optimizations.
     OPTIMIZATION_ALL                             = 0xFFFFFFFF,
 
@@ -645,6 +652,7 @@ enum OptimizationFlags : unsigned long
                               OPTIMIZATION_COMP_LUT1D |
                               OPTIMIZATION_LUT_INV_FAST |
                               OPTIMIZATION_FAST_LOG_EXP_POW |
+                              OPTIMIZATION_NATIVE_GPU_TRILINEAR |
                               OPTIMIZATION_COMP_SEPARABLE_PREFIX),
 
     OPTIMIZATION_GOOD      = OPTIMIZATION_VERY_GOOD | OPTIMIZATION_COMP_LUT3D,

--- a/src/OpenColorIO/GPUProcessor.cpp
+++ b/src/OpenColorIO/GPUProcessor.cpp
@@ -85,6 +85,9 @@ void GPUProcessor::Impl::finalize(const OpRcPtrVec & rawOps, OptimizationFlags o
     // Is NoOp ?
     m_isNoOp  = m_ops.isNoOp();
 
+    // Store optimization flags for use when generating shader code.
+    m_oFlags = oFlags;
+
     // Does the color processing introduce crosstalk between the pixel channels?
     m_hasChannelCrosstalk = m_ops.hasChannelCrosstalk();
 
@@ -104,7 +107,7 @@ void GPUProcessor::Impl::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCrea
     // Create the shader program information.
     for(const auto & op : m_ops)
     {
-        op->extractGpuShaderInfo(shaderCreator);
+        op->extractGpuShaderInfo(shaderCreator, m_oFlags);
     }
 
     WriteShaderHeader(shaderCreator);

--- a/src/OpenColorIO/GPUProcessor.h
+++ b/src/OpenColorIO/GPUProcessor.h
@@ -41,6 +41,7 @@ private:
     OpRcPtrVec    m_ops;
     bool          m_isNoOp = false;
     bool          m_hasChannelCrosstalk = true;
+    OptimizationFlags m_oFlags = OPTIMIZATION_DEFAULT;
     std::string   m_cacheID;
     mutable Mutex m_mutex;
 };

--- a/src/OpenColorIO/Op.h
+++ b/src/OpenColorIO/Op.h
@@ -246,7 +246,7 @@ public:
     virtual bool supportedByLegacyShader() const { return true; }
 
     // Create & add the gpu shader information needed by the op. Op has to be finalized.
-    virtual void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const = 0;
+    virtual void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags oFlags = OPTIMIZATION_DEFAULT) const = 0;
 
     virtual bool isDynamic() const;
     virtual bool hasDynamicProperty(DynamicPropertyType type) const;

--- a/src/OpenColorIO/ops/cdl/CDLOp.cpp
+++ b/src/OpenColorIO/ops/cdl/CDLOp.cpp
@@ -50,7 +50,7 @@ public:
 
     ConstOpCPURcPtr getCPUOp(bool fastLogExpPow) const override;
 
-    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const override;
 
 protected:
     ConstCDLOpDataRcPtr cdlData() const { return DynamicPtrCast<const CDLOpData>(data()); }
@@ -133,7 +133,7 @@ ConstOpCPURcPtr CDLOp::getCPUOp(bool fastLogExpPow) const
     return GetCDLCPURenderer(data, fastLogExpPow);
 }
 
-void CDLOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
+void CDLOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const
 {
     ConstCDLOpDataRcPtr data = cdlData();
     GetCDLGPUShaderProgram(shaderCreator, data);

--- a/src/OpenColorIO/ops/exponent/ExponentOp.cpp
+++ b/src/OpenColorIO/ops/exponent/ExponentOp.cpp
@@ -150,7 +150,7 @@ public:
 
     ConstOpCPURcPtr getCPUOp(bool fastLogExpPow) const override;
 
-    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const override;
 
 protected:
     ConstExponentOpDataRcPtr expData() const { return DynamicPtrCast<const ExponentOpData>(data()); }
@@ -251,7 +251,7 @@ ConstOpCPURcPtr ExponentOp::getCPUOp(bool /*fastLogExpPow*/) const
     return std::make_shared<ExponentOpCPU>(expData());
 }
 
-void ExponentOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
+void ExponentOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const
 {
     GpuShaderText ss(shaderCreator->getLanguage());
     ss.indent();

--- a/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOp.cpp
+++ b/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOp.cpp
@@ -49,7 +49,7 @@ public:
 
     ConstOpCPURcPtr getCPUOp(bool fastLogExpPow) const override;
 
-    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const override;
 
 protected:
     ConstExposureContrastOpDataRcPtr ecData() const
@@ -135,7 +135,7 @@ ConstOpCPURcPtr ExposureContrastOp::getCPUOp(bool /*fastLogExpPow*/) const
     return GetExposureContrastCPURenderer(ecOpData);
 }
 
-void ExposureContrastOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
+void ExposureContrastOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const
 {
     ConstExposureContrastOpDataRcPtr ecOpData = ecData();
     GetExposureContrastGPUShaderProgram(shaderCreator, ecOpData);

--- a/src/OpenColorIO/ops/fixedfunction/FixedFunctionOp.cpp
+++ b/src/OpenColorIO/ops/fixedfunction/FixedFunctionOp.cpp
@@ -45,7 +45,7 @@ public:
 
     ConstOpCPURcPtr getCPUOp(bool fastLogExpPow) const override;
 
-    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const override;
 
 protected:
     ConstFixedFunctionOpDataRcPtr fnData() const { return DynamicPtrCast<const FixedFunctionOpData>(data()); }
@@ -125,7 +125,7 @@ ConstOpCPURcPtr FixedFunctionOp::getCPUOp(bool /*fastLogExpPow*/) const
     return GetFixedFunctionCPURenderer(data);
 }
 
-void FixedFunctionOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
+void FixedFunctionOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const
 {
     ConstFixedFunctionOpDataRcPtr fnOpData = fnData();
     GetFixedFunctionGPUShaderProgram(shaderCreator, fnOpData);

--- a/src/OpenColorIO/ops/gamma/GammaOp.cpp
+++ b/src/OpenColorIO/ops/gamma/GammaOp.cpp
@@ -44,7 +44,7 @@ public:
 
     ConstOpCPURcPtr getCPUOp(bool fastLogExpPow) const override;
 
-    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const override;
 
 protected:
     ConstGammaOpDataRcPtr gammaData() const { return DynamicPtrCast<const GammaOpData>(data()); }
@@ -123,7 +123,7 @@ ConstOpCPURcPtr GammaOp::getCPUOp(bool fastLogExpPow) const
     return GetGammaRenderer(data, fastLogExpPow);
 }
 
-void GammaOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
+void GammaOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const
 {
     ConstGammaOpDataRcPtr data = gammaData();
     GetGammaGPUShaderProgram(shaderCreator, data);

--- a/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOp.cpp
+++ b/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOp.cpp
@@ -52,7 +52,7 @@ public:
 
     ConstOpCPURcPtr getCPUOp(bool fastLogExpPow) const override;
 
-    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const override;
 
 protected:
     ConstGradingPrimaryOpDataRcPtr primaryData() const
@@ -190,7 +190,7 @@ ConstOpCPURcPtr GradingPrimaryOp::getCPUOp(bool /*fastLogExpPow*/) const
     return GetGradingPrimaryCPURenderer(data);
 }
 
-void GradingPrimaryOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
+void GradingPrimaryOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const
 {
     ConstGradingPrimaryOpDataRcPtr data = primaryData();
     GetGradingPrimaryGPUShaderProgram(shaderCreator, data);

--- a/src/OpenColorIO/ops/gradingrgbcurve/GradingRGBCurveOp.cpp
+++ b/src/OpenColorIO/ops/gradingrgbcurve/GradingRGBCurveOp.cpp
@@ -52,7 +52,7 @@ public:
 
     ConstOpCPURcPtr getCPUOp(bool fastLogExpPow) const override;
 
-    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const override;
 
 protected:
     ConstGradingRGBCurveOpDataRcPtr rgbCurveData() const
@@ -190,7 +190,7 @@ ConstOpCPURcPtr GradingRGBCurveOp::getCPUOp(bool /*fastLogExpPow*/) const
     return GetGradingRGBCurveCPURenderer(data);
 }
 
-void GradingRGBCurveOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
+void GradingRGBCurveOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const
 {
     ConstGradingRGBCurveOpDataRcPtr data = rgbCurveData();
     GetGradingRGBCurveGPUShaderProgram(shaderCreator, data);

--- a/src/OpenColorIO/ops/gradingtone/GradingToneOp.cpp
+++ b/src/OpenColorIO/ops/gradingtone/GradingToneOp.cpp
@@ -52,7 +52,7 @@ public:
 
     ConstOpCPURcPtr getCPUOp(bool fastLogExpPow) const override;
 
-    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const override;
 
 protected:
     ConstGradingToneOpDataRcPtr toneData() const
@@ -184,7 +184,7 @@ ConstOpCPURcPtr GradingToneOp::getCPUOp(bool /*fastLogExpPow*/) const
     return GetGradingToneCPURenderer(data);
 }
 
-void GradingToneOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
+void GradingToneOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const
 {
     ConstGradingToneOpDataRcPtr data = toneData();
     GetGradingToneGPUShaderProgram(shaderCreator, data);

--- a/src/OpenColorIO/ops/log/LogOp.cpp
+++ b/src/OpenColorIO/ops/log/LogOp.cpp
@@ -44,7 +44,7 @@ public:
 
     ConstOpCPURcPtr getCPUOp(bool fastLogExpPow) const override;
 
-    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const override;
 
 protected:
     ConstLogOpDataRcPtr logData() const { return DynamicPtrCast<const LogOpData>(data()); }
@@ -110,7 +110,7 @@ ConstOpCPURcPtr LogOp::getCPUOp(bool fastLogExpPow) const
     return GetLogRenderer(data, fastLogExpPow);
 }
 
-void LogOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
+void LogOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const
 {
     ConstLogOpDataRcPtr data = logData();
     GetLogGPUShaderProgram(shaderCreator, data);

--- a/src/OpenColorIO/ops/lut1d/Lut1DOp.cpp
+++ b/src/OpenColorIO/ops/lut1d/Lut1DOp.cpp
@@ -52,7 +52,7 @@ public:
     ConstOpCPURcPtr getCPUOp(bool fastLogExpPow) const override;
 
     bool supportedByLegacyShader() const override { return false; }
-    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const override;
 
     ConstLut1DOpDataRcPtr lut1DData() const { return DynamicPtrCast<const Lut1DOpData>(data()); }
     Lut1DOpDataRcPtr lut1DData() { return DynamicPtrCast<Lut1DOpData>(data()); }
@@ -154,7 +154,7 @@ ConstOpCPURcPtr Lut1DOp::getCPUOp(bool /*fastLogExpPow*/) const
     return GetLut1DRenderer(data, BIT_DEPTH_F32, BIT_DEPTH_F32);
 }
 
-void Lut1DOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
+void Lut1DOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const
 {
     ConstLut1DOpDataRcPtr lutData = lut1DData();
     if (lutData->getDirection() == TRANSFORM_DIR_INVERSE)

--- a/src/OpenColorIO/ops/lut3d/Lut3DOp.cpp
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOp.cpp
@@ -98,7 +98,7 @@ public:
     ConstOpCPURcPtr getCPUOp(bool fastLogExpPow) const override;
 
     bool supportedByLegacyShader() const override { return false; }
-    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags oFlags) const override;
 
 protected:
     ConstLut3DOpDataRcPtr lut3DData() const
@@ -200,7 +200,7 @@ ConstOpCPURcPtr Lut3DOp::getCPUOp(bool /*fastLogExpPow*/) const
     return GetLut3DRenderer(data);
 }
 
-void Lut3DOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
+void Lut3DOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags oFlags) const
 {
     ConstLut3DOpDataRcPtr lutData = lut3DData();
     if (lutData->getDirection() == TRANSFORM_DIR_INVERSE)
@@ -216,7 +216,7 @@ void Lut3DOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
         lutData = tmp;
     }
 
-    GetLut3DGPUShaderProgram(shaderCreator, lutData);
+    GetLut3DGPUShaderProgram(shaderCreator, lutData, oFlags);
 }
 }
 

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpGPU.h
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpGPU.h
@@ -12,7 +12,7 @@
 namespace OCIO_NAMESPACE
 {
 
-void GetLut3DGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator, ConstLut3DOpDataRcPtr & lutData);
+void GetLut3DGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator, ConstLut3DOpDataRcPtr & lutData, OptimizationFlags oFlags);
 
 } // namespace OCIO_NAMESPACE
 

--- a/src/OpenColorIO/ops/matrix/MatrixOp.cpp
+++ b/src/OpenColorIO/ops/matrix/MatrixOp.cpp
@@ -62,7 +62,7 @@ public:
 
     ConstOpCPURcPtr getCPUOp(bool fastLogExpPow) const override;
 
-    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const override;
 
 protected:
     ConstMatrixOpDataRcPtr matrixData() const { return DynamicPtrCast<const MatrixOpData>(data()); }
@@ -187,7 +187,7 @@ ConstOpCPURcPtr MatrixOffsetOp::getCPUOp(bool /*fastLogExpPow*/) const
     return GetMatrixRenderer(data);
 }
 
-void MatrixOffsetOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
+void MatrixOffsetOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const
 {
     ConstMatrixOpDataRcPtr data = matrixData();
     if (data->getDirection() == TRANSFORM_DIR_INVERSE)

--- a/src/OpenColorIO/ops/noop/NoOps.cpp
+++ b/src/OpenColorIO/ops/noop/NoOps.cpp
@@ -51,7 +51,7 @@ public:
     void apply(const void * inImg, void * outImg, long numPixels) const override
     { memcpy(outImg, inImg, numPixels * 4 * sizeof(float)); }
 
-    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & /*shaderCreator*/) const override {}
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & /*shaderCreator*/, OptimizationFlags /*oFlags*/) const override {}
 
     void getGpuAllocation(AllocationData & allocation) const;
 
@@ -322,7 +322,7 @@ public:
     void apply(const void * inImg, void * outImg, long numPixels) const override
     { memcpy(outImg, inImg, numPixels * 4 * sizeof(float)); }
 
-    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & /*shaderCreator*/) const override {}
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & /*shaderCreator*/, OptimizationFlags /*oFlags*/) const override {}
 
 private:
     std::string m_fileReference;
@@ -408,7 +408,7 @@ public:
     void apply(const void * inImg, void * outImg, long numPixels) const override
     { memcpy(outImg, inImg, numPixels * 4 * sizeof(float)); }
 
-    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & /*shaderCreator*/) const override {}
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & /*shaderCreator*/, OptimizationFlags /*oFlags*/) const override {}
 
 private:
     std::string m_look;

--- a/src/OpenColorIO/ops/range/RangeOp.cpp
+++ b/src/OpenColorIO/ops/range/RangeOp.cpp
@@ -51,7 +51,7 @@ public:
 
     ConstOpCPURcPtr getCPUOp(bool fastLogExpPow) const override;
 
-    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const override;
+    void extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const override;
 
 protected:
     ConstRangeOpDataRcPtr rangeData() const { return DynamicPtrCast<const RangeOpData>(data()); }
@@ -199,7 +199,7 @@ ConstOpCPURcPtr RangeOp::getCPUOp(bool /*fastLogExpPow*/) const
     return GetRangeRenderer(data);
 }
 
-void RangeOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator) const
+void RangeOp::extractGpuShaderInfo(GpuShaderCreatorRcPtr & shaderCreator, OptimizationFlags /*oFlags*/) const
 {
     ConstRangeOpDataRcPtr data = rangeData();
     if (data->getDirection() == TRANSFORM_DIR_INVERSE)


### PR DESCRIPTION
This new code path can be enabled by disabling the new default-enabled OPTIMIZATION_NATIVE_GPU_TRILINEAR optimization flag.

The existing code path used the GPU's native trilinear texture interpolation function, which (although faster) quantized the lookup coordinates and could cause color banding.  That's still the default, but now full-precision trilinear interpolation can optionally be used instead.

## WIP

This is PR is WIP.  It functions, but it's not ready to merge yet:

- It wasn't clear how best to get the optimization flags to the shader generation code in `GetLut3DGPUShaderProgram()`.  I tried several approaches, but every approach ended up affecting *some* public API.
- The approach I finally landed on was to store the optimization flags in `GPUProcessor::Impl`, and then pass them to `Op::extractGpuShaderInfo()` via a new argument with a default value.  Of all the approaches I tried, this seemed to have the lowest impact on both the code and the API.
- Unfortunately, this still breaks ABI compatibility (I think--I'm not totally sure how default arguments work at the ABI level in C++).  Additionally, default arguments are apparently [forbidden](https://opencolorio.readthedocs.io/en/latest/guides/contributing/contributing.html#misc-rules) in the OCIO code base, so that's probably not the way forward, regardless.

I am *very much* open to suggestions for a better approach to get the optimization flags to `GetLut3DGPUShaderProgram()`.

## Performance

Some initial naive performance tests indicate that the high precision code is notably slower than than GPU-native trilinear interpolation, but about on par with OCIO's tetrahedral interpolation.  More testing is needed, however.  For example, using higher-res LUTs and testing on a variety of GPUs.  I'll update with actual data once I've had a better go at this.