### PR TITLE
Update README.md to include link to main documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Web Resources
 -------------
 
 * Website: <http://opencolorio.org>
+* Documentation: <https://opencolorio.readthedocs.io/en/latest/>
 * Mailing lists:
   * Developer: <ocio-dev@lists.aswf.io>
   * User: <ocio-user@lists.aswf.io>


### PR DESCRIPTION
Seams odd not to link directly to it from the README

also testing Easy CLA

Signed-off-by: Kevin Wheatley <kevin.wheatley@framestore.com>
