### PR TITLE
Adsk Contrib - Issue #2111 Absolute paths not working through proxy

### DIFF
--- a/src/OpenColorIO/PathUtils.cpp
+++ b/src/OpenColorIO/PathUtils.cpp
@@ -88,20 +88,20 @@ std::string GetFastFileHash(const std::string & filename, const Context & contex
             fileHashResultPtr->ready = true;
 
             std::string h = "";
-            if (!context.getConfigIOProxy())
-            {
-                // Default case.
-                h = g_hashFunction(filename);
-            }
-            else
+            if (!pystring::os::path::isabs(filename) && context.getConfigIOProxy())
             {
                 // Case for when ConfigIOProxy is used (callbacks mechanism).
                 h = context.getConfigIOProxy()->getFastLutFileHash(filename.c_str());
             }
+            else
+            {
+                // Default case
+                h = g_hashFunction(filename);
+            }
 
             fileHashResultPtr->hash = h;
         }
-    
+
         hash = fileHashResultPtr->hash;
     }
 

--- a/src/OpenColorIO/PathUtils.cpp
+++ b/src/OpenColorIO/PathUtils.cpp
@@ -88,10 +88,16 @@ std::string GetFastFileHash(const std::string & filename, const Context & contex
             fileHashResultPtr->ready = true;
 
             std::string h = "";
-            if (!pystring::os::path::isabs(filename) && context.getConfigIOProxy())
+            if (context.getConfigIOProxy())
             {
                 // Case for when ConfigIOProxy is used (callbacks mechanism).
                 h = context.getConfigIOProxy()->getFastLutFileHash(filename.c_str());
+
+                // For absolute paths, if the proxy does not provide a hash, try the file system.
+                if (h.empty() && pystring::os::path::isabs(filename)) 
+                {
+                    h = g_hashFunction(filename);
+                }
             }
             else
             {

--- a/src/OpenColorIO/transforms/FileTransform.cpp
+++ b/src/OpenColorIO/transforms/FileTransform.cpp
@@ -190,7 +190,7 @@ std::unique_ptr<std::istream> getLutData(
     const std::string & filepath, 
     std::ios_base::openmode mode)
 {
-    if (config.getConfigIOProxy())
+    if (!pystring::os::path::isabs(filepath) && config.getConfigIOProxy())
     {
         std::vector<uint8_t> buffer = config.getConfigIOProxy()->getLutData(filepath.c_str());
         std::stringstream ss;

--- a/src/OpenColorIO/transforms/FileTransform.cpp
+++ b/src/OpenColorIO/transforms/FileTransform.cpp
@@ -209,7 +209,7 @@ std::unique_ptr<std::istream> getLutData(
         // if the buffer is empty, we'll try the file system for abs paths.
         if (!buffer.empty() || !pystring::os::path::isabs(filepath)) 
         {
-            auto pss = std::make_unique<std::stringstream>();
+            auto pss = std::unique_ptr<std::stringstream>(new std::stringstream);
             pss->write(reinterpret_cast<const char*>(buffer.data()), buffer.size());
 
             return pss;
@@ -217,8 +217,8 @@ std::unique_ptr<std::istream> getLutData(
     }
 
     // Default behavior. Return file stream.
-    return std::make_unique<std::ifstream>(
-        Platform::filenameToUTF(filepath), mode);
+    return std::unique_ptr<std::ifstream>(new std::ifstream(
+        Platform::filenameToUTF(filepath), mode));
 }
 
 bool CollectContextVariables(const Config &, 

--- a/src/OpenColorIO/transforms/FileTransform.cpp
+++ b/src/OpenColorIO/transforms/FileTransform.cpp
@@ -200,13 +200,13 @@ std::unique_ptr<std::istream> getLutData(
         } 
         catch (const std::exception&) 
         {
-            // If the path is absolute, we'll try the file system. but otherwise
+            // If the path is absolute, we'll try the file system, but otherwise
             // nothing to do.
             if (!pystring::os::path::isabs(filepath)) 
               throw;
         }
 
-        // if the buffer is empty, we'll try the file system for abs paths.
+        // If the buffer is empty, we'll try the file system for abs paths.
         if (!buffer.empty() || !pystring::os::path::isabs(filepath)) 
         {
             auto pss = std::unique_ptr<std::stringstream>(new std::stringstream);
@@ -217,7 +217,7 @@ std::unique_ptr<std::istream> getLutData(
     }
 
     // Default behavior. Return file stream.
-    return std::unique_ptr<std::ifstream>(new std::ifstream(
+    return std::unique_ptr<std::istream>(new std::ifstream(
         Platform::filenameToUTF(filepath), mode));
 }
 

--- a/src/OpenColorIO/transforms/FileTransform.cpp
+++ b/src/OpenColorIO/transforms/FileTransform.cpp
@@ -190,37 +190,35 @@ std::unique_ptr<std::istream> getLutData(
     const std::string & filepath, 
     std::ios_base::openmode mode)
 {
-    if (!pystring::os::path::isabs(filepath) && config.getConfigIOProxy())
+    if (config.getConfigIOProxy())
     {
-        std::vector<uint8_t> buffer = config.getConfigIOProxy()->getLutData(filepath.c_str());
-        std::stringstream ss;
-        ss.write(reinterpret_cast<const char*>(buffer.data()), buffer.size());
+        std::vector<uint8_t> buffer;
+        // Try to open through proxy.
+        try 
+        {
+            buffer = config.getConfigIOProxy()->getLutData(filepath.c_str());
+        } 
+        catch (const std::exception&) 
+        {
+            // If the path is absolute, we'll try the file system. but otherwise
+            // nothing to do.
+            if (!pystring::os::path::isabs(filepath)) 
+              throw;
+        }
 
-        return std::unique_ptr<std::stringstream>(
-            new std::stringstream(std::move(ss))
-        );
+        // if the buffer is empty, we'll try the file system for abs paths.
+        if (!buffer.empty() || !pystring::os::path::isabs(filepath)) 
+        {
+            auto pss = std::make_unique<std::stringstream>();
+            pss->write(reinterpret_cast<const char*>(buffer.data()), buffer.size());
+
+            return pss;
+        }
     }
 
     // Default behavior. Return file stream.
-    return std::unique_ptr<std::ifstream>(
-        new std::ifstream(Platform::filenameToUTF(filepath).c_str(), mode)
-    );
-}
-
-// Close stream returned by getLutData
-void closeLutStream(const Config & config, const std::istream & istream)
-{
-    // No-op when it is using ConfigIOProxy since getLutData returns a vector<uint8_t>.
-    if (config.getConfigIOProxy() == nullptr)
-    {
-        // The std::istream is coming from a std::ifstream.
-        // Pointer cast to ifstream and then close it.
-        std::ifstream * pIfStream = (std::ifstream *) &istream;
-        if (pIfStream->is_open())
-        {
-            pIfStream->close();
-        }
-    }
+    return std::make_unique<std::ifstream>(
+        Platform::filenameToUTF(filepath), mode);
 }
 
 bool CollectContextVariables(const Config &, 
@@ -635,9 +633,8 @@ void LoadFileUncached(FileFormat * & returnFormat,
                 filepath, 
                 tryFormat->isBinary() ? std::ios_base::binary : std::ios_base::in 
             );
-            auto & filestream = *pStream;
             
-            if (!filestream.good())
+            if (!pStream || !pStream->good())
             {
                 std::ostringstream os;
                 os << "The specified FileTransform srcfile, '";
@@ -647,7 +644,7 @@ void LoadFileUncached(FileFormat * & returnFormat,
                 throw Exception(os.str().c_str());
             }
 
-            CachedFileRcPtr cachedFile = tryFormat->read(filestream, filepath, interp);
+            CachedFileRcPtr cachedFile = tryFormat->read(*pStream, filepath, interp);
 
             if(IsDebugLoggingEnabled())
             {
@@ -660,17 +657,10 @@ void LoadFileUncached(FileFormat * & returnFormat,
             returnFormat = tryFormat;
             returnCachedFile = cachedFile;
 
-            closeLutStream(config, filestream);
-
             return;
         }
         catch(std::exception & e)
         {
-            if (pStream)
-            {
-                closeLutStream(config, *pStream); 
-            }
-
             primaryErrorText += "    '";
             primaryErrorText += tryFormat->getName();
             primaryErrorText += "' failed with: ";
@@ -712,9 +702,8 @@ void LoadFileUncached(FileFormat * & returnFormat,
                 filepath, 
                 altFormat->isBinary() ? std::ios_base::binary : std::ios_base::in 
             );
-            auto& filestream = *pStream;
             
-            if (!filestream.good())
+            if (!pStream || !pStream->good())
             {
                 std::ostringstream os;
                 os << "The specified FileTransform srcfile, '";
@@ -725,7 +714,7 @@ void LoadFileUncached(FileFormat * & returnFormat,
                 throw Exception(os.str().c_str());
             }
 
-            cachedFile = altFormat->read(filestream, filepath, interp);
+            cachedFile = altFormat->read(*pStream, filepath, interp);
 
             if(IsDebugLoggingEnabled())
             {
@@ -738,17 +727,10 @@ void LoadFileUncached(FileFormat * & returnFormat,
             returnFormat = altFormat;
             returnCachedFile = cachedFile;
 
-            closeLutStream(config, filestream);
-
             return;
         }
         catch(std::exception & e)
         {
-            if (pStream)
-            {
-                closeLutStream(config, *pStream); 
-            }
-            
             if(IsDebugLoggingEnabled())
             {
                 std::ostringstream os;

--- a/tests/cpu/OCIOZArchive_tests.cpp
+++ b/tests/cpu/OCIOZArchive_tests.cpp
@@ -332,18 +332,6 @@ OCIO_ADD_TEST(OCIOZArchive, context_test_for_search_paths_and_filetransform_sour
     auto testPaths = [&mat](const OCIO::ConfigRcPtr & cfg, const OCIO::ContextRcPtr ctx) 
     {
         {
-            const std::string filePath = OCIO::GetTestFilesDir() + "/matrix_example4x4.ctf";
-            OCIO::FileTransformRcPtr transform = OCIO::FileTransform::Create();
-            transform->setSrc(filePath.c_str());
-            OCIO::ConstProcessorRcPtr processor = cfg->getProcessor(transform);
-            OCIO::ConstTransformRcPtr tr = processor->createGroupTransform()->getTransform(0);
-            auto mtx = OCIO::DynamicPtrCast<const OCIO::MatrixTransform>(tr);
-            OCIO_REQUIRE_ASSERT(mtx);
-            mtx->getMatrix(mat);
-            OCIO_CHECK_EQUAL(mat[0], 3.24);
-        }
-
-        {
             // This is independent of the context.
             OCIO::ConstProcessorRcPtr processor = cfg->getProcessor(ctx, "shot1_lut1_cs", "reference");
             OCIO::ConstTransformRcPtr tr = processor->createGroupTransform()->getTransform(0);
@@ -446,6 +434,29 @@ OCIO_ADD_TEST(OCIOZArchive, context_test_for_search_paths_and_filetransform_sour
             OCIO_REQUIRE_ASSERT(mtx);
             mtx->getMatrix(mat);
             OCIO_CHECK_EQUAL(mat[0], 4.);
+        }
+
+        {
+            // File transform source is an absolute path, not in the archive.
+            const std::string filePath =
+                OCIO::GetTestFilesDir() + "/matrix_example4x4.ctf";
+            OCIO::FileTransformRcPtr transform = OCIO::FileTransform::Create();
+            transform->setSrc(filePath.c_str());
+            OCIO::ConstProcessorRcPtr processor = cfg->getProcessor(transform);
+            OCIO::ConstTransformRcPtr tr =
+                processor->createGroupTransform()->getTransform(0);
+            auto mtx = OCIO::DynamicPtrCast<const OCIO::MatrixTransform>(tr);
+            OCIO_REQUIRE_ASSERT(mtx);
+            mtx->getMatrix(mat);
+            OCIO_CHECK_EQUAL(mat[0], 3.24);
+        }
+
+        {
+            // File transform source is an abs path but doesn't exist anywhere.
+            const std::string filePath = OCIO::GetTestFilesDir() + "/missing.ctf";
+            OCIO::FileTransformRcPtr transform = OCIO::FileTransform::Create();
+            transform->setSrc(filePath.c_str());
+            OCIO_CHECK_THROW(cfg->getProcessor(transform), OCIO::Exception);
         }
     };
 

--- a/tests/cpu/OCIOZArchive_tests.cpp
+++ b/tests/cpu/OCIOZArchive_tests.cpp
@@ -332,6 +332,18 @@ OCIO_ADD_TEST(OCIOZArchive, context_test_for_search_paths_and_filetransform_sour
     auto testPaths = [&mat](const OCIO::ConfigRcPtr & cfg, const OCIO::ContextRcPtr ctx) 
     {
         {
+            const std::string filePath = OCIO::GetTestFilesDir() + "/matrix_example4x4.ctf";
+            OCIO::FileTransformRcPtr transform = OCIO::FileTransform::Create();
+            transform->setSrc(filePath.c_str());
+            OCIO::ConstProcessorRcPtr processor = cfg->getProcessor(transform);
+            OCIO::ConstTransformRcPtr tr = processor->createGroupTransform()->getTransform(0);
+            auto mtx = OCIO::DynamicPtrCast<const OCIO::MatrixTransform>(tr);
+            OCIO_REQUIRE_ASSERT(mtx);
+            mtx->getMatrix(mat);
+            OCIO_CHECK_EQUAL(mat[0], 3.24);
+        }
+
+        {
             // This is independent of the context.
             OCIO::ConstProcessorRcPtr processor = cfg->getProcessor(ctx, "shot1_lut1_cs", "reference");
             OCIO::ConstTransformRcPtr tr = processor->createGroupTransform()->getTransform(0);


### PR DESCRIPTION
Fixing issue #2111 
- Added fallback mechanism for files with absolute paths so that if the proxy doesn't provide hash or the content, the file system will be used. We still expect the proxy to provide files with relative paths.

- Removed closeLutStream() function as both the ifstream and the stringstream objects that getLutData may return use RAII idiom. Since we already use unique pointers to hold the objects, we don't need to worry about closing the file or freeing memory.

- Added OCIOZ unit tests for existing and non-existing files with absolute paths.