### PR TITLE
Adsk Contrib - Allow read and write of file rules without color space validation

### DIFF
--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -4034,7 +4034,7 @@ inline void load(const YAML::Node & node, ViewingRulesRcPtr & vr)
     catch (Exception & ex)
     {
         std::ostringstream os;
-        os << "File rules: " << ex.what();
+        os << "Viewing rules: " << ex.what();
         throwError(node, os.str().c_str());
     }
 }
@@ -4658,13 +4658,15 @@ inline void load(const YAML::Node& node, ConfigRcPtr & config, const char* filen
         config->setWorkingDir(configrootdir.c_str());
     }
 
-    auto defaultCS = config->getColorSpace(ROLE_DEFAULT);
     if (!fileRulesFound)
     {
         if (config->getMajorVersion() >= 2)
         {
-            if (!defaultCS)
+            if (!config->hasRole(ROLE_DEFAULT))
             {
+                // Note that no validation of the default color space is done (e.g. to check that
+                // it exists in the config) in order to enable loading configs that are only
+                // partially complete. The caller may use config->validate() after, if desired.
                 throwError(node, "The config must contain either a Default file rule or "
                                  "the 'default' role.");
             }
@@ -4683,6 +4685,7 @@ inline void load(const YAML::Node& node, ConfigRcPtr & config, const char* filen
     else
     {
         // If default role is also defined.
+        auto defaultCS = config->getColorSpace(ROLE_DEFAULT);
         if (defaultCS)
         {
             const auto defaultRule = fileRules->getNumEntries() - 1;
@@ -4815,18 +4818,11 @@ inline void save(YAML::Emitter & out, const Config & config)
         const char* role = config.getRoleName(i);
         if(role && *role)
         {
-            ConstColorSpaceRcPtr colorspace = config.getColorSpace(role);
-            if(colorspace)
-            {
-                out << YAML::Key << role;
-                out << YAML::Value << config.getColorSpace(role)->getName();
-            }
-            else
-            {
-                std::ostringstream os;
-                os << "Colorspace associated to the role '" << role << "', does not exist.";
-                throw Exception(os.str().c_str());
-            }
+            // Note that no validation of the name strings is done here (e.g. to check that
+            // they exist in the config) in order to enable serializing configs that are only
+            // partially complete. The caller may use config->validate() first, if desired.
+            out << YAML::Key << role;
+            out << YAML::Value << config.getRoleColorSpace(i);
         }
     }
     out << YAML::EndMap;

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -1911,16 +1911,6 @@ OCIO_ADD_TEST(Config, context_variable_with_search_path_v2)
     }
 }
 
-OCIO_ADD_TEST(Config, role_without_colorspace)
-{
-    OCIO::ConfigRcPtr config = OCIO::Config::Create()->createEditableCopy();
-    config->setRole("reference", "UnknownColorSpace");
-
-    std::ostringstream os;
-    OCIO_CHECK_THROW_WHAT(config->serialize(os), OCIO::Exception,
-                          "Colorspace associated to the role 'reference', does not exist");
-}
-
 OCIO_ADD_TEST(Config, env_colorspace_name)
 {
     // Unset the env. variable to make sure the test start in the right environment.


### PR DESCRIPTION
It is generally possible to read and write configs that are syntactically valid but which are incomplete and hence would not pass validation. (For example, it is currently possible to serialize or load a config without any displays and views and would hence fail validation.) This is useful in scenarios where one wants to serialize configs that are only partially complete.

Currently, OCIOYaml.cpp is doing some inappropriate validation during config serialization and parsing regarding the default role and the FileRules Default rule. This PR removes those checks from OCIOYaml.cpp but adds unit tests to confirm that config->validate would still catch these problems. 

This gives the calling program the flexibility to serialize a partial config, for example that has a role that refers to a color space that may not have been added yet. Of course, before any config is used the caller should call validate, which is normally where problems of this type are supposed to be surfaced.