### PR TITLE
Fix building on x86 32-bit Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,8 +180,11 @@ option(OCIO_USE_OIIO_FOR_APPS "Request OIIO to build apps (ociolutimage, ociocon
 
 
 if (NOT APPLE)
-    if ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(AMD64|IA64|EM64T|X86|x86_64|i386|i686)")
+    if ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(AMD64|IA64|EM64T|x86_64|X86|i386|i686)")
         # Intel-based architecture (not APPLE)
+        if ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(X86|i386|i686)")
+            set(OCIO_ARCH_X86_32 1)
+        endif()
         set(OCIO_ARCH_X86 1)
         set(OCIO_BUILD_ENABLE_OPTIMIZATIONS_SSE ON)
         set(OCIO_BUILD_ENABLE_OPTIMIZATIONS_AVX ON)

--- a/src/OpenColorIO/CPUInfo.cpp
+++ b/src/OpenColorIO/CPUInfo.cpp
@@ -50,6 +50,13 @@ static inline void cpuid(int index, int *data)
 {
 #if _MSC_VER
     __cpuid(data, index);
+#elif OCIO_ARCH_X86_32
+    __asm__ volatile (
+        "mov    %%ebx, %%esi \n\t"
+        "cpuid               \n\t"
+        "xchg   %%ebx, %%esi"
+        : "=a" (data[0]), "=S" (data[1]), "=c" (data[2]), "=d" (data[3])
+        : "0" (index), "2"(0));
 #else
     __asm__ volatile (
         "mov    %%rbx, %%rsi \n\t"

--- a/src/OpenColorIO/CPUInfoConfig.h.in
+++ b/src/OpenColorIO/CPUInfoConfig.h.in
@@ -3,6 +3,7 @@
 
 
 #cmakedefine01 OCIO_ARCH_X86
+#cmakedefine01 OCIO_ARCH_X86_32
 
 // Relevant only for arm64 architecture.
 #if defined(__aarch64__)


### PR DESCRIPTION
Fixes https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1841

`rbx` and `rsi` are 64-bit registers, in 32-bt you need to use `ebx` and `esi`

This 32-bit platform  probably isn't getting much testing these days, I'm getting a lot of test failures on my VM. 

```
[  23/1066] [MixingSlider / basic                                        ] - FAILED
[ 155/1066] [CPUProcessor / optimizations                                ] - FAILED
[ 162/1066] [DynamicPropertyImpl / grading_rgb_curve_knots               ] - FAILED
[ 175/1066] [FileFormat3DL / load                                        ] - FAILED
[ 196/1066] [FileFormatCTF / clf_examples                                ] - FAILED
[ 219/1066] [FileFormatCTF / tabluation_support                          ] - FAILED
[ 264/1066] [FileFormatCTF / indexMap_test1_clfv2                        ] - FAILED
[ 419/1066] [FileFormatCTF / bake_1d_3d                                  ] - FAILED
[ 422/1066] [FileFormatD1DL / test_lut1d_8i_8i                           ] - FAILED
[ 425/1066] [FileFormatD1DL / test_lut1d_16f_12i                         ] - FAILED
[ 429/1066] [FileFormatHDL / bake_1d_shaper                              ] - FAILED
[ 464/1066] [FileFormatResolveCube / bake_1d_shaper                      ] - FAILED
[ 473/1066] [FileFormatSpi1D / bake_1d_shaper                            ] - FAILED
[ 534/1066] [GpuShader / MetalSupport8                                   ] - FAILED
[ 626/1066] [ExposureContrastRenderer / video                            ] - FAILED
[ 627/1066] [ExposureContrastRenderer / log                              ] - FAILED
[ 669/1066] [GammaOp / combining                                         ] - FAILED
[ 794/1066] [Lut1DRenderer / lut_1d_inv_decreasing_reversals             ] - FAILED
[ 961/1066] [SSE2 / packed_all_test                                      ] - FAILED
[ 968/1066] [AVX / packed_all_test                                       ] - FAILED
[ 975/1066] [AVX2 / packed_all_test                                      ] - FAILED
```

A lot of them look like rounding errors similar to the ones we get one arm64
