### PR TITLE
CI Workflows various fixes

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -41,7 +41,7 @@ jobs:
       CC: gcc
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 50
       - name: Install docs env

--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -27,15 +27,15 @@ jobs:
   # ---------------------------------------------------------------------------
 
   linux_sonarcloud:
-    name: 'Linux CentOS 7 VFX CY2022 SonarCloud <GCC 9.3.1>'
+    name: 'Linux VFX CY2023 SonarCloud'
     # Don't run on OCIO forks
     if: github.repository == 'AcademySoftwareFoundation/OpenColorIO'
-    # GH-hosted VM. The build runs in CentOS 7 'container' defined below.
+    # GH-hosted VM. The build runs in ASWF 'container' defined below.
     runs-on: ubuntu-latest
     container:
       # DockerHub: https://hub.docker.com/u/aswf
       # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
-      image: aswf/ci-ocio:2022
+      image: aswf/ci-ocio:2023
     env:
       CXX: g++
       CC: gcc
@@ -44,6 +44,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 50
+      - name:  Install sonar-scanner and build-wrapper
+        uses: sonarsource/sonarcloud-github-c-cpp@v2
       - name: Install docs env
         run: share/ci/scripts/linux/yum/install_docs_env.sh
       - name: Install tests env
@@ -79,4 +81,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: sonar-scanner -X -Dsonar.login=$SONAR_TOKEN
+        run: sonar-scanner

--- a/.github/workflows/ci-macarm.yml
+++ b/.github/workflows/ci-macarm.yml
@@ -72,11 +72,11 @@ jobs:
             python-version: '3.11'
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install docs env
         run: share/ci/scripts/macos/install_docs_env.sh
         if: matrix.build-docs == 'ON'

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -388,11 +388,11 @@ jobs:
             python-version: '3.7'
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install docs env
         run: share/ci/scripts/macos/install_docs_env.sh
         if: matrix.build-docs == 'ON'
@@ -533,11 +533,11 @@ jobs:
             python-version: '3.7'
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install docs env
         run: |
           DOXYGEN_PATH=$GITHUB_WORKSPACE/doxygen

--- a/.github/workflows/dependencies_latest.yml
+++ b/.github/workflows/dependencies_latest.yml
@@ -189,11 +189,11 @@ jobs:
             use-oiio: 'OFF'
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install docs env
         run: share/ci/scripts/macos/install_docs_env.sh
         if: matrix.build-docs == 'ON'
@@ -294,11 +294,11 @@ jobs:
             use-oiio: 'OFF'
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install docs env
         run: |
           DOXYGEN_PATH=$GITHUB_WORKSPACE/doxygen

--- a/.github/workflows/platform_latest.yml
+++ b/.github/workflows/platform_latest.yml
@@ -86,7 +86,7 @@ jobs:
       CC: ${{ matrix.cc-compiler }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install tests env
         run: share/ci/scripts/linux/yum/install_tests_env.sh
       - name: Create build directories
@@ -197,11 +197,11 @@ jobs:
             python-version: '3.11'
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install tests env
         run: share/ci/scripts/macos/install_tests_env.sh
       - name: Create build directories
@@ -308,11 +308,11 @@ jobs:
             python-version: '3.11'
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install tests env
         run: share/ci/scripts/windows/install_tests_env.sh
         shell: bash

--- a/.github/workflows/platform_latest.yml
+++ b/.github/workflows/platform_latest.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        build: [1, 2, 3, 4]
+        build: [1, 2]
         include:
           # -------------------------------------------------------------------
           # GCC
@@ -46,7 +46,7 @@ jobs:
             build-python: ON
             build-type: Release
             build-shared: ON
-            cxx-standard: 20
+            cxx-standard: 23
             cxx-compiler: g++
             cc-compiler: gcc
             compiler-desc: GCC
@@ -55,7 +55,7 @@ jobs:
             build-python: OFF
             build-type: Debug
             build-shared: ON
-            cxx-standard: 20
+            cxx-standard: 23
             cxx-compiler: g++
             cc-compiler: gcc
             compiler-desc: GCC
@@ -63,24 +63,26 @@ jobs:
           # -------------------------------------------------------------------
           # Clang
           # -------------------------------------------------------------------
-          - build: 3
-            build-python: ON
-            build-type: Release
-            build-shared: ON
-            cxx-standard: 20
-            cxx-compiler: clang++
-            cc-compiler: clang
-            compiler-desc: Clang
-            enable-sanitizer: OFF
-          - build: 4
-            build-python: OFF
-            build-type: Debug
-            build-shared: ON
-            cxx-standard: 20
-            cxx-compiler: clang++
-            cc-compiler: clang
-            compiler-desc: Clang
-            enable-sanitizer: ON
+          # TODO: Re-enable clang when the following issue get fixed:
+          # https://github.com/actions/runner-images/issues/8659
+          # - build: 3
+          #   build-python: ON
+          #   build-type: Release
+          #   build-shared: ON
+          #   cxx-standard: 23
+          #   cxx-compiler: clang++
+          #   cc-compiler: clang
+          #   compiler-desc: Clang
+          #   enable-sanitizer: OFF
+          # - build: 4
+          #   build-python: OFF
+          #   build-type: Debug
+          #   build-shared: ON
+          #   cxx-standard: 23
+          #   cxx-compiler: clang++
+          #   cc-compiler: clang
+          #   compiler-desc: Clang
+          #   enable-sanitizer: ON
     env:
       CXX: ${{ matrix.cxx-compiler }}
       CC: ${{ matrix.cc-compiler }}
@@ -185,14 +187,14 @@ jobs:
             build-python: ON
             build-type: Release
             build-shared: ON
-            cxx-standard: 20
+            cxx-standard: 23
             enable-sanitizer: OFF
             python-version: '3.11'
           - build: 2
             build-python: OFF
             build-type: Debug
             build-shared: ON
-            cxx-standard: 20
+            cxx-standard: 23
             enable-sanitizer: ON
             python-version: '3.11'
     steps:
@@ -298,13 +300,13 @@ jobs:
             build-python: ON
             build-type: Release
             build-shared: ON
-            cxx-standard: 20
+            cxx-standard: 23
             python-version: '3.11'
           - build: 2
             build-python: ON
             build-type: Debug
             build-shared: ON
-            cxx-standard: 20
+            cxx-standard: 23
             python-version: '3.11'
     steps:
       - name: Setup Python

--- a/.github/workflows/wheel_workflow.yml
+++ b/.github/workflows/wheel_workflow.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Build SDist
       run: pipx run build --sdist
@@ -59,8 +59,9 @@ jobs:
     - name: Check metadata
       run: pipx run twine check dist/*
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
+        name: cibw-sdist
         path: dist/*.tar.gz
 
   # ---------------------------------------------------------------------------
@@ -82,106 +83,107 @@ jobs:
           # -------------------------------------------------------------------
           - build: CPython 3.7 64 bits manylinux_2_28
             manylinux: manylinux_2_28
-            python: cp37-manylinux*
+            python: cp37-manylinux_x86_64
             arch: x86_64
           - build: CPython 3.8 64 bits manylinux_2_28
             manylinux: manylinux_2_28
-            python: cp38-manylinux*
+            python: cp38-manylinux_x86_64
             arch: x86_64
           - build: CPython 3.9 64 bits manylinux_2_28
             manylinux: manylinux_2_28
-            python: cp39-manylinux*
+            python: cp39-manylinux_x86_64
             arch: x86_64
           - build: CPython 3.10 64 bits manylinux_2_28
             manylinux: manylinux_2_28
-            python: cp310-manylinux*
+            python: cp310-manylinux_x86_64
             arch: x86_64
           - build: CPython 3.11 64 bits manylinux_2_28
             manylinux: manylinux_2_28
-            python: cp311-manylinux*
+            python: cp311-manylinux_x86_64
             arch: x86_64
           - build: CPython 3.12 64 bits manylinux_2_28
             manylinux: manylinux_2_28
-            python: cp312-manylinux*
+            python: cp312-manylinux_x86_64
             arch: x86_64
           # -------------------------------------------------------------------
           # CPython 64 bits manylinux2014
           # -------------------------------------------------------------------
-          - build: CPython 3.7 64 bits  manylinux2014
+          - build: CPython 3.7 64 bits manylinux2014
             manylinux: manylinux2014
-            python: cp37-manylinux*
+            python: cp37-manylinux_x86_64
             arch: x86_64
-          - build: CPython 3.8 64 bits  manylinux2014
+          - build: CPython 3.8 64 bits manylinux2014
             manylinux: manylinux2014
-            python: cp38-manylinux*
+            python: cp38-manylinux_x86_64
             arch: x86_64
-          - build: CPython 3.9 64 bits  manylinux2014
+          - build: CPython 3.9 64 bits manylinux2014
             manylinux: manylinux2014
-            python: cp39-manylinux*
+            python: cp39-manylinux_x86_64
             arch: x86_64
-          - build: CPython 3.10 64 bits  manylinux2014
+          - build: CPython 3.10 64 bits manylinux2014
             manylinux: manylinux2014
-            python: cp310-manylinux*
+            python: cp310-manylinux_x86_64
             arch: x86_64
-          - build: CPython 3.11 64 bits  manylinux2014
+          - build: CPython 3.11 64 bits manylinux2014
             manylinux: manylinux2014
-            python: cp311-manylinux*
+            python: cp311-manylinux_x86_64
             arch: x86_64
-          - build: CPython 3.12 64 bits  manylinux2014
+          - build: CPython 3.12 64 bits manylinux2014
             manylinux: manylinux2014
-            python: cp312-manylinux*
+            python: cp312-manylinux_x86_64
             arch: x86_64
           # -------------------------------------------------------------------
           # CPython ARM 64 bits manylinux2014
           # -------------------------------------------------------------------
           - build: CPython 3.7 ARM 64 bits manylinux2014
             manylinux: manylinux2014
-            python: cp37-manylinux*
+            python: cp37-manylinux_aarch64
             arch: aarch64
           - build: CPython 3.8 ARM 64 bits manylinux2014
             manylinux: manylinux2014
-            python: cp38-manylinux*
+            python: cp38-manylinux_aarch64
             arch: aarch64
           - build: CPython 3.9 ARM 64 bits manylinux2014
             manylinux: manylinux2014
-            python: cp39-manylinux*
+            python: cp39-manylinux_aarch64
             arch: aarch64
           - build: CPython 3.10 ARM 64 bits manylinux2014
             manylinux: manylinux2014
-            python: cp310-manylinux*
+            python: cp310-manylinux_aarch64
             arch: aarch64
           - build: CPython 3.11 ARM 64 bits manylinux2014
             manylinux: manylinux2014
-            python: cp311-manylinux*
+            python: cp311-manylinux_aarch64
             arch: aarch64
           - build: CPython 3.12 ARM 64 bits manylinux2014
             manylinux: manylinux2014
-            python: cp312-manylinux*
+            python: cp312-manylinux_aarch64
             arch: aarch64
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.8'
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux }}
           CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: cibw-wheels-${{ matrix.python }}-${{ matrix.manylinux }}
           path: ./wheelhouse/*.whl
 
   # ---------------------------------------------------------------------------
@@ -202,58 +204,59 @@ jobs:
           # CPython 64 bits
           # -------------------------------------------------------------------
           - build: CPython 3.7 64 bits
-            python: cp37-*
+            python: cp37-macosx_x86_64
             arch: x86_64
           - build: CPython 3.8 64 bits
-            python: cp38-*
+            python: cp38-macosx_x86_64
             arch: x86_64
           - build: CPython 3.9 64 bits
-            python: cp39-*
+            python: cp39-macosx_x86_64
             arch: x86_64
           - build: CPython 3.10 64 bits
-            python: cp310-*
+            python: cp310-macosx_x86_64
             arch: x86_64
           - build: CPython 3.11 64 bits
-            python: cp311-*
+            python: cp311-macosx_x86_64
             arch: x86_64
           - build: CPython 3.12 64 bits
-            python: cp312-*
+            python: cp312-macosx_x86_64
             arch: x86_64
           # -------------------------------------------------------------------
           # CPython ARM 64 bits
           # -------------------------------------------------------------------
           - build: CPython 3.8 ARM 64 bits
-            python: cp38-*
+            python: cp38-macosx_arm64
             arch: arm64
           - build: CPython 3.9 ARM 64 bits
-            python: cp39-*
+            python: cp39-macosx_arm64
             arch: arm64
           - build: CPython 3.10 ARM 64 bits
-            python: cp310-*
+            python: cp310-macosx_arm64
             arch: arm64
           - build: CPython 3.11 ARM 64 bits
-            python: cp311-*
+            python: cp311-macosx_arm64
             arch: arm64
           - build: CPython 3.12 ARM 64 bits
-            python: cp312-*
+            python: cp312-macosx_arm64
             arch: arm64
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.8'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: cibw-wheels-${{ matrix.python }}
           path: ./wheelhouse/*.whl
 
   # ---------------------------------------------------------------------------
@@ -274,40 +277,41 @@ jobs:
           # CPython 64 bits
           # -------------------------------------------------------------------
           - build: CPython 3.7 64 bits
-            python: cp37-*
+            python: cp37-win_amd64
             arch: AMD64
           - build: CPython 3.8 64 bits
-            python: cp38-*
+            python: cp38-win_amd64
             arch: AMD64
           - build: CPython 3.9 64 bits
-            python: cp39-*
+            python: cp39-win_amd64
             arch: AMD64
           - build: CPython 3.10 64 bits
-            python: cp310-*
+            python: cp310-win_amd64
             arch: AMD64
           - build: CPython 3.11 64 bits
-            python: cp311-*
+            python: cp311-win_amd64
             arch: AMD64
           - build: CPython 3.12 64 bits
-            python: cp312-*
+            python: cp312-win_amd64
             arch: AMD64
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.8'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: cibw-wheels-${{ matrix.python }}
           path: ./wheelhouse/*.whl
 
 
@@ -316,12 +320,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          pattern: cibw-*
           path: dist
+          merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/share/ci/scripts/multi/install_osl.sh
+++ b/share/ci/scripts/multi/install_osl.sh
@@ -20,8 +20,6 @@ fi
 
 mkdir build
 cd build
-# FIXME: Revert OSL_BUILD_TESTS to OFF when OSL 1.12 is released
-# CMake configure fails when tests are off, only fixed in 1.12 dev branch
 
 if [[ $OSTYPE == 'darwin'* ]]; then
     cmake -DCMAKE_BUILD_TYPE=Release \
@@ -29,7 +27,7 @@ if [[ $OSTYPE == 'darwin'* ]]; then
         -DCMAKE_CXX_STANDARD=14 \
         -DCMAKE_C_COMPILER=$(brew --prefix llvm@15)/bin/clang \
         -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@15)/bin/clang++ \
-        -DOSL_BUILD_TESTS=ON \
+        -DOSL_BUILD_TESTS=OFF \
         -DVERBOSE=ON \
         -DSTOP_ON_WARNING=OFF \
         -DBoost_NO_BOOST_CMAKE=ON \
@@ -39,17 +37,26 @@ else # not macOS
     cmake -DCMAKE_BUILD_TYPE=Release \
         ${INSTALL_TARGET:+"-DCMAKE_INSTALL_PREFIX="${INSTALL_TARGET}""} \
         -DCMAKE_CXX_STANDARD=14 \
-        -DOSL_BUILD_TESTS=ON \
+        -DOSL_BUILD_TESTS=OFF \
         -DVERBOSE=ON \
         -DSTOP_ON_WARNING=OFF \
         -DBoost_NO_BOOST_CMAKE=ON \
         ../.
 fi
 
+# OSL 1.13+ yield a permission error on mac OS.
+# "file cannot create directory: /usr/local/cmake.  Maybe need administrative privileges."
+if [[ $OSTYPE == 'darwin'* ]]; then
+sudo cmake --build . \
+           --target install \
+           --config Release \
+           --parallel 2
+else # not macOS
 cmake --build . \
       --target install \
       --config Release \
       --parallel 2
+fi
 
 cd ../..
 rm -rf OpenShadingLanguage

--- a/share/cmake/modules/FindExtPackages.cmake
+++ b/share/cmake/modules/FindExtPackages.cmake
@@ -179,8 +179,7 @@ if(OCIO_BUILD_PYTHON OR OCIO_BUILD_DOCS)
         # pybind11 2.9 fixes issues with MS Visual Studio 2022 (Debug).
         ocio_handle_dependency(  pybind11 REQUIRED ALLOW_INSTALL
                                  MIN_VERSION 2.9.2
-                                 RECOMMENDED_VERSION 2.9.2
-                                 RECOMMENDED_VERSION_REASON "Pybind 2.10.0+ does not work with Python 2.7 anymore")
+                                 RECOMMENDED_VERSION 2.11.1)
     endif()
 endif()
 

--- a/src/bindings/python/PyPackedImageDesc.cpp
+++ b/src/bindings/python/PyPackedImageDesc.cpp
@@ -15,10 +15,7 @@ void bindPyPackedImageDesc(py::module & m)
         .def(py::init([](py::buffer & data, long width, long height, long numChannels) 
             { 
                 PyPackedImageDesc * p = new PyPackedImageDesc();
-
-                py::gil_scoped_release release;
                 p->m_data[0] = data;
-                py::gil_scoped_acquire acquire;
 
                 py::buffer_info info = p->m_data[0].request();
                 checkBufferType(info, py::dtype("float32"));
@@ -39,10 +36,7 @@ void bindPyPackedImageDesc(py::module & m)
                          ptrdiff_t yStrideBytes) 
             { 
                 PyPackedImageDesc * p = new PyPackedImageDesc();
-
-                py::gil_scoped_release release;
                 p->m_data[0] = data;
-                py::gil_scoped_acquire acquire;
 
                 py::buffer_info info = p->m_data[0].request();
                 checkBufferType(info, bitDepth);
@@ -65,10 +59,7 @@ void bindPyPackedImageDesc(py::module & m)
                          ChannelOrdering chanOrder) 
             { 
                 PyPackedImageDesc * p = new PyPackedImageDesc();
-
-                py::gil_scoped_release release;
                 p->m_data[0] = data;
-                py::gil_scoped_acquire acquire;
 
                 py::buffer_info info = p->m_data[0].request();
                 checkBufferType(info, py::dtype("float32"));
@@ -89,10 +80,7 @@ void bindPyPackedImageDesc(py::module & m)
                          ptrdiff_t yStrideBytes) 
             { 
                 PyPackedImageDesc * p = new PyPackedImageDesc();
-
-                py::gil_scoped_release release;
                 p->m_data[0] = data;
-                py::gil_scoped_acquire acquire;
                 
                 py::buffer_info info = p->m_data[0].request();
                 checkBufferType(info, bitDepth);


### PR DESCRIPTION
This PR attempt to fix various issues on the GHA workflows:
* Dependency latest was failing due to a recent OSL update, I updated the code adding #ifdef to handle the changes, tagging @lgritz for visibility.
* Platform latest failing on ubuntu-latest / Clang combo, proposing to disable those 2 jobs for the time being until the underlying issue gets fixed (https://github.com/actions/runner-images/issues/8659). Also updated the C++ standard to 23 to stay "bleeding edge".
* Wheel workflow Windows failure required an update of cibuildwheel version. Updating the upload artifact action to remove the deprecation warning also required a change in the artifact layout, now each wheel is upload as a separate artifact you can find and download on the workflow summary page.
* Updating the Node JS based action to remove deprecation warnings yielded an issue when running in ASWF docker images (<= 2022 IIRC) due to incompatible GLibC version, see https://github.com/AcademySoftwareFoundation/OpenColorIO/actions/runs/7836526047/job/21384368269, might be something to raise on the CI working group.
* The analysis workflow is still failing at the upload report step, discussing with @jfpanisset it seems like a security feature of Github where PR can't have access to secrets to avoid leakage, will have to see if the fix works after merging.
* ~~Update the CI on Linux to add VFX 2024 Reference Platform new containers (thanks @jfpanisset), there is currently an issue with OIIO's Ptex dependency which might need a fix in the OCIO Docker image.~~ Revert this change, will wait for the next ASWF Docker release.
* Fixed a likely issue of incorrect Pybind11 usage mentioned in #1939 which seem hard to reproduce but ran into it while updating Platform latest to C++23 (which required a Pybind11 version update) on the Windows jobs.