### PR TITLE
Fix CPUProcessor Dynamic Property API

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -29,9 +29,7 @@ jobs:
   linux_sonarcloud:
     name: 'Linux CentOS 7 VFX CY2022 SonarCloud <GCC 9.3.1>'
     # Don't run on OCIO forks
-    if: |
-      github.repository == 'AcademySoftwareFoundation/OpenColorIO' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+    if: github.repository == 'AcademySoftwareFoundation/OpenColorIO'
     # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
     runs-on: ubuntu-latest
     container:

--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -2593,6 +2593,10 @@ public:
      * there is one in the CPU processor.
      */
     DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const;
+    /// True if at least one dynamic property of that type exists.
+    bool hasDynamicProperty(DynamicPropertyType type) const noexcept;
+    /// True if at least one dynamic property of any type exists and is dynamic.
+    bool isDynamic() const noexcept;
 
     /**
      * \brief Apply to an image with any kind of channel ordering while

--- a/include/OpenColorIO/OpenColorTransforms.h
+++ b/include/OpenColorIO/OpenColorTransforms.h
@@ -687,7 +687,7 @@ extern OCIOEXPORT std::ostream & operator<<(std::ostream &, const GradingTone &)
  *            OCIO::DynamicPropertyValue::AsGradingPrimary(dynProp);
  *        OCIO::GradingPrimary primary = primaryProp->getValue();
  *        primary.m_saturation += 0.1f;
- *        rgbCurveProp->setValue(primary);
+ *        primaryProp->setValue(primary);
  *    }
  *    if (cpuProcessor->hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_GRADING_RGBCURVE))
  *    {

--- a/src/OpenColorIO/CPUProcessor.cpp
+++ b/src/OpenColorIO/CPUProcessor.cpp
@@ -239,6 +239,52 @@ case in:                                              \
     throw Exception("Unsupported bit-depths");
 }
 
+bool CPUProcessor::Impl::isDynamic() const noexcept
+{
+    if (m_inBitDepthOp->isDynamic())
+    {
+        return true;
+    }
+
+    for (const auto & op : m_cpuOps)
+    {
+        if (op->isDynamic())
+        {
+            return true;
+        }
+    }
+
+    if (m_outBitDepthOp->isDynamic())
+    {
+        return true;
+    }
+
+    return false;
+}
+
+bool CPUProcessor::Impl::hasDynamicProperty(DynamicPropertyType type) const noexcept
+{
+    if (m_inBitDepthOp->hasDynamicProperty(type))
+    {
+        return true;
+    }
+
+    for (const auto & op : m_cpuOps)
+    {
+        if (op->hasDynamicProperty(type))
+        {
+            return true;
+        }
+    }
+
+    if (m_outBitDepthOp->hasDynamicProperty(type))
+    {
+        return true;
+    }
+
+    return false;
+}
+
 DynamicPropertyRcPtr CPUProcessor::Impl::getDynamicProperty(DynamicPropertyType type) const
 {
     if (m_inBitDepthOp->hasDynamicProperty(type))
@@ -470,6 +516,16 @@ BitDepth CPUProcessor::getInputBitDepth() const
 BitDepth CPUProcessor::getOutputBitDepth() const
 {
     return getImpl()->getOutputBitDepth();
+}
+
+bool CPUProcessor::isDynamic() const noexcept
+{
+    return getImpl()->isDynamic();
+}
+
+bool CPUProcessor::hasDynamicProperty(DynamicPropertyType type) const noexcept
+{
+    return getImpl()->hasDynamicProperty(type);
 }
 
 DynamicPropertyRcPtr CPUProcessor::getDynamicProperty(DynamicPropertyType type) const

--- a/src/OpenColorIO/CPUProcessor.h
+++ b/src/OpenColorIO/CPUProcessor.h
@@ -39,6 +39,8 @@ public:
     BitDepth getInputBitDepth() const noexcept { return m_inBitDepth; }
     BitDepth getOutputBitDepth() const noexcept { return m_outBitDepth; }
 
+    bool isDynamic() const noexcept;
+    bool hasDynamicProperty(DynamicPropertyType type) const noexcept;
     DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const;
 
     void apply(const ImageDesc & imgDesc) const;

--- a/src/OpenColorIO/Op.cpp
+++ b/src/OpenColorIO/Op.cpp
@@ -24,6 +24,11 @@
 
 namespace OCIO_NAMESPACE
 {
+bool OpCPU::isDynamic() const
+{
+    return false;
+}
+
 bool OpCPU::hasDynamicProperty(DynamicPropertyType /* type */) const
 {
     return false;

--- a/src/OpenColorIO/Op.h
+++ b/src/OpenColorIO/Op.h
@@ -45,6 +45,7 @@ public:
     // the 1D LUT CPU Op where the finalization depends on input and output bit depths.
     virtual void apply(const void * inImg, void * outImg, long numPixels) const = 0;
 
+    virtual bool isDynamic() const;
     virtual bool hasDynamicProperty(DynamicPropertyType type) const;
     virtual DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const;
 };

--- a/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpCPU.cpp
+++ b/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpCPU.cpp
@@ -25,6 +25,7 @@ public:
     explicit ECRendererBase(ConstExposureContrastOpDataRcPtr & ec);
     virtual ~ECRendererBase();
 
+    bool isDynamic() const override;
     bool hasDynamicProperty(DynamicPropertyType type) const override;
     DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const override;
 
@@ -62,6 +63,11 @@ ECRendererBase::ECRendererBase(ConstExposureContrastOpDataRcPtr & ec)
 
 ECRendererBase::~ECRendererBase()
 {
+}
+
+bool ECRendererBase::isDynamic() const
+{
+    return m_exposure->isDynamic() || m_contrast->isDynamic() || m_gamma->isDynamic();
 }
 
 bool ECRendererBase::hasDynamicProperty(DynamicPropertyType type) const
@@ -701,4 +707,3 @@ OpCPURcPtr GetExposureContrastCPURenderer(ConstExposureContrastOpDataRcPtr & ec)
 }
 
 } // namespace OCIO_NAMESPACE
-

--- a/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOpCPU.cpp
+++ b/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOpCPU.cpp
@@ -25,6 +25,7 @@ public:
 
     explicit GradingPrimaryOpCPU(ConstGradingPrimaryOpDataRcPtr & gp);
 
+    bool isDynamic() const override;
     bool hasDynamicProperty(DynamicPropertyType type) const override;
     DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const override;
 
@@ -40,6 +41,11 @@ GradingPrimaryOpCPU::GradingPrimaryOpCPU(ConstGradingPrimaryOpDataRcPtr & gp)
     {
         m_gp = m_gp->createEditableCopy();
     }
+}
+
+bool GradingPrimaryOpCPU::isDynamic() const
+{
+    return m_gp->isDynamic();
 }
 
 bool GradingPrimaryOpCPU::hasDynamicProperty(DynamicPropertyType type) const

--- a/src/OpenColorIO/ops/gradingrgbcurve/GradingRGBCurveOpCPU.cpp
+++ b/src/OpenColorIO/ops/gradingrgbcurve/GradingRGBCurveOpCPU.cpp
@@ -25,6 +25,7 @@ public:
 
     explicit GradingRGBCurveOpCPU(ConstGradingRGBCurveOpDataRcPtr & grgbc);
 
+    bool isDynamic() const override;
     bool hasDynamicProperty(DynamicPropertyType type) const override;
     DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const override;
 
@@ -62,6 +63,11 @@ GradingRGBCurveOpCPU::GradingRGBCurveOpCPU(ConstGradingRGBCurveOpDataRcPtr & grg
     {
         m_grgbcurve = m_grgbcurve->createEditableCopy();
     }
+}
+
+bool GradingRGBCurveOpCPU::isDynamic() const
+{
+    return m_grgbcurve->isDynamic();
 }
 
 bool GradingRGBCurveOpCPU::hasDynamicProperty(DynamicPropertyType type) const

--- a/src/OpenColorIO/ops/gradingtone/GradingToneOpCPU.cpp
+++ b/src/OpenColorIO/ops/gradingtone/GradingToneOpCPU.cpp
@@ -25,6 +25,7 @@ public:
 
     explicit GradingToneOpCPU(ConstGradingToneOpDataRcPtr & gt);
 
+    bool isDynamic() const override;
     bool hasDynamicProperty(DynamicPropertyType type) const override;
     DynamicPropertyRcPtr getDynamicProperty(DynamicPropertyType type) const override;
 
@@ -42,6 +43,11 @@ GradingToneOpCPU::GradingToneOpCPU(ConstGradingToneOpDataRcPtr & gt)
     {
         m_gt = m_gt->createEditableCopy();
     }
+}
+
+bool GradingToneOpCPU::isDynamic() const
+{
+    return m_gt->isDynamic();
 }
 
 bool GradingToneOpCPU::hasDynamicProperty(DynamicPropertyType type) const

--- a/src/bindings/python/PyCPUProcessor.cpp
+++ b/src/bindings/python/PyCPUProcessor.cpp
@@ -36,6 +36,13 @@ void bindPyCPUProcessor(py::module & m)
             }, 
             "type"_a, 
              DOC(CPUProcessor, getDynamicProperty))
+        .def("hasDynamicProperty",
+             (bool (CPUProcessor::*)(DynamicPropertyType) const noexcept)
+             &CPUProcessor::hasDynamicProperty,
+             "type"_a,
+             DOC(CPUProcessor, hasDynamicProperty))
+        .def("isDynamic", &CPUProcessor::isDynamic,
+             DOC(CPUProcessor, isDynamic))
 
         .def("apply", [](CPUProcessorRcPtr & self, PyImageDesc & imgDesc) 
             {

--- a/src/bindings/python/PyTypes.cpp
+++ b/src/bindings/python/PyTypes.cpp
@@ -527,6 +527,8 @@ void bindPyTypes(py::module & m)
                DOC(PyOpenColorIO, GpuLanguage, GPU_LANGUAGE_HLSL_DX11))
         .value("GPU_LANGUAGE_MSL_2_0", GPU_LANGUAGE_MSL_2_0,
                DOC(PyOpenColorIO, GpuLanguage, GPU_LANGUAGE_MSL_2_0))
+        .value("LANGUAGE_OSL_1", LANGUAGE_OSL_1,
+               DOC(PyOpenColorIO, GpuLanguage, LANGUAGE_OSL_1))
         .export_values();
 
     py::enum_<EnvironmentMode>(

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -4,6 +4,21 @@
 # Define used for tests in tests/cpu/Context_tests.cpp
 add_definitions("-DOCIO_SOURCE_DIR=${PROJECT_SOURCE_DIR}")
 
+
+macro(add_ocio_test_variant NAME BINARY)
+    add_test(NAME ${NAME} COMMAND ${BINARY} ${ARGN})
+
+    if(OCIO_ENABLE_SANITIZER)
+        # - Ignore odr-violation warning coming supposedly from compiling OCIO
+        # sources within the test target as well as linking to the library.
+        # - Provide better stack traces for malloc related leaks.
+        set_tests_properties(${NAME} PROPERTIES
+            ENVIRONMENT
+                "ASAN_OPTIONS=detect_odr_violation=0:fast_unwind_on_malloc=0"
+        )
+    endif()
+endmacro()
+
 function(add_ocio_test NAME SOURCES PRIVATE_INCLUDES)
     set(TEST_BINARY "test_${NAME}_exec")
     set(TEST_NAME "test_${NAME}")
@@ -72,37 +87,27 @@ function(add_ocio_test NAME SOURCES PRIVATE_INCLUDES)
     )
 
     if(OCIO_ARCH_X86)
-        add_test(NAME ${TEST_NAME} COMMAND ${TEST_BINARY})
-        add_test(NAME ${TEST_NAME}_no_accel COMMAND ${TEST_BINARY} --no_accel)
+        add_ocio_test_variant(${TEST_NAME} ${TEST_BINARY})
+        add_ocio_test_variant(${TEST_NAME}_no_accel ${TEST_BINARY} --no_accel)
         if(${OCIO_USE_SSE2})
-            add_test(NAME ${TEST_NAME}_sse2 COMMAND ${TEST_BINARY} --sse2)
+            add_ocio_test_variant(${TEST_NAME}_sse2 ${TEST_BINARY} --sse2)
             if(${OCIO_USE_F16C})
-                add_test(NAME ${TEST_NAME}_sse2+f16c COMMAND ${TEST_BINARY} --sse2 --f16c)
+                add_ocio_test_variant(${TEST_NAME}_sse2+f16c ${TEST_BINARY} --sse2 --f16c)
             endif()
         endif()
 
         if(${OCIO_USE_AVX})
-            add_test(NAME ${TEST_NAME}_avx COMMAND ${TEST_BINARY} --avx)
+            add_ocio_test_variant(${TEST_NAME}_avx ${TEST_BINARY} --avx)
             if(${OCIO_USE_F16C})
-                add_test(NAME ${TEST_NAME}_avx+f16c COMMAND ${TEST_BINARY} --avx --f16c)
+                add_ocio_test_variant(${TEST_NAME}_avx+f16c ${TEST_BINARY} --avx --f16c)
             endif()
         endif()
 
         if(${OCIO_USE_AVX2})
-            add_test(NAME ${TEST_NAME}_avx2 COMMAND ${TEST_BINARY} --avx2)
+            add_ocio_test_variant(${TEST_NAME}_avx2 ${TEST_BINARY} --avx2)
         endif()
     else()
-        add_test(NAME ${TEST_NAME} COMMAND ${TEST_BINARY})
-    endif()
-
-    if(OCIO_ENABLE_SANITIZER)
-        # Ignore odr-violation warning coming supposeddly from compiling OCIO
-        # sources within the test target as well as linking to the library.
-        # Provide better stack traces for malloc related leaks.
-        set_tests_properties(${TEST_NAME} PROPERTIES
-            ENVIRONMENT
-                "ASAN_OPTIONS=detect_odr_violation=0:fast_unwind_on_malloc=0"
-        )
+        add_ocio_test_variant(${TEST_NAME} ${TEST_BINARY})
     endif()
 
 endfunction(add_ocio_test)

--- a/tests/cpu/CPUProcessor_tests.cpp
+++ b/tests/cpu/CPUProcessor_tests.cpp
@@ -13,6 +13,27 @@
 namespace OCIO = OCIO_NAMESPACE;
 
 
+OCIO_ADD_TEST(CPUProcessor, dynamic_properties)
+{
+    OCIO::ExposureContrastTransformRcPtr ec = OCIO::ExposureContrastTransform::Create();
+
+    ec->setExposure(1.2);
+    ec->setPivot(0.5);
+    ec->makeContrastDynamic();
+
+    OCIO::ConfigRcPtr config = OCIO::Config::Create();
+    auto cpuProc = config->getProcessor(ec)->getDefaultCPUProcessor();
+    OCIO_CHECK_ASSERT(cpuProc->isDynamic());
+    OCIO_CHECK_ASSERT(cpuProc->hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST));
+    OCIO_CHECK_ASSERT(!cpuProc->hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE));
+    OCIO::DynamicPropertyRcPtr dpc;
+    OCIO_CHECK_NO_THROW(dpc = cpuProc->getDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST));
+    OCIO_CHECK_ASSERT(dpc);
+    OCIO_CHECK_THROW_WHAT(cpuProc->getDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE),
+                          OCIO::Exception,
+                          "Cannot find dynamic property; not used by CPU processor.");
+}
+
 OCIO_ADD_TEST(CPUProcessor, flag_composition)
 {
     // The test validates the build of a custom optimization flag.

--- a/tests/python/CPUProcessorTest.py
+++ b/tests/python/CPUProcessorTest.py
@@ -274,6 +274,9 @@ class CPUProcessorTest(unittest.TestCase):
         proc = self.config.getProcessor(tr)
         cpu_proc = proc.getDefaultCPUProcessor()
 
+        self.assertTrue(cpu_proc.isDynamic())
+        self.assertTrue(cpu_proc.hasDynamicProperty(OCIO.DYNAMIC_PROPERTY_EXPOSURE))
+
         # Validate default +0 stops exposure
         self.assertEqual(
             cpu_proc.applyRGB([1.0, 1.0, 1.0]),

--- a/tests/python/GradingPrimaryTransformTest.py
+++ b/tests/python/GradingPrimaryTransformTest.py
@@ -134,6 +134,9 @@ class GradingPrimaryTransformTest(unittest.TestCase):
         proc = cfg.getProcessor(group)
         cpu = proc.getDefaultCPUProcessor()
 
+        self.assertTrue(cpu.isDynamic())
+        self.assertTrue(cpu.hasDynamicProperty(OCIO.DYNAMIC_PROPERTY_GRADING_PRIMARY))
+
         dp = cpu.getDynamicProperty(OCIO.DYNAMIC_PROPERTY_GRADING_PRIMARY)
         self.assertEqual(dp.getType(), OCIO.DYNAMIC_PROPERTY_GRADING_PRIMARY)
 


### PR DESCRIPTION
This PR contains minor fixes (split into individual commits):
* Add hasDynamic(type) and isDynamic() methods to CPUProcessor (#1799)
* Add missing OSL language enum from Python bindings (#1820)
* Tentatively fix an issue with ASAN on the Platform latest nightly
* Tentatively fix Analysis nightly never running