### PR TITLE
Restore GPU workflow and minor updates to CI

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -527,7 +527,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install docs env
-        run: share/ci/scripts/windows/install_docs_env.sh
+        run: |
+          DOXYGEN_PATH=$GITHUB_WORKSPACE/doxygen
+          share/ci/scripts/windows/install_docs_env.sh "$DOXYGEN_PATH"
+          echo "$DOXYGEN_PATH" >> $GITHUB_PATH
         shell: bash
         if: matrix.build-docs == 'ON'
       - name: Install tests env

--- a/.github/workflows/gpu_workflow.yml
+++ b/.github/workflows/gpu_workflow.yml
@@ -16,8 +16,6 @@ on:
     tags-ignore:
       - v0.*
       - v1.*
-    paths:
-      - .github/workflows/gpu_workflow.yml
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/.github/workflows/platform_latest.yml
+++ b/.github/workflows/platform_latest.yml
@@ -104,7 +104,7 @@ jobs:
                 -DOCIO_BUILD_OPENFX=ON \
                 -DOCIO_BUILD_GPU_TESTS=OFF \
                 -DOCIO_BUILD_PYTHON=${{ matrix.build-python}} \
-                -DOCIO_USE_SSE=ON \
+                -DOCIO_USE_SIMD=ON \
                 -DOCIO_USE_OIIO_FOR_APPS=OFF \
                 -DOCIO_INSTALL_EXT_PACKAGES=ALL \
                 -DOCIO_WARNING_AS_ERROR=ON \
@@ -219,7 +219,7 @@ jobs:
                 -DOCIO_BUILD_OPENFX=ON \
                 -DOCIO_BUILD_GPU_TESTS=OFF \
                 -DOCIO_BUILD_PYTHON=${{ matrix.build-python}} \
-                -DOCIO_USE_SSE=ON \
+                -DOCIO_USE_SIMD=ON \
                 -DOCIO_USE_OIIO_FOR_APPS=OFF \
                 -DOCIO_INSTALL_EXT_PACKAGES=ALL \
                 -DOCIO_WARNING_AS_ERROR=ON \
@@ -333,7 +333,7 @@ jobs:
                 -DOCIO_BUILD_OPENFX=ON \
                 -DOCIO_BUILD_GPU_TESTS=OFF \
                 -DOCIO_BUILD_PYTHON=${{ matrix.build-python}} \
-                -DOCIO_USE_SSE=ON \
+                -DOCIO_USE_SIMD=ON \
                 -DOCIO_USE_OIIO_FOR_APPS=OFF \
                 -DOCIO_INSTALL_EXT_PACKAGES=ALL \
                 -DOCIO_WARNING_AS_ERROR=ON \

--- a/share/cmake/modules/install/InstallOpenEXR.cmake
+++ b/share/cmake/modules/install/InstallOpenEXR.cmake
@@ -110,7 +110,7 @@ if(NOT OpenEXR_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACK
             -DBUILD_SHARED_LIBS=OFF
             -DBUILD_TESTING=OFF
             -DOPENEXR_INSTALL_EXAMPLES=OFF
-            -DOPENEXR_INSTALL_TOOLS=OFF
+            -DOPENEXR_BUILD_TOOLS=OFF
             # Try to use in-source built Imath first, if available.
             -DCMAKE_PREFIX_PATH=${_EXT_DIST_ROOT}
         )

--- a/share/cmake/utils/CompilerFlags.cmake
+++ b/share/cmake/utils/CompilerFlags.cmake
@@ -107,8 +107,8 @@ if(USE_GCC OR USE_CLANG)
     endif()
 
     if(OCIO_ENABLE_SANITIZER)
-        set(PLATFORM_COMPILE_OPTIONS "${PLATFORM_COMPILE_OPTIONS};-fno-omit-frame-pointer;-fsanitize=address")
-        set(PLATFORM_LINK_OPTIONS "${PLATFORM_LINK_OPTIONS};-fsanitize=address")
+        set(PLATFORM_COMPILE_OPTIONS "${PLATFORM_COMPILE_OPTIONS};-fno-omit-frame-pointer;-fsanitize=address;-fsanitize=undefined")
+        set(PLATFORM_LINK_OPTIONS "${PLATFORM_LINK_OPTIONS};-fsanitize=address;-fsanitize=undefined")
     endif()
 
 endif()

--- a/tests/cpu/BitDepthUtils_tests.cpp
+++ b/tests/cpu/BitDepthUtils_tests.cpp
@@ -16,9 +16,6 @@ OCIO_ADD_TEST(BitDepthUtils, get_bitdepth_max_value)
 
     OCIO_CHECK_EQUAL(OCIO::GetBitDepthMaxValue(OCIO::BIT_DEPTH_F16), 1.0);
     OCIO_CHECK_EQUAL(OCIO::GetBitDepthMaxValue(OCIO::BIT_DEPTH_F32), 1.0);
-
-    OCIO_CHECK_THROW_WHAT(
-        OCIO::GetBitDepthMaxValue((OCIO::BitDepth)42), OCIO::Exception, "not supported");
 }
 
 OCIO_ADD_TEST(BitDepthUtils, is_float_bitdepth)
@@ -36,9 +33,6 @@ OCIO_ADD_TEST(BitDepthUtils, is_float_bitdepth)
 
     OCIO_CHECK_THROW_WHAT(
         OCIO::IsFloatBitDepth(OCIO::BIT_DEPTH_UINT32), OCIO::Exception, "not supported");
-
-    OCIO_CHECK_THROW_WHAT(
-        OCIO::IsFloatBitDepth((OCIO::BitDepth)42), OCIO::Exception, "not supported");
 }
 
 OCIO_ADD_TEST(BitDepthUtils, get_channel_size)

--- a/tests/cpu/ops/exposurecontrast/ExposureContrastOpData_tests.cpp
+++ b/tests/cpu/ops/exposurecontrast/ExposureContrastOpData_tests.cpp
@@ -63,10 +63,6 @@ OCIO_ADD_TEST(ExposureContrastOpData, style)
     OCIO_CHECK_NO_THROW(styleName =
         ConvertToString(OCIO::ExposureContrastOpData::STYLE_LOGARITHMIC_REV));
     OCIO_CHECK_EQUAL(styleName, OCIO::EC_STYLE_LOGARITHMIC_REV);
-
-    OCIO_CHECK_THROW_WHAT(
-        ConvertToString((OCIO::ExposureContrastOpData::Style)-1),
-        OCIO::Exception, "Unknown exposure contrast style");
 }
 
 OCIO_ADD_TEST(ExposureContrastOpData, accessors)
@@ -336,4 +332,3 @@ OCIO_ADD_TEST(ExposureContrastOpData, replace_dynamic_property)
                      OCIO::Exception);
     OCIO_CHECK_THROW(ec1.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST), OCIO::Exception);
 }
-

--- a/tests/cpu/ops/lut3d/Lut3DOp_tests.cpp
+++ b/tests/cpu/ops/lut3d/Lut3DOp_tests.cpp
@@ -126,11 +126,6 @@ OCIO_ADD_TEST(GenerateIdentityLut3D, throw_lut)
         lut.data(), lutSize, 2, OCIO::LUT3DORDER_FAST_RED),
         OCIO::Exception, "less than 3 channels");
 
-    // GenerateIdentityLut3D with unknown order.
-    OCIO_CHECK_THROW_WHAT(GenerateIdentityLut3D(
-        lut.data(), lutSize, 3, (OCIO::Lut3DOrder)42),
-        OCIO::Exception, "Unknown Lut3DOrder");
-
     // Get3DLutEdgeLenFromNumPixels with not cubic size.
     OCIO_CHECK_THROW_WHAT(OCIO::Get3DLutEdgeLenFromNumPixels(10),
         OCIO::Exception, "Cannot infer 3D LUT size");
@@ -674,4 +669,3 @@ OCIO_ADD_TEST(Lut3DTransform, build_op)
 // TODO: Port syncolor test: renderer\test\CPURenderer_cases.cpp_inc - CPURendererLUT3D_Green
 // TODO: Port syncolor test: renderer\test\CPURenderer_cases.cpp_inc - CPURendererLUT3D_Red
 // TODO: Port syncolor test: renderer\test\CPURenderer_cases.cpp_inc - CPURendererLUT3D_Example
-


### PR DESCRIPTION
Tentatively restore runs for the GPU workflow which haven't run for the past 3 months now due to wrong filtering settings (I) introduced during a previous update. Also enabled the undefined behaviour sanitizer to the nightly build as it is easy to use alongside address, some unit tests are then removed as these were triggering it (assuming we don't need to test UB).