### PR TITLE
PR: Implement support for Astral's uv.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ dist*
 mastercopy
 *.pyc
 !*.yml
-.vscode
+.idea/
+.venv/
+.vscode/
 
-src/apps/ocioview/poetry.lock
+src/apps/ocioview/uv.lock

--- a/src/apps/ocioview/pyproject.toml
+++ b/src/apps/ocioview/pyproject.toml
@@ -1,49 +1,75 @@
-[tool.poetry]
+[project]
 name = "ocioview"
 version = "0.1.0"
 description = "OpenColorIO config visual editor application"
-license = "BSD-3-Clause"
-authors = ["Contributors to the OpenColorIO Project"]
+requires-python = ">=3.10,<3.14"
+authors = [
+    { name = "Contributors to the OpenColorIO Project" }
+]
+maintainers = [
+    { name = "Contributors to the OpenColorIO Project" }
+]
+license = { text = "BSD-3-Clause" }
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Software Development",
+]
+dependencies = [
+    "colour-science>=0.4.5,<0.5",
+    "colour-visuals",
+    "imageio>=2,< 3",
+    "networkx>=3,<4",
+    "numpy>=1.24,<3",
+    "opencolorio>=2,<3",
+    "pygfx>=0.1,<0.3",
+    "pygments",
+    "pyopengl",
+    "pyside6",
+    "qtawesome",
+    "scipy>=1.10,<2",
+]
 
-[tool.poetry.dependencies]
-python = ">= 3.9, < 3.12"
-colour-science = {git = "https://github.com/colour-science/colour.git"}
-colour-visuals = {git = "https://github.com/colour-science/colour-visuals.git"}
-imageio = ">= 2, < 3"
-networkx = ">= 2.7, < 3"
-numpy = ">= 1.22, < 2"
-opencolorio = "*"
-pygfx = "*"
-pygments = "*"
-pyopengl = "*"
-pyside6 = "*"
-qtawesome = "*"
-scipy = ">= 1.8, < 2"
-wpgu = "*"
+[tool.uv.sources]
+"colour-visuals" = { git = "https://github.com/colour-science/colour-visuals.git" }
 
-[tool.poetry.group.dev.dependencies]
-black = "*"
-blackdoc = "*"
-coverage = "!= 6.3"
-coveralls = "*"
-flynt = "*"
-invoke = "*"
-jupyter = "*"
-pre-commit = "*"
-pyright = "*"
-pytest = "*"
-pytest-cov = "*"
-pytest-qt = "*"
-pytest-xdist = "*"
-ruff = "*"
-toml = "*"
-twine = "*"
+[project.optional-dependencies]
+docs = [
+    "restructuredtext-lint",
+    "sphinx",
+]
 
-[tool.poetry.group.docs.dependencies]
-pydata-sphinx-theme = "*"
-restructuredtext-lint = "*"
-sphinx = "*"
-sphinxcontrib-bibtex = "*"
+[tool.uv]
+package = true
+dev-dependencies = [
+    "black",
+    "coverage",
+    "coveralls",
+    "hatch",
+    "invoke",
+    "jupyter",
+    "pre-commit",
+    "pyright",
+    "pytest",
+    "pytest-cov",
+    "pytest-xdist",
+    "toml",
+    "twine",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = [ "ocioview" ]
 
 [tool.black]
 line-length = 79
@@ -85,7 +111,7 @@ filterwarnings = [
 ]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 88
 select = [
     "A", # flake8-builtins
@@ -128,7 +154,7 @@ select = [
     "TRY", # tryceratops
     "UP", # pyupgrade
     "W", # pydocstyle
-    "YTT" # flake8-2020
+    "YTT", # flake8-2020
 ]
 ignore = [
     "B008",
@@ -162,6 +188,7 @@ ignore = [
     "RET508",
     "TRY003",
     "TRY300",
+    "UP038",
 ]
 typing-modules = ["colour.hints"]
 fixable = ["B", "C", "E", "F", "PIE", "RUF", "SIM", "UP", "W"]
@@ -172,6 +199,5 @@ convention = "numpy"
 [tool.ruff.per-file-ignores]
 "docs/*" = ["INP"]
 
-[build-system]
-requires = ["poetry_core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+[tool.ruff.format]
+docstring-code-format = true

--- a/src/apps/ocioview/requirements.txt
+++ b/src/apps/ocioview/requirements.txt
@@ -1,4 +1,4 @@
-colour-science @ git+https://github.com/colour-science/colour.git
+colour-science
 colour-visuals @ git+https://github.com/colour-science/colour-visuals.git
 imageio
 networkx
@@ -10,4 +10,3 @@ PyOpenGL
 PySide6
 QtAwesome
 scipy
-wgpu


### PR DESCRIPTION
This PR implements support for [Astral's uv](https://docs.astral.sh/uv/) and drops support for [Poetry](https://python-poetry.org).

- The `pyproject.toml` file is now much more standard and can use with many other tools.
- Assuming that *uv* is installed, *OCIO View* can now be launched as follows: `uv run main.py`.
- The virtual environment for development that now lives in the `.venv` directory next to the source, can be created as follows: `uv sync --all-extras`.