### PR TITLE
build(windows):Update Installminizip-ng.cmake

### DIFF
--- a/share/cmake/modules/install/Installminizip-ng.cmake
+++ b/share/cmake/modules/install/Installminizip-ng.cmake
@@ -131,6 +131,7 @@ if(NOT minizip-ng_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_P
                             --config ${CMAKE_BUILD_TYPE}
                             --target install
                             --parallel
+        DEPENDS ZLIB::ZLIB        # minizip-ng depends on zlib
     )
 
     add_dependencies(MINIZIP::minizip-ng minizip-ng_install)


### PR DESCRIPTION
Fix an occasional race condition caused by minizip-ng building before zlib.