### PR TITLE
Fix some compatibility issues for building on some platforms

### DIFF
--- a/src/OpenColorIO/ConfigUtils.cpp
+++ b/src/OpenColorIO/ConfigUtils.cpp
@@ -3,7 +3,7 @@
 
 #include "ConfigUtils.h"
 #include "MathUtils.h"
-#include "pystring/pystring.h"
+#include "pystring.h"
 #include "utils/StringUtils.h"
 
 namespace OCIO_NAMESPACE

--- a/src/OpenColorIO/FileRules.cpp
+++ b/src/OpenColorIO/FileRules.cpp
@@ -62,7 +62,7 @@ std::string ConvertToRegularExpression(const char * globPattern, bool ignoreCase
 
     if (ignoreCase)
     {
-        const size_t length = strlen(globPattern);
+        const size_t length = std::strlen(globPattern);
         bool respectCase = false;
         for (size_t i = 0; i < length; ++i)
         {


### PR DESCRIPTION
There is a file that was added/changed to include pystring which is a regression to the changes in #1901 which fixed problems with the include directory of pystring by removing the `pystring/` directory prefix from the include path.

I also suggest adding std for strlen which also otherwise fails to build in some compiler/OS constellations, at least when building for conan.