### PR TITLE
Alpha channel should be 1 by default, rather than 0

### DIFF
--- a/src/OpenColorIO/ImagePacking.cpp
+++ b/src/OpenColorIO/ImagePacking.cpp
@@ -70,7 +70,7 @@ void Generic<Type>::PackRGBAFromImageDesc(const GenericImageDesc & srcImg,
         inBitDepthBuffer[4*pixelsCopied+0] = *rPtr;
         inBitDepthBuffer[4*pixelsCopied+1] = *gPtr;
         inBitDepthBuffer[4*pixelsCopied+2] = *bPtr;
-        inBitDepthBuffer[4*pixelsCopied+3] = aPtr ? *aPtr : (Type)0.0f;
+        inBitDepthBuffer[4*pixelsCopied+3] = aPtr ? *aPtr : (Type)1.0f;
 
         pixelsCopied++;
         xIndex++;
@@ -140,7 +140,7 @@ void Generic<float>::PackRGBAFromImageDesc(const GenericImageDesc & srcImg,
         outputBuffer[4*pixelsCopied+0] = *rPtr;
         outputBuffer[4*pixelsCopied+1] = *gPtr;
         outputBuffer[4*pixelsCopied+2] = *bPtr;
-        outputBuffer[4*pixelsCopied+3] = aPtr ? *aPtr : 0.0f;
+        outputBuffer[4*pixelsCopied+3] = aPtr ? *aPtr : 1.0f;
 
         pixelsCopied++;
         xIndex++;


### PR DESCRIPTION
Related to issue #1781 .
https://github.com/AcademySoftwareFoundation/OpenColorIO/issues/1781

For CPU processor, when source has no alpha (RGB) but dest does (RGBA) make it default to 1.
GPU Processors (new and legacy) did not seem to have this issue, alpha was already set to 1.  Let me know if this is not the case.

Tested changes with ocioconvert and changed the output to force RGBA, since the  default is to use inplace conversion (did not check in those changes).
Tested with all the ocioconvert test cases (basic, --lut, --view, --invertview --namedtransform, --invnamed transform), and various EXR file sizes.  

Before the changes alpha would be 0, so image was not viewable.  After the changes then images can be viewed and from inspection the alpha channel is now 1.0.
