### PR TITLE
Change recommended Imath version to 3.1.12.

### DIFF
--- a/share/cmake/modules/FindExtPackages.cmake
+++ b/share/cmake/modules/FindExtPackages.cmake
@@ -77,7 +77,7 @@ ocio_handle_dependency(  pystring REQUIRED ALLOW_INSTALL
 # https://github.com/AcademySoftwareFoundation/Imath
 ocio_handle_dependency(  Imath REQUIRED ALLOW_INSTALL
                          MIN_VERSION 3.1.1
-                         RECOMMENDED_VERSION 3.1.6
+                         RECOMMENDED_VERSION 3.1.12
                          RECOMMENDED_VERSION_REASON "Latest version tested with OCIO")
 
 ###############################################################################


### PR DESCRIPTION
Chage the recommended Imath version to 3.1.12 (latest available).

Imath 3.1.10 included a fix that should resolve Issue #1764.

Signed-off-by: Mark Titchener <mark.titchener@foundry.com>