### PR TITLE
Fix AVX instructions used on CPUs that don't support them

### DIFF
--- a/src/OpenColorIO/CPUInfo.cpp
+++ b/src/OpenColorIO/CPUInfo.cpp
@@ -107,7 +107,7 @@ CPUInfo::CPUInfo()
             flags |= X86_CPU_FLAG_SSE42;
 
         /* Check OSXSAVE and AVX bits */
-        if (info.reg.ecx & 0x18000000)
+        if ((info.reg.ecx & 0x18000000) == 0x18000000)
         {
             xcr = xgetbv();
             if(xcr & 0x6) {
@@ -129,7 +129,7 @@ CPUInfo::CPUInfo()
 
         /* OPMASK/ZMM state */
         if ((xcr & 0xe0) == 0xe0) {
-            if ((flags & X86_CPU_FLAG_AVX2) && (info.reg.ebx & 0xd0030000))
+            if ((flags & X86_CPU_FLAG_AVX2) && ((info.reg.ebx & 0xd0030000) == 0xd0030000))
                 flags |= X86_CPU_FLAG_AVX512;
         }
     }

--- a/src/OpenColorIO/CPUInfo.cpp
+++ b/src/OpenColorIO/CPUInfo.cpp
@@ -110,7 +110,7 @@ CPUInfo::CPUInfo()
         if ((info.reg.ecx & 0x18000000) == 0x18000000)
         {
             xcr = xgetbv();
-            if(xcr & 0x6) {
+            if((xcr & 0x6) == 0x6) {
                 flags |= X86_CPU_FLAG_AVX;
 
                 if(info.reg.ecx & 0x20000000) {


### PR DESCRIPTION
It's supposed to check all bits are enabled, not just one of them. This causes a crash using OpenColorIO on older CPUs.

Thanks to Ray Molenkamp for help tracking this down.