### PR TITLE
Fix for GitHub Actions node.js glibc issue

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -59,7 +59,7 @@ jobs:
       # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
       image: aswf/ci-ocio:${{ matrix.vfx-cy }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
         include:

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -320,7 +320,7 @@ jobs:
   # ---------------------------------------------------------------------------
 
   macos:
-    name: 'macOS 11
+    name: 'macOS 12
       <AppleClang 
        arch=${{ matrix.arch-type }},
        config=${{ matrix.build-type }}, 
@@ -334,7 +334,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       matrix:
         build: [1, 2, 3, 4]

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -60,9 +60,7 @@ jobs:
       image: aswf/ci-ocio:${{ matrix.vfx-cy }}
     strategy:
       matrix:
-#        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-        # Temporarily turn off docs builds.
-        build: [1, 2, 3, 4, 5, 6, 7, 9, 10, 12]
+        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
         include:
           # -------------------------------------------------------------------
           # VFX CY2023 (Python 3.10)
@@ -83,7 +81,8 @@ jobs:
           - build: 11
             build-type: Release
             build-shared: 'ON'
-            build-docs: 'ON'
+            build-docs: 'OFF'
+#            build-docs: 'ON'
             build-openfx: 'ON'
             use-simd: 'OFF'
             use-oiio: 'OFF'
@@ -125,7 +124,8 @@ jobs:
           - build: 8
             build-type: Release
             build-shared: 'ON'
-            build-docs: 'ON'
+            build-docs: 'OFF'
+#            build-docs: 'ON'
             build-openfx: 'ON'
             use-simd: 'OFF'
             use-oiio: 'OFF'

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -59,6 +59,7 @@ jobs:
       # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
       image: aswf/ci-ocio:${{ matrix.vfx-cy }}
     strategy:
+      fail-fast: false
       matrix:
         build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
         include:

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -81,8 +81,8 @@ jobs:
           - build: 11
             build-type: Release
             build-shared: 'ON'
-            build-docs: 'OFF'
-#            build-docs: 'ON'
+#            build-docs: 'OFF'
+            build-docs: 'ON'
             build-openfx: 'ON'
             use-simd: 'OFF'
             use-oiio: 'OFF'

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -60,7 +60,9 @@ jobs:
       image: aswf/ci-ocio:${{ matrix.vfx-cy }}
     strategy:
       matrix:
-        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+#        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        # Temporarily turn off docs builds.
+        build: [1, 2, 3, 4, 5, 6, 7, 9, 10, 12]
         include:
           # -------------------------------------------------------------------
           # VFX CY2023 (Python 3.10)

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -233,6 +233,8 @@ jobs:
     env:
       CXX: ${{ matrix.cxx-compiler }}
       CC: ${{ matrix.cc-compiler }}
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -60,24 +60,8 @@ jobs:
       image: aswf/ci-ocio:${{ matrix.vfx-cy }}
     strategy:
       matrix:
-        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
         include:
-          # -------------------------------------------------------------------
-          # VFX CY2023 (Python 3.10)
-          # -------------------------------------------------------------------
-          - build: 13
-            build-type: Debug
-            build-shared: 'ON'
-            build-docs: 'OFF'
-            build-openfx: 'OFF'
-            use-simd: 'ON'
-            use-oiio: 'OFF'
-            cxx-standard: 17
-            cxx-compiler: clang++
-            cc-compiler: clang
-            compiler-desc: Clang
-            vfx-cy: 2024
-            install-ext-packages: MISSING
           # -------------------------------------------------------------------
           # VFX CY2023 (Python 3.10)
           # -------------------------------------------------------------------

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -60,8 +60,24 @@ jobs:
       image: aswf/ci-ocio:${{ matrix.vfx-cy }}
     strategy:
       matrix:
-        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
         include:
+          # -------------------------------------------------------------------
+          # VFX CY2023 (Python 3.10)
+          # -------------------------------------------------------------------
+          - build: 13
+            build-type: Debug
+            build-shared: 'ON'
+            build-docs: 'OFF'
+            build-openfx: 'OFF'
+            use-simd: 'ON'
+            use-oiio: 'OFF'
+            cxx-standard: 17
+            cxx-compiler: clang++
+            cc-compiler: clang
+            compiler-desc: Clang
+            vfx-cy: 2024
+            install-ext-packages: MISSING
           # -------------------------------------------------------------------
           # VFX CY2023 (Python 3.10)
           # -------------------------------------------------------------------
@@ -81,7 +97,6 @@ jobs:
           - build: 11
             build-type: Release
             build-shared: 'ON'
-#            build-docs: 'OFF'
             build-docs: 'ON'
             build-openfx: 'ON'
             use-simd: 'OFF'
@@ -124,8 +139,7 @@ jobs:
           - build: 8
             build-type: Release
             build-shared: 'ON'
-            build-docs: 'OFF'
-#            build-docs: 'ON'
+            build-docs: 'ON'
             build-openfx: 'ON'
             use-simd: 'OFF'
             use-oiio: 'OFF'

--- a/share/ci/scripts/linux/yum/install_docs_env.sh
+++ b/share/ci/scripts/linux/yum/install_docs_env.sh
@@ -6,9 +6,11 @@ set -ex
 
 HERE=$(dirname $0)
 
-# The yum install doxygen command started failing since mirrorlist.centos.org
-# was turned off. However, it seems that Doxygen is already installed on our containers
-# so this command is not currently necessary:
+# The yum install doxygen command started failing during CI since mirrorlist.centos.org
+# was turned off. However, it seems that Doxygen is already installed on the containers
+# used for CI, so this command is not currently necessary there. You will need to
+# uncomment this line if you want to build the documentation on Linux but don't have
+# doxygen already installed.
 # bash $HERE/install_doxygen.sh latest
 
 pip install -r $HERE/../../../../../docs/requirements.txt

--- a/share/ci/scripts/linux/yum/install_docs_env.sh
+++ b/share/ci/scripts/linux/yum/install_docs_env.sh
@@ -6,5 +6,9 @@ set -ex
 
 HERE=$(dirname $0)
 
-bash $HERE/install_doxygen.sh latest
+# The yum install doxygen command started failing since mirrorlist.centos.org
+# was turned off. However, it seems that Doxygen is already installed on our containers
+# so this command is not currently necessary:
+# bash $HERE/install_doxygen.sh latest
+
 pip install -r $HERE/../../../../../docs/requirements.txt

--- a/share/ci/scripts/linux/yum/install_doxygen.sh
+++ b/share/ci/scripts/linux/yum/install_doxygen.sh
@@ -7,11 +7,7 @@ set -ex
 DOXYGEN_VERSION="$1"
 
 if [ "$DOXYGEN_VERSION" == "latest" ]; then
-    yum repolist
-    yum --disablerepo=mirrorlist.centos.org
     yum install -y doxygen
 else
-    yum repolist
-    yum --disablerepo=mirrorlist.centos.org
     yum install -y doxygen-${DOXYGEN_VERSION}
 fi

--- a/share/ci/scripts/linux/yum/install_doxygen.sh
+++ b/share/ci/scripts/linux/yum/install_doxygen.sh
@@ -7,7 +7,11 @@ set -ex
 DOXYGEN_VERSION="$1"
 
 if [ "$DOXYGEN_VERSION" == "latest" ]; then
+    yum repolist
+    yum --disablerepo=mirrorlist.centos.org
     yum install -y doxygen
 else
+    yum repolist
+    yum --disablerepo=mirrorlist.centos.org
     yum install -y doxygen-${DOXYGEN_VERSION}
 fi


### PR DESCRIPTION
The Actions runners have stopped working for the Linux Docker containers for years 2022 and earlier due to a change on the GitHub side related to Node.js updates.

The proposed work-around is to continue to use the older actions/checkout@v3 and set the env vars in this PR to use the older node version.

For reference:
https://github.com/actions/runner/issues/2906#issuecomment-2209653912
https://academysoftwarefdn.slack.com/archives/C0169RX7MMK/p1720211076837729

In addition, there is another CentOS-related problem (a yum mirror was shut down) which is preventing the Linux builds from working if the documentation support is on, so I modified the installer script to work around that.

Finally, the macos-11 runners no longer work, so I updated to the macos-12 runners. (The ARM macos-14 runners were not modified.)