### PR TITLE
Do not assume minizip-ng uses zlib for compression

### DIFF
--- a/src/OpenColorIO/OCIOZArchive.cpp
+++ b/src/OpenColorIO/OCIOZArchive.cpp
@@ -24,7 +24,6 @@
 #include "mz_strm_mem.h"
 #include "mz_strm_os.h"
 #include "mz_strm_split.h"
-#include "mz_strm_zlib.h"
 #include "mz_zip.h"
 #include "mz_zip_rw.h"
 


### PR DESCRIPTION
The file mz_strm_zlib.h does not exist if minizip-ng enables compression via means other than zlib.
Since none of the functions provided by mz_strm_zlib.h are used (mz_stream_zlib_*), it can be safely removed.