### PR TITLE
Issue #1874 Cast to unsigned char for isspace.

### DIFF
--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -106,7 +106,7 @@ inline std::string LeftTrim(std::string str, char c)
 // Starting from the left, trim all the space characters i.e. space, tabulation, etc.
 inline std::string LeftTrim(std::string str)
 {
-    const auto it = std::find_if(str.begin(), str.end(), [](char ch) { return !std::isspace(ch); });
+    const auto it = std::find_if(str.begin(), str.end(), [](char ch) { return !std::isspace(static_cast<unsigned char>(ch)); });
     str.erase(str.begin(), it);
     return str;
 }
@@ -123,7 +123,7 @@ inline std::string RightTrim(std::string str, char c)
 inline std::string RightTrim(std::string str)
 {
     const auto it =
-        std::find_if(str.rbegin(), str.rend(), [](char ch) { return !std::isspace(ch); });
+        std::find_if(str.rbegin(), str.rend(), [](char ch) { return !std::isspace(static_cast<unsigned char>(ch)); });
     str.erase(it.base(), str.end());
     return str;
 }

--- a/tests/utils/StringUtils_tests.cpp
+++ b/tests/utils/StringUtils_tests.cpp
@@ -50,6 +50,11 @@ OCIO_ADD_TEST(StringUtils, trim)
         const std::string str = StringUtils::Trim(ref);
         OCIO_CHECK_EQUAL(str, "lOwEr 1*& ctfG");
     }
+
+    {
+        constexpr char ref2[]{ -1, -2, -3, '\0' };
+        const std::string str = StringUtils::Trim(ref2);
+    }
 }
 
 OCIO_ADD_TEST(StringUtils, split)

--- a/tests/utils/StringUtils_tests.cpp
+++ b/tests/utils/StringUtils_tests.cpp
@@ -52,6 +52,7 @@ OCIO_ADD_TEST(StringUtils, trim)
     }
 
     {
+        // Test that no assert happens when the Trim argument is not an unsigned char (see issue #1874).
         constexpr char ref2[]{ -1, -2, -3, '\0' };
         const std::string str = StringUtils::Trim(ref2);
     }


### PR DESCRIPTION
Fix for: https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1874

Cast to unsigned char before using std:isspace().

From cppreference:

Like all other functions from cctype, the behavior of std::isspace is undefined if the argument's value is neither representable as unsigned char nor equal to EOF. To use these functions safely with plain chars (or signed chars), the argument should first be converted to unsigned char