### PR TITLE
Skip processor concatenation if the display color space is also data.

### DIFF
--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -4723,16 +4723,25 @@ ConstProcessorRcPtr Config::GetProcessorFromConfigs(const ConstContextRcPtr & sr
     if (!p2)
     {
         throw Exception("Can't create the processor for the destination config "
-            "and the destination color space.");
+            "and the destination display view transform.");
     }
 
     ProcessorRcPtr processor = Processor::Create();
     processor->getImpl()->setProcessorCacheFlags(srcConfig->getImpl()->m_cacheFlags);
 
-    // If the source color spaces is a data space, its corresponding processor
+    const char* csName = dstConfig->getDisplayViewColorSpaceName(dstDisplay, dstView);
+    const char* displayColorSpaceName = View::UseDisplayName(csName) ? dstDisplay : csName;
+    ConstColorSpaceRcPtr displayColorSpace = dstConfig->getColorSpace(displayColorSpaceName);
+    if (!displayColorSpace)
+    {
+        throw Exception("Can't create the processor for the destination config: "
+            "display color space not found.");
+    }
+
+    // If either of the color spaces are data spaces, its corresponding processor
     // will be empty, but need to make sure the entire result is also empty to
     // better match the semantics of how data spaces are handled.
-    if (!srcColorSpace->isData())
+    if (!srcColorSpace->isData() && !displayColorSpace->isData())
     {
         if (direction == TRANSFORM_DIR_INVERSE)
         {

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -4719,6 +4719,15 @@ ConstProcessorRcPtr Config::GetProcessorFromConfigs(const ConstContextRcPtr & sr
             "the source color space.");
     }
 
+    const char* csName = dstConfig->getDisplayViewColorSpaceName(dstDisplay, dstView);
+    const char* displayColorSpaceName = View::UseDisplayName(csName) ? dstDisplay : csName;
+    ConstColorSpaceRcPtr displayColorSpace = dstConfig->getColorSpace(displayColorSpaceName);
+    if (!displayColorSpace)
+    {
+        throw Exception("Can't create the processor for the destination config: "
+            "display color space not found.");
+    }
+
     auto p2 = dstConfig->getProcessor(dstContext, dstInterchangeName, dstDisplay, dstView, direction);
     if (!p2)
     {
@@ -4728,15 +4737,6 @@ ConstProcessorRcPtr Config::GetProcessorFromConfigs(const ConstContextRcPtr & sr
 
     ProcessorRcPtr processor = Processor::Create();
     processor->getImpl()->setProcessorCacheFlags(srcConfig->getImpl()->m_cacheFlags);
-
-    const char* csName = dstConfig->getDisplayViewColorSpaceName(dstDisplay, dstView);
-    const char* displayColorSpaceName = View::UseDisplayName(csName) ? dstDisplay : csName;
-    ConstColorSpaceRcPtr displayColorSpace = dstConfig->getColorSpace(displayColorSpaceName);
-    if (!displayColorSpace)
-    {
-        throw Exception("Can't create the processor for the destination config: "
-            "display color space not found.");
-    }
 
     // If either of the color spaces are data spaces, its corresponding processor
     // will be empty, but need to make sure the entire result is also empty to

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -5924,6 +5924,7 @@ displays:
   displayname:
     - !<View> {name: view1, colorspace: displaytest1}
     - !<View> {name: view2, view_transform: vt1, display_colorspace: display2}
+    - !<View> {name: view3, colorspace: data_space}
 
 view_transforms:
   - !<ViewTransform>
@@ -6165,6 +6166,13 @@ display_colorspaces:
     t4 = group->getTransform(4);
     auto ff4 = OCIO_DYNAMIC_POINTER_CAST<OCIO::FixedFunctionTransform>(t4);
     OCIO_CHECK_ASSERT(ff4);
+
+    // If one of the spaces is a data space, the whole result must be a no-op.
+    OCIO_CHECK_NO_THROW(p = OCIO::Config::GetProcessorFromConfigs(
+        config2, "test2", config1, "displayname", "view3", OCIO::TRANSFORM_DIR_FORWARD));
+    OCIO_REQUIRE_ASSERT(p);
+    group = p->createGroupTransform();
+    OCIO_REQUIRE_EQUAL(group->getNumTransforms(), 0);
 
     constexpr const char * SIMPLE_CONFIG3{ R"(
 ocio_profile_version: 2


### PR DESCRIPTION
Our QA stumbled onto this issue with the new merged processor function. It does not act as a passthrough with `Raw` display-view(s), but it should.