### PR TITLE
Proposed fix for pystring include paths

### DIFF
--- a/share/cmake/modules/Findpystring.cmake
+++ b/share/cmake/modules/Findpystring.cmake
@@ -28,12 +28,13 @@ if(NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL ALL)
     # Find include directory
     find_path(pystring_INCLUDE_DIR
         NAMES
-            pystring/pystring.h
+            pystring.h
         HINTS
             ${pystring_ROOT}
         PATH_SUFFIXES
             include
             pystring/include
+            include/pystring
     )
 
     # Find library

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -34,7 +34,7 @@
 #include "Platform.h"
 #include "PrivateTypes.h"
 #include "Processor.h"
-#include "pystring/pystring.h"
+#include "pystring.h"
 #include "transforms/FileTransform.h"
 #include "utils/StringUtils.h"
 #include "ViewingRules.h"

--- a/src/OpenColorIO/Context.cpp
+++ b/src/OpenColorIO/Context.cpp
@@ -15,7 +15,7 @@
 #include "OCIOZArchive.h"
 #include "PathUtils.h"
 #include "PrivateTypes.h"
-#include "pystring/pystring.h"
+#include "pystring.h"
 #include "utils/StringUtils.h"
 
 namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -19,7 +19,7 @@
 #include "ParseUtils.h"
 #include "PathUtils.h"
 #include "Platform.h"
-#include "pystring/pystring.h"
+#include "pystring.h"
 #include "utils/StringUtils.h"
 #include "ViewingRules.h"
 #include "yaml-cpp/yaml.h"

--- a/src/OpenColorIO/OCIOZArchive.cpp
+++ b/src/OpenColorIO/OCIOZArchive.cpp
@@ -11,7 +11,7 @@
 #include <OpenColorIO/OpenColorIO.h>
 #include "Mutex.h"
 #include "Platform.h"
-#include "pystring/pystring.h"
+#include "pystring.h"
 #include "utils/StringUtils.h"
 #include "transforms/FileTransform.h"
 

--- a/src/OpenColorIO/Op.cpp
+++ b/src/OpenColorIO/Op.cpp
@@ -20,7 +20,7 @@
 #include "ops/lut1d/Lut1DOp.h"
 #include "ops/lut3d/Lut3DOp.h"
 #include "ops/range/RangeOp.h"
-#include "pystring/pystring.h"
+#include "pystring.h"
 
 namespace OCIO_NAMESPACE
 {

--- a/src/OpenColorIO/PathUtils.cpp
+++ b/src/OpenColorIO/PathUtils.cpp
@@ -10,7 +10,7 @@
 #include "Mutex.h"
 #include "PathUtils.h"
 #include "Platform.h"
-#include "pystring/pystring.h"
+#include "pystring.h"
 #include "utils/StringUtils.h"
 #include "OCIOZArchive.h"
 

--- a/src/OpenColorIO/fileformats/FileFormatCTF.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCTF.cpp
@@ -23,7 +23,7 @@
 #include "OpBuilders.h"
 #include "ops/noop/NoOps.h"
 #include "Platform.h"
-#include "pystring/pystring.h"
+#include "pystring.h"
 #include "TransformBuilder.h"
 #include "transforms/FileTransform.h"
 #include "utils/StringUtils.h"

--- a/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
@@ -16,7 +16,7 @@
 #include "ops/lut1d/Lut1DOp.h"
 #include "ops/lut3d/Lut3DOp.h"
 #include "ParseUtils.h"
-#include "pystring/pystring.h"
+#include "pystring.h"
 #include "Platform.h"
 #include "transforms/FileTransform.h"
 #include "utils/StringUtils.h"

--- a/src/OpenColorIO/fileformats/FileFormatICC.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatICC.cpp
@@ -15,7 +15,7 @@
 #include "ops/matrix/MatrixOp.h"
 #include "ops/range/RangeOp.h"
 #include "Platform.h"
-#include "pystring/pystring.h"
+#include "pystring.h"
 #include "transforms/FileTransform.h"
 
 

--- a/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
@@ -13,7 +13,7 @@
 #include "ops/lut3d/Lut3DOp.h"
 #include "ParseUtils.h"
 #include "Platform.h"
-#include "pystring/pystring.h"
+#include "pystring.h"
 #include "transforms/FileTransform.h"
 #include "utils/StringUtils.h"
 #include "utils/NumberUtils.h"

--- a/src/OpenColorIO/transforms/FileTransform.cpp
+++ b/src/OpenColorIO/transforms/FileTransform.cpp
@@ -19,7 +19,7 @@
 #include "ops/noop/NoOps.h"
 #include "PathUtils.h"
 #include "Platform.h"
-#include "pystring/pystring.h"
+#include "pystring.h"
 #include "utils/StringUtils.h"
 
 namespace OCIO_NAMESPACE


### PR DESCRIPTION
Make Findpystring.cmake return the full include directory to pystring so that prefixing includes with "pystring/" is no longer required.

This changes the behaviour of the included Findpystring.cmake to match the bahaviour of other regular find_package modules to report the full include directory removing the requirement to use "pystring/" when including "pystring.h" etc.
(This follows from https://github.com/conan-io/conan-center-index/pull/20703#discussion_r1383018774)