### PR TITLE
Adsk Contrib - Locking sphinx to the latest successful build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,7 @@
 urllib3<2
 # The builds for documentation fails with <0.18.0
 docutils>=0.18.1
+sphinx<=7.1.2
 six
 testresources
 recommonmark


### PR DESCRIPTION
Our CI workflow uses the latest Sphinx version for the documentation, but it keeps breaking the builds.
I am trying to lock the version to the previous successful documentation build.

With the 2.3 release coming pretty soon, we need successful CIs. Otherwise, we need to overwrite the CI checks in the PRs.