### PR TITLE
Fix linking when building fully shared with the dependencies also build as shared libraries

### DIFF
--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -302,7 +302,7 @@ target_include_directories(OpenColorIO
 )
 
 target_link_libraries(OpenColorIO
-    PRIVATE
+    PUBLIC
         expat::expat
         Imath::Imath
         pystring::pystring


### PR DESCRIPTION
I'd suggest to fix the linking to ensure OpenColorIO can be build with its own requirements build as shared libraries. Currently it will throw linker errors when linking all the included CLI tools.

For more details, also see: https://github.com/conan-io/conan-center-index/pull/23112

Up to now the conan recipe didn't run with dynamic linking as there was a blocker in the configuration to link minizip-ng dynamically. When I tried to fix it locally, I came up with this change. Otherwise it can also be done by fixing the linking of all the tools to include the requirements manually.