### PR TITLE
Updated documentation Specifying types for GradingPrimary attributes #1640

### DIFF
--- a/docs/api/python/src/pyopencolorio_gradingprimary.rst
+++ b/docs/api/python/src/pyopencolorio_gradingprimary.rst
@@ -37,5 +37,11 @@
    .. attribute:: pivot
       :type: float
 
+   .. attribute:: pivotBlack
+      :type: float
+
+   .. attribute:: pivotWhite
+      :type: float
+
    .. attribute:: saturation
       :type: float

--- a/docs/api/python/src/pyopencolorio_gradingprimary.rst
+++ b/docs/api/python/src/pyopencolorio_gradingprimary.rst
@@ -6,3 +6,36 @@
    :members:
    :undoc-members:
    :special-members: __init__, __str__
+
+   .. attribute:: brightness
+      :type: GradingRGBM
+
+   .. attribute:: clampBlack
+      :type: float
+
+   .. attribute:: clampWhite
+      :type: float
+
+   .. attribute:: contrast
+      :type: GradingRGBM
+
+   .. attribute:: exposure
+      :type: GradingRGBM
+
+   .. attribute:: gain
+      :type: GradingRGBM
+
+   .. attribute:: gamma
+      :type: GradingRGBM
+
+   .. attribute:: lift
+      :type: GradingRGBM
+
+   .. attribute:: offset
+      :type: GradingRGBM
+
+   .. attribute:: pivot
+      :type: float
+
+   .. attribute:: saturation
+      :type: float


### PR DESCRIPTION
# Updated Documentation: Specify Types for GradingPrimary Attributes

## Description:
This pull request updates the documentation for the GradingPrimary class in OpenColorIO to specify the expected types for its attributes, enhancing clarity for developers mentioned in the issue #1640 

Changes Made:
Added type specifications for the following attributes:
- brightness: `GradingRGBM`
- clampBlack: `float`
- clampWhite: `float`
- contrast: `GradingRGBM`
- exposure: `GradingRGBM`
- gain: `GradingRGBM`
- gamma: `GradingRGBM`
- lift: `GradingRGBM`
- offset: `GradingRGBM`
- pivot: `float`
- saturation: `float`