### PR TITLE
Adding color space attribs: interop_id, amf_transform & icc_profile_name

### DIFF
--- a/docs/api/python/frozen/pyopencolorio_colorspace.rst
+++ b/docs/api/python/frozen/pyopencolorio_colorspace.rst
@@ -20,7 +20,7 @@
 
       2. __init__(self: PyOpenColorIO.ColorSpace, referenceSpace: PyOpenColorIO.ReferenceSpaceType) -> None
 
-      3. __init__(self: PyOpenColorIO.ColorSpace, referenceSpace: PyOpenColorIO.ReferenceSpaceType = <ReferenceSpaceType.REFERENCE_SPACE_SCENE: 0>, name: str = '', aliases: List[str] = [], family: str = '', encoding: str = '', equalityGroup: str = '', description: str = '', bitDepth: PyOpenColorIO.BitDepth = <BitDepth.BIT_DEPTH_UNKNOWN: 0>, isData: bool = False, allocation: PyOpenColorIO.Allocation = <Allocation.ALLOCATION_UNIFORM: 1>, allocationVars: List[float] = [], toReference: PyOpenColorIO.Transform = None, fromReference: PyOpenColorIO.Transform = None, categories: List[str] = []) -> None
+      3. __init__(self: PyOpenColorIO.ColorSpace, referenceSpace: PyOpenColorIO.ReferenceSpaceType = <ReferenceSpaceType.REFERENCE_SPACE_SCENE: 0>, name: str = '', aliases: List[str] = [], family: str = '', encoding: str = '', equalityGroup: str = '', description: str = '', bitDepth: PyOpenColorIO.BitDepth = <BitDepth.BIT_DEPTH_UNKNOWN: 0>, isData: bool = False, allocation: PyOpenColorIO.Allocation = <Allocation.ALLOCATION_UNIFORM: 1>, allocationVars: List[float] = [], toReference: PyOpenColorIO.Transform = None, fromReference: PyOpenColorIO.Transform = None, categories: List[str] = [], interopID: str = '', amfTransformIDs: str = '', iccProfileName: str = '') -> None
 
 
    .. py:method:: ColorSpace.addAlias(self: PyOpenColorIO.ColorSpace, alias: str) -> None
@@ -46,6 +46,14 @@
       :module: PyOpenColorIO
 
       Clear all the categories.
+
+
+   .. py:method:: ColorSpace.getAMFTransformIDs(self: PyOpenColorIO.ColorSpace) -> str
+      :module: PyOpenColorIO
+
+      Get/Set the AMF transform IDs for the color space.
+
+      The AMF transform IDs are used to identify specific transforms in the ACES Metadata File. Multiple transform IDs can be specified in a newline-separated string.
 
 
    .. py:method:: ColorSpace.getAliases(self: PyOpenColorIO.ColorSpace) -> PyOpenColorIO.ColorSpace.ColorSpaceAliasIterator
@@ -104,6 +112,21 @@
       Get the family, for use in user interfaces (optional) The family string could use a '/' separator to indicate levels to be used by hierarchical menus.
 
 
+   .. py:method:: ColorSpace.getICCProfileName(self: PyOpenColorIO.ColorSpace) -> str
+      :module: PyOpenColorIO
+
+      Get/Set the ICC profile name for the color space.
+
+      The ICC profile name identifies the ICC color profile associated with this color space. This can be used to link OCIO color spaces with corresponding ICC profiles for applications that need to work with both color management systems.
+
+
+   .. py:method:: ColorSpace.getInteropID(self: PyOpenColorIO.ColorSpace) -> str
+      :module: PyOpenColorIO
+
+      Get/Set the interop ID for the color space.
+
+      The interop ID is a standardized identifier to uniquely identify commonly used color spaces. These IDs are defined by the Academy Software Foundation's Color Interop Forum project. If you create your own ID, you must prefix it with unique characters that will ensure it won't conflict with future Color Interop Forum IDs.
+
    .. py:method:: ColorSpace.getName(self: PyOpenColorIO.ColorSpace) -> str
       :module: PyOpenColorIO
 
@@ -121,6 +144,11 @@
 
       If a transform in the specified direction has been specified, return it. Otherwise return a null ConstTransformRcPtr
 
+
+   .. py:method:: ColorSpace.hasAlias(self: PyOpenColorIO.ColorSpace, alias: str) -> bool
+      :module: PyOpenColorIO
+
+      Return true if alias exists.
 
    .. py:method:: ColorSpace.hasCategory(self: PyOpenColorIO.ColorSpace, category: str) -> bool
       :module: PyOpenColorIO
@@ -168,6 +196,10 @@
          Will do nothing if the category is missing.
 
 
+   .. py:method:: ColorSpace.setAMFTransformIDs(self: PyOpenColorIO.ColorSpace, amfTransformIDs: str) -> None
+      :module: PyOpenColorIO
+
+
    .. py:method:: ColorSpace.setAllocation(self: PyOpenColorIO.ColorSpace, allocation: PyOpenColorIO.Allocation) -> None
       :module: PyOpenColorIO
 
@@ -196,6 +228,14 @@
       :module: PyOpenColorIO
 
       Set the family, for use in user interfaces (optional)
+
+
+   .. py:method:: ColorSpace.setICCProfileName(self: PyOpenColorIO.ColorSpace, iccProfileName: str) -> None
+      :module: PyOpenColorIO
+
+
+   .. py:method:: ColorSpace.setInteropID(self: PyOpenColorIO.ColorSpace, interopID: str) -> None
+      :module: PyOpenColorIO
 
 
    .. py:method:: ColorSpace.setIsData(self: PyOpenColorIO.ColorSpace, isData: bool) -> None

--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -1979,6 +1979,37 @@ public:
     const char * getDescription() const noexcept;
     void setDescription(const char * description);
 
+    /**
+     * Get/Set the interop ID for the color space.
+     *
+     * The interop ID is a standardized identifier to uniquely identify commonly
+     * used color spaces. These IDs are defined by the Academy Software
+     * Foundation's Color Interop Forum project. If you create your own ID, you
+     * must prefix it with unique characters that will ensure it won't conflict
+     * with future Color Interop Forum IDs.
+     */
+    const char * getInteropID() const noexcept;
+    void setInteropID(const char * interopID);
+
+    /**
+     * Get/Set the AMF transform IDs for the color space.
+     * 
+     * The AMF transform IDs are used to identify specific transforms in the ACES Metadata File.
+     * Multiple transform IDs can be specified in a newline-separated string.
+     */
+    const char * getAMFTransformIDs() const noexcept;
+    void setAMFTransformIDs(const char * amfTransformIDs);
+
+    /**
+     * Get/Set the ICC profile name for the color space.
+     * 
+     * The ICC profile name identifies the ICC color profile associated with this color space.
+     * This can be used to link OCIO color spaces with corresponding ICC profiles for
+     * applications that need to work with both color management systems.
+     */
+    const char * getICCProfileName() const noexcept;
+    void setICCProfileName(const char * iccProfileName);
+
     BitDepth getBitDepth() const noexcept;
     void setBitDepth(BitDepth bitDepth);
 

--- a/src/OpenColorIO/Baker.cpp
+++ b/src/OpenColorIO/Baker.cpp
@@ -126,7 +126,7 @@ void Baker::setFormat(const char * formatName)
         {
             if (formatInfoVec[i].capabilities & FORMAT_CAPABILITY_BAKE)
             {
-                getImpl()->m_formatName = formatName;
+                getImpl()->m_formatName = formatName ? formatName : "";
                 return;
             }
         }
@@ -155,7 +155,7 @@ FormatMetadata & Baker::getFormatMetadata()
 
 void Baker::setInputSpace(const char * inputSpace)
 {
-    getImpl()->m_inputSpace = inputSpace;
+    getImpl()->m_inputSpace = inputSpace ? inputSpace : "";
 }
 
 const char * Baker::getInputSpace() const
@@ -165,7 +165,7 @@ const char * Baker::getInputSpace() const
 
 void Baker::setShaperSpace(const char * shaperSpace)
 {
-    getImpl()->m_shaperSpace = shaperSpace;
+    getImpl()->m_shaperSpace = shaperSpace ? shaperSpace : "";
 }
 
 const char * Baker::getShaperSpace() const
@@ -175,7 +175,7 @@ const char * Baker::getShaperSpace() const
 
 void Baker::setLooks(const char * looks)
 {
-    getImpl()->m_looks = looks;
+    getImpl()->m_looks = looks ? looks : "";
 }
 
 const char * Baker::getLooks() const
@@ -185,7 +185,7 @@ const char * Baker::getLooks() const
 
 void Baker::setTargetSpace(const char * targetSpace)
 {
-    getImpl()->m_targetSpace = targetSpace;
+    getImpl()->m_targetSpace = targetSpace ? targetSpace : "";
 }
 
 const char * Baker::getTargetSpace() const
@@ -205,7 +205,7 @@ const char * Baker::getView() const
 
 void Baker::setDisplayView(const char * display, const char * view)
 {
-    if (!display ^ !view)
+    if (!display || !view)
     {
         throw Exception("Both display and view must be set.");
     }

--- a/src/OpenColorIO/ColorSpace.cpp
+++ b/src/OpenColorIO/ColorSpace.cpp
@@ -24,6 +24,9 @@ public:
     std::string m_equalityGroup;
     std::string m_description;
     std::string m_encoding;
+    std::string m_interopID;
+    std::string m_AMFTransformIDs;
+    std::string m_ICCProfileName;
     StringUtils::StringVec m_aliases;
 
     BitDepth m_bitDepth{ BIT_DEPTH_UNKNOWN };
@@ -62,6 +65,9 @@ public:
             m_equalityGroup = rhs.m_equalityGroup;
             m_description = rhs.m_description;
             m_encoding = rhs.m_encoding;
+            m_interopID = rhs.m_interopID;
+            m_AMFTransformIDs = rhs.m_AMFTransformIDs;
+            m_ICCProfileName = rhs.m_ICCProfileName;
             m_bitDepth = rhs.m_bitDepth;
             m_isData = rhs.m_isData;
             m_referenceSpaceType = rhs.m_referenceSpaceType;
@@ -195,7 +201,7 @@ const char * ColorSpace::getFamily() const noexcept
 
 void ColorSpace::setFamily(const char * family)
 {
-    getImpl()->m_family = family;
+    getImpl()->m_family = family ? family : "";
 }
 
 const char * ColorSpace::getEqualityGroup() const noexcept
@@ -205,7 +211,7 @@ const char * ColorSpace::getEqualityGroup() const noexcept
 
 void ColorSpace::setEqualityGroup(const char * equalityGroup)
 {
-    getImpl()->m_equalityGroup = equalityGroup;
+    getImpl()->m_equalityGroup = equalityGroup ? equalityGroup : "";
 }
 
 const char * ColorSpace::getDescription() const noexcept
@@ -215,7 +221,37 @@ const char * ColorSpace::getDescription() const noexcept
 
 void ColorSpace::setDescription(const char * description)
 {
-    getImpl()->m_description = description;
+    getImpl()->m_description = description ? description : "";
+}
+
+const char * ColorSpace::getInteropID() const noexcept
+{
+    return getImpl()->m_interopID.c_str();
+}
+
+void ColorSpace::setInteropID(const char * interopID)
+{
+    getImpl()->m_interopID = interopID ? interopID : "";
+}
+
+const char * ColorSpace::getAMFTransformIDs() const noexcept
+{
+    return getImpl()->m_AMFTransformIDs.c_str();
+}
+
+void ColorSpace::setAMFTransformIDs(const char * amfTransformIDs)
+{
+    getImpl()->m_AMFTransformIDs = amfTransformIDs ? amfTransformIDs : "";
+}
+
+const char * ColorSpace::getICCProfileName() const noexcept
+{
+    return getImpl()->m_ICCProfileName.c_str();
+}
+
+void ColorSpace::setICCProfileName(const char * iccProfileName)
+{
+    getImpl()->m_ICCProfileName = iccProfileName ? iccProfileName : "";
 }
 
 BitDepth ColorSpace::getBitDepth() const noexcept
@@ -265,7 +301,7 @@ const char * ColorSpace::getEncoding() const noexcept
 
 void ColorSpace::setEncoding(const char * encoding)
 {
-    getImpl()->m_encoding = encoding;
+    getImpl()->m_encoding = encoding ? encoding : "";
 }
 
 bool ColorSpace::isData() const noexcept
@@ -371,7 +407,6 @@ std::ostream & operator<< (std::ostream & os, const ColorSpace & cs)
         break;
     }
     os << "name=" << cs.getName() << ", ";
-    std::string str{ cs.getFamily() };
     const auto numAliases = cs.getNumAliases();
     if (numAliases == 1)
     {
@@ -386,6 +421,15 @@ std::ostream & operator<< (std::ostream & os, const ColorSpace & cs)
         }
         os << "], ";
     }
+
+    std::string str;
+    
+    str = cs.getInteropID();
+    if (!str.empty())
+    {
+        os << "interop_id=" << str << ", ";
+    }
+    str = cs.getFamily();
     if (!str.empty())
     {
         os << "family=" << str << ", ";
@@ -428,6 +472,16 @@ std::ostream & operator<< (std::ostream & os, const ColorSpace & cs)
     if (!str.empty())
     {
         os << ", description=" << str;
+    }
+    str = cs.getAMFTransformIDs();
+    if (!str.empty())
+    {
+        os << ", amf_transform_ids=" << str;
+    }
+    str = cs.getICCProfileName();
+    if (!str.empty())
+    {
+        os << ", icc_profile_name=" << str;
     }
     if(cs.getTransform(COLORSPACE_DIR_TO_REFERENCE))
     {

--- a/src/OpenColorIO/Context.cpp
+++ b/src/OpenColorIO/Context.cpp
@@ -253,7 +253,7 @@ void Context::setWorkingDir(const char * dirname)
 {
     AutoMutex lock(getImpl()->m_resultsCacheMutex);
 
-    getImpl()->m_workingDir = dirname;
+    getImpl()->m_workingDir = dirname ? dirname : "";
     getImpl()->clearCaches();
 }
 

--- a/src/OpenColorIO/Look.cpp
+++ b/src/OpenColorIO/Look.cpp
@@ -86,7 +86,7 @@ const char * Look::getName() const
 
 void Look::setName(const char * name)
 {
-    getImpl()->m_name = name;
+    getImpl()->m_name = name ? name : "";
 }
 
 const char * Look::getProcessSpace() const
@@ -96,7 +96,7 @@ const char * Look::getProcessSpace() const
 
 void Look::setProcessSpace(const char * processSpace)
 {
-    getImpl()->m_processSpace = processSpace;
+    getImpl()->m_processSpace = processSpace ? processSpace : "";
 }
 
 ConstTransformRcPtr Look::getTransform() const
@@ -126,7 +126,7 @@ const char * Look::getDescription() const
 
 void Look::setDescription(const char * description)
 {
-    getImpl()->m_description = description;
+    getImpl()->m_description = description ? description : "";
 }
 
 bool CollectContextVariables(const Config & config,

--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -3202,10 +3202,25 @@ inline void load(const YAML::Node& node, ColorSpaceRcPtr& cs, unsigned int major
                 cs->addAlias(alias.c_str());
             }
         }
+        else if (key == "interop_id") 
+        {
+            load(iter->second, stringval);
+            cs->setInteropID(stringval.c_str());
+        }
         else if(key == "description")
         {
             loadDescription(iter->second, stringval);
             cs->setDescription(stringval.c_str());
+        }
+        else if (key == "amf_transform_ids") 
+        {
+            load(iter->second, stringval);
+            cs->setAMFTransformIDs(stringval.c_str());
+        }
+        else if (key == "icc_profile_name") 
+        {
+            load(iter->second, stringval);
+            cs->setICCProfileName(stringval.c_str());
         }
         else if(key == "family")
         {
@@ -3323,11 +3338,37 @@ inline void save(YAML::Emitter& out, ConstColorSpaceRcPtr cs, unsigned int major
         }
         out << YAML::Flow << YAML::Value << aliases;
     }
+    
+    const std::string interopID{ cs->getInteropID() };
+    if (!interopID.empty())
+    {
+        out << YAML::Key << "interop_id";
+        out << YAML::Value << interopID;
+    }
+
     out << YAML::Key << "family" << YAML::Value << cs->getFamily();
+
     out << YAML::Key << "equalitygroup" << YAML::Value << cs->getEqualityGroup();
+
     out << YAML::Key << "bitdepth" << YAML::Value;
     save(out, cs->getBitDepth());
+    
     saveDescription(out, cs->getDescription());
+
+    const std::string amfTransformIDs{cs->getAMFTransformIDs()};
+    if (!amfTransformIDs.empty()) 
+    {
+        out << YAML::Key << "amf_transform_ids";
+        out << YAML::Value << amfTransformIDs;
+    }
+
+    const std::string iccProfileName{cs->getICCProfileName()};
+    if (!iccProfileName.empty()) 
+    {
+        out << YAML::Key << "icc_profile_name";
+        out << YAML::Value << iccProfileName;
+    }
+
     out << YAML::Key << "isdata" << YAML::Value << cs->isData();
 
     if(cs->getNumCategories() > 0)
@@ -4754,10 +4795,12 @@ inline void save(YAML::Emitter & out, const Config & config)
 {
     std::stringstream ss;
     const unsigned configMajorVersion = config.getMajorVersion();
+    const unsigned configMinorVersion = config.getMinorVersion();
+
     ss << configMajorVersion;
-    if(config.getMinorVersion()!=0)
+    if(configMinorVersion != 0)
     {
-        ss << "." << config.getMinorVersion();
+        ss << "." << configMinorVersion;
     }
 
     out << YAML::Block;

--- a/src/OpenColorIO/Platform.cpp
+++ b/src/OpenColorIO/Platform.cpp
@@ -154,6 +154,11 @@ bool isEnvPresent(const char * name)
 
 int Strcasecmp(const char * str1, const char * str2)
 {
+    if (!str1 || !str2) 
+    {
+        throw Exception("String pointer for comparison must not be null.");
+    }
+
 #ifdef _WIN32
     return ::_stricmp(str1, str2);
 #else
@@ -163,6 +168,11 @@ int Strcasecmp(const char * str1, const char * str2)
 
 int Strncasecmp(const char * str1, const char * str2, size_t n)
 {
+    if (!str1 || !str2) 
+    {
+        throw Exception("String pointer for comparison must not be null.");
+    }
+
 #ifdef _WIN32
     return ::_strnicmp(str1, str2, n);
 #else

--- a/src/OpenColorIO/ViewTransform.cpp
+++ b/src/OpenColorIO/ViewTransform.cpp
@@ -91,7 +91,7 @@ const char * ViewTransform::getName() const noexcept
 
 void ViewTransform::setName(const char * name) noexcept
 {
-    getImpl()->m_name = name;
+    getImpl()->m_name = name ? name : "";
 }
 
 const char * ViewTransform::getFamily() const noexcept
@@ -101,7 +101,7 @@ const char * ViewTransform::getFamily() const noexcept
 
 void ViewTransform::setFamily(const char * family)
 {
-    getImpl()->m_family = family;
+    getImpl()->m_family = family ? family : "";
 }
 
 const char * ViewTransform::getDescription() const noexcept
@@ -111,7 +111,7 @@ const char * ViewTransform::getDescription() const noexcept
 
 void ViewTransform::setDescription(const char * description)
 {
-    getImpl()->m_description = description;
+    getImpl()->m_description = description ? description : "";
 }
 
 bool ViewTransform::hasCategory(const char * category) const

--- a/src/bindings/python/PyColorSpace.cpp
+++ b/src/bindings/python/PyColorSpace.cpp
@@ -90,7 +90,10 @@ void bindPyColorSpace(py::module & m)
                          const std::vector<float> & allocationVars,
                          const TransformRcPtr & toReference,
                          const TransformRcPtr & fromReference,
-                         const std::vector<std::string> & categories) 
+                         const std::vector<std::string> & categories,
+                         const std::string & interopID,
+                         const std::string& AMFTransformID,
+                         const std::string& ICCProfileName) 
             {
                 ColorSpaceRcPtr p = ColorSpace::Create(referenceSpace);
                 if (!aliases.empty())
@@ -102,11 +105,14 @@ void bindPyColorSpace(py::module & m)
                     }
                 }
                 // Setting the name will remove alias named the same, so set name after.
-                if (!name.empty())          { p->setName(name.c_str()); }
-                if (!family.empty())        { p->setFamily(family.c_str()); }
-                if (!encoding.empty())      { p->setEncoding(encoding.c_str()); }
-                if (!equalityGroup.empty()) { p->setEqualityGroup(equalityGroup.c_str()); }
-                if (!description.empty())   { p->setDescription(description.c_str()); }
+                if (!name.empty())           { p->setName(name.c_str()); }
+                if (!family.empty())         { p->setFamily(family.c_str()); }
+                if (!encoding.empty())       { p->setEncoding(encoding.c_str()); }
+                if (!equalityGroup.empty())  { p->setEqualityGroup(equalityGroup.c_str()); }
+                if (!description.empty())    { p->setDescription(description.c_str()); }
+                if (!interopID.empty())      { p->setInteropID(interopID.c_str()); }
+                if (!AMFTransformID.empty()) { p->setAMFTransformIDs(AMFTransformID.c_str()); }
+                if (!ICCProfileName.empty()) { p->setICCProfileName(ICCProfileName.c_str()); }
                 p->setBitDepth(bitDepth);
                 p->setIsData(isData);
                 p->setAllocation(allocation);
@@ -150,6 +156,9 @@ void bindPyColorSpace(py::module & m)
              "toReference"_a = DEFAULT->getTransform(COLORSPACE_DIR_TO_REFERENCE),
              "fromReference"_a = DEFAULT->getTransform(COLORSPACE_DIR_FROM_REFERENCE),
              "categories"_a = getCategoriesStdVec(DEFAULT),
+             "interopID"_a = DEFAULT->getInteropID(),
+             "amfTransformIDs"_a = DEFAULT->getAMFTransformIDs(),
+             "iccProfileName"_a = DEFAULT->getICCProfileName(),
              DOC(ColorSpace, Create, 2))
 
         .def("__deepcopy__", [](const ConstColorSpaceRcPtr & self, py::dict)
@@ -193,6 +202,18 @@ void bindPyColorSpace(py::module & m)
              DOC(ColorSpace, getDescription))
         .def("setDescription", &ColorSpace::setDescription, "description"_a, 
              DOC(ColorSpace, setDescription))
+        .def("getInteropID", &ColorSpace::getInteropID,
+             DOC(ColorSpace, getInteropID))
+        .def("setInteropID", &ColorSpace::setInteropID, "interopID"_a,
+             DOC(ColorSpace, setInteropID))
+        .def("getAMFTransformIDs", &ColorSpace::getAMFTransformIDs,
+             DOC(ColorSpace, getAMFTransformIDs))
+        .def("setAMFTransformIDs", &ColorSpace::setAMFTransformIDs, "amfTransformIDs"_a,
+             DOC(ColorSpace, setAMFTransformIDs))
+        .def("getICCProfileName", &ColorSpace::getICCProfileName,
+             DOC(ColorSpace, getICCProfileName))
+        .def("setICCProfileName", &ColorSpace::setICCProfileName, "iccProfileName"_a,
+             DOC(ColorSpace, setICCProfileName))
         .def("getBitDepth", &ColorSpace::getBitDepth, 
              DOC(ColorSpace, getBitDepth))
         .def("setBitDepth", &ColorSpace::setBitDepth, "bitDepth"_a, 

--- a/tests/cpu/ColorSpace_tests.cpp
+++ b/tests/cpu/ColorSpace_tests.cpp
@@ -39,7 +39,39 @@ OCIO_ADD_TEST(ColorSpace, basic)
     OCIO_CHECK_ASSERT(!cs->isData());
     OCIO_CHECK_EQUAL(OCIO::ALLOCATION_UNIFORM, cs->getAllocation());
     OCIO_CHECK_EQUAL(0, cs->getAllocationNumVars());
+    
+    // Check the nullptr assignment hardening.
+    // First set the fields to non-empty values.
+    cs->setName("NAME");
+    cs->setDescription("DESC");
+    cs->setFamily("FAMILY");
+    cs->setEqualityGroup("EQGRP");
+    cs->setEncoding("ENC");
+    cs->setAMFTransformIDs("AMF");
+    cs->setInteropID("INTEROP");
+    cs->setICCProfileName("ICC");
 
+    // Set to nullptr, this should erase the old values.
+    OCIO_CHECK_NO_THROW(cs->setName(nullptr));
+    OCIO_CHECK_NO_THROW(cs->setDescription(nullptr));
+    OCIO_CHECK_NO_THROW(cs->setFamily(nullptr));
+    OCIO_CHECK_NO_THROW(cs->setEqualityGroup(nullptr));
+    OCIO_CHECK_NO_THROW(cs->setEncoding(nullptr));
+    OCIO_CHECK_NO_THROW(cs->setAMFTransformIDs(nullptr));
+    OCIO_CHECK_NO_THROW(cs->setInteropID(nullptr));
+    OCIO_CHECK_NO_THROW(cs->setICCProfileName(nullptr));
+
+    // Check that the values are empty now.
+    OCIO_CHECK_ASSERT(!*cs->getName());
+    OCIO_CHECK_ASSERT(!*cs->getDescription());
+    OCIO_CHECK_ASSERT(!*cs->getFamily());
+    OCIO_CHECK_ASSERT(!*cs->getEqualityGroup());
+    OCIO_CHECK_ASSERT(!*cs->getEncoding());
+    OCIO_CHECK_ASSERT(!*cs->getAMFTransformIDs());
+    OCIO_CHECK_ASSERT(!*cs->getInteropID());
+    OCIO_CHECK_ASSERT(!*cs->getICCProfileName());
+
+    // Test set/get roundtrip.
     cs->setName("name");
     OCIO_CHECK_EQUAL(std::string("name"), cs->getName());
     cs->setFamily("family");
@@ -63,10 +95,17 @@ OCIO_ADD_TEST(ColorSpace, basic)
     cs->getAllocationVars(readVars);
     OCIO_CHECK_EQUAL(1.f, readVars[0]);
     OCIO_CHECK_EQUAL(2.f, readVars[1]);
+    cs->setInteropID("interop_id");
+    OCIO_CHECK_EQUAL(std::string("interop_id"), cs->getInteropID());
+    cs->setAMFTransformIDs("amf_transform_id1\namf_tranform_id2");
+    OCIO_CHECK_EQUAL(std::string("amf_transform_id1\namf_tranform_id2"),
+                     cs->getAMFTransformIDs());
+    cs->setICCProfileName("icc_profile_name");
+    OCIO_CHECK_EQUAL(std::string("icc_profile_name"), cs->getICCProfileName());
 
     std::ostringstream oss;
     oss << *cs;
-    OCIO_CHECK_EQUAL(oss.str().size(), 193);
+    OCIO_CHECK_EQUAL(oss.str().size(), 305);
 }
 
 OCIO_ADD_TEST(ColorSpace, alias)
@@ -618,6 +657,81 @@ active_views: []
         cfgRes += EndRes;
 
         OCIO_CHECK_EQUAL(cfgRes, os.str());
+    }
+
+    // Test that the interop_id can't be used in v2.0 config.
+    {
+        constexpr char End[]{R"(colorspaces:
+  - !<ColorSpace>
+    name: raw
+    interop_id: data
+    family: raw
+    equalitygroup: ""
+    bitdepth: 32f
+    description: Some text.
+    isdata: true
+    allocation: uniform
+)"};
+        std::string cfgString{Start};
+        cfgString += End;
+
+        std::istringstream is;
+        is.str(cfgString);
+        OCIO::ConstConfigRcPtr config;
+        OCIO_CHECK_THROW_WHAT(
+            config = OCIO::Config::CreateFromStream(is),
+            OCIO::Exception, 
+            "Config failed validation. The color space 'raw' has non-empty InteropID and config version is less than 2.5.");
+    }
+
+    // Test that the amf_transform_ids can't be used in v2.0 config.
+    {
+        constexpr char End[]{R"(colorspaces:
+  - !<ColorSpace>
+    name: raw
+    amf_transform_ids: this:shouldnt:be:here
+    family: raw
+    equalitygroup: ""
+    bitdepth: 32f
+    description: Some text.
+    isdata: true
+    allocation: uniform
+)"};
+        std::string cfgString{Start};
+        cfgString += End;
+
+        std::istringstream is;
+        is.str(cfgString);
+        OCIO::ConstConfigRcPtr config;
+        OCIO_CHECK_THROW_WHAT(
+            config = OCIO::Config::CreateFromStream(is), OCIO::Exception,
+            "Config failed validation. The color space 'raw' has non-empty "
+            "AMFTransformIDs and config version is less than 2.5.");
+    }
+
+    // Test that the icc_profile_name can't be used in v2.0 config.
+    {
+        constexpr char End[]{R"(colorspaces:
+  - !<ColorSpace>
+    name: raw
+    icc_profile_name: not valid in v2.0 config
+    family: raw
+    equalitygroup: ""
+    bitdepth: 32f
+    description: Some text.
+    isdata: true
+    allocation: uniform
+)"};
+        std::string cfgString{Start};
+        cfgString += End;
+
+        std::istringstream is;
+        is.str(cfgString);
+        OCIO::ConstConfigRcPtr config;
+        OCIO_CHECK_THROW_WHAT(
+            config = OCIO::Config::CreateFromStream(is), OCIO::Exception,
+            "Config failed validation. The color space 'raw' has non-empty "
+            "ICCProfileName and config version is less than 2.5.");
     }
 }
 
@@ -1701,4 +1815,251 @@ colorspaces:
             "The heuristics currently only support scene-referred color spaces. Please set the interchange roles."
         );
     }
+}
+
+OCIO_ADD_TEST(ColorSpace, interop_id)
+{
+    OCIO::ColorSpaceRcPtr cs = OCIO::ColorSpace::Create();
+    
+    // Test default value.
+    OCIO_CHECK_EQUAL(std::string(cs->getInteropID()), "");
+
+    // Test setting and getting single profile name.
+    const char * interop_id = "srgb_p3d65_scene";
+    cs->setInteropID(interop_id);
+    OCIO_CHECK_EQUAL(std::string(cs->getInteropID()), interop_id);
+
+    // Test setting empty string.
+    cs->setInteropID("");
+    OCIO_CHECK_EQUAL(std::string(cs->getICCProfileName()), "");
+
+    // Test setting and getting another value.
+    const char * anotherID= "lin_rec2020_scene";
+    cs->setInteropID(anotherID);
+    OCIO_CHECK_EQUAL(std::string(cs->getInteropID()), anotherID);
+
+    // Test setting null pointer (should be safe).
+    OCIO_CHECK_NO_THROW(cs->setInteropID(nullptr));
+    OCIO_CHECK_EQUAL(std::string(cs->getInteropID()), "");
+
+    // Test copy constructor preserves ICC profile name.
+    cs->setInteropID(interop_id);
+    OCIO::ColorSpaceRcPtr copy = cs->createEditableCopy();
+    OCIO_CHECK_EQUAL(std::string(copy->getInteropID()), interop_id);
+}
+
+OCIO_ADD_TEST(ColorSpace, interop_id_serialization)
+{
+    // Test YAML serialization and deserialization of InteropID.
+    auto cfg = OCIO::Config::Create();
+    auto cs = OCIO::ColorSpace::Create();
+    cs->setName("test_colorspace");
+    
+    const std::string interop_id = "lin_rec709_scene";
+    
+    cs->setInteropID(interop_id.c_str());
+    cfg->addColorSpace(cs);
+
+    // Serialize the Config.
+    std::stringstream ss;
+    cfg->serialize(ss);
+    std::string yamlStr = ss.str();
+
+    // Verify interop_id appears in YAML.
+    OCIO_CHECK_NE(yamlStr.find("interop_id"), std::string::npos);
+    OCIO_CHECK_NE(yamlStr.find(interop_id), std::string::npos);
+
+    // Deserialize and verify.
+    std::istringstream iss(yamlStr);
+    OCIO::ConstConfigRcPtr deserializedCfg;
+    OCIO_CHECK_NO_THROW(deserializedCfg = OCIO::Config::CreateFromStream(iss));
+
+    // Verify interop_id is preserved.
+    OCIO::ConstColorSpaceRcPtr deserializedCs = deserializedCfg->getColorSpace("test_colorspace");
+    OCIO_CHECK_EQUAL(std::string(deserializedCs->getInteropID()), interop_id);
+
+    // verify that that earlier versions reject interop_id.
+    OCIO::ConfigRcPtr cfgCopy = cfg->createEditableCopy();
+    cfgCopy->setVersion(2, 4);
+    OCIO_CHECK_THROW_WHAT(
+        cfgCopy->serialize(ss), 
+        OCIO::Exception,
+        "Config failed validation. The color space 'test_colorspace' has non-empty "
+        "InteropID and config version is less than 2.5.");
+
+    // Test with empty interop_id (should not appear in YAML).
+    cs->setInteropID(nullptr);
+    cfg->addColorSpace(cs); // Replace the existing CS.
+    ss.str("");
+    cfg->serialize(ss);
+    std::string yamlStr2 = ss.str();
+
+    // Verify empty imterop_id does not appear in YAML.
+    OCIO_CHECK_EQUAL(yamlStr2.find("interop_id"), std::string::npos);
+}
+
+OCIO_ADD_TEST(ColorSpace, amf_transform_ids)
+{
+    OCIO::ColorSpaceRcPtr cs = OCIO::ColorSpace::Create();
+    
+    // Test default value.
+    OCIO_CHECK_EQUAL(std::string(cs->getAMFTransformIDs()), "");
+
+    // Test setting and getting single ID.
+    const char * singleID = "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScc_to_ACES.a1.0.3";
+    cs->setAMFTransformIDs(singleID);
+    OCIO_CHECK_EQUAL(std::string(cs->getAMFTransformIDs()), singleID);
+
+    // Test setting to empty string.
+    cs->setAMFTransformIDs("");
+    OCIO_CHECK_EQUAL(std::string(cs->getAMFTransformIDs()), "");    
+    
+    // Test setting and getting multiple IDs.
+    const char * multipleIDs = 
+        "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScc_to_ACES.a1.0.3\n"
+        "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScc.a1.0.3";
+    cs->setAMFTransformIDs(multipleIDs);
+    OCIO_CHECK_EQUAL(std::string(cs->getAMFTransformIDs()), multipleIDs);
+
+    // Test setting to nullptr.
+    cs->setDescription(nullptr);
+    cs->setAMFTransformIDs(nullptr);
+    OCIO_CHECK_EQUAL(std::string(cs->getAMFTransformIDs()), "");
+
+    // Test copy constructor preserves AMF transform IDs.
+    cs->setAMFTransformIDs(singleID);
+    OCIO::ColorSpaceRcPtr copy = cs->createEditableCopy();
+    OCIO_CHECK_EQUAL(std::string(copy->getAMFTransformIDs()), singleID);
+}
+
+OCIO_ADD_TEST(ColorSpace, amf_transform_ids_serialization)
+{
+    // Test YAML serialization and deserialization of AmfTransformIDs.
+    auto cfg = OCIO::Config::Create();
+    auto cs = OCIO::ColorSpace::Create();
+    cs->setName("test_colorspace");
+    
+    const std::string amfIDs = 
+        "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScc_to_ACES.a1.0.3\n"
+        "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScc.a1.0.3";
+    
+    cs->setAMFTransformIDs(amfIDs.c_str());
+    cfg->addColorSpace(cs);
+
+    // Serialize the Config.
+    std::stringstream ss;
+    cfg->serialize(ss);
+    std::string yamlStr = ss.str();
+
+    // Verify AmfTransformIDs appears in YAML.
+    OCIO_CHECK_NE(yamlStr.find("amf_transform_ids"), std::string::npos);
+    OCIO_CHECK_NE(yamlStr.find("ACEScsc.Academy.ACEScc_to_ACES"), std::string::npos);
+
+    // Deserialize and verify.
+    std::istringstream iss(yamlStr);
+    OCIO::ConstConfigRcPtr deserializedCfg;
+    OCIO_CHECK_NO_THROW(deserializedCfg = OCIO::Config::CreateFromStream(iss));
+
+    // Verify AmfTransformIDs is preserved.
+    OCIO::ConstColorSpaceRcPtr deserializedCs = deserializedCfg->getColorSpace("test_colorspace");
+    OCIO_CHECK_EQUAL(std::string(deserializedCs->getAMFTransformIDs()), amfIDs);
+
+    // Verify that that earlier versions reject amf_transform_ids.
+    OCIO::ConfigRcPtr cfgCopy = cfg->createEditableCopy();
+    cfgCopy->setVersion(2,4);
+    OCIO_CHECK_THROW_WHAT(cfgCopy->serialize(ss), 
+        OCIO::Exception,
+        "Config failed validation. The color space 'test_colorspace' has non-empty "
+        "AMFTransformIDs and config version is less than 2.5.");
+
+    // Test with empty AmfTransformIDs (should not appear in YAML).
+    cs->setAMFTransformIDs(nullptr);
+    cfg->addColorSpace(cs); // Replace the existing CS.
+    ss.str("");
+    cfg->serialize(ss);
+    std::string yamlStr2 = ss.str();
+
+    // Verify empty AmfTransformIDs does not appear in YAML.
+    OCIO_CHECK_EQUAL(yamlStr2.find("amf_transform_ids"), std::string::npos);
+}
+
+OCIO_ADD_TEST(ColorSpace, icc_profile_name)
+{
+    OCIO::ColorSpaceRcPtr cs = OCIO::ColorSpace::Create();
+    
+    // Test default value.
+    OCIO_CHECK_EQUAL(std::string(cs->getICCProfileName()), "");
+
+    // Test setting and getting single profile name.
+    const char * profileName = "sRGB IEC61966-2.1";
+    cs->setICCProfileName(profileName);
+    OCIO_CHECK_EQUAL(std::string(cs->getICCProfileName()), profileName);
+
+    // Test setting and getting another profile name.
+    const char * anotherProfile = "Adobe RGB (1998)";
+    cs->setICCProfileName(anotherProfile);
+    OCIO_CHECK_EQUAL(std::string(cs->getICCProfileName()), anotherProfile);
+
+    // Test setting empty string.
+    cs->setICCProfileName("");
+    OCIO_CHECK_EQUAL(std::string(cs->getICCProfileName()), "");
+
+    // Test setting null pointer (should be safe).
+    OCIO_CHECK_NO_THROW(cs->setICCProfileName(nullptr));
+    OCIO_CHECK_EQUAL(std::string(cs->getICCProfileName()), "");
+
+    // Test copy constructor preserves ICC profile name.
+    cs->setICCProfileName(profileName);
+    OCIO::ColorSpaceRcPtr copy = cs->createEditableCopy();
+    OCIO_CHECK_EQUAL(std::string(copy->getICCProfileName()), profileName);
+}
+
+OCIO_ADD_TEST(ColorSpace, icc_profile_name_serialization)
+{
+    // Test YAML serialization and deserialization of IccProfileName.
+    auto cfg = OCIO::Config::Create();
+    auto cs = OCIO::ColorSpace::Create();
+    cs->setName("test_colorspace");
+    
+    const std::string profileName = "sRGB IEC61966-2.1";
+    
+    cs->setICCProfileName(profileName.c_str());
+    cfg->addColorSpace(cs);
+
+    // Serialize the Config.
+    std::stringstream ss;
+    cfg->serialize(ss);
+    std::string yamlStr = ss.str();
+
+    // Verify IccProfileName appears in YAML.
+    OCIO_CHECK_NE(yamlStr.find("icc_profile_name"), std::string::npos);
+    OCIO_CHECK_NE(yamlStr.find(profileName), std::string::npos);
+
+    // Deserialize and verify.
+    std::istringstream iss(yamlStr);
+    OCIO::ConstConfigRcPtr deserializedCfg;
+    OCIO_CHECK_NO_THROW(deserializedCfg = OCIO::Config::CreateFromStream(iss));
+
+    // Verify IccProfileName is preserved.
+    OCIO::ConstColorSpaceRcPtr deserializedCs = deserializedCfg->getColorSpace("test_colorspace");
+    OCIO_CHECK_EQUAL(std::string(deserializedCs->getICCProfileName()), profileName);
+
+    // verify that that earlier versions reject amf_transform_ids.
+    OCIO::ConfigRcPtr cfgCopy = cfg->createEditableCopy();
+    cfgCopy->setVersion(2, 4);
+    OCIO_CHECK_THROW_WHAT(
+        cfgCopy->serialize(ss), 
+        OCIO::Exception,
+        "Config failed validation. The color space 'test_colorspace' has non-empty "
+        "ICCProfileName and config version is less than 2.5.");
+
+    // Test with empty IccProfileName (should not appear in YAML).
+    cs->setICCProfileName(nullptr);
+    cfg->addColorSpace(cs); // replace the existing CS
+    ss.str("");
+    cfg->serialize(ss);
+    std::string yamlStr2 = ss.str();
+
+    // Verify empty IccProfileName does not appear in YAML.
+    OCIO_CHECK_EQUAL(yamlStr2.find("icc_profile_name"), std::string::npos);
 }

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -2093,12 +2093,12 @@ OCIO_ADD_TEST(Config, version)
     {
         OCIO_CHECK_THROW_WHAT(config->setVersion(2, 9), OCIO::Exception,
                               "The minor version 9 is not supported for major version 2. "
-                              "Maximum minor version is 4");
+                              "Maximum minor version is 5");
 
         OCIO_CHECK_NO_THROW(config->setMajorVersion(2));
         OCIO_CHECK_THROW_WHAT(config->setMinorVersion(9), OCIO::Exception,
                               "The minor version 9 is not supported for major version 2. "
-                              "Maximum minor version is 4");
+                              "Maximum minor version is 5");
     }
 
     {

--- a/tests/python/ColorSpaceTest.py
+++ b/tests/python/ColorSpaceTest.py
@@ -42,6 +42,9 @@ class ColorSpaceTest(unittest.TestCase):
         self.colorspace.setTransform(direction=OCIO.COLORSPACE_DIR_FROM_REFERENCE, transform=mat)
         self.colorspace.addAlias('alias')
         self.colorspace.addCategory('cat')
+        self.colorspace.setInteropID('ACEScg')
+        self.colorspace.setAMFTransformIDs('urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CG_to_ACES.a1.0.3')
+        self.colorspace.setICCProfileName('sRGB IEC61966-2.1')
 
         other = copy.deepcopy(self.colorspace)
         self.assertFalse(other is self.colorspace)
@@ -59,6 +62,9 @@ class ColorSpaceTest(unittest.TestCase):
         self.assertTrue(other.getTransform(OCIO.COLORSPACE_DIR_FROM_REFERENCE).equals(self.colorspace.getTransform(OCIO.COLORSPACE_DIR_FROM_REFERENCE)))
         self.assertEqual(list(other.getAliases()), list(self.colorspace.getAliases()))
         self.assertEqual(list(other.getCategories()), list(self.colorspace.getCategories()))
+        self.assertEqual(other.getInteropID(), self.colorspace.getInteropID())
+        self.assertEqual(other.getAMFTransformIDs(), self.colorspace.getAMFTransformIDs())
+        self.assertEqual(other.getICCProfileName(), self.colorspace.getICCProfileName())
 
     def test_allocation(self):
         """
@@ -279,6 +285,9 @@ class ColorSpaceTest(unittest.TestCase):
         self.assertFalse(cs.isData())
         self.assertEqual(cs.getAllocation(), OCIO.ALLOCATION_UNIFORM)
         self.assertEqual(cs.getAllocationVars(), [])
+        self.assertEqual(cs.getInteropID(), '')
+        self.assertEqual(cs.getAMFTransformIDs(), '')
+        self.assertEqual(cs.getICCProfileName(), '')
 
     def test_data(self):
         """
@@ -632,9 +641,138 @@ colorspaces:
         test_display_referred(self, cfg, "scene_linear-trans-alias", False)
         test_display_referred(self, cfg, "scene_ref", False)
         
+    def test_interop_id(self):
+        """
+        Test the setInteropID() and getInteropID() methods.
+        """
+        
+        # Test default value (should be empty).
+        self.assertEqual(self.colorspace.getInteropID(), '')
+        
+        # Test setting and getting a simple interop ID.
+        test_id = 'lin_ap0_scene'
+        self.colorspace.setInteropID(test_id)
+        self.assertEqual(self.colorspace.getInteropID(), test_id)
+        
+        # Test setting and getting a different interop ID.
+        test_id2 = 'srgb_ap1_scene'
+        self.colorspace.setInteropID(test_id2)
+        self.assertEqual(self.colorspace.getInteropID(), test_id2)
+        
+        # Test setting empty string.
+        self.colorspace.setInteropID('')
+        self.assertEqual(self.colorspace.getInteropID(), '')
+        
+        # Test setting None (should convert to empty string).
+        self.colorspace.setInteropID('something')
+        self.colorspace.setInteropID(None)
+        self.assertEqual(self.colorspace.getInteropID(), '')
+        
+        # Test wrong type (should raise TypeError).
+        with self.assertRaises(TypeError):
+            self.colorspace.setInteropID(123)
+        
+        with self.assertRaises(TypeError):
+            self.colorspace.setInteropID(['list'])
+
+    def test_amf_transform_ids(self):
+        """
+        Test the setAMFTransformIDs() and getAMFTransformIDs() methods.
+        """
+        
+        # Test default value (should be empty).
+        self.assertEqual(self.colorspace.getAMFTransformIDs(), '')
+        
+        # Test setting and getting a single transform ID.
+        single_id = 'urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CG_to_ACES.a1.0.3'
+        self.colorspace.setAMFTransformIDs(single_id)
+        self.assertEqual(self.colorspace.getAMFTransformIDs(), single_id)
+        
+        # Test setting and getting multiple transform IDs (newline-separated).
+        multiple_ids = ('urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.CG_to_ACES.a1.0.3\n'
+                       'urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_CG.a1.0.3\n'
+                       'urn:ampas:aces:transformId:v1.5:RRT.a1.0.3')
+        self.colorspace.setAMFTransformIDs(multiple_ids)
+        self.assertEqual(self.colorspace.getAMFTransformIDs(), multiple_ids)
+        
+        # Test setting empty string.
+        self.colorspace.setAMFTransformIDs('')
+        self.assertEqual(self.colorspace.getAMFTransformIDs(), '')
+        
+        # Test setting None (should convert to empty string).
+        self.colorspace.setAMFTransformIDs('something')
+        self.colorspace.setAMFTransformIDs(None)
+        self.assertEqual(self.colorspace.getAMFTransformIDs(), '')
+        
+        # Test with different line endings.
+        mixed_endings = 'id1\nid2\rid3\r\nid4'
+        self.colorspace.setAMFTransformIDs(mixed_endings)
+        self.assertEqual(self.colorspace.getAMFTransformIDs(), mixed_endings)
+        
+        # Test with leading/trailing whitespace.
+        whitespace_ids = '  \n  id1  \n  id2  \n  '
+        self.colorspace.setAMFTransformIDs(whitespace_ids)
+        self.assertEqual(self.colorspace.getAMFTransformIDs(), whitespace_ids)
+        
+        # Test wrong type (should raise TypeError).
+        with self.assertRaises(TypeError):
+            self.colorspace.setAMFTransformIDs(123)
+        
+        with self.assertRaises(TypeError):
+            self.colorspace.setAMFTransformIDs(['list', 'of', 'ids'])
+
+    def test_icc_profile_name(self):
+        """
+        Test the setICCProfileName() and getICCProfileName() methods.
+        """
+        
+        # Test default value (should be empty).
+        self.assertEqual(self.colorspace.getICCProfileName(), '')
+        
+        # Test setting and getting a simple profile name.
+        profile_name = 'sRGB IEC61966-2.1'
+        self.colorspace.setICCProfileName(profile_name)
+        self.assertEqual(self.colorspace.getICCProfileName(), profile_name)
+        
+        # Test setting and getting a different profile name.
+        profile_name2 = 'Adobe RGB (1998)'
+        self.colorspace.setICCProfileName(profile_name2)
+        self.assertEqual(self.colorspace.getICCProfileName(), profile_name2)
+        
+        # Test with a more complex profile name.
+        complex_name = 'Display P3 - Apple Cinema Display (Calibrated 2023-01-15)'
+        self.colorspace.setICCProfileName(complex_name)
+        self.assertEqual(self.colorspace.getICCProfileName(), complex_name)
+
+        # Test setting empty string.
+        self.colorspace.setICCProfileName('')
+        self.assertEqual(self.colorspace.getICCProfileName(), '')
+        
+        # Test setting None (should convert to empty string).
+        self.colorspace.setICCProfileName('something')
+        self.colorspace.setICCProfileName(None)
+        self.assertEqual(self.colorspace.getICCProfileName(), '')
+        
+        # Test with special characters and numbers.
+        special_name = 'ProPhoto RGB v2.0 (γ=1.8) [Custom Profile #123]'
+        self.colorspace.setICCProfileName(special_name)
+        self.assertEqual(self.colorspace.getICCProfileName(), special_name)
+        
+        # Test with Unicode characters.
+        unicode_name = 'Профиль RGB γ=2.2'
+        self.colorspace.setICCProfileName(unicode_name)
+        self.assertEqual(self.colorspace.getICCProfileName(), unicode_name)
+        
+        # Test wrong type (should raise TypeError).
+        with self.assertRaises(TypeError):
+            self.colorspace.setICCProfileName(123)
+        
+        with self.assertRaises(TypeError):
+            self.colorspace.setICCProfileName(['profile', 'name'])
+
     def test_processor_to_known_colorspace(self):
         
-        CONFIG = """ocio_profile_version: 2
+        CONFIG = """ocio_profile_version: 2.5
 
 roles:
   default: raw
@@ -690,12 +828,14 @@ colorspaces:
   - !<ColorSpace>
     name: ACES cg
     description: An ACEScg space with an unusual spelling.
+    interop_id: lin_ap1_scene
     isdata: false
     to_scene_reference: !<BuiltinTransform> {style: ACEScg_to_ACES2065-1}
 
   - !<ColorSpace>
     name: Linear ITU-R BT.709
     description: A linear Rec.709 space with an unusual spelling.
+    interop_id: lin_rec709_scene
     isdata: false
     from_scene_reference: !<GroupTransform>
       name: AP0 to Linear Rec.709 (sRGB)


### PR DESCRIPTION
- Addressing the issues #1975, #2152 and #2153
- Bumped the config version to 2.5
- newly added attributes require v2.5 config both for serialization and de-serialization and will throw if they appear in older configs.
- Hardened multiple existing functions against null parameters. Previously those functions were crashing if null is passed, as assigning null to std::string is undefined behavior.
- Expanded tests to some affected functions' unit tests to include null passing. Setters will take null as empty string. compare functions will throw.