### PR TITLE
PR: Update `color_space_to_rgb_colourspace` member usage in *OCIOView*.

### DIFF
--- a/src/apps/ocioview/ocioview/inspect/chromaticities_inspector.py
+++ b/src/apps/ocioview/ocioview/inspect/chromaticities_inspector.py
@@ -24,7 +24,7 @@ from ..constants import ICON_SIZE_TAB
 from ..message_router import MessageRouter
 from ..processor_context import ProcessorContext
 from ..utils import (
-    color_space_to_RGB_Colourspace,
+    color_space_to_rgb_colourspace,
     get_glyph_icon,
     subsampling_factor,
 )
@@ -503,7 +503,7 @@ class ChromaticitiesInspector(QtWidgets.QWidget):
                     self._context.transform_item_name,
                 ]
 
-            rgb_colourspace = color_space_to_RGB_Colourspace(
+            rgb_colourspace = color_space_to_rgb_colourspace(
                 self._context.input_color_space
             )
 
@@ -535,7 +535,7 @@ class ChromaticitiesInspector(QtWidgets.QWidget):
                 ),
             ]
 
-            rgb_colourspace = color_space_to_RGB_Colourspace(
+            rgb_colourspace = color_space_to_rgb_colourspace(
                 chromaticities_colorspace
             )
 


### PR DESCRIPTION
I missed updating some part of the code after accepting some inline suggestions during the Github review. This prevents OCIOView to start because of an import exception. I thought I had tested the branch fully but looks like I did not. This fixes the issue and I double-checked this time!

Thanks to [mmdanggg2](https://github.com/mmdanggg2) for the report.