### PR TITLE
PR: Add `DISPLAY - CIE-XYZ-D65_to_DisplayP3-HDR` builtin transform.

### DIFF
--- a/src/OpenColorIO/transforms/builtins/Displays.cpp
+++ b/src/OpenColorIO/transforms/builtins/Displays.cpp
@@ -358,6 +358,12 @@ void RegisterAll(BuiltinTransformRegistryImpl & registry) noexcept
         registry.addBuiltin("DISPLAY - CIE-XYZ-D65_to_DisplayP3", 
                             "Convert CIE XYZ (D65 white) to Apple Display P3",
                             CIE_XYZ_D65_to_DisplayP3_Functor);
+
+        // NOTE: This builtin is defined to be able to partition SDR and HDR view transforms under two separate
+        // displays rather than a single one.
+        registry.addBuiltin("DISPLAY - CIE-XYZ-D65_to_DisplayP3-HDR",
+                            "Convert CIE XYZ (D65 white) to Apple Display P3 (HDR)",
+                            CIE_XYZ_D65_to_DisplayP3_Functor);
     }
 
     {

--- a/tests/cpu/transforms/BuiltinTransform_tests.cpp
+++ b/tests/cpu/transforms/BuiltinTransform_tests.cpp
@@ -626,6 +626,9 @@ AllValues UnitTestValues
     { "DISPLAY - CIE-XYZ-D65_to_DisplayP3",
         { 1.0e-6f,
         { 0.5f, 0.4f, 0.3f }, { 0.882580907776f, 0.581526360743f,  0.5606367050000f } } },
+    { "DISPLAY - CIE-XYZ-D65_to_DisplayP3-HDR",
+        { 1.0e-6f,
+        { 0.5f, 0.4f, 0.3f }, { 0.882580907776f, 0.581526360743f,  0.5606367050000f } } },
 
     { "CURVE - ST-2084_to_LINEAR", 
         { 4.0e-5f,


### PR DESCRIPTION
This PR adds the `DISPLAY - CIE-XYZ-D65_to_DisplayP3-HDR` builtin transform: The intent is to provide a new display that can help partition better the SDR and HDR view transforms for *Display P3*. This will be especially useful for the OpenColorIO-Config-ACES generator.

References AcademySoftwareFoundation/OpenColorIO-Config-ACES#130