### PR TITLE
Change OCIO_PYTHON_LOAD_DLLS_FROM_PATH to opt-in

### DIFF
--- a/.github/workflows/wheel_workflow.yml
+++ b/.github/workflows/wheel_workflow.yml
@@ -174,7 +174,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.1
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -192,7 +192,7 @@ jobs:
 
   macos:
     name: Build wheels on macOS
-    runs-on: macos-12
+    runs-on: macos-13
     # Don't run on OCIO forks
     if: |
       github.event_name != 'schedule' ||
@@ -231,7 +231,7 @@ jobs:
           python-version: '3.9'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.1
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -286,7 +286,7 @@ jobs:
           python-version: '3.9'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.1
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -341,7 +341,7 @@ jobs:
           python-version: '3.9'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.1
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}

--- a/docs/quick_start/installation.rst
+++ b/docs/quick_start/installation.rst
@@ -126,7 +126,7 @@ Required components:
 - CMake >= 3.14
 - \*Expat >= 2.4.1 (XML parser for CDL/CLF/CTF)
 - \*yaml-cpp >= 0.7.0 (YAML parser for Configs)
-- \*Imath >= 3.0 (for half domain LUTs)
+- \*Imath >= 3.1.1 (for half domain LUTs)
 - \*pystring >= 1.1.3
 - \*minizip-ng >= 3.0.7 (for config archiving)
 - \*ZLIB >= 1.2.13 (for config archiving)
@@ -135,14 +135,14 @@ Optional OCIO functionality also depends on:
 
 - \*Little CMS >= 2.2 (for ociobakelut ICC profile baking)
 - \*OpenGL GLUT & GLEW (for ociodisplay)
-- \*OpenEXR >= 3.0 (for apps including ocioconvert)
-- OpenImageIO >= 2.1.9 (for apps including ocioconvert)
+- \*OpenEXR >= 3.0.5 (for apps including ocioconvert)
+- OpenImageIO >= 2.2.14 (for apps including ocioconvert)
 - \*OpenFX >= 1.4 (for the OpenFX plug-ins)
 - OpenShadingLanguage >= 1.11 (for the OSL unit tests)
 - Doxygen (for the docs)
 - NumPy (optionally used in the Python test suite)
 - \*pybind11 >= 2.9.2 (for the Python binding)
-- Python >= 2.7 (for the Python binding only)
+- Python >= 3.7 (for the Python binding only)
 - Python 3.7 - 3.9 (for building the documentation)
 
 Building the documentation requires the following packages, available via PyPI:

--- a/src/bindings/python/package/__init__.py
+++ b/src/bindings/python/package/__init__.py
@@ -24,13 +24,15 @@ if platform.system() == "Windows":
 # 2 - Checking that the directories exist and are not "."
 # 3 - Add them to the DLL load path.
 #
-# The behavior described above is opt-out which means that it is activated by default. 
-# A user can opt-out and use the default behavior of Python 3.8+ by setting OCIO_PYTHON_LOAD_DLLS_FROM_PATH 
-# environment variable to 0.
+# The behavior described above is opt-in which means that it is deactivated by default.
+# A user can opt-in by setting OCIO_PYTHON_LOAD_DLLS_FROM_PATH environment variable to 1.
+# Please note that OCIO 2.4.0 and earlier had this behavior opt-out but it was changed
+# in 2.4.1 after it was found problematic in uncontrolled environment (causing segfault
+# on PyOpenColorIO import) as well as for security reasons.
 #
 
 if sys.version_info >= (3, 8) and platform.system() == "Windows":
-    if os.getenv("OCIO_PYTHON_LOAD_DLLS_FROM_PATH", "1") == "1":
+    if os.getenv("OCIO_PYTHON_LOAD_DLLS_FROM_PATH", "0") == "1":
         for path in os.getenv("PATH", "").split(os.pathsep):
             if os.path.exists(path) and path != ".":
                 os.add_dll_directory(path)


### PR DESCRIPTION
This PR makes OCIO_PYTHON_LOAD_DLLS_FROM_PATH opt-in by default. It also bump the macOS runners on the wheel workflow to macos-13 and update cibuildwheel to the latest.