### PR TITLE
fix: use system `include pystring.h` for `ConfigUtils.cpp`

### DIFF
--- a/src/OpenColorIO/ConfigUtils.cpp
+++ b/src/OpenColorIO/ConfigUtils.cpp
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <pystring.h>
+
 #include "ConfigUtils.h"
 #include "MathUtils.h"
-#include "pystring/pystring.h"
 #include "utils/StringUtils.h"
 
 namespace OCIO_NAMESPACE


### PR DESCRIPTION
closes #1920

cc @doug-walker @wahn