### PR TITLE
Adsk Contrib - Add cmake option to turn off half-float lookup table in Imath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,9 @@ option(OCIO_BUILD_FROZEN_DOCS "Specify whether to build frozen documentation, ne
 option(OCIO_BUILD_DOCS "Specify whether to build documentation" ${OCIO_BUILD_FROZEN_DOCS})
 
 option(OCIO_BUILD_PYTHON "Specify whether to build python bindings" ON)
+
+option(OCIO_USE_HALF_LOOKUP_TABLE "Determines if the Imath library should use a 64k LUT for half conversions" ON)
+
 set (OCIO_PYTHON_VERSION "" CACHE STRING
      "Preferred Python version (if any) in case multiple are available")
 

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -221,6 +221,10 @@ if(OCIO_USE_SIMD AND (OCIO_ARCH_X86 OR OCIO_USE_SSE2NEON))
     set_property(SOURCE ops/lut3d/Lut3DOpCPU_AVX512.cpp APPEND PROPERTY COMPILE_OPTIONS ${OCIO_AVX512_ARGS})
 endif()
 
+if(NOT OCIO_USE_HALF_LOOKUP_TABLE)
+    add_compile_definitions(IMATH_HALF_NO_LOOKUP_TABLE)
+endif()
+
 configure_file(CPUInfoConfig.h.in CPUInfoConfig.h)
 
 add_library(OpenColorIO ${SOURCES})
@@ -307,7 +311,6 @@ target_include_directories(OpenColorIO
 
 target_link_libraries(OpenColorIO
     PRIVATE
-        expat::expat
         Imath::Imath
         pystring::pystring
         "$<BUILD_INTERFACE:sampleicc::sampleicc>"
@@ -315,8 +318,15 @@ target_link_libraries(OpenColorIO
         "$<BUILD_INTERFACE:utils::strings>"
         "$<BUILD_INTERFACE:xxHash>"
         ${YAML_CPP_LIBRARIES}
-        MINIZIP::minizip-ng
 )
+
+if(OCIO_LUT_SUPPORT)
+    target_link_libraries(OpenColorIO PRIVATE expat::expat)
+endif()
+
+if(OCIO_ARCHIVE_SUPPORT)
+    target_link_libraries(OpenColorIO PRIVATE MINIZIP::minizip-ng)
+endif()
 
 if(OCIO_USE_SIMD AND OCIO_USE_SSE2NEON AND COMPILER_SUPPORTS_SSE_WITH_SSE2NEON)
     target_link_libraries(OpenColorIO PRIVATE $<BUILD_INTERFACE:sse2neon>)

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -311,6 +311,7 @@ target_include_directories(OpenColorIO
 
 target_link_libraries(OpenColorIO
     PRIVATE
+        expat::expat
         Imath::Imath
         pystring::pystring
         "$<BUILD_INTERFACE:sampleicc::sampleicc>"
@@ -318,15 +319,8 @@ target_link_libraries(OpenColorIO
         "$<BUILD_INTERFACE:utils::strings>"
         "$<BUILD_INTERFACE:xxHash>"
         ${YAML_CPP_LIBRARIES}
+        MINIZIP::minizip-ng
 )
-
-if(OCIO_LUT_SUPPORT)
-    target_link_libraries(OpenColorIO PRIVATE expat::expat)
-endif()
-
-if(OCIO_ARCHIVE_SUPPORT)
-    target_link_libraries(OpenColorIO PRIVATE MINIZIP::minizip-ng)
-endif()
 
 if(OCIO_USE_SIMD AND OCIO_USE_SSE2NEON AND COMPILER_SUPPORTS_SSE_WITH_SSE2NEON)
     target_link_libraries(OpenColorIO PRIVATE $<BUILD_INTERFACE:sse2neon>)


### PR DESCRIPTION
Adding OCIO_USE_HALF_LOOKUP_TABLE cmake option. If set to OFF, it adds IMATH_HALF_NO_LOOKUP_TABLE compiler definition which in return turns off the look up table that's used for half-float to float conversion, shaving off 256kB of binary size and run time footprint.

Please see half.h for the details of the half->single conversion table: https://github.com/AcademySoftwareFoundation/Imath/blob/main/src/Imath/half.h#L116-L152