### PR TITLE
Adsk Contrib - Fix for the doxygen installation failure in the Dependencies latest workflow (Windows)

### DIFF
--- a/.github/workflows/dependencies_latest.yml
+++ b/.github/workflows/dependencies_latest.yml
@@ -292,7 +292,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install docs env
-        run: share/ci/scripts/windows/install_docs_env.sh
+        run: |
+          DOXYGEN_PATH=$GITHUB_WORKSPACE/doxygen
+          share/ci/scripts/windows/install_docs_env.sh "$DOXYGEN_PATH"
+          echo "$DOXYGEN_PATH" >> $GITHUB_PATH
         shell: bash
         if: matrix.build-docs == 'ON'
       - name: Install tests env

--- a/share/ci/scripts/windows/install_docs_env.sh
+++ b/share/ci/scripts/windows/install_docs_env.sh
@@ -5,6 +5,7 @@
 set -ex
 
 HERE=$(dirname $0)
+DOXYGEN_LOCATION="$1"
 
-bash $HERE/install_doxygen.sh latest
+bash $HERE/install_doxygen.sh "$DOXYGEN_LOCATION"
 pip install -r $HERE/../../../../docs/requirements.txt

--- a/share/ci/scripts/windows/install_doxygen.sh
+++ b/share/ci/scripts/windows/install_doxygen.sh
@@ -4,10 +4,18 @@
 
 set -ex
 
-DOXYGEN_VERSION="$1"
+DOXYGEN_LOCATION="$1"
 
-if [ "$DOXYGEN_VERSION" == "latest" ]; then
-    choco install doxygen.install
-else
-    choco install doxygen.install --version=${DOXYGEN_VERSION}
-fi
+# Utility to parse JSON object.
+choco install jq
+
+# Get the URL of the latest zip package for Doxygen.
+url=$(curl -s 'https://api.github.com/repos/doxygen/doxygen/releases/latest' | jq -r '.assets[] | select(.name | test("doxygen-.*windows.x64.bin.zip")) | .browser_download_url')
+
+# Download the zip.
+mkdir $DOXYGEN_LOCATION
+cd $DOXYGEN_LOCATION
+powershell 'iwr -URI '$url' -OutFile doxygen.zip'
+
+# Unzip the file into $DOXYGEN_LOCATION.
+unzip -o doxygen.zip


### PR DESCRIPTION
This is a tentative fix for the failure in the dependencies' latest workflow with the Doxygen installation (it seems to be failing randomly). 

We are using the package manager Chocolatey, and the Chocolatey package is getting the doxygen files from Sourceforge. It seems like there are issues with either the Chocolatey package or SourceForge and that causes the download to fail.

I've changed the script to download the doxygen release manually from GitHub and install it manually.

---

An alternative to this would be to ask the maintainer of the doxygen package on Chocolatey (https://github.com/mlt/chocolatey-packages) to download Doxygen from their GitHub release.