### PR TITLE
Adsk contrib - Fix issue with urllib3 version and the container images for the CIs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,8 @@
+# Fix an issue with the OCIO's Linux container images that have OpenSSL under 1.1.1.
+# If the container images are updated with OpenSSL 1.1.1+, the restriction on
+# urllib3 version <2 can be removed.
+urllib3<2
+# The builds for documentation fails with <0.18.0
 docutils>=0.18.1
 six
 testresources

--- a/src/bindings/python/package/__init__.py
+++ b/src/bindings/python/package/__init__.py
@@ -16,7 +16,7 @@ import os, sys, platform
 # environment variable to 0.
 #
 
-if sys.version_info >= (3, 8) and platform.system() == "Windows" and os.getenv("OCIO_PYTHON_LOAD_DLLS_FROM_PATH", "0") == "1":
+if sys.version_info >= (3, 8) and platform.system() == "Windows" and os.getenv("OCIO_PYTHON_LOAD_DLLS_FROM_PATH", "1") == "1":
     for path in os.getenv("PATH", "").split(os.pathsep):
         if os.path.exists(path) and path != ".":
             os.add_dll_directory(path)

--- a/src/bindings/python/package/__init__.py
+++ b/src/bindings/python/package/__init__.py
@@ -16,7 +16,7 @@ import os, sys, platform
 # environment variable to 0.
 #
 
-if sys.version_info >= (3, 8) and platform.system() == "Windows" and os.getenv("OCIO_PYTHON_LOAD_DLLS_FROM_PATH", "1") == "1":
+if sys.version_info >= (3, 8) and platform.system() == "Windows" and os.getenv("OCIO_PYTHON_LOAD_DLLS_FROM_PATH", "0") == "1":
     for path in os.getenv("PATH", "").split(os.pathsep):
         if os.path.exists(path) and path != ".":
             os.add_dll_directory(path)


### PR DESCRIPTION
The PR fixes the issue with the CI and Dependencies latest workflow.

Since we don't control the versions of the Python modules for documentation, it is installing the latest version. Unfortunately, in OCIO's CentOS container images, the latest Urllib3 is not compatible with the OpenSSL version installed in those container images.