### PR TITLE
Darwin: use the correct include for locale functions

### DIFF
--- a/src/utils/NumberUtils.h
+++ b/src/utils/NumberUtils.h
@@ -11,9 +11,12 @@
 #endif
 
 #include <cstdlib>
+#ifdef __APPLE__
+#include <xlocale.h>
+#else
 #include <locale>
+#endif
 #include <system_error>
-#include <type_traits>
 
 namespace OCIO_NAMESPACE
 {


### PR DESCRIPTION
Fixes #1973