### PR TITLE
ocioview updates & fixes

### DIFF
--- a/src/apps/ocioview/ocioview/constants.py
+++ b/src/apps/ocioview/ocioview/constants.py
@@ -10,8 +10,9 @@ from PySide6 import QtCore, QtGui
 ROOT_DIR = Path(__file__).parent.parent
 
 # Sizes
-ICON_SIZE_ITEM = QtCore.QSize(20, 20)
-ICON_SIZE_BUTTON = QtCore.QSize(24, 24)
+ICON_SIZE_BUTTON = QtCore.QSize(18, 18)
+ICON_SIZE_ITEM = QtCore.QSize(18, 18)
+ICON_SIZE_TAB = QtCore.QSize(16, 16)
 ICON_SCALE_FACTOR = 1.15
 
 MARGIN_WIDTH = 13  # Pixels

--- a/src/apps/ocioview/ocioview/inspect/code_inspector.py
+++ b/src/apps/ocioview/ocioview/inspect/code_inspector.py
@@ -8,6 +8,7 @@ import PyOpenColorIO as ocio
 from pygments.formatters import HtmlFormatter
 from PySide6 import QtCore, QtGui, QtWidgets
 
+from ..constants import ICON_SIZE_TAB
 from ..message_router import MessageRouter
 from ..utils import get_glyph_icon, processor_to_shader_html
 from ..widgets import EnumComboBox, LogView
@@ -26,7 +27,7 @@ class CodeInspector(QtWidgets.QWidget):
 
     @classmethod
     def icon(cls) -> QtGui.QIcon:
-        return get_glyph_icon("mdi6.code-json")
+        return get_glyph_icon("mdi6.code-json", size=ICON_SIZE_TAB)
 
     def __init__(self, parent: Optional[QtCore.QObject] = None):
         super().__init__(parent=parent)
@@ -40,7 +41,9 @@ class CodeInspector(QtWidgets.QWidget):
 
         html_css = HtmlFormatter(style="material").get_style_defs()
         # Update line number colors to match palette
-        html_css = html_css.replace("#263238", palette.color(palette.ColorRole.Base).name())
+        html_css = html_css.replace(
+            "#263238", palette.color(palette.ColorRole.Base).name()
+        )
         html_css = html_css.replace(
             "#37474F", palette.color(palette.ColorRole.Text).darker(150).name()
         )
@@ -61,9 +64,7 @@ class CodeInspector(QtWidgets.QWidget):
 
         self.gpu_language_box = EnumComboBox(ocio.GpuLanguage)
         self.gpu_language_box.setSizeAdjustPolicy(QtWidgets.QComboBox.AdjustToContents)
-        self.gpu_language_box.set_member(
-            MessageRouter.get_instance().get_gpu_language()
-        )
+        self.gpu_language_box.set_member(MessageRouter.get_instance().gpu_language)
         self.gpu_language_box.currentIndexChanged[int].connect(
             self._on_gpu_language_changed
         )
@@ -74,12 +75,20 @@ class CodeInspector(QtWidgets.QWidget):
 
         # Layout
         self.tabs = QtWidgets.QTabWidget()
-        self.tabs.addTab(self.config_view, get_glyph_icon("mdi6.code-json"), "Config")
         self.tabs.addTab(
-            self.ctf_view, get_glyph_icon("mdi6.code-tags"), "Processor (CTF)"
+            self.config_view,
+            get_glyph_icon("mdi6.code-json", size=ICON_SIZE_TAB),
+            "Config",
         )
         self.tabs.addTab(
-            self.shader_view, get_glyph_icon("mdi6.dots-grid"), "Processor (Shader)"
+            self.ctf_view,
+            get_glyph_icon("mdi6.code-tags", size=ICON_SIZE_TAB),
+            "Processor (CTF)",
+        )
+        self.tabs.addTab(
+            self.shader_view,
+            get_glyph_icon("mdi6.dots-grid", size=ICON_SIZE_TAB),
+            "Processor (Shader)",
         )
 
         layout = QtWidgets.QVBoxLayout()
@@ -186,7 +195,7 @@ class CodeInspector(QtWidgets.QWidget):
         MessageRouter, which will provide future GPU processors.
         """
         gpu_language = self.gpu_language_box.currentData()
-        MessageRouter.get_instance().set_gpu_language(gpu_language)
+        MessageRouter.get_instance().gpu_language = gpu_language
         if self._prev_gpu_proc is not None:
             shader_html_data = processor_to_shader_html(
                 self._prev_gpu_proc, gpu_language
@@ -210,22 +219,22 @@ class CodeInspector(QtWidgets.QWidget):
         msg_router = MessageRouter.get_instance()
 
         if index == -1:
-            msg_router.set_config_updates_allowed(False)
-            msg_router.set_ctf_updates_allowed(False)
-            msg_router.set_shader_updates_allowed(False)
+            msg_router.config_updates_allowed = False
+            msg_router.ctf_updates_allowed = False
+            msg_router.shader_updates_allowed = False
             return
 
         widget = self.tabs.widget(index)
 
         if widget == self.config_view:
-            msg_router.set_config_updates_allowed(True)
-            msg_router.set_ctf_updates_allowed(False)
-            msg_router.set_shader_updates_allowed(False)
+            msg_router.config_updates_allowed = True
+            msg_router.ctf_updates_allowed = False
+            msg_router.shader_updates_allowed = False
         elif widget == self.ctf_view:
-            msg_router.set_config_updates_allowed(False)
-            msg_router.set_ctf_updates_allowed(True)
-            msg_router.set_shader_updates_allowed(False)
+            msg_router.config_updates_allowed = False
+            msg_router.ctf_updates_allowed = True
+            msg_router.shader_updates_allowed = False
         elif widget == self.shader_view:
-            msg_router.set_config_updates_allowed(False)
-            msg_router.set_ctf_updates_allowed(False)
-            msg_router.set_shader_updates_allowed(True)
+            msg_router.config_updates_allowed = False
+            msg_router.ctf_updates_allowed = False
+            msg_router.shader_updates_allowed = True

--- a/src/apps/ocioview/ocioview/inspect/curve_inspector.py
+++ b/src/apps/ocioview/ocioview/inspect/curve_inspector.py
@@ -12,6 +12,7 @@ from PySide6 import QtCore, QtGui, QtWidgets
 
 from ..constants import R_COLOR, G_COLOR, B_COLOR, GRAY_COLOR, ICON_SIZE_TAB
 from ..message_router import MessageRouter
+from ..processor_context import ProcessorContext
 from ..utils import get_glyph_icon, SignalsBlocked
 from ..widgets import EnumComboBox, FloatEditArray, IntEdit
 
@@ -603,10 +604,13 @@ class CurveView(QtWidgets.QGraphicsView):
         self.update()
 
     @QtCore.Slot(ocio.CPUProcessor)
-    def _on_processor_ready(self, cpu_proc: ocio.CPUProcessor) -> None:
+    def _on_processor_ready(
+        self, proc_context: ProcessorContext, cpu_proc: ocio.CPUProcessor
+    ) -> None:
         """
         Update curves from sampled OCIO CPU processor.
 
+        :param proc_context: OCIO processor context data
         :param cpu_proc: CPU processor of currently viewed transform
         """
         self.reset()

--- a/src/apps/ocioview/ocioview/inspect/curve_inspector.py
+++ b/src/apps/ocioview/ocioview/inspect/curve_inspector.py
@@ -10,7 +10,7 @@ import numpy as np
 import PyOpenColorIO as ocio
 from PySide6 import QtCore, QtGui, QtWidgets
 
-from ..constants import R_COLOR, G_COLOR, B_COLOR, GRAY_COLOR
+from ..constants import R_COLOR, G_COLOR, B_COLOR, GRAY_COLOR, ICON_SIZE_TAB
 from ..message_router import MessageRouter
 from ..utils import get_glyph_icon, SignalsBlocked
 from ..widgets import EnumComboBox, FloatEditArray, IntEdit
@@ -39,7 +39,7 @@ class CurveInspector(QtWidgets.QWidget):
 
     @classmethod
     def icon(cls) -> QtGui.QIcon:
-        return get_glyph_icon("mdi6.chart-bell-curve-cumulative")
+        return get_glyph_icon("mdi6.chart-bell-curve-cumulative", size=ICON_SIZE_TAB)
 
     def __init__(self, parent: Optional[QtCore.QObject] = None):
         super().__init__(parent=parent)
@@ -256,14 +256,14 @@ class CurveView(QtWidgets.QGraphicsView):
         super().showEvent(event)
 
         msg_router = MessageRouter.get_instance()
-        msg_router.set_cpu_processor_updates_allowed(True)
+        msg_router.cpu_processor_updates_allowed = True
 
     def hideEvent(self, event: QtGui.QHideEvent) -> None:
         """Stop listening for processor updates, if not visible."""
         super().hideEvent(event)
 
         msg_router = MessageRouter.get_instance()
-        msg_router.set_cpu_processor_updates_allowed(False)
+        msg_router.cpu_processor_updates_allowed = False
 
     def resizeEvent(self, event: QtGui.QResizeEvent) -> None:
         """Re-fit graph on resize, to always be centered."""

--- a/src/apps/ocioview/ocioview/inspect/log_inspector.py
+++ b/src/apps/ocioview/ocioview/inspect/log_inspector.py
@@ -6,6 +6,7 @@ from typing import Optional
 import PyOpenColorIO as ocio
 from PySide6 import QtCore, QtGui, QtWidgets
 
+from ..constants import ICON_SIZE_TAB
 from ..log_handlers import set_logging_level
 from ..message_router import MessageRouter
 from ..utils import get_glyph_icon
@@ -23,7 +24,7 @@ class LogInspector(QtWidgets.QWidget):
 
     @classmethod
     def icon(cls) -> QtGui.QIcon:
-        return get_glyph_icon("ph.terminal-window")
+        return get_glyph_icon("ph.terminal-window", size=ICON_SIZE_TAB)
 
     def __init__(self, parent: Optional[QtCore.QObject] = None):
         super().__init__(parent=parent)

--- a/src/apps/ocioview/ocioview/items/active_display_view_edit.py
+++ b/src/apps/ocioview/ocioview/items/active_display_view_edit.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
+from ..constants import ICON_SIZE_ITEM
 from ..widgets import ItemModelListWidget
 from ..utils import get_glyph_icon
 from .active_display_view_model import ActiveDisplayModel, ActiveViewModel
@@ -60,7 +61,7 @@ class ActiveDisplayViewEdit(QtWidgets.QWidget):
 
     @classmethod
     def item_type_icon(cls) -> QtGui.QIcon:
-        return get_glyph_icon("mdi6.sort-bool-ascending-variant")
+        return get_glyph_icon("mdi6.sort-bool-ascending-variant", size=ICON_SIZE_ITEM)
 
     @classmethod
     def item_type_label(cls, plural: bool = False) -> str:

--- a/src/apps/ocioview/ocioview/items/color_space_edit.py
+++ b/src/apps/ocioview/ocioview/items/color_space_edit.py
@@ -8,6 +8,7 @@ from PySide6 import QtCore, QtWidgets
 import PyOpenColorIO as ocio
 
 from ..config_cache import ConfigCache
+from ..constants import ICON_SIZE_ITEM
 from ..utils import get_glyph_icon
 from ..widgets import (
     CheckBox,
@@ -39,12 +40,17 @@ class ColorSpaceParamEdit(BaseConfigItemParamEdit):
         self.reference_space_type_combo = EnumComboBox(
             ocio.ReferenceSpaceType,
             icons={
-                ocio.REFERENCE_SPACE_SCENE: get_glyph_icon("ph.sun"),
-                ocio.REFERENCE_SPACE_DISPLAY: get_glyph_icon("ph.monitor"),
+                ocio.REFERENCE_SPACE_SCENE: get_glyph_icon(
+                    "ph.sun", size=ICON_SIZE_ITEM
+                ),
+                ocio.REFERENCE_SPACE_DISPLAY: get_glyph_icon(
+                    "ph.monitor", size=ICON_SIZE_ITEM
+                ),
             },
         )
         self.aliases_list = StringListWidget(
-            item_basename="alias", item_icon=get_glyph_icon("ph.bookmark-simple")
+            item_basename="alias",
+            item_icon=get_glyph_icon("ph.bookmark-simple", size=ICON_SIZE_ITEM),
         )
         self.family_edit = CallbackComboBox(ConfigCache.get_families, editable=True)
         self.encoding_edit = CallbackComboBox(ConfigCache.get_encodings, editable=True)
@@ -61,7 +67,7 @@ class ColorSpaceParamEdit(BaseConfigItemParamEdit):
         )
         self.categories_list = StringListWidget(
             item_basename="category",
-            item_icon=get_glyph_icon("ph.bookmarks-simple"),
+            item_icon=get_glyph_icon("ph.bookmarks-simple", size=ICON_SIZE_ITEM),
             get_presets=self._get_available_categories,
         )
 

--- a/src/apps/ocioview/ocioview/items/color_space_model.py
+++ b/src/apps/ocioview/ocioview/items/color_space_model.py
@@ -8,6 +8,7 @@ import PyOpenColorIO as ocio
 from PySide6 import QtCore, QtGui
 
 from ..config_cache import ConfigCache
+from ..constants import ICON_SIZE_ITEM
 from ..ref_space_manager import ReferenceSpaceManager
 from ..utils import get_enum_member, get_glyph_icon
 from .config_item_model import ColumnDesc, BaseConfigItemModel
@@ -50,8 +51,10 @@ class ColorSpaceModel(BaseConfigItemModel):
         self._items = ocio.ColorSpaceSet()
 
         self._ref_space_icons = {
-            ocio.REFERENCE_SPACE_SCENE: get_glyph_icon("ph.sun"),
-            ocio.REFERENCE_SPACE_DISPLAY: get_glyph_icon("ph.monitor"),
+            ocio.REFERENCE_SPACE_SCENE: get_glyph_icon("ph.sun", size=ICON_SIZE_ITEM),
+            ocio.REFERENCE_SPACE_DISPLAY: get_glyph_icon(
+                "ph.monitor", size=ICON_SIZE_ITEM
+            ),
         }
 
         # Update on external config changes, in this case when a required reference

--- a/src/apps/ocioview/ocioview/items/color_space_model.py
+++ b/src/apps/ocioview/ocioview/items/color_space_model.py
@@ -65,10 +65,10 @@ class ColorSpaceModel(BaseConfigItemModel):
         return [item.getName() for item in self._get_items()]
 
     def get_item_transforms(
-        self, item_name: str
+        self, item_label: str
     ) -> tuple[Optional[ocio.Transform], Optional[ocio.Transform]]:
-        # Get view name from subscription item name
-        item_name = self.extract_subscription_item_name(item_name)
+        # Get color space name from subscription item label
+        item_name = self.extract_subscription_item_name(item_label)
 
         ref_space_name = ReferenceSpaceManager.scene_reference_space().getName()
         return (

--- a/src/apps/ocioview/ocioview/items/config_item_edit.py
+++ b/src/apps/ocioview/ocioview/items/config_item_edit.py
@@ -316,10 +316,10 @@ class BaseConfigItemEdit(QtWidgets.QWidget):
             )
         ):
             current_index = self.list.current_index()
-            item_name = self.model.format_subscription_item_name(current_index)
-            if item_name:
+            item_label = self.model.format_subscription_item_label(current_index)
+            if item_label:
                 TransformManager.set_subscription(
-                    int(event.text()), self.model, item_name
+                    int(event.text()), self.model, item_label
                 )
                 return True
 

--- a/src/apps/ocioview/ocioview/items/config_item_edit.py
+++ b/src/apps/ocioview/ocioview/items/config_item_edit.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
-from ..constants import MARGIN_WIDTH
+from ..constants import MARGIN_WIDTH, ICON_SIZE_TAB
 from ..transform_manager import TransformManager
 from ..transforms import TransformEditStack
 from ..utils import get_glyph_icon, SignalsBlocked
@@ -47,14 +47,16 @@ class BaseConfigItemParamEdit(QtWidgets.QWidget):
 
         if self.__has_transforms__:
             self.__has_tabs__ = True
-            no_tf_color = palette.color(palette.ColorGroup.Disabled, palette.ColorRole.Text)
-            self._from_ref_icon = get_glyph_icon("mdi6.layers-plus")
-            self._no_from_ref_icon = get_glyph_icon(
-                "mdi6.layers-plus", color=no_tf_color
+            no_tf_color = palette.color(
+                palette.ColorGroup.Disabled, palette.ColorRole.Text
             )
-            self._to_ref_icon = get_glyph_icon("mdi6.layers-minus")
+            self._from_ref_icon = get_glyph_icon("mdi6.layers-plus", size=ICON_SIZE_TAB)
+            self._no_from_ref_icon = get_glyph_icon(
+                "mdi6.layers-plus", color=no_tf_color, size=ICON_SIZE_TAB
+            )
+            self._to_ref_icon = get_glyph_icon("mdi6.layers-minus", size=ICON_SIZE_TAB)
             self._no_to_ref_icon = get_glyph_icon(
-                "mdi6.layers-minus", color=no_tf_color
+                "mdi6.layers-minus", color=no_tf_color, size=ICON_SIZE_TAB
             )
 
         # Widgets

--- a/src/apps/ocioview/ocioview/items/config_item_model.py
+++ b/src/apps/ocioview/ocioview/items/config_item_model.py
@@ -6,9 +6,10 @@ from dataclasses import dataclass
 from typing import Any, Optional, Type, Union
 
 import PyOpenColorIO as ocio
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtGui
 
 from ..config_cache import ConfigCache
+from ..constants import ICON_SIZE_ITEM
 from ..transform_manager import TransformManager, TransformAgent
 from ..undo import ItemModelUndoCommand, ConfigSnapshotUndoCommand
 from ..utils import get_glyph_icon, next_name, item_type_label
@@ -74,7 +75,7 @@ class BaseConfigItemModel(QtCore.QAbstractTableModel):
         :return: Item type icon
         """
         if cls.__icon__ is None:
-            cls.__icon__ = get_glyph_icon(cls.__icon_glyph__)
+            cls.__icon__ = get_glyph_icon(cls.__icon_glyph__, size=ICON_SIZE_ITEM)
         return cls.__icon__
 
     @classmethod

--- a/src/apps/ocioview/ocioview/items/config_properties_edit.py
+++ b/src/apps/ocioview/ocioview/items/config_properties_edit.py
@@ -7,7 +7,7 @@ from typing import Optional
 import PyOpenColorIO as ocio
 from PySide6 import QtWidgets
 
-from ..constants import RGB
+from ..constants import RGB, ICON_SIZE_ITEM
 from ..widgets import (
     ComboBox,
     LineEdit,
@@ -40,12 +40,13 @@ class ConfigPropertiesParamEdit(BaseConfigItemParamEdit):
         self.description_edit = TextEdit()
         self.env_vars_table = StringMapTableWidget(
             ("Name", "Default Value"),
-            item_icon=get_glyph_icon("mdi6.variable"),
+            item_icon=get_glyph_icon("mdi6.variable", size=ICON_SIZE_ITEM),
             default_key_prefix="ENV_VAR_",
             default_value="value",
         )
         self.search_path_list = StringListWidget(
-            item_icon=get_glyph_icon("ph.file-search"), get_item=self._get_search_path
+            item_icon=get_glyph_icon("ph.file-search", size=ICON_SIZE_ITEM),
+            get_item=self._get_search_path,
         )
         self.working_dir_edit = PathEdit(QtWidgets.QFileDialog.Directory)
         self.family_separator_edit = LineEdit()

--- a/src/apps/ocioview/ocioview/items/display_view_edit.py
+++ b/src/apps/ocioview/ocioview/items/display_view_edit.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
+from ..constants import ICON_SIZE_ITEM
 from ..utils import get_glyph_icon
 from .active_display_view_edit import ActiveDisplayViewEdit
 from .shared_view_edit import SharedViewEdit
@@ -22,7 +23,7 @@ class DisplayViewEdit(QtWidgets.QWidget):
         """
         :return: Item type icon
         """
-        return get_glyph_icon("mdi6.monitor-eye")
+        return get_glyph_icon("mdi6.monitor-eye", size=ICON_SIZE_ITEM)
 
     @classmethod
     def item_type_label(cls, plural: bool = False) -> str:

--- a/src/apps/ocioview/ocioview/items/file_rule_edit.py
+++ b/src/apps/ocioview/ocioview/items/file_rule_edit.py
@@ -6,6 +6,7 @@ from typing import Optional
 from PySide6 import QtCore, QtWidgets
 
 from ..config_cache import ConfigCache
+from ..constants import ICON_SIZE_ITEM
 from ..utils import get_glyph_icon
 from ..widgets import (
     CallbackComboBox,
@@ -69,7 +70,7 @@ class FileRuleParamEdit(BaseConfigItemParamEdit):
             if file_rule_type in (FileRuleType.RULE_BASIC, FileRuleType.RULE_REGEX):
                 custom_keys_table = StringMapTableWidget(
                     ("Key Name", "Key Value"),
-                    item_icon=get_glyph_icon("ph.key"),
+                    item_icon=get_glyph_icon("ph.key", size=ICON_SIZE_ITEM),
                     default_key_prefix="key_",
                     default_value="value",
                 )

--- a/src/apps/ocioview/ocioview/items/file_rule_model.py
+++ b/src/apps/ocioview/ocioview/items/file_rule_model.py
@@ -9,6 +9,7 @@ import PyOpenColorIO as ocio
 from PySide6 import QtCore, QtGui
 
 from ..config_cache import ConfigCache
+from ..constants import ICON_SIZE_ITEM
 from ..undo import ConfigSnapshotUndoCommand
 from ..utils import get_glyph_icon, next_name
 from .config_item_model import ColumnDesc, BaseConfigItemModel
@@ -77,7 +78,7 @@ class FileRuleModel(BaseConfigItemModel):
             FileRuleType.RULE_OCIO_V1: "mdi6.contain",
             FileRuleType.RULE_DEFAULT: "ph.arrow-line-down",
         }
-        return get_glyph_icon(glyph_names[rule_type])
+        return get_glyph_icon(glyph_names[rule_type], size=ICON_SIZE_ITEM)
 
     @classmethod
     def has_presets(cls) -> bool:

--- a/src/apps/ocioview/ocioview/items/look_model.py
+++ b/src/apps/ocioview/ocioview/items/look_model.py
@@ -35,10 +35,10 @@ class LookModel(BaseConfigItemModel):
         return [item.getName() for item in self._get_items()]
 
     def get_item_transforms(
-        self, item_name: str
+        self, item_label: str
     ) -> tuple[Optional[ocio.Transform], Optional[ocio.Transform]]:
-        # Get view name from subscription item name
-        item_name = self.extract_subscription_item_name(item_name)
+        # Get look name from subscription item label
+        item_name = self.extract_subscription_item_name(item_label)
 
         scene_ref_name = ReferenceSpaceManager.scene_reference_space().getName()
         return (

--- a/src/apps/ocioview/ocioview/items/named_transform_edit.py
+++ b/src/apps/ocioview/ocioview/items/named_transform_edit.py
@@ -6,6 +6,7 @@ from typing import Optional
 from PySide6 import QtWidgets
 
 from ..config_cache import ConfigCache
+from ..constants import ICON_SIZE_ITEM
 from ..utils import get_glyph_icon
 from ..widgets import CallbackComboBox, StringListWidget, TextEdit
 from .config_item_edit import BaseConfigItemParamEdit, BaseConfigItemEdit
@@ -28,14 +29,15 @@ class NamedTransformParamEdit(BaseConfigItemParamEdit):
 
         # Widgets
         self.aliases_list = StringListWidget(
-            item_basename="alias", item_icon=get_glyph_icon("ph.bookmark-simple")
+            item_basename="alias",
+            item_icon=get_glyph_icon("ph.bookmark-simple", size=ICON_SIZE_ITEM),
         )
         self.family_edit = CallbackComboBox(ConfigCache.get_families, editable=True)
         self.encoding_edit = CallbackComboBox(ConfigCache.get_encodings, editable=True)
         self.description_edit = TextEdit()
         self.categories_list = StringListWidget(
             item_basename="category",
-            item_icon=get_glyph_icon("ph.bookmarks-simple"),
+            item_icon=get_glyph_icon("ph.bookmarks-simple", size=ICON_SIZE_ITEM),
             get_presets=self._get_available_categories,
         )
 

--- a/src/apps/ocioview/ocioview/items/named_transform_model.py
+++ b/src/apps/ocioview/ocioview/items/named_transform_model.py
@@ -46,10 +46,10 @@ class NamedTransformModel(BaseConfigItemModel):
         return [item.getName() for item in self._get_items()]
 
     def get_item_transforms(
-        self, item_name: str
+        self, item_label: str
     ) -> tuple[Optional[ocio.Transform], Optional[ocio.Transform]]:
-        # Get view name from subscription item name
-        item_name = self.extract_subscription_item_name(item_name)
+        # Get named transform name from subscription item label
+        item_name = self.extract_subscription_item_name(item_label)
 
         config = ocio.GetCurrentConfig()
         named_transform = config.getNamedTransform(item_name)

--- a/src/apps/ocioview/ocioview/items/named_transform_model.py
+++ b/src/apps/ocioview/ocioview/items/named_transform_model.py
@@ -8,6 +8,7 @@ import PyOpenColorIO as ocio
 from PySide6 import QtCore, QtGui
 
 from ..config_cache import ConfigCache
+from ..constants import ICON_SIZE_ITEM
 from ..utils import get_glyph_icon
 from .config_item_model import ColumnDesc, BaseConfigItemModel
 
@@ -39,7 +40,7 @@ class NamedTransformModel(BaseConfigItemModel):
     def __init__(self, parent: Optional[QtCore.QObject] = None):
         super().__init__(parent=parent)
 
-        self._item_icon = get_glyph_icon("ph.arrow-square-right")
+        self._item_icon = get_glyph_icon("ph.arrow-square-right", size=ICON_SIZE_ITEM)
 
     def get_item_names(self) -> list[str]:
         return [item.getName() for item in self._get_items()]

--- a/src/apps/ocioview/ocioview/items/rule_edit.py
+++ b/src/apps/ocioview/ocioview/items/rule_edit.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
+from ..constants import ICON_SIZE_ITEM
 from ..utils import get_glyph_icon
 from .file_rule_edit import FileRuleEdit
 from .utils import adapt_splitter_sizes
@@ -22,7 +23,7 @@ class RuleEdit(QtWidgets.QWidget):
         """
         :return: Item type icon
         """
-        return get_glyph_icon("mdi6.list-status")
+        return get_glyph_icon("mdi6.list-status", size=ICON_SIZE_ITEM)
 
     @classmethod
     def item_type_label(cls, plural: bool = False) -> str:

--- a/src/apps/ocioview/ocioview/items/view_edit.py
+++ b/src/apps/ocioview/ocioview/items/view_edit.py
@@ -276,13 +276,13 @@ class ViewEdit(BaseConfigItemEdit):
         """
         for i in range(self.model.rowCount()):
             view_index = self.model.index(i, self.model.NAME.column)
-            item_name = self.model.format_subscription_item_name(view_index)
-            prev_item_name = self.model.format_subscription_item_name(
+            item_label = self.model.format_subscription_item_label(view_index)
+            prev_item_label = self.model.format_subscription_item_label(
                 view_index, display=prev_display
             )
-            slot = TransformManager.get_subscription_slot(self.model, prev_item_name)
+            slot = TransformManager.get_subscription_slot(self.model, prev_item_label)
             if slot != -1:
-                TransformManager.set_subscription(slot, self.model, item_name)
+                TransformManager.set_subscription(slot, self.model, item_label)
 
     @QtCore.Slot(int)
     def _on_display_changed(self, display_row: int) -> None:

--- a/src/apps/ocioview/ocioview/items/view_edit.py
+++ b/src/apps/ocioview/ocioview/items/view_edit.py
@@ -260,7 +260,7 @@ class ViewEdit(BaseConfigItemEdit):
         signal is emitted twice when pressing enter. See:
             https://forum.qt.io/topic/39141/qlineedit-editingfinished-signal-is-emitted-twice
         """
-        view_type = self._get_view_type(self.list.current_row())
+        view_type, _ = self._get_view_type(self.list.current_row())
         self.param_edit.display_edits[view_type].blockSignals(True)
         self._display_mapper.submit()
         self.param_edit.display_edits[view_type].blockSignals(False)

--- a/src/apps/ocioview/ocioview/items/view_model.py
+++ b/src/apps/ocioview/ocioview/items/view_model.py
@@ -7,6 +7,7 @@ import PyOpenColorIO as ocio
 from PySide6 import QtCore, QtGui
 
 from ..config_cache import ConfigCache
+from ..constants import ICON_SIZE_ITEM
 from ..ref_space_manager import ReferenceSpaceManager
 from ..undo import ConfigSnapshotUndoCommand
 from ..utils import get_glyph_icon, next_name
@@ -44,7 +45,7 @@ class ViewModel(BaseConfigItemModel):
             ViewType.VIEW_DISPLAY: "mdi6.eye-outline",
             ViewType.VIEW_SCENE: "mdi6.eye",
         }
-        return get_glyph_icon(glyph_names[view_type])
+        return get_glyph_icon(glyph_names[view_type], size=ICON_SIZE_ITEM)
 
     @classmethod
     def has_presets(cls) -> bool:
@@ -353,9 +354,13 @@ class ViewModel(BaseConfigItemModel):
 
         # Display views
         for name in config.getViews(ocio.VIEW_DISPLAY_DEFINED, self._display):
+            view_type, warning = get_view_type(self._display, name)
+            if warning:
+                self.warning_raised.emit(warning)
+
             self._items.append(
                 View(
-                    get_view_type(self._display, name),
+                    view_type,
                     name,
                     config.getDisplayViewColorSpaceName(self._display, name),
                     config.getDisplayViewTransformName(self._display, name),

--- a/src/apps/ocioview/ocioview/items/view_model.py
+++ b/src/apps/ocioview/ocioview/items/view_model.py
@@ -239,12 +239,12 @@ class ViewModel(BaseConfigItemModel):
         return None
 
     def get_item_transforms(
-        self, item_name: str
+        self, item_label: str
     ) -> tuple[Optional[ocio.Transform], Optional[ocio.Transform]]:
 
         if self._display is not None:
-            # Get view name from subscription item name
-            item_name = self.extract_subscription_item_name(item_name)
+            # Get view name from subscription item label
+            item_name = self.extract_subscription_item_name(item_label)
 
             scene_ref_name = ReferenceSpaceManager.scene_reference_space().getName()
             return (
@@ -264,20 +264,20 @@ class ViewModel(BaseConfigItemModel):
         else:
             return None, None
 
-    def format_subscription_item_name(
+    def format_subscription_item_label(
         self,
         item_name_or_index: Union[str, QtCore.QModelIndex],
         display: Optional[str] = None,
         **kwargs,
     ) -> Optional[str]:
-        item_name = super().format_subscription_item_name(item_name_or_index)
-        if item_name and (display or self._display):
-            return f"{display or self._display}/{item_name}"
+        item_label = super().format_subscription_item_label(item_name_or_index)
+        if item_label and (display or self._display):
+            return f"{display or self._display}/{item_label}"
         else:
-            return item_name
+            return item_label
 
-    def extract_subscription_item_name(self, subscription_item_name: str) -> str:
-        item_name = super().extract_subscription_item_name(subscription_item_name)
+    def extract_subscription_item_name(self, item_label: str) -> str:
+        item_name = super().extract_subscription_item_name(item_label)
         if self._display and item_name.startswith(self._display + "/"):
             item_name = item_name[len(self._display) + 1 :]
         return item_name
@@ -290,7 +290,7 @@ class ViewModel(BaseConfigItemModel):
             # Insert display name before view
             item_name = self.get_item_name(index)
             text = text.replace(
-                f"({item_name})", f"({self.format_subscription_item_name(item_name)})"
+                f"({item_name})", f"({self.format_subscription_item_label(item_name)})"
             )
         return text
 

--- a/src/apps/ocioview/ocioview/items/view_transform_edit.py
+++ b/src/apps/ocioview/ocioview/items/view_transform_edit.py
@@ -8,6 +8,7 @@ from PySide6 import QtWidgets
 import PyOpenColorIO as ocio
 
 from ..config_cache import ConfigCache
+from ..constants import ICON_SIZE_ITEM
 from ..utils import get_glyph_icon
 from ..widgets import EnumComboBox, CallbackComboBox, StringListWidget, TextEdit
 from .config_item_edit import BaseConfigItemParamEdit, BaseConfigItemEdit
@@ -32,15 +33,19 @@ class ViewTransformParamEdit(BaseConfigItemParamEdit):
         self.reference_space_type_combo = EnumComboBox(
             ocio.ReferenceSpaceType,
             icons={
-                ocio.REFERENCE_SPACE_SCENE: get_glyph_icon("ph.sun"),
-                ocio.REFERENCE_SPACE_DISPLAY: get_glyph_icon("ph.monitor"),
+                ocio.REFERENCE_SPACE_SCENE: get_glyph_icon(
+                    "ph.sun", size=ICON_SIZE_ITEM
+                ),
+                ocio.REFERENCE_SPACE_DISPLAY: get_glyph_icon(
+                    "ph.monitor", size=ICON_SIZE_ITEM
+                ),
             },
         )
         self.family_edit = CallbackComboBox(ConfigCache.get_families, editable=True)
         self.description_edit = TextEdit()
         self.categories_list = StringListWidget(
             item_basename="category",
-            item_icon=get_glyph_icon("ph.bookmarks-simple"),
+            item_icon=get_glyph_icon("ph.bookmarks-simple", size=ICON_SIZE_ITEM),
             get_presets=self._get_available_categories,
         )
 

--- a/src/apps/ocioview/ocioview/items/view_transform_model.py
+++ b/src/apps/ocioview/ocioview/items/view_transform_model.py
@@ -8,6 +8,7 @@ import PyOpenColorIO as ocio
 from PySide6 import QtCore, QtGui
 
 from ..config_cache import ConfigCache
+from ..constants import ICON_SIZE_ITEM
 from ..utils import get_enum_member, get_glyph_icon
 from .config_item_model import ColumnDesc, BaseConfigItemModel
 from .utils import get_scene_to_display_transform, get_display_to_scene_transform
@@ -40,8 +41,10 @@ class ViewTransformModel(BaseConfigItemModel):
         super().__init__(parent=parent)
 
         self._ref_space_icons = {
-            ocio.REFERENCE_SPACE_SCENE: get_glyph_icon("ph.sun"),
-            ocio.REFERENCE_SPACE_DISPLAY: get_glyph_icon("ph.monitor"),
+            ocio.REFERENCE_SPACE_SCENE: get_glyph_icon("ph.sun", size=ICON_SIZE_ITEM),
+            ocio.REFERENCE_SPACE_DISPLAY: get_glyph_icon(
+                "ph.monitor", size=ICON_SIZE_ITEM
+            ),
         }
 
     def get_item_names(self) -> list[str]:

--- a/src/apps/ocioview/ocioview/items/view_transform_model.py
+++ b/src/apps/ocioview/ocioview/items/view_transform_model.py
@@ -51,10 +51,10 @@ class ViewTransformModel(BaseConfigItemModel):
         return [item.getName() for item in self._get_items()]
 
     def get_item_transforms(
-        self, item_name: str
+        self, item_label: str
     ) -> tuple[Optional[ocio.Transform], Optional[ocio.Transform]]:
-        # Get view name from subscription item name
-        item_name = self.extract_subscription_item_name(item_name)
+        # Get view transform name from subscription item label
+        item_name = self.extract_subscription_item_name(item_label)
 
         config = ocio.GetCurrentConfig()
         view_transform = config.getViewTransform(item_name)

--- a/src/apps/ocioview/ocioview/items/viewing_rule_edit.py
+++ b/src/apps/ocioview/ocioview/items/viewing_rule_edit.py
@@ -6,6 +6,7 @@ from typing import Optional
 from PySide6 import QtCore, QtWidgets
 
 from ..config_cache import ConfigCache
+from ..constants import ICON_SIZE_ITEM
 from ..utils import get_glyph_icon
 from ..widgets import (
     FormLayout,
@@ -43,7 +44,7 @@ class ViewingRuleParamEdit(BaseConfigItemParamEdit):
         self.color_space_list.view.setItemDelegate(ColorSpaceDelegate())
         self.custom_keys_table_a = StringMapTableWidget(
             ("Key Name", "Key Value"),
-            item_icon=get_glyph_icon("ph.key"),
+            item_icon=get_glyph_icon("ph.key", size=ICON_SIZE_ITEM),
             default_key_prefix="key_",
             default_value="value",
         )
@@ -61,7 +62,7 @@ class ViewingRuleParamEdit(BaseConfigItemParamEdit):
         )
         self.custom_keys_table_b = StringMapTableWidget(
             ("Key Name", "Key Value"),
-            item_icon=get_glyph_icon("ph.key"),
+            item_icon=get_glyph_icon("ph.key", size=ICON_SIZE_ITEM),
             default_key_prefix="key_",
             default_value="value",
         )

--- a/src/apps/ocioview/ocioview/items/viewing_rule_model.py
+++ b/src/apps/ocioview/ocioview/items/viewing_rule_model.py
@@ -10,6 +10,7 @@ import PyOpenColorIO as ocio
 from PySide6 import QtCore, QtGui
 
 from ..config_cache import ConfigCache
+from ..constants import ICON_SIZE_ITEM
 from ..undo import ConfigSnapshotUndoCommand
 from ..utils import get_glyph_icon, next_name
 from .config_item_model import ColumnDesc, BaseConfigItemModel
@@ -58,7 +59,7 @@ class ViewingRuleModel(BaseConfigItemModel):
             ViewingRuleType.RULE_COLOR_SPACE: "ph.swap",
             ViewingRuleType.RULE_ENCODING: "mdi6.sine-wave",
         }
-        return get_glyph_icon(glyph_names[rule_type])
+        return get_glyph_icon(glyph_names[rule_type], size=ICON_SIZE_ITEM)
 
     @classmethod
     def has_presets(cls) -> bool:

--- a/src/apps/ocioview/ocioview/main_window.py
+++ b/src/apps/ocioview/ocioview/main_window.py
@@ -14,6 +14,7 @@ from .config_dock import ConfigDock
 from .constants import ICON_PATH_OCIO
 from .inspect_dock import InspectDock
 from .message_router import MessageRouter
+from .ref_space_manager import ReferenceSpaceManager
 from .settings import settings
 from .undo import undo_stack
 from .viewer_dock import ViewerDock
@@ -147,6 +148,9 @@ class OCIOView(QtWidgets.QMainWindow):
         # Initialize
         if config_path is not None:
             self.load_config(config_path)
+        else:
+            # New config
+            self._init_config_tracking()
 
         self._update_recent_configs_menu()
         self._update_window_title()
@@ -156,8 +160,10 @@ class OCIOView(QtWidgets.QMainWindow):
 
     def reset(self) -> None:
         """
-        Reset application, reloading the current OCIO config.
+        Reset application from the current OCIO config.
         """
+        self._init_config_tracking()
+
         self.config_dock.reset()
         self.viewer_dock.reset()
         self.inspect_dock.reset()
@@ -189,7 +195,6 @@ class OCIOView(QtWidgets.QMainWindow):
 
         config = ocio.Config.CreateRaw()
         ocio.SetCurrentConfig(config)
-
         self.reset()
 
     def load_config(self, config_path: Optional[Path] = None) -> None:
@@ -226,8 +231,6 @@ class OCIOView(QtWidgets.QMainWindow):
         config = ocio.Config.CreateFromFile(self._config_path.as_posix())
         ocio.SetCurrentConfig(config)
         self.reset()
-
-        self._update_cache_id()
 
     def save_config(self) -> bool:
         """
@@ -532,3 +535,8 @@ class OCIOView(QtWidgets.QMainWindow):
 
         # No unsaved changes
         return True
+
+    def _init_config_tracking(self) -> None:
+        """Setup app-dependent config objects and change tracking."""
+        ReferenceSpaceManager.init_reference_spaces()
+        self._update_cache_id()

--- a/src/apps/ocioview/ocioview/message_router.py
+++ b/src/apps/ocioview/ocioview/message_router.py
@@ -329,6 +329,54 @@ class MessageRouter(QtCore.QObject):
         """Forward unknown attribute requests to internal runner."""
         return getattr(self._runner, item)
 
+    @property
+    def gpu_language(self) -> ocio.GpuLanguage:
+        return self._runner.gpu_language
+
+    @gpu_language.setter
+    def gpu_language(self, gpu_language: ocio.GpuLanguage) -> None:
+        self._runner.gpu_language = gpu_language
+
+    @property
+    def config_updates_allowed(self) -> bool:
+        return self._runner.config_updates_allowed
+
+    @config_updates_allowed.setter
+    def config_updates_allowed(self, allowed: bool) -> None:
+        self._runner.config_updates_allowed = allowed
+
+    @property
+    def ctf_updates_allowed(self) -> bool:
+        return self._runner.ctf_updates_allowed
+
+    @ctf_updates_allowed.setter
+    def ctf_updates_allowed(self, allowed: bool) -> None:
+        self._runner.ctf_updates_allowed = allowed
+
+    @property
+    def image_updates_allowed(self) -> bool:
+        return self._runner.image_updates_allowed
+
+    @image_updates_allowed.setter
+    def image_updates_allowed(self, allowed: bool) -> None:
+        self._runner.image_updates_allowed = allowed
+
+    @property
+    def processor_updates_allowed(self) -> bool:
+        return self._runner.processor_updates_allowed
+
+    @processor_updates_allowed.setter
+    def processor_updates_allowed(self, allowed: bool) -> None:
+        self._runner.processor_updates_allowed = allowed
+
+    @property
+    def shader_updates_allowed(self) -> bool:
+        return self._runner.shader_updates_allowed
+
+    @shader_updates_allowed.setter
+    def shader_updates_allowed(self, allowed: bool) -> None:
+        self._runner.shader_updates_allowed = allowed
+
     def end_routing(self) -> None:
         """Stop message routing thread."""
         if not self._runner.is_routing():

--- a/src/apps/ocioview/ocioview/message_router.py
+++ b/src/apps/ocioview/ocioview/message_router.py
@@ -71,46 +71,56 @@ class MessageRunner(QtCore.QObject):
         self._ctf_updates_allowed = False
         self._shader_updates_allowed = False
 
-    def get_gpu_language(self) -> ocio.GpuLanguage:
+    @property
+    def gpu_language(self) -> ocio.GpuLanguage:
         return self._gpu_language
 
-    def set_gpu_language(self, gpu_language: ocio.GpuLanguage) -> None:
+    @gpu_language.setter
+    def gpu_language(self, gpu_language: ocio.GpuLanguage) -> None:
         self._gpu_language = gpu_language
         if self._shader_updates_allowed and self._prev_proc is not None:
             # Rebroadcast last processor record
             message_queue.put_nowait(self._prev_proc)
 
+    @property
     def config_updates_allowed(self) -> bool:
         return self._config_updates_allowed
 
-    def set_config_updates_allowed(self, allowed: bool) -> None:
+    @config_updates_allowed.setter
+    def config_updates_allowed(self, allowed: bool) -> None:
         self._config_updates_allowed = allowed
         if allowed and self._prev_config is not None:
             # Rebroadcast last config record
             message_queue.put_nowait(self._prev_config)
 
+    @property
     def cpu_processor_updates_allowed(self) -> bool:
         return self._cpu_processor_updates_allowed
 
-    def set_cpu_processor_updates_allowed(self, allowed: bool) -> None:
+    @cpu_processor_updates_allowed.setter
+    def cpu_processor_updates_allowed(self, allowed: bool) -> None:
         self._cpu_processor_updates_allowed = allowed
         if allowed and self._prev_config is not None:
             # Rebroadcast last config record
             message_queue.put_nowait(self._prev_config)
 
+    @property
     def ctf_updates_allowed(self) -> bool:
         return self._ctf_updates_allowed
 
-    def set_ctf_updates_allowed(self, allowed: bool) -> None:
+    @ctf_updates_allowed.setter
+    def ctf_updates_allowed(self, allowed: bool) -> None:
         self._ctf_updates_allowed = allowed
         if allowed and self._prev_proc is not None:
             # Rebroadcast last processor record
             message_queue.put_nowait(self._prev_proc)
 
+    @property
     def shader_updates_allowed(self) -> bool:
         return self._shader_updates_allowed
 
-    def set_shader_updates_allowed(self, allowed: bool) -> None:
+    @shader_updates_allowed.setter
+    def shader_updates_allowed(self, allowed: bool) -> None:
         self._shader_updates_allowed = allowed
         if allowed and self._prev_proc is not None:
             # Rebroadcast last processor record

--- a/src/apps/ocioview/ocioview/message_router.py
+++ b/src/apps/ocioview/ocioview/message_router.py
@@ -13,6 +13,7 @@ import numpy as np
 import PyOpenColorIO as ocio
 from PySide6 import QtCore, QtGui, QtWidgets
 
+from .processor_context import ProcessorContext
 from .utils import config_to_html, processor_to_ctf_html, processor_to_shader_html
 
 
@@ -34,7 +35,7 @@ class MessageRunner(QtCore.QObject):
     config_html_ready = QtCore.Signal(str)
     ctf_html_ready = QtCore.Signal(str, ocio.GroupTransform)
     image_ready = QtCore.Signal(np.ndarray)
-    processor_ready = QtCore.Signal(ocio.CPUProcessor)
+    processor_ready = QtCore.Signal(ProcessorContext, ocio.CPUProcessor)
     shader_html_ready = QtCore.Signal(str, ocio.GPUProcessor)
 
     LOOP_INTERVAL = 0.5  # In seconds
@@ -66,7 +67,7 @@ class MessageRunner(QtCore.QObject):
         self._gpu_language = ocio.GPU_LANGUAGE_GLSL_4_0
 
         self._prev_config = None
-        self._prev_cpu_proc = None
+        self._prev_proc_data = None
         self._prev_image_array = None
 
         self._config_updates_allowed = False
@@ -82,9 +83,9 @@ class MessageRunner(QtCore.QObject):
     @gpu_language.setter
     def gpu_language(self, gpu_language: ocio.GpuLanguage) -> None:
         self._gpu_language = gpu_language
-        if self._shader_updates_allowed and self._prev_cpu_proc is not None:
+        if self._shader_updates_allowed and self._prev_proc_data is not None:
             # Rebroadcast last processor record
-            message_queue.put_nowait(self._prev_cpu_proc)
+            message_queue.put_nowait(self._prev_proc_data)
 
     @property
     def config_updates_allowed(self) -> bool:
@@ -104,9 +105,9 @@ class MessageRunner(QtCore.QObject):
     @ctf_updates_allowed.setter
     def ctf_updates_allowed(self, allowed: bool) -> None:
         self._ctf_updates_allowed = allowed
-        if allowed and self._prev_cpu_proc is not None:
+        if allowed and self._prev_proc_data is not None:
             # Rebroadcast last processor record
-            message_queue.put_nowait(self._prev_cpu_proc)
+            message_queue.put_nowait(self._prev_proc_data)
 
     @property
     def image_updates_allowed(self) -> bool:
@@ -126,9 +127,9 @@ class MessageRunner(QtCore.QObject):
     @processor_updates_allowed.setter
     def processor_updates_allowed(self, allowed: bool) -> None:
         self._processor_updates_allowed = allowed
-        if allowed and self._prev_config is not None:
-            # Rebroadcast last config record
-            message_queue.put_nowait(self._prev_config)
+        if allowed and self._prev_proc_data is not None:
+            # Rebroadcast last processor record
+            message_queue.put_nowait(self._prev_proc_data)
 
     @property
     def shader_updates_allowed(self) -> bool:
@@ -137,9 +138,9 @@ class MessageRunner(QtCore.QObject):
     @shader_updates_allowed.setter
     def shader_updates_allowed(self, allowed: bool) -> None:
         self._shader_updates_allowed = allowed
-        if allowed and self._prev_cpu_proc is not None:
+        if allowed and self._prev_proc_data is not None:
             # Rebroadcast last processor record
-            message_queue.put_nowait(self._prev_cpu_proc)
+            message_queue.put_nowait(self._prev_proc_data)
 
     def is_routing(self) -> bool:
         """Whether runner is routing messages."""
@@ -168,14 +169,19 @@ class MessageRunner(QtCore.QObject):
                     self._handle_config_message(msg_raw)
 
             # OCIO processor
-            elif isinstance(msg_raw, ocio.Processor):
-                self._prev_cpu_proc = msg_raw
+            elif (
+                isinstance(msg_raw, tuple)
+                and len(msg_raw) == 2
+                and isinstance(msg_raw[0], ProcessorContext)
+                and isinstance(msg_raw[1], ocio.Processor)
+            ):
+                self._prev_proc_data = msg_raw
                 if (
                     self._processor_updates_allowed
                     or self._ctf_updates_allowed
                     or self._shader_updates_allowed
                 ):
-                    self._handle_processor_message(msg_raw)
+                    self._handle_processor_message(*msg_raw)
 
             # Image array
             elif isinstance(msg_raw, np.ndarray):
@@ -185,7 +191,7 @@ class MessageRunner(QtCore.QObject):
 
             # Python or OCIO log record
             else:
-                self._handle_log_message(msg_raw)
+                self._handle_log_message(str(msg_raw))
 
         self._is_routing = False
 
@@ -202,22 +208,27 @@ class MessageRunner(QtCore.QObject):
             # Pass error to log
             self._handle_log_message(str(e), force_level=self.LOG_LEVEL_WARNING)
 
-    def _handle_processor_message(self, cpu_proc: ocio.Processor) -> None:
+    def _handle_processor_message(
+        self,
+        proc_context: ProcessorContext,
+        proc: ocio.Processor,
+    ) -> None:
         """
         Handle OCIO processor received in the message queue.
 
-        :param cpu_proc: OCIO processor instance
+        :param proc_context: OCIO processor context data
+        :param proc: OCIO processor instance
         """
         try:
             if self._processor_updates_allowed:
-                self.processor_ready.emit(cpu_proc.getDefaultCPUProcessor())
+                self.processor_ready.emit(proc_context, proc.getDefaultCPUProcessor())
 
             if self._ctf_updates_allowed:
-                ctf_html_data, group_tf = processor_to_ctf_html(cpu_proc)
+                ctf_html_data, group_tf = processor_to_ctf_html(proc)
                 self.ctf_html_ready.emit(ctf_html_data, group_tf)
 
             if self._shader_updates_allowed:
-                gpu_proc = cpu_proc.getDefaultGPUProcessor()
+                gpu_proc = proc.getDefaultGPUProcessor()
                 shader_html_data = processor_to_shader_html(
                     gpu_proc, self._gpu_language
                 )

--- a/src/apps/ocioview/ocioview/processor_context.py
+++ b/src/apps/ocioview/ocioview/processor_context.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Type
+
+
+@dataclass
+class ProcessorContext:
+    """
+    Data about current config items that constructed a processor.
+    """
+
+    input_color_space: str | None
+    """Input color space name."""
+
+    transform_item_type: Type | None
+    """Config item type for output transform."""
+
+    transform_item_name: str | None
+    """Config item name for output transform."""
+
+    inverse: bool = False
+    """
+    True if the processor is converting from the output transform to 
+    the input color space, otherwise the processor is converting from 
+    the input color space to the output transform.
+    """

--- a/src/apps/ocioview/ocioview/processor_context.py
+++ b/src/apps/ocioview/ocioview/processor_context.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Type
 
+import PyOpenColorIO as ocio
+
 
 @dataclass
 class ProcessorContext:
@@ -22,9 +24,5 @@ class ProcessorContext:
     transform_item_name: str | None
     """Transform source config item name."""
 
-    inverse: bool = False
-    """
-    True if the processor is converting from the transform to the input 
-    color space, otherwise the processor is converting from the input 
-    color space to the transform.
-    """
+    transform_direction: ocio.TransformDirection = ocio.TRANSFORM_DIR_FORWARD
+    """Transform direction being viewed."""

--- a/src/apps/ocioview/ocioview/processor_context.py
+++ b/src/apps/ocioview/ocioview/processor_context.py
@@ -17,14 +17,14 @@ class ProcessorContext:
     """Input color space name."""
 
     transform_item_type: Type | None
-    """Config item type for output transform."""
+    """Transform source config item type."""
 
     transform_item_name: str | None
-    """Config item name for output transform."""
+    """Transform source config item name."""
 
     inverse: bool = False
     """
-    True if the processor is converting from the output transform to 
-    the input color space, otherwise the processor is converting from 
-    the input color space to the output transform.
+    True if the processor is converting from the transform to the input 
+    color space, otherwise the processor is converting from the input 
+    color space to the transform.
     """

--- a/src/apps/ocioview/ocioview/ref_space_manager.py
+++ b/src/apps/ocioview/ocioview/ref_space_manager.py
@@ -14,6 +14,11 @@ class ReferenceSpaceManager:
     _ref_subscribers: list[Callable] = []
 
     @classmethod
+    def init_reference_spaces(cls) -> None:
+        cls._update_scene_reference_space()
+        cls._update_display_reference_space()
+
+    @classmethod
     def subscribe_to_reference_spaces(cls, ref_callback: Callable) -> None:
         """
         Subscribe to reference space updates.

--- a/src/apps/ocioview/ocioview/transform_manager.py
+++ b/src/apps/ocioview/ocioview/transform_manager.py
@@ -1,10 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright Contributors to the OpenColorIO Project.
 
+from __future__ import annotations
+
 from collections import defaultdict
 from dataclasses import dataclass
 from functools import partial
-from typing import Callable, Optional
+from typing import Callable, Optional, Type, Union
 
 import PyOpenColorIO as ocio
 from PySide6 import QtCore, QtGui
@@ -140,7 +142,7 @@ class TransformManager:
     @classmethod
     def get_subscription_slot_color(
         cls, slot: int, saturation: float = 0.5, value: float = 1.0
-    ) -> Optional[QtGui.QColor]:
+    ) -> Union[QtGui.QColor, None]:
         """
         Return a standard subscription slot color for use in GUI
         elements.
@@ -157,7 +159,7 @@ class TransformManager:
             return None
 
     @classmethod
-    def get_subscription_slot_icon(cls, slot: int) -> Optional[QtGui.QIcon]:
+    def get_subscription_slot_icon(cls, slot: int) -> Union[QtGui.QIcon, None]:
         """
         Return a standard subscription slot icon for use in GUI
         elements.
@@ -186,13 +188,46 @@ class TransformManager:
             return None
 
     @classmethod
-    def get_subscription_menu_items(cls) -> list[tuple[int, str, QtGui.QIcon]]:
+    def get_subscription_slot_item_type(cls, slot: int) -> Type | None:
+        """
+        Return the item type associated with the given subscription
+        slot.
+
+        :param slot: Subscription slot number
+        :return: Item type, if slot number is valid
+        """
+        if slot != -1 and slot in cls._tf_subscriptions:
+            return cls._tf_subscriptions[slot].item_model.__item_type__
+        else:
+            return None
+
+    @classmethod
+    def get_subscription_slot_item_name(cls, slot: int) -> str | None:
+        """
+        Return the item name associated with the given subscription
+        slot.
+
+        :param slot: Subscription slot number
+        :return: Item name, if slot number is valid
+        """
+        if slot != -1 and slot in cls._tf_subscriptions:
+            return cls._tf_subscriptions[slot].item_name
+        else:
+            return None
+
+    @classmethod
+    def get_subscription_menu_items(cls) -> list[tuple[int, Type, str, QtGui.QIcon]]:
         """
         :return: Subscription slots, their names, and respective item
             type icons, for use in subscription menus.
         """
         return [
-            (i, s.item_name, cls.get_subscription_slot_icon(i))
+            (
+                i,
+                s.item_model.__item_type__,
+                s.item_name,
+                cls.get_subscription_slot_icon(i),
+            )
             for i, s in sorted(cls._tf_subscriptions.items())
         ]
 

--- a/src/apps/ocioview/ocioview/transform_manager.py
+++ b/src/apps/ocioview/ocioview/transform_manager.py
@@ -9,6 +9,7 @@ from typing import Callable, Optional
 import PyOpenColorIO as ocio
 from PySide6 import QtCore, QtGui
 
+from .constants import ICON_SIZE_ITEM
 from .utils import get_glyph_icon
 
 
@@ -178,7 +179,9 @@ class TransformManager:
                 9: "nine",
             }[slot]
             color = cls.get_subscription_slot_color(slot)
-            return get_glyph_icon(f"ph.number-circle-{slot_word}", color=color)
+            return get_glyph_icon(
+                f"ph.number-circle-{slot_word}", color=color, size=ICON_SIZE_ITEM
+            )
         else:
             return None
 

--- a/src/apps/ocioview/ocioview/transforms/transform_edit.py
+++ b/src/apps/ocioview/ocioview/transforms/transform_edit.py
@@ -45,7 +45,7 @@ class BaseTransformEdit(QtWidgets.QFrame):
         :return: Transform type icon
         """
         if cls.__icon__ is None:
-            cls.__icon__ = get_glyph_icon(cls.__icon_glyph__)
+            cls.__icon__ = get_glyph_icon(cls.__icon_glyph__, size=ICON_SIZE_ITEM)
         return cls.__icon__
 
     @classmethod

--- a/src/apps/ocioview/ocioview/utils.py
+++ b/src/apps/ocioview/ocioview/utils.py
@@ -42,6 +42,7 @@ def get_glyph_icon(
     scale_factor: float = ICON_SCALE_FACTOR,
     color: Optional[QtGui.QColor] = None,
     as_widget: bool = False,
+    size: QtCore.QSize = ICON_SIZE_BUTTON,
 ) -> Union[QtGui.QIcon, QtWidgets.QLabel]:
     """
     Get named glyph QIcon from QtAwesome.
@@ -51,6 +52,7 @@ def get_glyph_icon(
     :param color: Optional icon color override
     :param as_widget: Set to True to return a widget displaying the
         icon instead of a QIcon.
+    :param size: Override icon size
     :return: Glyph QIcon or QLabel
     """
     kwargs = {"scale_factor": scale_factor}
@@ -61,7 +63,7 @@ def get_glyph_icon(
 
     if as_widget:
         widget = QtWidgets.QLabel()
-        widget.setPixmap(icon.pixmap(ICON_SIZE_BUTTON))
+        widget.setPixmap(icon.pixmap(size))
         return widget
     else:
         return icon

--- a/src/apps/ocioview/ocioview/viewer/image_plane.py
+++ b/src/apps/ocioview/ocioview/viewer/image_plane.py
@@ -352,7 +352,7 @@ class ImagePlane(QtOpenGLWidgets.QOpenGLWidget):
                 color_space_name,
                 self._ocio_proc_context.transform_item_type,
                 self._ocio_proc_context.transform_item_name,
-                self._ocio_proc_context.inverse,
+                self._ocio_proc_context.direction,
             )
         else:
             proc_context = ProcessorContext(color_space_name, None, None)

--- a/src/apps/ocioview/ocioview/viewer/image_viewer.py
+++ b/src/apps/ocioview/ocioview/viewer/image_viewer.py
@@ -421,13 +421,13 @@ class ImageViewer(QtWidgets.QWidget):
 
     def transform_item_type(self) -> Type | None:
         """
-        :return: Config item type associated with transform
+        :return: Transform source config item type
         """
         return self.tf_box.currentData(role=self.ROLE_ITEM_TYPE)
 
     def transform_item_name(self) -> str | None:
         """
-        :return: Config item name associated with transform
+        :return: Transform source config item name
         """
         return self.tf_box.currentText()
 

--- a/src/apps/ocioview/ocioview/viewer/image_viewer.py
+++ b/src/apps/ocioview/ocioview/viewer/image_viewer.py
@@ -295,7 +295,7 @@ class ImageViewer(QtWidgets.QWidget):
                 self.input_color_space(),
                 self.transform_item_type(),
                 self.transform_item_name(),
-                self.is_inverse_transform(),
+                self.transform_direction(),
             ),
             force_update=force,
         )
@@ -399,7 +399,7 @@ class ImageViewer(QtWidgets.QWidget):
                 self.input_color_space(),
                 self.transform_item_type(),
                 self.transform_item_name(),
-                tf_direction == ocio.TRANSFORM_DIR_INVERSE,
+                tf_direction,
             ),
             transform=self._tf_inv
             if tf_direction == ocio.TRANSFORM_DIR_INVERSE
@@ -447,13 +447,6 @@ class ImageViewer(QtWidgets.QWidget):
         :param direction: Set the transform direction to be viewed
         """
         self.tf_direction_button.setChecked(direction == ocio.TRANSFORM_DIR_INVERSE)
-
-    def is_inverse_transform(self) -> bool:
-        """
-        :return: Whether the viewer is converting from the output
-            transform to the input color space.
-        """
-        return self.tf_direction_button.isChecked()
 
     def exposure(self) -> float:
         """
@@ -683,7 +676,7 @@ class ImageViewer(QtWidgets.QWidget):
                 input_color_space,
                 self.transform_item_type(),
                 self.transform_item_name(),
-                self.is_inverse_transform(),
+                self.transform_direction(),
             )
         )
 

--- a/src/apps/ocioview/ocioview/viewer/image_viewer.py
+++ b/src/apps/ocioview/ocioview/viewer/image_viewer.py
@@ -10,7 +10,7 @@ from PySide6 import QtCore, QtGui, QtWidgets
 
 from ..transform_manager import TransformManager
 from ..config_cache import ConfigCache
-from ..constants import GRAY_COLOR, R_COLOR, G_COLOR, B_COLOR
+from ..constants import GRAY_COLOR, R_COLOR, G_COLOR, B_COLOR, ICON_SIZE_TAB
 from ..utils import get_glyph_icon, SignalsBlocked
 from ..widgets import ComboBox, CallbackComboBox
 from .image_plane import ImagePlane
@@ -48,7 +48,7 @@ class ImageViewer(QtWidgets.QWidget):
         """
         :return: Viewer type icon
         """
-        return get_glyph_icon("mdi6.image-outline")
+        return get_glyph_icon("mdi6.image-outline", size=ICON_SIZE_TAB)
 
     @classmethod
     def viewer_type_label(cls) -> str:

--- a/src/apps/ocioview/ocioview/viewer/image_viewer.py
+++ b/src/apps/ocioview/ocioview/viewer/image_viewer.py
@@ -48,6 +48,7 @@ class ImageViewer(QtWidgets.QWidget):
 
     ROLE_SLOT = QtCore.Qt.UserRole + 1
     ROLE_ITEM_TYPE = QtCore.Qt.UserRole + 2
+    ROLE_ITEM_NAME = QtCore.Qt.UserRole + 3
 
     @classmethod
     def viewer_type_icon(cls) -> QtGui.QIcon:
@@ -429,7 +430,7 @@ class ImageViewer(QtWidgets.QWidget):
         """
         :return: Transform source config item name
         """
-        return self.tf_box.currentText()
+        return self.tf_box.currentData(role=self.ROLE_ITEM_NAME)
 
     def transform_direction(self) -> ocio.TransformDirection:
         """
@@ -541,13 +542,14 @@ class ImageViewer(QtWidgets.QWidget):
             self.tf_box.addItem(self.PASSTHROUGH)
             self.tf_box.setItemData(0, -1, role=self.ROLE_SLOT)
 
-            for i, (slot, item_type, item_name, item_type_icon) in enumerate(
+            for i, (slot, item_label, item_type, item_name, slot_icon) in enumerate(
                 menu_items
             ):
                 index = i + 1
-                self.tf_box.addItem(item_type_icon, item_name)
+                self.tf_box.addItem(slot_icon, item_label)
                 self.tf_box.setItemData(index, slot, role=self.ROLE_SLOT)
                 self.tf_box.setItemData(index, item_type, role=self.ROLE_ITEM_TYPE)
+                self.tf_box.setItemData(index, item_name, role=self.ROLE_ITEM_NAME)
                 if slot == current_slot:
                     target_index = index  # Offset for "Passthrough" item
 

--- a/src/apps/ocioview/ocioview/widgets/structure.py
+++ b/src/apps/ocioview/ocioview/widgets/structure.py
@@ -6,7 +6,7 @@ from typing import Optional, Union
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
-from ..constants import ICON_SIZE_BUTTON, BORDER_COLOR_ROLE
+from ..constants import ICON_SIZE_BUTTON, ICON_SIZE_TAB, BORDER_COLOR_ROLE
 from ..style import apply_top_tool_bar_style
 from ..utils import get_icon
 
@@ -82,6 +82,7 @@ class TabbedDockWidget(QtWidgets.QDockWidget):
 
         # Widgets
         self.tabs = QtWidgets.QTabWidget()
+        self.tabs.setIconSize(ICON_SIZE_TAB)
         self.setWidget(self.tabs)
 
         # Connections
@@ -137,8 +138,8 @@ class TabbedDockWidget(QtWidgets.QDockWidget):
         xform = QtGui.QTransform()
         xform.rotate(icon_rot)
 
-        pixmap = icon.pixmap(ICON_SIZE_BUTTON)
-        pixmap = pixmap.transformed(xform)
+        pixmap = icon.pixmap(ICON_SIZE_TAB)
+        pixmap = pixmap.transformed(xform, QtCore.Qt.SmoothTransformation)
 
         return QtGui.QIcon(pixmap)
 


### PR DESCRIPTION
This PR makes a number of updates and improvements to `ocioview`:

- When closing the application or creating a new config, users will now only be prompted to save their config if changes have been made. Previously the initial application state would be detected as a modified config. Note: config modification detection is limited to the data included in the config's cache ID, which does not currently include the config's name or description.
- Per suggestion from @KelSolaar in #1912 , changed the message router interface to use properties instead of getters and setters.
- Added a warning when loading a config that contains a view definition that references a view transform and non-display color space, which results in that view being interpreted as a OCIO v1 style view, dropping the view transform. Technically OCIO supports a view with a view transform and a scene reference color space, but in ocioview we intentionally limit color space selection to display color spaces when using a view transform.
- Improved consistency of icon sizing throughout application, and improved pixmap transformation quality for consistent icon filtering across tabs, buttons, and items.
- Added `ProcessorContext` interface to reference input and output processor parameters so application components that receive a viewer's processor can inspect the config items that created it. This dataclass includes the processor's: input color space name, output transform item type, output transform item name, and transform direction. This should resolve questions raised in #1914 .