### PR TITLE
Enhance ociochecklut to print the output after each step in a multi-t…

### DIFF
--- a/src/apps/ociochecklut/main.cpp
+++ b/src/apps/ociochecklut/main.cpp
@@ -272,7 +272,7 @@ int main (int argc, const char* argv[])
         try
         {
             auto processor = config->getProcessor(t);
-            if (printops)
+            if (printops || stepInfo)
             {
                 auto transform = processor->createGroupTransform();
                 std::cout << "Transform operators: " << std::endl;

--- a/src/apps/ociochecklut/main.cpp
+++ b/src/apps/ociochecklut/main.cpp
@@ -50,12 +50,16 @@ public:
     void setGPU(OCIO::ConstGPUProcessorRcPtr gpu)
     {
         m_gpu = gpu;
-        m_oglApp = OCIO::OglApp::CreateOglApp("ociochecklut", 256, 20);
-
-        if (m_verbose)
+        if (!m_oglApp)
         {
-            m_oglApp->printGLInfo();
+            m_oglApp = OCIO::OglApp::CreateOglApp("ociochecklut", 256, 20);
+
+            if (m_verbose)
+            {
+                m_oglApp->printGLInfo();
+            }
         }
+
         m_oglApp->setPrintShader(m_verbose);
         float image[4]{ 0.f, 0.f, 0.f, 0.f };
         m_oglApp->initImage(1, 1, OCIO::OglApp::COMPONENTS_RGBA, image);
@@ -191,6 +195,7 @@ int main (int argc, const char* argv[])
     bool usegpu        = false;
     bool usegpuLegacy  = false;
     bool outputgpuInfo = false;
+    bool stepInfo      = false;
 
     ArgParse ap;
     ap.options("ociochecklut -- check any LUT file and optionally convert a pixel\n\n"
@@ -199,6 +204,7 @@ int main (int argc, const char* argv[])
                "<SEPARATOR>", "Options:",
                "-t", &test, "Test a set a predefined RGB values",
                "-v", &verbose, "Verbose",
+               "-s", &stepInfo, "Print the output after each step in a multi - transform LUT",
                "--help", &help, "Print help message",
                "--inv", &invlut, "Apply LUT in inverse direction",
                "--gpu", &usegpu, "Use GPU instead of CPU",
@@ -346,7 +352,7 @@ int main (int argc, const char* argv[])
               0.f,   1.f,   0.f,
               0.f,   0.f,   1.f };
 
-        if (verbose)
+        if (verbose || stepInfo)
         {
             std::cout << std::endl;
         }
@@ -357,59 +363,140 @@ int main (int argc, const char* argv[])
             {
                 std::vector<float> pixel = { input[curPix], input[curPix+1], input[curPix+2],
                                              comp == 3 ? 0.0f : input[curPix + 3] };
-                try
-                {
-                    proc.apply(pixel);
-                }
-                catch (const OCIO::Exception & e)
-                {
-                    std::cerr << "ERROR: Processing pixel: " << e.what() << std::endl;
-                    return 1;
-                }
-                catch (...)
-                {
-                    std::cerr << "ERROR: Unknown error encountered while processing pixel." << std::endl;
-                    return 1;
-                }
 
-                // Print to string so that in & out values can be aligned if needed.
-
-                std::vector<std::string> out;
-                ToString(out, pixel, 0, comp);
-
-                if (verbose)
+                if (stepInfo)
                 {
-                    std::vector<std::string> in;
-                    ToString(in, input, curPix, comp);
-
-                    std::cout << "Input  [R G B";
-                    if (comp == 4)
+                    // Process each step in a multi - transform LUT
+                    try
                     {
-                        std::cout << " A";
-                    }
-                    std::cout << "]: [";
-                    PrintAlignedVec(in, out, comp);
-                    std::cout << "]" << std::endl;
+                        // Create GroupTransform so that each can be processed one at a time. 
+                        auto processor = config->getProcessor(t);
+                        auto transform = processor->createGroupTransform();
+                        std::vector<float> inputPixel = pixel;
+                        std::vector<float> outputPixel = pixel;
+                        const auto numTransforms = transform->getNumTransforms();
+                        
+                        std::cout << std::endl;
 
-                    std::cout << "Output [R G B";
-                    if (comp == 4)
-                    {
-                        std::cout << " A";
+                        for (int i = 0; i < numTransforms; ++i)
+                        {
+                            auto transformStep = transform->getTransform(i);
+                            auto processorStep = config->getProcessor(transformStep);
+
+                            if (usegpu || usegpuLegacy)
+                            {
+                                proc.setGPU(usegpuLegacy ? processorStep->getOptimizedLegacyGPUProcessor(OCIO::OPTIMIZATION_DEFAULT, 32)
+                                    : processorStep->getDefaultGPUProcessor());
+                            }
+                            else
+                            {
+                                proc.setCPU(processorStep->getDefaultCPUProcessor());
+                            }
+                            
+                            // Process the pixel
+                            proc.apply(outputPixel);
+
+                            // Print the input/output pixel
+                            std::vector<std::string> in;
+                            ToString(in, inputPixel, 0, comp);
+
+                            std::vector<std::string> out;
+                            ToString(out, outputPixel, 0, comp);
+
+                            std::cout << "Transform " << i << ": " << std::endl;
+                            std::cout << "Input  [R G B";
+                            if (comp == 4)
+                            {
+                                std::cout << " A";
+                            }
+                            std::cout << "]: [";
+                            PrintAlignedVec(in, out, comp);
+                            std::cout << "]" << std::endl;
+
+                            std::cout << "Output [R G B";
+                            if (comp == 4)
+                            {
+                                std::cout << " A";
+                            }
+                            std::cout << "]: [";
+                            PrintAlignedVec(out, in, comp);
+                            std::cout << "]" << std::endl;
+
+                            inputPixel = outputPixel;         
+                        }
                     }
-                    std::cout << "]: [";
-                    PrintAlignedVec(out, in, comp);
-                    std::cout << "]" << std::endl;
+                    catch (const OCIO::Exception& exception)
+                    {
+                        std::cerr << "ERROR: " << exception.what() << std::endl;
+                        return 1;
+                    }
+                    catch (...)
+                    {
+                        std::cerr << "ERROR: Unknown error encountered while processing single step operator." << std::endl;
+                        return 1;
+                    }
+
+                    curPix += comp;
                 }
                 else
                 {
-                    std::cout << out[0] << " " << out[1] << " " << out[2];
-                    if (comp == 4)
+                    // Process in a single step
+                    try
                     {
-                        std::cout << " " << out[3];
+                        proc.apply(pixel);
                     }
+                    catch (const OCIO::Exception& e)
+                    {
+                        std::cerr << "ERROR: Processing pixel: " << e.what() << std::endl;
+                        return 1;
+                    }
+                    catch (...)
+                    {
+                        std::cerr << "ERROR: Unknown error encountered while processing pixel." << std::endl;
+                        return 1;
+                    }
+
+                    // Print to string so that in & out values can be aligned if needed.
+
+                    std::vector<std::string> out;
+                    ToString(out, pixel, 0, comp);
+
                     std::cout << std::endl;
-                }
-                curPix += comp;
+
+                    if (verbose)
+                    {
+                        std::vector<std::string> in;
+                        ToString(in, input, curPix, comp);
+
+                        std::cout << "Input  [R G B";
+                        if (comp == 4)
+                        {
+                            std::cout << " A";
+                        }
+                        std::cout << "]: [";
+                        PrintAlignedVec(in, out, comp);
+                        std::cout << "]" << std::endl;
+
+                        std::cout << "Output [R G B";
+                        if (comp == 4)
+                        {
+                            std::cout << " A";
+                        }
+                        std::cout << "]: [";
+                        PrintAlignedVec(out, in, comp);
+                        std::cout << "]" << std::endl;
+                    }
+                    else
+                    {
+                        std::cout << out[0] << " " << out[1] << " " << out[2];
+                        if (comp == 4)
+                        {
+                            std::cout << " " << out[3];
+                        }
+                        std::cout << std::endl;
+                    }
+                    curPix += comp;
+                }               
             }
             else if (test)
             {

--- a/src/apps/ociochecklut/main.cpp
+++ b/src/apps/ociochecklut/main.cpp
@@ -272,7 +272,7 @@ int main (int argc, const char* argv[])
         try
         {
             auto processor = config->getProcessor(t);
-            if (printops || stepInfo)
+            if (printops)
             {
                 auto transform = processor->createGroupTransform();
                 std::cout << "Transform operators: " << std::endl;
@@ -403,7 +403,7 @@ int main (int argc, const char* argv[])
                             std::vector<std::string> out;
                             ToString(out, outputPixel, 0, comp);
 
-                            std::cout << "Transform " << i << ": " << std::endl;
+                            std::cout << "\n" << *(transform->getTransform(i)) << std::endl;
                             std::cout << "Input  [R G B";
                             if (comp == 4)
                             {


### PR DESCRIPTION
…ransform LUT

-s option will print the output after each step in the transform.

Tested with single RGB input as well as -t predefined RGB values.
Tested with various CLF files from OpenColorIO\tests\data\files\clf that have one, two and multiple operations.
Tested with --inv, --gpu, --gpulegacy

For cases with multiple operations, there are some differences in ouptut due to precision.  For example:


Example with 2 Transforms:

>>ociochecklut.exe lut1d_comp.clf 0.18 0.18 0.18 -v

OCIO Version: 2.4.0dev


Input  [R G B]: [     0.18     0.18      0.18]
Output [R G B]: [0.5528838 0.525246 0.4975982]

>>ociochecklut.exe lut1d_comp.clf 0.18 0.18 0.18 -v -s

OCIO Version: 2.4.0dev


Transform 0:
Input  [R G B]: [     0.18      0.18      0.18]
Output [R G B]: [0.3441569 0.3441569 0.3441569]
Transform 1:
Input  [R G B]: [0.3441569 0.3441569 0.3441569]
Output [R G B]: [0.5528837  0.525246 0.4975982]

Example with 9 Transforms:
>>ociochecklut.exe multiple_ops.clf 0.18 0.18 0.18 -v

OCIO Version: 2.4.0dev


Input  [R G B]: [     0.18      0.18        0.18]
Output [R G B]: [0.2754872 0.3039555 -0.06960445]

>>ociochecklut.exe multiple_ops.clf 0.18 0.18 0.18 -v -s

OCIO Version: 2.4.0dev


Transform 0:
Input  [R G B]: [     0.18      0.18       0.18]
Output [R G B]: [0.1866483 0.2251173 0.08405399]
Transform 1:
Input  [R G B]: [0.1866483 0.2251173 0.08405399]
Output [R G B]: [0.2978297  0.394014 0.01335724]
Transform 2:
Input  [R G B]: [0.2978297  0.394014  0.01335724]
Output [R G B]: [0.3367588 0.4664171 -0.04671562]
Transform 3:
Input  [R G B]: [0.3367588 0.4664171 -0.04671562]
Output [R G B]: [0.3179022 0.4337091 -0.01955034]
Transform 4:
Input  [R G B]: [0.3179022 0.4337091 -0.01955034]
Output [R G B]: [0.2819128 0.3884552 -0.01955034]
Transform 5:
Input  [R G B]: [0.2819128 0.3884552 -0.01955034]
Output [R G B]: [0.6754353  0.760067 -0.05077279]
Transform 6:
Input  [R G B]: [0.6754353  0.760067 -0.05077279]
Output [R G B]: [0.6506769 0.6723613 -0.08869568]
Transform 7:
Input  [R G B]: [0.6506769 0.6723613   -0.08869568]
Output [R G B]: [0.2754877 0.3039553 -0.0006977472]
Transform 8:
Input  [R G B]: [0.2754877 0.3039553 -0.0006977472]
Output [R G B]: [0.2754877 0.3039553   -0.06960447]

