### PR TITLE
Fix issue with ocio_depts handling spaces in file paths

### DIFF
--- a/share/dev/windows/ocio.bat
+++ b/share/dev/windows/ocio.bat
@@ -77,7 +77,7 @@ if NOT "%~1"=="" (
 
 rem If not overridden by the cmd line args, find and use the latest Visual Studio
 if NOT DEFINED MSVS_PATH (
-    for /f %%i in ('"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -format value -property installationPath -latest') do (
+    for /f "delims=" %%i in ('"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -format value -property installationPath -latest') do (
         echo Found Visual Studio installation at '%%i'
         set MSVS_PATH=%%i
     )

--- a/share/dev/windows/ocio_deps.bat
+++ b/share/dev/windows/ocio_deps.bat
@@ -105,7 +105,7 @@ if ErrorLevel 1 (
 
 echo Checking for Microsoft Visual Studio...
 set MSVS_PATH=
-for /f %%i in ('"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -format value -property installationPath -latest') do (
+for /f "delims=" %%i in ('"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -format value -property installationPath -latest') do (
     echo Found Visual Studio installation at '%%i'
     set MSVS_PATH=%%i
 )


### PR DESCRIPTION
`share/dev/windows/ocio_deps.bat` was not able to find the installed visual studio location due to the space in the paths. This is because `for /f` splits on spaces and tabs by default.

For example, `C:\Program Files (x86)` becomes `C:\Program`.

Adding `delims=` to avoid splitting the output of the command and keeps the entire path in `%%i`.