### PR TITLE
Build: enable parallel source file compilation on MSVC

### DIFF
--- a/share/cmake/utils/CompilerFlags.cmake
+++ b/share/cmake/utils/CompilerFlags.cmake
@@ -74,6 +74,9 @@ if(USE_MSVC)
         set(PLATFORM_COMPILE_OPTIONS "${PLATFORM_COMPILE_OPTIONS};/WX")
     endif()
 
+    # Enable parallel compilation of source files
+    set(PLATFORM_COMPILE_OPTIONS "${PLATFORM_COMPILE_OPTIONS};/MP")
+
 elseif(USE_CLANG)
 
     set(PLATFORM_COMPILE_OPTIONS "${PLATFORM_COMPILE_OPTIONS};-DUSE_CLANG")


### PR DESCRIPTION
By default Visual Studio projects do not compile source files in parallel. Add "/MP" flag to enable that.

From scratch OCIO build on Ryzen 5950X, VS2022: 580sec -> 208sec. Most of remaining single-threaded time is cloning external libraries or building external libraries (most of them don't do parallel compilation either). But within building OCIO itself, CPU usage goes close to 100% instead of 5%.