### PR TITLE
Fix narrowing conversion error on riscv64

### DIFF
--- a/tests/utils/StringUtils_tests.cpp
+++ b/tests/utils/StringUtils_tests.cpp
@@ -53,7 +53,7 @@ OCIO_ADD_TEST(StringUtils, trim)
 
     {
         // Test that no assert happens when the Trim argument is not an unsigned char (see issue #1874).
-        constexpr char ref2[]{ -1, -2, -3, '\0' };
+        constexpr char ref2[]{ char(-1), char(-2), char(-3), '\0' };
         const std::string str = StringUtils::Trim(ref2);
     }
 }


### PR DESCRIPTION
Fix a narrowing conversion error on RISCV64 build. (https://github.com/AcademySoftwareFoundation/OpenColorIO/pull/1888)
```
[6/477] Building CXX object tests/utils/CMakeFiles/test_utils_exec.dir/StringUtils_tests.cpp.o
FAILED: tests/utils/CMakeFiles/test_utils_exec.dir/StringUtils_tests.cpp.o 
/usr/bin/c++  -I/build/opencolorio/src/OpenColorIO-2.3.1/tests/testutils/.. -isystem /build/opencolorio/src/OpenColorIO-2.3.1/src/utils/.. -march=rv64gc -mabi=lp64d -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -Wp,-D_GLIBCXX_ASSERTIONS -g -ffile-prefix-map=/build/opencolorio/src=/usr/src/debug/opencolorio -flto=auto -ffat-lto-objects -O3 -DNDEBUG -std=c++14 -fvisibility=hidden -fvisibility-inlines-hidden -DUSE_GCC -Wall -Wextra -Wswitch-enum -MD -MT tests/utils/CMakeFiles/test_utils_exec.dir/StringUtils_tests.cpp.o -MF tests/utils/CMakeFiles/test_utils_exec.dir/StringUtils_tests.cpp.o.d -o tests/utils/CMakeFiles/test_utils_exec.dir/StringUtils_tests.cpp.o -c /build/opencolorio/src/OpenColorIO-2.3.1/tests/utils/StringUtils_tests.cpp
/build/opencolorio/src/OpenColorIO-2.3.1/tests/utils/StringUtils_tests.cpp: In function ‘void ociotest_StringUtils_trim()’:
/build/opencolorio/src/OpenColorIO-2.3.1/tests/utils/StringUtils_tests.cpp:56:32: error: narrowing conversion of ‘-1’ from ‘int’ to ‘char’ [-Wnarrowing]
   56 |         constexpr char ref2[]{ -1, -2, -3, '\0' };
      |                                ^~
/build/opencolorio/src/OpenColorIO-2.3.1/tests/utils/StringUtils_tests.cpp:56:36: error: narrowing conversion of ‘-2’ from ‘int’ to ‘char’ [-Wnarrowing]
   56 |         constexpr char ref2[]{ -1, -2, -3, '\0' };
      |                                    ^~
/build/opencolorio/src/OpenColorIO-2.3.1/tests/utils/StringUtils_tests.cpp:56:40: error: narrowing conversion of ‘-3’ from ‘int’ to ‘char’ [-Wnarrowing]
   56 |         constexpr char ref2[]{ -1, -2, -3, '\0' };

```
