### PR TITLE
Fix documentation build

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -756,9 +756,8 @@ public:
                                          const char * builtinColorSpaceName);
 
     /**
-     * \defgroup Methods related to Roles.
-     * @{
-     *    
+     * Methods related to Roles.
+     *
      * A role allows a config author to indicate that a given color space should be used
      * for a particular purpose.  
      *

--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -799,11 +799,8 @@ public:
     const char * getRoleColorSpace(const char * roleName) const noexcept;
 
     /**
-     * \defgroup Methods related to displays and views.
-     * @{
-     */
-
-    /**
+     * Methods related to displays and views.
+     *
      * The following methods only manipulate active displays and views. Active
      * displays and views are defined from an env. variable or from the config file.
      *
@@ -920,11 +917,8 @@ public:
     /// Clear all the displays.
     void clearDisplays();
 
-    /** @} */
-
     /**
-     * \defgroup Methods related to the Virtual Display.
-     * @{
+     * Methods related to the Virtual Display.
      *
      *  ...  (See descriptions for the non-virtual methods above.)
      *
@@ -1003,8 +997,6 @@ public:
      * Returns the index of the display.
      */
     int instantiateDisplayFromICCProfile(const char * ICCProfileFilepath);
-
-    /** @} */
 
     /**
      * \brief
@@ -1153,8 +1145,7 @@ public:
     void clearViewTransforms();
 
     /**
-     * \defgroup Methods related to named transforms.
-     * @{
+     * Methods related to named transforms.
      */
 
     /**
@@ -1196,8 +1187,6 @@ public:
 
     /// Clear all named transforms.
     void clearNamedTransforms();
-
-    /** @} */
 
     // 
     // File Rules
@@ -2122,8 +2111,7 @@ private:
     const Impl * getImpl() const { return m_impl; }
 };
 
-/** \defgroup ColorSpaceSetOperators
- *  @{
+/** ColorSpaceSetOperators
  */
 
 /**
@@ -2162,8 +2150,6 @@ extern OCIOEXPORT ConstColorSpaceSetRcPtr operator&&(const ConstColorSpaceSetRcP
  */
 extern OCIOEXPORT ConstColorSpaceSetRcPtr operator-(const ConstColorSpaceSetRcPtr & lcss,
                                                     const ConstColorSpaceSetRcPtr & rcss);
-
-/** @}*/
 
 
 //
@@ -3740,8 +3726,7 @@ public:
     virtual bool isSupported() const noexcept = 0;
 
     /**
-     * \defgroup Methods to access some information of the attached and active monitors.
-     * @{
+     * Methods to access some information of the attached and active monitors.
      */
 
     /// Get the number of active monitors reported by the operating system.
@@ -3757,8 +3742,6 @@ public:
     virtual const char * getMonitorName(size_t idx) const = 0;
     /// Get the ICC profile path associated to the monitor.
     virtual const char * getProfileFilepath(size_t idx) const = 0;
-
-    /** @} */
 
 protected:
     SystemMonitors() = default;

--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -726,8 +726,7 @@ extern OCIOEXPORT ExposureContrastStyle ExposureContrastStyleFromString(const ch
 extern OCIOEXPORT const char * NegativeStyleToString(NegativeStyle style);
 extern OCIOEXPORT NegativeStyle NegativeStyleFromString(const char * style);
 
-/** \defgroup Env. variables.
- *  @{
+/** Env. variables.
  *
  * These environmental variables are used by the OpenColorIO library.
  * For variables that allow specifying more than one token, they should be separated by commas.
@@ -776,10 +775,7 @@ extern OCIOEXPORT const char * OCIO_OPTIMIZATION_FLAGS_ENVVAR;
  */
 extern OCIOEXPORT const char * OCIO_USER_CATEGORIES_ENVVAR;
 
-/** @}*/
-
-/** \defgroup VarsRoles
- *  @{
+/** VarsRoles
  */
 
 // TODO: Move to .rst
@@ -852,10 +848,7 @@ extern OCIOEXPORT const char * ROLE_INTERCHANGE_SCENE;
  */
 extern OCIOEXPORT const char * ROLE_INTERCHANGE_DISPLAY;
 
-/** @}*/
-
-/** \defgroup VarsSharedView
- *  @{
+/** VarsSharedView
  */
 
 /*!rst::
@@ -870,10 +863,7 @@ Shared View
  */
 extern OCIOEXPORT const char * OCIO_VIEW_USE_DISPLAY_NAME;
 
-/** @}*/
-
-/** \defgroup VarsFormatMetadata
- *  @{
+/** VarsFormatMetadata
  */
 
 // TODO: Move to .rst
@@ -929,10 +919,7 @@ extern OCIOEXPORT const char * METADATA_NAME;
  */
 extern OCIOEXPORT const char * METADATA_ID;
 
-/** @}*/
-
-/** \defgroup VarsCaches
- *  @{
+/** VarsCaches
  */
 
 /*!rst::
@@ -962,8 +949,6 @@ extern OCIOEXPORT const char * OCIO_DISABLE_PROCESSOR_CACHES;
 // not match. That fallback introduces a major performance hit in some cases so there is an env.
 // variable to disable the fallback.
 extern OCIOEXPORT const char * OCIO_DISABLE_CACHE_FALLBACK;
-
-/** @}*/
 
 
 // Archive config feature

--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -775,9 +775,6 @@ extern OCIOEXPORT const char * OCIO_OPTIMIZATION_FLAGS_ENVVAR;
  */
 extern OCIOEXPORT const char * OCIO_USER_CATEGORIES_ENVVAR;
 
-/** VarsRoles
- */
-
 // TODO: Move to .rst
 /*!rst::
 Roles
@@ -848,9 +845,6 @@ extern OCIOEXPORT const char * ROLE_INTERCHANGE_SCENE;
  */
 extern OCIOEXPORT const char * ROLE_INTERCHANGE_DISPLAY;
 
-/** VarsSharedView
- */
-
 /*!rst::
 Shared View
 ***********
@@ -862,9 +856,6 @@ Shared View
  * has the same name as the display the shared view is used by.
  */
 extern OCIOEXPORT const char * OCIO_VIEW_USE_DISPLAY_NAME;
-
-/** VarsFormatMetadata
- */
 
 // TODO: Move to .rst
 /*!rst::
@@ -918,9 +909,6 @@ extern OCIOEXPORT const char * METADATA_NAME;
  * (i.e. MatrixTransform, etc.) to get/set the id of the corresponding process node.
  */
 extern OCIOEXPORT const char * METADATA_ID;
-
-/** VarsCaches
- */
 
 /*!rst::
 Caches


### PR DESCRIPTION
Fixes for documentation build under Doxygen 1.9.7, the issues seem to be related to our support of groups (\defgroup) in the step that generates the docstrings.h header from the Doxygen XMLs, for now I just removed the groups because it appears we don't handle groups properly in the generated documentation anyway.

Extracted from #1802 