### PR TITLE
Fix CPU unit test failures on recent macOS ARM platforms

### DIFF
--- a/tests/cpu/CPUProcessor_tests.cpp
+++ b/tests/cpu/CPUProcessor_tests.cpp
@@ -2772,14 +2772,27 @@ void ComputeImage(unsigned width, unsigned height, unsigned nChannels,
     for(size_t idx=0; idx<(width*height);)
     {
         // Manual computation of the results.
+        // Break operations into steps similar to cpu processor
+        // to avoid potential fma compiler optimizations
+        const float in_scale[4]{ float(inValues[idx+0]) * inScale,
+                                 float(inValues[idx+1]) * inScale,
+                                 float(inValues[idx+2]) * inScale,
+                                 nChannels==4
+                                     ? float(inValues[idx+3]) * inScale
+                                     : 0.0f
+                                };
 
-        const float pxl[4]{ (float(inValues[idx+0]) * inScale + (float)offset4[0]) * outScale,
-                            (float(inValues[idx+1]) * inScale + (float)offset4[1]) * outScale,
-                            (float(inValues[idx+2]) * inScale + (float)offset4[2]) * outScale,
-                            nChannels==4
-                                ? ((float(inValues[idx+3]) * inScale + (float)offset4[3]) * outScale)
-                                : 0.0f
-                          };
+        const float operation[4]{ in_scale[0] + (float)offset4[0],
+                                  in_scale[1] + (float)offset4[1],
+                                  in_scale[2] + (float)offset4[2],
+                                  in_scale[3] + (float)offset4[3],
+                                };
+
+        const float pxl[4]{ operation[0] * outScale,
+                            operation[1] * outScale,
+                            operation[2] * outScale,
+                            operation[3] * outScale,
+                      };
 
         // Validate all the results.
 

--- a/tests/cpu/UnitTestUtils.cpp
+++ b/tests/cpu/UnitTestUtils.cpp
@@ -6,6 +6,7 @@
 
 #include "Logging.h"
 #include "OpBuilders.h"
+#include "ParseUtils.h"
 #include "UnitTestUtils.h"
 #include "utils/StringUtils.h"
 
@@ -69,6 +70,28 @@ ConstProcessorRcPtr GetFileTransformProcessor(const std::string & fileName)
     ConfigRcPtr config = Config::Create();
     // Get the processor corresponding to the transform.
     return config->getProcessor(fileTransform);
+}
+
+bool StringFloatVecClose(std::string value, std::string expected, float eps)
+{
+    std::vector<float> a;
+    std::vector<float> b;
+    if (StringVecToFloatVec(a, StringUtils::SplitByWhiteSpaces(value)) &&
+        StringVecToFloatVec(b, StringUtils::SplitByWhiteSpaces(expected)))
+    {
+        if (a.size() == b.size())
+        {
+            for(unsigned int i = 0; i < a.size(); i++)
+            {
+                if (std::abs(a[i] - b[i]) >= eps)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+    return false;
 }
 
 std::string CreateTemporaryDirectory(const std::string & name)

--- a/tests/cpu/UnitTestUtils.h
+++ b/tests/cpu/UnitTestUtils.h
@@ -93,6 +93,17 @@ inline bool EqualWithSafeRelError(T value,
         / div) <= eps;
 }
 
+bool StringFloatVecClose(std::string value, std::string expected, float eps);
+
+#define OCIO_CHECK_STR_FLOAT_VEC_CLOSE_FROM(x,y,tol,line)                    \
+    (OCIO::StringFloatVecClose(x,y,tol)) ? ((void)0)                         \
+         : ((std::cout << __FILE__ << ":" << line << ":\n"                   \
+             << "FAILED: " << FIELD_STR(x) << " == " << FIELD_STR(y) << "\n" \
+             << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"),      \
+            (void)++unit_test_failures)
+
+#define OCIO_CHECK_STR_FLOAT_VEC_CLOSE(x,y,tol) OCIO_CHECK_STR_FLOAT_VEC_CLOSE_FROM(x,y,tol,__LINE__)
+
 // C++20 introduces new strongly typed, UTF-8 based, char8_t and u8string types
 // which are not implicitly convertible to char and std::string respectively.
 // Here we simply choose to ignore these new types for unit tests while the

--- a/tests/cpu/fileformats/FileFormatCTF_tests.cpp
+++ b/tests/cpu/fileformats/FileFormatCTF_tests.cpp
@@ -6934,8 +6934,23 @@ OCIO_ADD_TEST(CTFTransform, grading_rgbcurve_lin_ctf)
 </ProcessList>
 )" };
 
-        OCIO_CHECK_EQUAL(expected.size(), outputTransform.str().size());
-        OCIO_CHECK_EQUAL(expected, outputTransform.str());
+        const StringUtils::StringVec osvec  = StringUtils::SplitByLines(outputTransform.str());
+        const StringUtils::StringVec resvec = StringUtils::SplitByLines(expected);
+        OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
+        for(unsigned int i = 0; i < resvec.size(); ++i)
+        {
+            if ( (i >= 5 && i <= 7) ||
+                 (i >= 12 && i <= 15) ||
+                 (i == 18))
+            {
+                OCIO_CHECK_STR_FLOAT_VEC_CLOSE(osvec[i], resvec[i], 1e-5f);
+            }
+            else
+            {
+                OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
+            }
+
+        }
     }
 
     // All curves are default curves, no curve is saved.
@@ -8326,8 +8341,23 @@ R"(<?xml version="1.0" encoding="UTF-8"?>
     </LUT3D>
 </ProcessList>
 )" };
-    OCIO_CHECK_EQUAL(expectedCLF.size(), output1.str().size());
-    OCIO_CHECK_EQUAL(expectedCLF, output1.str());
+
+    const StringUtils::StringVec osvec  = StringUtils::SplitByLines(output1.str());
+    const StringUtils::StringVec resvec = StringUtils::SplitByLines(expectedCLF);
+    OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
+    for(unsigned int i = 0; i < resvec.size(); ++i)
+    {
+        if ( (i >= 10 && i <= 19) ||
+             (i >= 24 && i <= 31))
+        {
+            OCIO_CHECK_STR_FLOAT_VEC_CLOSE(osvec[i], resvec[i], 1e-5f);
+        }
+        else
+        {
+            OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
+        }
+
+    }
 }
 
 OCIO_ADD_TEST(FileFormatCTF, lut_interpolation_option)

--- a/tests/cpu/fileformats/FileFormatHDL_tests.cpp
+++ b/tests/cpu/fileformats/FileFormatHDL_tests.cpp
@@ -5,6 +5,7 @@
 #include "fileformats/FileFormatHDL.cpp"
 
 #include "testutils/UnitTest.h"
+#include "UnitTestUtils.h"
 
 namespace OCIO = OCIO_NAMESPACE;
 
@@ -325,8 +326,23 @@ OCIO_ADD_TEST(FileFormatHDL, bake_1d_shaper)
         "\t16.291878\n"
         "}\n";
 
-        OCIO_CHECK_EQUAL(expectedHDL.size(), outputHDL.str().size());
-        OCIO_CHECK_EQUAL(expectedHDL, outputHDL.str());
+        const StringUtils::StringVec osvec  = StringUtils::SplitByLines(expectedHDL);
+        const StringUtils::StringVec resvec = StringUtils::SplitByLines(outputHDL.str());
+        OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
+        for(unsigned int i = 0; i < resvec.size(); ++i)
+        {
+            if ( (i >= 10 && i <= 19) ||
+                 (i >= 22 && i <= 31) ||
+                 (i >= 34 && i <= 43))
+            {
+                OCIO_CHECK_STR_FLOAT_VEC_CLOSE(osvec[i], resvec[i], 1e-5f);
+            }
+            else
+            {
+                OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
+            }
+
+        }
     }
 }
 

--- a/tests/cpu/fileformats/FileFormatResolveCube_tests.cpp
+++ b/tests/cpu/fileformats/FileFormatResolveCube_tests.cpp
@@ -384,7 +384,14 @@ OCIO_ADD_TEST(FileFormatResolveCube, bake_1d_shaper)
         OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
         for(unsigned int i = 0; i < resvec.size(); ++i)
         {
-            OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
+            if (i <= 0)
+            {
+                OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
+            }
+            else
+            {
+                OCIO_CHECK_STR_FLOAT_VEC_CLOSE(osvec[i], resvec[i], 1e-5f);
+            }
         }
     }
 }
@@ -445,7 +452,14 @@ OCIO_ADD_TEST(FileFormatResolveCube, bake_3d)
     OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
     {
-        OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
+        if (i <= 3)
+        {
+            OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
+        }
+        else
+        {
+            OCIO_CHECK_STR_FLOAT_VEC_CLOSE(osvec[i], resvec[i], 1e-5f);
+        }
     }
 }
 
@@ -522,7 +536,14 @@ OCIO_ADD_TEST(FileFormatResolveCube, bake_1d_3d)
     OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
     {
-        OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
+        if (i <= 2)
+        {
+            OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
+        }
+        else
+        {
+            OCIO_CHECK_STR_FLOAT_VEC_CLOSE(osvec[i], resvec[i], 1e-5f);
+        }
     }
 }
 

--- a/tests/cpu/fileformats/FileFormatSpi1D_tests.cpp
+++ b/tests/cpu/fileformats/FileFormatSpi1D_tests.cpp
@@ -482,7 +482,14 @@ OCIO_ADD_TEST(FileFormatSpi1D, bake_1d_shaper)
         OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
         for(unsigned int i = 0; i < resvec.size(); ++i)
         {
-            OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
+            if (i <= 5 || i >= 15)
+            {
+                OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
+            }
+            else
+            {
+                OCIO_CHECK_STR_FLOAT_VEC_CLOSE(osvec[i], resvec[i], 1e-5f);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes the macOS ARM CPU unit tests for https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1946.

For the string comparison failures I add a utility function called `StringFloatVecClose` that converts the string values to float and compares with a threshold. 

There is still a metal unit test failure happening on my machine, haven't looked into the cause of it.