### PR TITLE
Adsk contrib - Fix for dependencies workflow

### DIFF
--- a/.github/workflows/dependencies_latest.yml
+++ b/.github/workflows/dependencies_latest.yml
@@ -219,6 +219,9 @@ jobs:
           share/ci/scripts/multi/install_oiio.sh latest $EXT_PATH
           share/ci/scripts/multi/install_osl.sh latest $EXT_PATH
           share/ci/scripts/multi/install_openfx.sh latest $EXT_PATH
+      - name: Print some variables
+        run: |
+          brew --prefix llvm@15
       - name: Create build directories
         run: |
           mkdir _install

--- a/.github/workflows/dependencies_latest.yml
+++ b/.github/workflows/dependencies_latest.yml
@@ -221,7 +221,7 @@ jobs:
           share/ci/scripts/multi/install_openfx.sh latest $EXT_PATH
       - name: Print some variables
         run: |
-          brew --prefix llvm
+          ls -alH $(brew --prefix llvm)
       - name: Create build directories
         run: |
           mkdir _install

--- a/.github/workflows/dependencies_latest.yml
+++ b/.github/workflows/dependencies_latest.yml
@@ -219,9 +219,6 @@ jobs:
           share/ci/scripts/multi/install_oiio.sh latest $EXT_PATH
           share/ci/scripts/multi/install_osl.sh latest $EXT_PATH
           share/ci/scripts/multi/install_openfx.sh latest $EXT_PATH
-      - name: Print some variables
-        run: |
-          brew --prefix llvm@15
       - name: Create build directories
         run: |
           mkdir _install

--- a/.github/workflows/dependencies_latest.yml
+++ b/.github/workflows/dependencies_latest.yml
@@ -221,7 +221,7 @@ jobs:
           share/ci/scripts/multi/install_openfx.sh latest $EXT_PATH
       - name: Print some variables
         run: |
-          ls -alH $(brew --prefix llvm)
+          brew --prefix llvm@15
       - name: Create build directories
         run: |
           mkdir _install

--- a/.github/workflows/dependencies_latest.yml
+++ b/.github/workflows/dependencies_latest.yml
@@ -221,7 +221,7 @@ jobs:
           share/ci/scripts/multi/install_openfx.sh latest $EXT_PATH
       - name: Print some variables
         run: |
-          brew --prefix llvm@15
+          brew --prefix llvm
       - name: Create build directories
         run: |
           mkdir _install

--- a/share/ci/scripts/multi/install_osl.sh
+++ b/share/ci/scripts/multi/install_osl.sh
@@ -27,11 +27,13 @@ if [[ $OSTYPE == 'darwin'* ]]; then
     cmake -DCMAKE_BUILD_TYPE=Release \
         ${INSTALL_TARGET:+"-DCMAKE_INSTALL_PREFIX="${INSTALL_TARGET}""} \
         -DCMAKE_CXX_STANDARD=14 \
+        -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang \
+        -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++ \
         -DOSL_BUILD_TESTS=ON \
         -DVERBOSE=ON \
         -DSTOP_ON_WARNING=OFF \
         -DBoost_NO_BOOST_CMAKE=ON \
-        -DLLVM_ROOT=$(brew --prefix llvm) \
+        -DLLVM_ROOT=$(brew --prefix llvm@15) \
         ../.
 else # not macOS
     cmake -DCMAKE_BUILD_TYPE=Release \

--- a/share/ci/scripts/multi/install_osl.sh
+++ b/share/ci/scripts/multi/install_osl.sh
@@ -29,7 +29,7 @@ cmake -DCMAKE_BUILD_TYPE=Release \
       -DVERBOSE=ON \
       -DSTOP_ON_WARNING=OFF \
       -DBoost_NO_BOOST_CMAKE=ON \
-      -DLLVM_ROOT=$(brew --prefix llvm) \
+      -DLLVM_ROOT=$(brew --prefix llvm@15) \
       ../.
 cmake --build . \
       --target install \

--- a/share/ci/scripts/multi/install_osl.sh
+++ b/share/ci/scripts/multi/install_osl.sh
@@ -22,17 +22,28 @@ mkdir build
 cd build
 # FIXME: Revert OSL_BUILD_TESTS to OFF when OSL 1.12 is released
 # CMake configure fails when tests are off, only fixed in 1.12 dev branch
-cmake -DCMAKE_BUILD_TYPE=Release \
-      ${INSTALL_TARGET:+"-DCMAKE_INSTALL_PREFIX="${INSTALL_TARGET}""} \
-      -DCMAKE_CXX_STANDARD=14 \
-      -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang \
-      -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++ \
-      -DOSL_BUILD_TESTS=ON \
-      -DVERBOSE=ON \
-      -DSTOP_ON_WARNING=OFF \
-      -DBoost_NO_BOOST_CMAKE=ON \
-      -DLLVM_ROOT=$(brew --prefix llvm@15) \
-      ../.
+
+if [[ $OSTYPE == 'darwin'* ]]; then
+    cmake -DCMAKE_BUILD_TYPE=Release \
+        ${INSTALL_TARGET:+"-DCMAKE_INSTALL_PREFIX="${INSTALL_TARGET}""} \
+        -DCMAKE_CXX_STANDARD=14 \
+        -DOSL_BUILD_TESTS=ON \
+        -DVERBOSE=ON \
+        -DSTOP_ON_WARNING=OFF \
+        -DBoost_NO_BOOST_CMAKE=ON \
+        -DLLVM_ROOT=$(brew --prefix llvm) \
+        ../.
+else # not macOS
+    cmake -DCMAKE_BUILD_TYPE=Release \
+        ${INSTALL_TARGET:+"-DCMAKE_INSTALL_PREFIX="${INSTALL_TARGET}""} \
+        -DCMAKE_CXX_STANDARD=14 \
+        -DOSL_BUILD_TESTS=ON \
+        -DVERBOSE=ON \
+        -DSTOP_ON_WARNING=OFF \
+        -DBoost_NO_BOOST_CMAKE=ON \
+        ../.
+fi
+
 cmake --build . \
       --target install \
       --config Release \

--- a/share/ci/scripts/multi/install_osl.sh
+++ b/share/ci/scripts/multi/install_osl.sh
@@ -29,6 +29,7 @@ cmake -DCMAKE_BUILD_TYPE=Release \
       -DVERBOSE=ON \
       -DSTOP_ON_WARNING=OFF \
       -DBoost_NO_BOOST_CMAKE=ON \
+      -DLLVM_ROOT=$(brew --prefix llvm) \
       ../.
 cmake --build . \
       --target install \

--- a/share/ci/scripts/multi/install_osl.sh
+++ b/share/ci/scripts/multi/install_osl.sh
@@ -25,6 +25,8 @@ cd build
 cmake -DCMAKE_BUILD_TYPE=Release \
       ${INSTALL_TARGET:+"-DCMAKE_INSTALL_PREFIX="${INSTALL_TARGET}""} \
       -DCMAKE_CXX_STANDARD=14 \
+      -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang \
+      -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++ \
       -DOSL_BUILD_TESTS=ON \
       -DVERBOSE=ON \
       -DSTOP_ON_WARNING=OFF \


### PR DESCRIPTION
This is a fix for the failure in the dependencies workflow on macOS where OSL wasn't able to find the LLVM directory.