### PR TITLE
fix: adjust requirements.txt for documentation-building ci step

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,3 +11,4 @@ recommonmark
 sphinx-press-theme
 sphinx-tabs
 breathe
+setuptools<68.0.0


### PR DESCRIPTION
Make sure we're not getting a version of setuptools that's so new it breaks stuff for us.

Should fix CI failures like this one:
https://github.com/AcademySoftwareFoundation/OpenColorIO/actions/runs/14816012234/job/41596531770#step:4:311