### PR TITLE
Create RB-2.3.2 release

### DIFF
--- a/.github/workflows/wheel_workflow.yml
+++ b/.github/workflows/wheel_workflow.yml
@@ -78,45 +78,84 @@ jobs:
       matrix:
         include:
           # -------------------------------------------------------------------
-          # CPython 64 bits
+          # CPython 64 bits manylinux_2_28
           # -------------------------------------------------------------------
-          - build: CPython 3.7 64 bits
+          - build: CPython 3.7 64 bits manylinux_2_28
+            manylinux: manylinux_2_28
             python: cp37-manylinux*
             arch: x86_64
-          - build: CPython 3.8 64 bits
+          - build: CPython 3.8 64 bits manylinux_2_28
+            manylinux: manylinux_2_28
             python: cp38-manylinux*
             arch: x86_64
-          - build: CPython 3.9 64 bits
+          - build: CPython 3.9 64 bits manylinux_2_28
+            manylinux: manylinux_2_28
             python: cp39-manylinux*
             arch: x86_64
-          - build: CPython 3.10 64 bits
+          - build: CPython 3.10 64 bits manylinux_2_28
+            manylinux: manylinux_2_28
             python: cp310-manylinux*
             arch: x86_64
-          - build: CPython 3.11 64 bits
+          - build: CPython 3.11 64 bits manylinux_2_28
+            manylinux: manylinux_2_28
             python: cp311-manylinux*
             arch: x86_64
-          - build: CPython 3.12 64 bits
+          - build: CPython 3.12 64 bits manylinux_2_28
+            manylinux: manylinux_2_28
             python: cp312-manylinux*
             arch: x86_64
           # -------------------------------------------------------------------
-          # CPython ARM 64 bits
+          # CPython 64 bits manylinux2014
           # -------------------------------------------------------------------
-          - build: CPython 3.7 ARM 64 bits
+          - build: CPython 3.7 64 bits  manylinux2014
+            manylinux: manylinux2014
+            python: cp37-manylinux*
+            arch: x86_64
+          - build: CPython 3.8 64 bits  manylinux2014
+            manylinux: manylinux2014
+            python: cp38-manylinux*
+            arch: x86_64
+          - build: CPython 3.9 64 bits  manylinux2014
+            manylinux: manylinux2014
+            python: cp39-manylinux*
+            arch: x86_64
+          - build: CPython 3.10 64 bits  manylinux2014
+            manylinux: manylinux2014
+            python: cp310-manylinux*
+            arch: x86_64
+          - build: CPython 3.11 64 bits  manylinux2014
+            manylinux: manylinux2014
+            python: cp311-manylinux*
+            arch: x86_64
+          - build: CPython 3.12 64 bits  manylinux2014
+            manylinux: manylinux2014
+            python: cp312-manylinux*
+            arch: x86_64
+          # -------------------------------------------------------------------
+          # CPython ARM 64 bits manylinux2014
+          # -------------------------------------------------------------------
+          - build: CPython 3.7 ARM 64 bits manylinux2014
+            manylinux: manylinux2014
             python: cp37-manylinux*
             arch: aarch64
-          - build: CPython 3.8 ARM 64 bits
+          - build: CPython 3.8 ARM 64 bits manylinux2014
+            manylinux: manylinux2014
             python: cp38-manylinux*
             arch: aarch64
-          - build: CPython 3.9 ARM 64 bits
+          - build: CPython 3.9 ARM 64 bits manylinux2014
+            manylinux: manylinux2014
             python: cp39-manylinux*
             arch: aarch64
-          - build: CPython 3.10 ARM 64 bits
+          - build: CPython 3.10 ARM 64 bits manylinux2014
+            manylinux: manylinux2014
             python: cp310-manylinux*
             arch: aarch64
-          - build: CPython 3.11 ARM 64 bits
+          - build: CPython 3.11 ARM 64 bits manylinux2014
+            manylinux: manylinux2014
             python: cp311-manylinux*
             arch: aarch64
-          - build: CPython 3.12 ARM 64 bits
+          - build: CPython 3.12 ARM 64 bits manylinux2014
+            manylinux: manylinux2014
             python: cp312-manylinux*
             arch: aarch64
 
@@ -138,6 +177,8 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux }}
+          CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux }}
 
       - uses: actions/upload-artifact@v3
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 # Project definition.
 
 project(OpenColorIO 
-    VERSION 2.3.1
+    VERSION 2.3.2
     DESCRIPTION "OpenColorIO (OCIO) is a complete color management solution"
     HOMEPAGE_URL https://github.com/AcademySoftwareFoundation/OpenColorIO
     LANGUAGES CXX C)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,6 @@ test-command = [
     "ociocheck"
 ]
 
-manylinux-x86_64-image = "manylinux2014"
-manylinux-i686-image = "manylinux2014"
-manylinux-aarch64-image = "manylinux2014"
-
 [tool.cibuildwheel.linux]
 before-build = "share/ci/scripts/linux/yum/install_docs_env.sh"
 

--- a/share/cmake/utils/CheckSupportSSSE3.cmake
+++ b/share/cmake/utils/CheckSupportSSSE3.cmake
@@ -13,7 +13,7 @@ endif()
 
 # MSVC doesn't have flags
 if(USE_GCC OR USE_CLANG)
-    set(CMAKE_CXX_FLAGS "-w -msse3")
+    set(CMAKE_CXX_FLAGS "-w -mssse3")
 endif()
 
 if (APPLE AND __universal_build)

--- a/src/OpenColorIO/CPUInfo.cpp
+++ b/src/OpenColorIO/CPUInfo.cpp
@@ -107,10 +107,10 @@ CPUInfo::CPUInfo()
             flags |= X86_CPU_FLAG_SSE42;
 
         /* Check OSXSAVE and AVX bits */
-        if (info.reg.ecx & 0x18000000)
+        if ((info.reg.ecx & 0x18000000) == 0x18000000)
         {
             xcr = xgetbv();
-            if(xcr & 0x6) {
+            if((xcr & 0x6) == 0x6) {
                 flags |= X86_CPU_FLAG_AVX;
 
                 if(info.reg.ecx & 0x20000000) {
@@ -129,7 +129,7 @@ CPUInfo::CPUInfo()
 
         /* OPMASK/ZMM state */
         if ((xcr & 0xe0) == 0xe0) {
-            if ((flags & X86_CPU_FLAG_AVX2) && (info.reg.ebx & 0xd0030000))
+            if ((flags & X86_CPU_FLAG_AVX2) && ((info.reg.ebx & 0xd0030000) == 0xd0030000))
                 flags |= X86_CPU_FLAG_AVX512;
         }
     }

--- a/src/OpenColorIO/ConfigUtils.cpp
+++ b/src/OpenColorIO/ConfigUtils.cpp
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <pystring.h>
+
 #include "ConfigUtils.h"
 #include "MathUtils.h"
-#include "pystring/pystring.h"
 #include "utils/StringUtils.h"
 
 namespace OCIO_NAMESPACE

--- a/tests/utils/StringUtils_tests.cpp
+++ b/tests/utils/StringUtils_tests.cpp
@@ -53,7 +53,7 @@ OCIO_ADD_TEST(StringUtils, trim)
 
     {
         // Test that no assert happens when the Trim argument is not an unsigned char (see issue #1874).
-        constexpr char ref2[]{ -1, -2, -3, '\0' };
+        constexpr char ref2[]{ char(-1), char(-2), char(-3), '\0' };
         const std::string str = StringUtils::Trim(ref2);
     }
 }


### PR DESCRIPTION
Cherry-picked the following commits from main:

Fix ssse3 detection typo -- 003b6a19e6d6bc6574fe5c7e1e2eb833d09f3451
Use system include pystring.h -- e747e9c0bdf3c827f7e6f97fdfd2105016bd6034
Fix narrowing conversion error on riscv64 -- a95febc70ee964b337a8e4a79c909ab425b2e8fb
Add manylinux_2_28 Python wheels -- f9250992eb8bf48b082dee0c1a2610adc6bbda22
Enhance ociochecklut to print the output after each step-- aadf595946ed8a27d69ad0e338d0a8b779465707
Fix AVX instructions used on CPUs that don't support them -- 0c90ded16687b1b63f3e24ef417789c89b1dc509

Incremented the library version number to 2.3.2.