### PR TITLE
Fixed range function error in nuke colorlookup examples

### DIFF
--- a/share/nuke/examples/colorlookup_to_spi1d.py
+++ b/share/nuke/examples/colorlookup_to_spi1d.py
@@ -19,7 +19,7 @@ knob = nuke.selectedNode()['lut']
 SIZE = 2**10
 
 data = []
-for i in xrange(SIZE):
+for i in range(SIZE):
     x = i/(SIZE-1.0)
     data.append(knob.getValueAt(x))
 

--- a/share/nuke/examples/ocio_to_colorlookup_all.py
+++ b/share/nuke/examples/ocio_to_colorlookup_all.py
@@ -27,7 +27,7 @@ def Fit(value, fromMin, fromMax, toMin, toMax):
     return (value - fromMin) / (fromMax - fromMin) * (toMax - toMin) + toMin
 
 SIZE = 2**10
-for i in xrange(SIZE):
+for i in range(SIZE):
     x = i/(SIZE-1.0)
     
     x = Fit(x, 0.0, 1.0, -0.125, 1.5)

--- a/share/nuke/examples/ocio_to_colorlookup_rgb.py
+++ b/share/nuke/examples/ocio_to_colorlookup_rgb.py
@@ -21,7 +21,7 @@ knob.removeKeyAt(1.0, 3)
 
 
 SIZE = 11
-for i in xrange(SIZE):
+for i in range(SIZE):
     x = i/(SIZE-1.0)
     
     y = processor.applyRGB((x,x,x))


### PR DESCRIPTION
`xrange` was wrong in the example scripts.