### PR TITLE
Adsk Contrib - Add the ability to serialize temporary displays

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -1136,6 +1136,11 @@ public:
      * intended to be temporary (i.e. for the current session) and are not saved to a config file.
      */
     bool isDisplayTemporary(int index) const noexcept;
+    /**
+     * Allows setting the flag that controls whether a display is temporary. This may be helpful,
+     * for example, to share a config with a temporary instantiated display with an OFX plug-in.
+     */
+    void setDisplayTemporary(int index, bool isTemporary) noexcept;
 
     /**
      * Get either the shared or display-defined views for a display. The

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -4170,6 +4170,18 @@ bool Config::isDisplayTemporary(int index) const noexcept
     return false;
 }
 
+void Config::setDisplayTemporary(int index, bool isTemporary) noexcept
+{
+    if (index >= 0 || index < static_cast<int>(getImpl()->m_displays.size()))
+    {
+        getImpl()->m_displays[index].second.m_temporary = isTemporary;
+
+        getImpl()->m_displayCache.clear();
+        AutoMutex lock(getImpl()->m_cacheidMutex);
+        getImpl()->resetCacheIDs();
+    }
+}
+
 int Config::getNumViews(ViewType type, const char * display) const
 {
     if (!display || !*display)

--- a/src/bindings/python/PyConfig.cpp
+++ b/src/bindings/python/PyConfig.cpp
@@ -552,6 +552,18 @@ void bindPyConfig(py::module & m)
                  return false;
              },
              "display"_a)
+        .def("setDisplayTemporary", [](ConfigRcPtr & self, const std::string & display, bool isTemporary)
+             {
+                 for (int i = 0; i < self->getNumDisplaysAll(); i++)
+                 {
+                     std::string other(self->getDisplayAll(i));
+                     if (StringUtils::Compare(display, other))
+                     {
+                         self->setDisplayTemporary(i, isTemporary);
+                     }
+                 }
+             },
+             "display"_a, "isTemporary"_a)
         .def_static("AreVirtualViewsEqual", [](const ConstConfigRcPtr & first,
                                                const ConstConfigRcPtr & second,
                                                const char * viewName)

--- a/tests/python/ConfigTest.py
+++ b/tests/python/ConfigTest.py
@@ -1590,3 +1590,12 @@ class ConfigVirtualDisplayTest(unittest.TestCase):
                          "Display 'virtual_display' has a view 'Raw1' that " +
                          "refers to a color space or a named transform, " +
                          "'raw1', which is not defined.")
+
+    def test_temporary_display(self):
+        """
+        Test the ability to get and set the temporary display status.
+        """
+
+        self.assertFalse(self.cfg.isDisplayTemporary('sRGB'))
+        self.cfg.setDisplayTemporary('sRGB', True)
+        self.assertTrue(self.cfg.isDisplayTemporary('sRGB'))


### PR DESCRIPTION
When a new display is instantiated from a virtual display (for ICC profile support), the display is marked "temporary" so that it is not written if the config is serialized. This is because displays from ICC profiles are typically specific to a given workstation at a particular point in time and should not be made available for use by others.

However, now that OpenFX has OCIO support, a host application may need to serialize a config to share it with a plug-in and in this specialized situation it does make sense to serialize displays from ICC profiles.

To do this, pass "false" to the new setDisplayTemporary function on the Config class and the display, and its associated display color space, will be serialized.

The new function requires the integer index for the display. If this is not known, you may either iterate over the displays calling Config::isDisplayTemporary, or search for the index for a display name using:
`int idx = config->getDisplayAllByName(displayName);`