### PR TITLE
1857 ocioarchivedirmaincppo relocation r x86 64 32 against bss can not be used when making a pie object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 ###############################################################################
 # CMake definition.
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.15)
 
 set(CMAKE_MODULE_PATH
     ${CMAKE_MODULE_PATH}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,7 +341,15 @@ endif()
 ###############################################################################
 # Define compilation and link flags
 
+option(OCIO_BUILD_POSITION_INDEPENDENT_EXECUTABLES "Set to ON to build executables as PIE" OFF)
+
 include(CompilerFlags)
+
+if(OCIO_BUILD_POSITION_INDEPENDENT_EXECUTABLES AND NOT CMAKE_C_LINK_PIE_SUPPORTED)
+    message(FATAL_ERROR "PIE is not supported at link time.\n")
+else()
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
 
 ###############################################################################
 # External linking options

--- a/docs/quick_start/installation.rst
+++ b/docs/quick_start/installation.rst
@@ -316,6 +316,10 @@ build chains.)
 The CMake output prints information regarding which image library will be used for the
 command-line tools (as well as a lot of other info about the build configuration).
 
+Some OS distributions may require executables to be able to be executed using address space
+layout randomisation (ASLR). To Acheive this code generated needs to be position independent.
+To support thie please add ``-DOCIO_BUILD_POSITION_INDEPENDENT_EXECUTABLES=ON`` to your cmake
+configuration step.
 
 Documentation
 +++++++++++++

--- a/share/cmake/utils/CompilerFlags.cmake
+++ b/share/cmake/utils/CompilerFlags.cmake
@@ -48,6 +48,9 @@ endif()
 ###############################################################################
 # Compile flags
 
+include(CheckPIESupported)
+check_pie_supported()
+
 if(USE_MSVC)
 
     set(PLATFORM_COMPILE_OPTIONS "${PLATFORM_COMPILE_OPTIONS};/DUSE_MSVC")


### PR DESCRIPTION
As per the discussion #1857 add a configuration option to build executables as PIE.

Note, I looked at applying the position independence at a specific cmake target level but after
tracing though the dependencies this top level adjustment is basically the same but fewer lines of
CMake, i.e. we need to set the flag for all object files used in a given executable.

Signed-off-by: Kevin Wheatley <kevin.wheatley@framestore.com>
