### PR TITLE
Update library version in RB 2.4 branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ project(OpenColorIO
     LANGUAGES CXX C)
 
 # "dev", "beta1", rc1", etc or "" for an official release.
-set(OpenColorIO_VERSION_RELEASE_TYPE "dev")
+set(OpenColorIO_VERSION_RELEASE_TYPE "")
 
 
 ###############################################################################


### PR DESCRIPTION
Remove "dev" from the library version, set it to "2.4.0" in the RB-2.4 branch, in preparation for release.