### PR TITLE
Simplify the Findyaml-cpp module

### DIFF
--- a/src/cmake/Config.cmake.in
+++ b/src/cmake/Config.cmake.in
@@ -34,15 +34,18 @@ if (NOT @BUILD_SHARED_LIBS@) # NOT @BUILD_SHARED_LIBS@
         find_dependency(pystring @pystring_VERSION@)
     endif()
 
-    if (NOT TARGET yaml-cpp AND NOT TARGET yaml-cpp::yaml-cpp)
+    if (NOT TARGET yaml-cpp::yaml-cpp)
         find_dependency(yaml-cpp @yaml-cpp_VERSION@)
+        if (TARGET yaml-cpp AND NOT TARGET yaml-cpp::yaml-cpp)
+            add_library(yaml-cpp::yaml-cpp ALIAS yaml-cpp)
+        endif()
     endif()
 
     if (NOT TARGET ZLIB::ZLIB)
         # ZLIB_VERSION is available starting CMake 3.26+.
         # ZLIB_VERSION_STRING is still available for backward compatibility.
         # See https://cmake.org/cmake/help/git-stage/module/FindZLIB.html
-        
+
         if (@ZLIB_VERSION@) # @ZLIB_VERSION@
             find_dependency(ZLIB @ZLIB_VERSION@)
         else()


### PR DESCRIPTION
This fixes compatibility with yaml-cpp 0.8, which previously failed because of a `get_property` call with the wrong target name. I took the liberty to add a few simplifications along the way.