### PR TITLE
Fixes for the Wheel workflow

### DIFF
--- a/.github/workflows/wheel_workflow.yml
+++ b/.github/workflows/wheel_workflow.yml
@@ -386,8 +386,7 @@ jobs:
 
 
   upload_pypi:
-#    needs: [sdist, linux, macos, macos-arm, windows]
-    needs: [sdist, linux-arm, macos, macos-arm, windows]
+    needs: [sdist, linux, linux-arm, macos, macos-arm, windows]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:

--- a/share/cmake/modules/FindExtPackages.cmake
+++ b/share/cmake/modules/FindExtPackages.cmake
@@ -184,7 +184,6 @@ if(OCIO_BUILD_PYTHON OR OCIO_BUILD_DOCS)
 endif()
 
 # Set OpenEXR Minimum version as a variable since it it used at multiple places.
-# set(OpenEXR_MININUM_VERSION "3.0.5")
 set(OpenEXR_MININUM_VERSION "3.1.6")
 if((OCIO_BUILD_APPS AND OCIO_USE_OIIO_FOR_APPS) OR OCIO_BUILD_TESTS)
     # OpenImageIO is required for OSL unit test and optional for apps.


### PR DESCRIPTION
1. Huge thanks to Zach for figuring out the Mac problem. For now, I'm using his brew-uninstall technique.
2. The Linux x86 problem seems to be that it was trying to compile OpenEXR 3.1.5 and the runner now seems to be using a version of GCC that needs an extra include file. This was not fixed on the OpenEXR side until 3.1.6.