### PR TITLE
Add command line apps to Python wheel

### DIFF
--- a/.github/workflows/wheel_workflow.yml
+++ b/.github/workflows/wheel_workflow.yml
@@ -128,7 +128,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.0
+        uses: pypa/cibuildwheel@v2.13.1
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -194,7 +194,7 @@ jobs:
           python-version: '3.8'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.0
+        uses: pypa/cibuildwheel@v2.13.1
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -245,7 +245,7 @@ jobs:
           python-version: '3.8'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.12.0
+        uses: pypa/cibuildwheel@v2.13.1
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,7 @@ endif()
 # Other preferences
 
 option(OCIO_VERBOSE "Display more information when searching or installing dependencies" OFF)
+option(OCIO_USE_SOVERSION "Enable versioning in OCIO shared library name" ON)
 
 ###############################################################################
 # Warnings / debugging settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,9 +177,6 @@ endif()
 
 option(OCIO_USE_SSE "Specify whether to enable SSE CPU performance optimizations" ON)
 option(OCIO_USE_OIIO_FOR_APPS "Request OIIO to build apps (ociolutimage, ocioconvert and ociodisplay), the default uses OpenEXR." OFF)
-option(OCIO_NO_SONAME "Disable version symlink for OpenColorIO library" OFF)
-set (OCIO_PYTHON_INSTALL_RPATH "" CACHE STRING
-    "Specify the RPATHs to install for the Python module (darwin and linux only)")
 
 if ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(AMD64|IA64|EM64T|X86|x86_64|i386|i686)")
     option(OCIO_USE_SSE2 "Specify whether to enable SSE2 CPU performance optimizations" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ endif()
 
 ###############################################################################
 # Other preferences
+
 option(OCIO_VERBOSE "Display more information when searching or installing dependencies" OFF)
 
 ###############################################################################
@@ -176,6 +177,9 @@ endif()
 
 option(OCIO_USE_SSE "Specify whether to enable SSE CPU performance optimizations" ON)
 option(OCIO_USE_OIIO_FOR_APPS "Request OIIO to build apps (ociolutimage, ocioconvert and ociodisplay), the default uses OpenEXR." OFF)
+option(OCIO_NO_SONAME "Disable version symlink for OpenColorIO library" OFF)
+set (OCIO_PYTHON_INSTALL_RPATH "" CACHE STRING
+    "Specify the RPATHs to install for the Python module (darwin and linux only)")
 
 if ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(AMD64|IA64|EM64T|X86|x86_64|i386|i686)")
     option(OCIO_USE_SSE2 "Specify whether to enable SSE2 CPU performance optimizations" ON)
@@ -189,6 +193,7 @@ if ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(AMD64|IA64|EM64T|X86|x86_64|i386|i686)
     option(OCIO_USE_F16C  "Specify whether to enable F16C CPU performance optimizations" ON)
     set(OCIO_ARCH_X86 1)
 endif()
+
 
 ###############################################################################
 # GPU configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,11 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 build-verbosity = "1"
 
-test-command = "python {project}/tests/python/OpenColorIOTestSuite.py"
 test-requires = ["numpy"]
+test-command = [
+    "python {project}/tests/python/OpenColorIOTestSuite.py",
+    "ociocheck"
+]
 
 manylinux-x86_64-image = "manylinux2014"
 manylinux-i686-image = "manylinux2014"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 build-verbosity = "1"
 
-test-command = "python -m PyOpenColorIO.tests.OpenColorIOTestSuite"
+test-command = "python {project}/tests/python/OpenColorIOTestSuite.py"
 test-requires = ["numpy"]
 
 manylinux-x86_64-image = "manylinux2014"

--- a/share/cmake/macros/StripUtils.cmake
+++ b/share/cmake/macros/StripUtils.cmake
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+# This function is based on Pybind11's pybind11_strip.
+
+macro(ocio_strip_binary target_name)
+    string(TOUPPER "${CMAKE_BUILD_TYPE}" _uppercase_CMAKE_BUILD_TYPE)
+    if(NOT MSVC AND NOT "${_uppercase_CMAKE_BUILD_TYPE}" MATCHES DEBUG|RELWITHDEBINFO)
+        if(CMAKE_STRIP)
+            if(APPLE)
+                set(_strip_opt -x)
+            endif()
+
+            add_custom_command(
+                TARGET ${target_name}
+                POST_BUILD
+                COMMAND ${CMAKE_STRIP} ${_strip_opt} $<TARGET_FILE:${target_name}>
+            )
+            unset(_strip_opt)
+        endif()
+    endif()
+    unset(_uppercase_CMAKE_BUILD_TYPE)
+endmacro()

--- a/share/cmake/utils/CompilerFlags.cmake
+++ b/share/cmake/utils/CompilerFlags.cmake
@@ -120,7 +120,7 @@ endif()
 ###############################################################################
 # Define RPATH.
 
-if (UNIX AND NOT CMAKE_SKIP_RPATH)
+if (UNIX AND NOT CMAKE_SKIP_RPATH AND NOT CMAKE_INSTALL_RPATH)
     # With the 'usual' install path structure in mind, search from the bin directory
     # (i.e. a binary loading a dynamic library) and then from the current directory
     # (i.e. dynamic library loading another dynamic library).  

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -417,6 +417,7 @@ set_target_properties(OpenColorIO PROPERTIES
     LINK_OPTIONS "${CUSTOM_LINK_FLAGS}"
     VERSION       ${OpenColorIO_VERSION}
     SOVERSION     ${SOVERSION}
+    NO_SONAME     ${OCIO_NO_SONAME}
     PUBLIC_HEADER "${INSTALL_HEADERS}"
 )
 

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -411,12 +411,17 @@ elseif(APPLE)
     endif()
 endif()
 
+if (OCIO_USE_SOVERSION)
+    set_target_properties(OpenColorIO PROPERTIES
+        VERSION       ${OpenColorIO_VERSION}
+        SOVERSION     ${SOVERSION}
+    )
+endif()
+
 set_target_properties(OpenColorIO PROPERTIES
     OUTPUT_NAME   ${PROJECT_NAME}${OCIO_LIBNAME_SUFFIX}
     COMPILE_OPTIONS "${PLATFORM_COMPILE_OPTIONS}"
     LINK_OPTIONS "${CUSTOM_LINK_FLAGS}"
-    VERSION       ${OpenColorIO_VERSION}
-    SOVERSION     ${SOVERSION}
     PUBLIC_HEADER "${INSTALL_HEADERS}"
 )
 

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -417,7 +417,6 @@ set_target_properties(OpenColorIO PROPERTIES
     LINK_OPTIONS "${CUSTOM_LINK_FLAGS}"
     VERSION       ${OpenColorIO_VERSION}
     SOVERSION     ${SOVERSION}
-    NO_SONAME     ${OCIO_NO_SONAME}
     PUBLIC_HEADER "${INSTALL_HEADERS}"
 )
 

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpCPU.cpp
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpCPU.cpp
@@ -1664,7 +1664,6 @@ void InvLut3DRenderer::apply(const void * inImg, void * outImg, long numPixels) 
         // For now, if no result is found, return 0.
         float result[3] = { 0.f, 0.f, 0.f };
 
-        unsigned long cnt = 0;
         long level = 0;
         while (level >= 0)
         {
@@ -1680,7 +1679,6 @@ void InvLut3DRenderer::apply(const void * inImg, void * outImg, long numPixels) 
                     B <= levels[level].maxVals[node * chans + 2];
                 currentChild[level]++;
                 currentChildInd[level]++;
-                cnt++;
 
                 if (inRange)
                 {
@@ -1757,4 +1755,3 @@ ConstOpCPURcPtr GetLut3DRenderer(ConstLut3DOpDataRcPtr & lut)
 }
 
 } // namespace OCIO_NAMESPACE
-

--- a/src/apps/ocioarchive/CMakeLists.txt
+++ b/src/apps/ocioarchive/CMakeLists.txt
@@ -24,6 +24,9 @@ target_link_libraries(ocioarchive
         MINIZIP::minizip-ng
 )
 
+include(StripUtils)
+ocio_strip_binary(ocioarchive)
+
 install(TARGETS ocioarchive
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/src/apps/ociobakelut/CMakeLists.txt
+++ b/src/apps/ociobakelut/CMakeLists.txt
@@ -33,6 +33,9 @@ target_link_libraries(ociobakelut
         OpenColorIO
 )
 
+include(StripUtils)
+ocio_strip_binary(ociobakelut)
+
 install(TARGETS ociobakelut
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/src/apps/ociocheck/CMakeLists.txt
+++ b/src/apps/ociocheck/CMakeLists.txt
@@ -22,6 +22,9 @@ target_link_libraries(ociocheck
         OpenColorIO
 )
 
+include(StripUtils)
+ocio_strip_binary(ociocheck)
+
 install(TARGETS ociocheck
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/src/apps/ociochecklut/CMakeLists.txt
+++ b/src/apps/ociochecklut/CMakeLists.txt
@@ -30,6 +30,9 @@ target_link_libraries(ociochecklut
         OpenColorIO
 )
 
+include(StripUtils)
+ocio_strip_binary(ociochecklut)
+
 install(TARGETS ociochecklut
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/src/apps/ocioconvert/CMakeLists.txt
+++ b/src/apps/ocioconvert/CMakeLists.txt
@@ -34,6 +34,9 @@ target_link_libraries(ocioconvert
         OpenColorIO
 )
 
+include(StripUtils)
+ocio_strip_binary(ocioconvert)
+
 install(TARGETS ocioconvert
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/src/apps/ociodisplay/CMakeLists.txt
+++ b/src/apps/ociodisplay/CMakeLists.txt
@@ -47,6 +47,9 @@ target_link_libraries(ociodisplay
         OpenColorIO
 )
 
+include(StripUtils)
+ocio_strip_binary(ociodisplay)
+
 install(TARGETS ociodisplay
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/src/apps/ociolutimage/CMakeLists.txt
+++ b/src/apps/ociolutimage/CMakeLists.txt
@@ -27,6 +27,9 @@ target_link_libraries(ociolutimage
 		utils::strings
 )
 
+include(StripUtils)
+ocio_strip_binary(ociolutimage)
+
 install(TARGETS ociolutimage
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/src/apps/ociomakeclf/CMakeLists.txt
+++ b/src/apps/ociomakeclf/CMakeLists.txt
@@ -23,6 +23,9 @@ target_link_libraries(ociomakeclf
         utils::strings
 )
 
+include(StripUtils)
+ocio_strip_binary(ociomakeclf)
+
 install(TARGETS ociomakeclf
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/src/apps/ocioperf/CMakeLists.txt
+++ b/src/apps/ocioperf/CMakeLists.txt
@@ -19,6 +19,9 @@ target_link_libraries(ocioperf
         utils::strings
 )
 
+include(StripUtils)
+ocio_strip_binary(ocioperf)
+
 install(TARGETS ocioperf
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/src/apps/ociowrite/CMakeLists.txt
+++ b/src/apps/ociowrite/CMakeLists.txt
@@ -18,6 +18,9 @@ target_link_libraries(ociowrite
         OpenColorIO
 )
 
+include(StripUtils)
+ocio_strip_binary(ociowrite)
+
 install(TARGETS ociowrite
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/src/apps/pyocioamf/pyocioamf.py
+++ b/src/apps/pyocioamf/pyocioamf.py
@@ -470,9 +470,14 @@ def build_ctf(amf_path):
     ctf_path = name_ctf_output_file(amf_path)
     write_ctf(gt, config, amf_path, ctf_path, 'none')
 
-if __name__=='__main__':
-    """ Run the script from the command-line. """
+
+def main():
     import sys
     if len( sys.argv ) != 2:
         raise ValueError( "USAGE: python3 amf_to_ocio.py  <AMF_FILE>" )
     build_ctf( sys.argv[1] )
+
+
+if __name__=='__main__':
+    """ Run the script from the command-line. """
+    main()

--- a/src/apps/pyociodisplay/pyociodisplay.py
+++ b/src/apps/pyociodisplay/pyociodisplay.py
@@ -1337,7 +1337,7 @@ class ImageView(QtWidgets.QWidget):
         self.image_plane.update_gamma(value)
 
 
-if __name__ == "__main__":
+def main():
     # OpenGL core profile needed on macOS to access programmatic pipeline
     gl_format = QtOpenGL.QGLFormat()
     gl_format.setProfile(QtOpenGL.QGLFormat.CoreProfile)
@@ -1350,3 +1350,7 @@ if __name__ == "__main__":
     viewer = ImageView()
     viewer.show()
     app.exec_()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -170,7 +170,7 @@ if(UNIX)
 	set_property(TARGET PyOpenColorIO PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
-if (UNIX AND NOT CMAKE_SKIP_RPATH AND NOT OCIO_PYTHON_INSTALL_RPATH)
+if (UNIX AND NOT CMAKE_SKIP_RPATH AND NOT CMAKE_INSTALL_RPATH)
     # Update the default RPATH so the Python binding dynamic library can find the OpenColorIO
     # dynamic library based on the default installation directory structure.
     if (APPLE)

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -170,7 +170,7 @@ if(UNIX)
 	set_property(TARGET PyOpenColorIO PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 
-if (UNIX AND NOT CMAKE_SKIP_RPATH)
+if (UNIX AND NOT CMAKE_SKIP_RPATH AND NOT OCIO_PYTHON_INSTALL_RPATH)
     # Update the default RPATH so the Python binding dynamic library can find the OpenColorIO
     # dynamic library based on the default installation directory structure.
     if (APPLE)

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -251,6 +251,9 @@ set(PYTHON_VARIANT_PATH ${_Python_VARIANT_PATH} CACHE INTERNAL "")
 # Set to PyOpenColorIO site-package location.
 set(_PyOpenColorIO_SITE_PACKAGE_DIR "${PYTHON_VARIANT_PATH}/PyOpenColorIO")
 
+include(StripUtils)
+ocio_strip_binary(PyOpenColorIO)
+
 install(TARGETS PyOpenColorIO
     LIBRARY DESTINATION ${_PyOpenColorIO_SITE_PACKAGE_DIR}
 )

--- a/src/bindings/python/package/__init__.py
+++ b/src/bindings/python/package/__init__.py
@@ -19,7 +19,9 @@ import os, sys, platform
 if sys.version_info >= (3, 8) and platform.system() == "Windows":
     # Python wheel module is dynamically linked to the OCIO lib present in the same folder.
     here = os.path.abspath(os.path.dirname(__file__))
-    os.add_dll_directory(os.path.join(here, "bin"))
+    bin_dir = os.path.join(here, "bin")
+    if os.path.exists(bin_dir):
+        os.add_dll_directory(bin_dir)
 
     if os.getenv("OCIO_PYTHON_LOAD_DLLS_FROM_PATH", "1") == "1":
         for path in os.getenv("PATH", "").split(os.pathsep):

--- a/src/bindings/python/package/__init__.py
+++ b/src/bindings/python/package/__init__.py
@@ -4,6 +4,19 @@
 import os, sys, platform
 
 #
+# Python wheel module is dynamically linked to the OCIO DLL present in the bin folder.
+#
+
+if platform.system() == "Windows":
+    here = os.path.abspath(os.path.dirname(__file__))
+    bin_dir = os.path.join(here, "bin")
+    if os.path.exists(bin_dir):
+        if sys.version_info >= (3, 8):
+            os.add_dll_directory(bin_dir)
+        else:
+            os.environ['PATH'] = '{0};{1}'.format(bin_dir, os.getenv('PATH', ''))
+
+#
 # Python 3.8+ has stopped loading DLLs from PATH environment variable on Windows.
 #
 # This code reproduce the old behavior (loading DLLs from PATH) by doing the following:
@@ -17,12 +30,6 @@ import os, sys, platform
 #
 
 if sys.version_info >= (3, 8) and platform.system() == "Windows":
-    # Python wheel module is dynamically linked to the OCIO lib present in the same folder.
-    here = os.path.abspath(os.path.dirname(__file__))
-    bin_dir = os.path.join(here, "bin")
-    if os.path.exists(bin_dir):
-        os.add_dll_directory(bin_dir)
-
     if os.getenv("OCIO_PYTHON_LOAD_DLLS_FROM_PATH", "1") == "1":
         for path in os.getenv("PATH", "").split(os.pathsep):
             if os.path.exists(path) and path != ".":

--- a/src/bindings/python/package/__init__.py
+++ b/src/bindings/python/package/__init__.py
@@ -16,10 +16,15 @@ import os, sys, platform
 # environment variable to 0.
 #
 
-if sys.version_info >= (3, 8) and platform.system() == "Windows" and os.getenv("OCIO_PYTHON_LOAD_DLLS_FROM_PATH", "1") == "1":
-    for path in os.getenv("PATH", "").split(os.pathsep):
-        if os.path.exists(path) and path != ".":
-            os.add_dll_directory(path)
+if sys.version_info >= (3, 8) and platform.system() == "Windows":
+    # Python wheel module is dynamically linked to the OCIO lib present in the same folder.
+    here = os.path.abspath(os.path.dirname(__file__))
+    os.add_dll_directory(here)
+
+    if os.getenv("OCIO_PYTHON_LOAD_DLLS_FROM_PATH", "1") == "1":
+        for path in os.getenv("PATH", "").split(os.pathsep):
+            if os.path.exists(path) and path != ".":
+                os.add_dll_directory(path)
 
 del os, sys, platform
 

--- a/src/bindings/python/package/__init__.py
+++ b/src/bindings/python/package/__init__.py
@@ -19,7 +19,7 @@ import os, sys, platform
 if sys.version_info >= (3, 8) and platform.system() == "Windows":
     # Python wheel module is dynamically linked to the OCIO lib present in the same folder.
     here = os.path.abspath(os.path.dirname(__file__))
-    os.add_dll_directory(here)
+    os.add_dll_directory(os.path.join(here, "bin"))
 
     if os.getenv("OCIO_PYTHON_LOAD_DLLS_FROM_PATH", "1") == "1":
         for path in os.getenv("PATH", "").split(os.pathsep):

--- a/src/bindings/python/package/command_line.py
+++ b/src/bindings/python/package/command_line.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+import os
+import subprocess
+import sys
+
+
+BIN_DIR = os.path.join(os.path.dirname(__file__), 'bin')
+
+
+def call_program(name, args):
+    return subprocess.call([os.path.join(BIN_DIR, name)] + args, close_fds=False)
+
+
+def main():
+    name = os.path.basename(sys.argv[0])
+    raise SystemExit(call_program(name, sys.argv[1:]))

--- a/src/bindings/python/package/command_line.py
+++ b/src/bindings/python/package/command_line.py
@@ -10,7 +10,7 @@ BIN_DIR = os.path.join(os.path.dirname(__file__), 'bin')
 
 
 def call_program(name, args):
-    return subprocess.call([os.path.join(BIN_DIR, name)] + args, close_fds=False)
+    return subprocess.call([os.path.join(BIN_DIR, name)] + args)
 
 
 def main():

--- a/src/libutils/oglapphelpers/msl.mm
+++ b/src/libutils/oglapphelpers/msl.mm
@@ -199,7 +199,6 @@ void MetalBuilder::allocateAllTextures(unsigned startIndex)
 
     // This is the first available index for the textures.
     m_startIndex = startIndex;
-    unsigned currIndex = m_startIndex;
 
     // Process the 3D LUT first.
 
@@ -236,8 +235,6 @@ void MetalBuilder::allocateAllTextures(unsigned startIndex)
         // 3. Keep the texture id & name for the later enabling.
 
         m_textureIds.push_back(TextureId(texture, textureName, samplerState, samplerName, MTLTextureType3D));
-
-        currIndex++;
     }
 
     // Process the 1D LUTs.
@@ -278,7 +275,6 @@ void MetalBuilder::allocateAllTextures(unsigned startIndex)
 
         MTLTextureType type = (dimensions == GpuShaderDesc::TEXTURE_2D) ? MTLTextureType2D : MTLTextureType1D;
         m_textureIds.push_back(TextureId(texture, textureName, samplerState, samplerName, type));
-        currIndex++;
     }
 }
 

--- a/tests/python/ColorSpaceTest.py
+++ b/tests/python/ColorSpaceTest.py
@@ -749,7 +749,7 @@ colorspaces:
 
         cfg = OCIO.Config.CreateFromStream(CONFIG)
 
-        cfg.setSearchPath(TEST_DATAFILES_DIR)
+        cfg.addSearchPath(TEST_DATAFILES_DIR)
 
         # Make all color spaces suitable for the heuristics inactive.
         # The heuristics don't look at inactive color spaces.

--- a/tests/python/OpenColorIOTestSuite.py
+++ b/tests/python/OpenColorIOTestSuite.py
@@ -32,7 +32,7 @@ if len(sys.argv) > 1:
             opencolorio_dir, os.getenv('DYLD_LIBRARY_PATH', ''))
 
     sys.path.insert(0, pyopencolorio_dir)
-# Else it probably means direct invocation from installed package
+# Else it probably means direct invocation from cibuildwheel
 else:
     here = os.path.dirname(__file__)
     os.environ["TEST_DATAFILES_DIR"] = os.path.join(os.path.dirname(here), 'data', 'files')


### PR DESCRIPTION
This PR adds command line applications (C++ and Python) to the Python wheels, some points to note:
* The wheel size is growing significantly with this change, I took some actions to reduce it like striping binaries and removing the test suite but it is still around [20MB per wheel](https://test.pypi.org/project/opencolorio/2.3.0.dev4/#files). We might gain some more by using `-Os` and/or LTO to compile the apps but the most efficient way would most likely be to compile OCIO dynamically and have Python package and apps link to it. I haven't tried that and expect it will bring complexity to the build process.
* The PR also contains some C++ warnings fix,
* Documentation build fix extracted to #1809 

Note that I have no prior experience adding scripts to Python packages, I'm open to any suggestion.

Wheels are available on the test PyPI, install with this command (at your own risks):
`pip install -i https://test.pypi.org/simple/ opencolorio==2.3.0.dev4`