### PR TITLE
Adsk Contrib - Adding interchange attributes to ViewTransforms and Looks

### DIFF
--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -2044,7 +2044,7 @@ public:
      *
      * Currently supported attribute names are "amf_transform_ids" and
      * "icc_profile_name". Using any other name will throw. If the attribute is
-     * not defined, it'll return an empty string. Setting the value to an empty
+     * not defined, it will return an empty string. Setting the value to an empty
      * string will effectively delete the attribute.
      *
      * The AMF transform IDs are used to identify specific transforms in the
@@ -2411,7 +2411,7 @@ public:
     * Get/Set the interchange attributes.
     *
     * Currently the only supported attribute name is "amf_transform_ids". Using
-    * any other name will throw. If the attribute is not defined, it'll return
+    * any other name will throw. If the attribute is not defined, it will return
     * an empty string. Setting the value to an empty string will effectively
     * delete the attribute.
     *
@@ -2562,7 +2562,7 @@ public:
     * Get/Set the interchange attributes.
     *
     * Currently the only supported attribute name is "amf_transform_ids". Using
-    * any other name will throw. If the attribute is not defined, it'll return
+    * any other name will throw. If the attribute is not defined, it will return
     * an empty string. Setting the value to an empty string will effectively
     * delete the attribute.
     *

--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -2407,6 +2407,22 @@ public:
     const char * getDescription() const;
     void setDescription(const char * description);
 
+    /**
+    * Get/Set the interchange attributes.
+    *
+    * Currently the only supported attribute name is "amf_transform_ids". Using
+    * any other name will throw. If the attribute is not defined, it'll return
+    * an empty string. Setting the value to an empty string will effectively
+    * delete the attribute.
+    *
+    * The AMF transform IDs are used to identify specific transforms in the ACES
+    * Metadata File. Multiple transform IDs can be specified in a
+    * newline-separated string.
+    */
+    const char *getInterchangeAttribute(const char *attrName) const;
+    void setInterchangeAttribute(const char* attrName, const char *value);
+    std::map<std::string, std::string> getInterchangeAttributes() const noexcept;
+
     Look(const Look &) = delete;
     Look& operator= (const Look &) = delete;
     /// Do not use (needed only for pybind11).
@@ -2541,6 +2557,22 @@ public:
 
     const char * getDescription() const noexcept;
     void setDescription(const char * description);
+
+    /**
+    * Get/Set the interchange attributes.
+    *
+    * Currently the only supported attribute name is "amf_transform_ids". Using
+    * any other name will throw. If the attribute is not defined, it'll return
+    * an empty string. Setting the value to an empty string will effectively
+    * delete the attribute.
+    *
+    * The AMF transform IDs are used to identify specific transforms in the ACES
+    * Metadata File. Multiple transform IDs can be specified in a
+    * newline-separated string.
+    */
+    const char *getInterchangeAttribute(const char *attrName) const;
+    void setInterchangeAttribute(const char* attrName, const char *value);
+    std::map<std::string, std::string> getInterchangeAttributes() const noexcept;
 
     /// \see ColorSpace::hasCategory
     bool hasCategory(const char * category) const;

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -5904,6 +5904,38 @@ void Config::Impl::checkVersionConsistency() const
         throw Exception("Only version 2 (or higher) can have ViewTransforms.");
     }
 
+    // Check for new ViewTransform properties.
+
+    if (hexVersion < 0x02050000) 
+    {
+        for (const auto& vt : m_viewTransforms)
+        {
+            if (vt->getInterchangeAttributes().size()>0)
+            {
+                std::ostringstream os;
+                os << "Config failed validation. The view transform '" << vt->getName() << "' ";
+                os << "has non-empty interchange attributes and config version is less than 2.5.";
+                throw Exception(os.str().c_str());
+            }
+        }
+    }
+
+    // Check for new Look properties.
+
+    if (hexVersion < 0x02050000) 
+    {
+        for (const auto& look : m_looksList)
+        {
+            if (look->getInterchangeAttributes().size()>0)
+            {
+                std::ostringstream os;
+                os << "Config failed validation. The look '" << look->getName() << "' ";
+                os << "has non-empty interchange attributes and config version is less than 2.5.";
+                throw Exception(os.str().c_str());
+            }
+        }
+    }
+
     // Check for the NamedTransforms.
 
     if (m_majorVersion < 2 && m_allNamedTransforms.size() != 0)

--- a/src/OpenColorIO/Look.cpp
+++ b/src/OpenColorIO/Look.cpp
@@ -9,7 +9,13 @@
 #include <OpenColorIO/OpenColorIO.h>
 
 #include "ContextVariableUtils.h"
+#include "utils/StringUtils.h"
 
+namespace
+{
+const std::array<const std::string, 1> knownInterchangeNames = {
+    "amf_transform_ids" };
+}
 
 namespace OCIO_NAMESPACE
 {
@@ -29,6 +35,7 @@ public:
     std::string m_name;
     std::string m_processSpace;
     std::string m_description;
+    std::map<std::string, std::string> m_interchangeAttribs;
     TransformRcPtr m_transform;
     TransformRcPtr m_inverseTransform;
 
@@ -47,6 +54,8 @@ public:
             m_name = rhs.m_name;
             m_processSpace = rhs.m_processSpace;
             m_description = rhs.m_description;
+
+            m_interchangeAttribs = rhs.m_interchangeAttribs;
 
             m_transform = rhs.m_transform?
                 rhs.m_transform->createEditableCopy() : rhs.m_transform;
@@ -128,6 +137,63 @@ void Look::setDescription(const char * description)
 {
     getImpl()->m_description = description ? description : "";
 }
+
+const char * Look::getInterchangeAttribute(const char* attrName) const
+{
+    std::string name = attrName ? attrName : "";
+
+    for (auto& key : knownInterchangeNames)
+    {
+        // do case-insensitive comparison.
+        if (StringUtils::Compare(key, name))
+        {
+            auto it = m_impl->m_interchangeAttribs.find(key);
+            if (it != m_impl->m_interchangeAttribs.end())
+            {
+                return it->second.c_str();
+            }
+            return "";
+        }
+    }
+
+    std::ostringstream oss;
+    oss << "Unknown attribute name '" << name << "'.";
+    throw Exception(oss.str().c_str());
+}
+
+void Look::setInterchangeAttribute(const char* attrName, const char* value)
+{
+    std::string name = attrName ? attrName : "";
+
+    for (auto& key : knownInterchangeNames)
+    {
+        // Do case-insensitive comparison.
+        if (StringUtils::Compare(key, name))
+        {
+            // use key instead of name for storing in correct capitalization.
+            if (!value || !*value)
+            {
+                m_impl->m_interchangeAttribs.erase(key);
+            } 
+            else
+            {
+                m_impl->m_interchangeAttribs[key] = value;
+            }
+            return;
+        }
+    }
+
+    std::ostringstream oss;
+    oss << "Unknown attribute name '" << name << "'.";
+    throw Exception(oss.str().c_str());
+}
+
+std::map<std::string, std::string> Look::getInterchangeAttributes() const noexcept
+{
+    return m_impl->m_interchangeAttribs;
+}
+
+
 
 bool CollectContextVariables(const Config & config,
                              const Context & context,
@@ -214,6 +280,11 @@ std::ostream& operator<< (std::ostream& os, const Look& look)
     if (!desc.empty())
     {
         os << ", description=" << desc;
+    }
+
+    for (const auto& attr : look.getInterchangeAttributes())
+    {
+        os << ", " << attr.first << "=" << attr.second;
     }
 
     if(look.getTransform())

--- a/src/OpenColorIO/Look.cpp
+++ b/src/OpenColorIO/Look.cpp
@@ -170,7 +170,7 @@ void Look::setInterchangeAttribute(const char* attrName, const char* value)
         // Do case-insensitive comparison.
         if (StringUtils::Compare(key, name))
         {
-            // use key instead of name for storing in correct capitalization.
+            // Use key instead of name for storing in correct capitalization.
             if (!value || !*value)
             {
                 m_impl->m_interchangeAttribs.erase(key);

--- a/src/OpenColorIO/ViewTransform.cpp
+++ b/src/OpenColorIO/ViewTransform.cpp
@@ -154,7 +154,7 @@ void ViewTransform::setInterchangeAttribute(const char* attrName, const char* va
         // Do case-insensitive comparison.
         if (StringUtils::Compare(key, name))
         {
-            // use key instead of name for storing in correct capitalization.
+            // Use key instead of name for storing in correct capitalization.
             if (!value || !*value)
             {
                 m_impl->m_interchangeAttribs.erase(key);

--- a/src/OpenColorIO/ViewTransform.cpp
+++ b/src/OpenColorIO/ViewTransform.cpp
@@ -7,6 +7,12 @@
 
 #include "TokensManager.h"
 
+namespace
+{
+const std::array<const std::string, 1> knownInterchangeNames = {
+    "amf_transform_ids" };
+}
+
 namespace OCIO_NAMESPACE
 {
 
@@ -17,6 +23,7 @@ public:
     std::string m_family;
     std::string m_description;
     ReferenceSpaceType m_referenceSpaceType{ REFERENCE_SPACE_SCENE };
+    std::map<std::string, std::string> m_interchangeAttribs;
 
     TransformRcPtr m_toRefTransform;
     TransformRcPtr m_fromRefTransform;
@@ -41,6 +48,7 @@ public:
             m_description = rhs.m_description;
 
             m_referenceSpaceType = rhs.m_referenceSpaceType;
+            m_interchangeAttribs = rhs.m_interchangeAttribs;
 
             m_toRefTransform = rhs.m_toRefTransform ? rhs.m_toRefTransform->createEditableCopy() :
                                                       rhs.m_toRefTransform;
@@ -113,6 +121,62 @@ void ViewTransform::setDescription(const char * description)
 {
     getImpl()->m_description = description ? description : "";
 }
+
+const char * ViewTransform::getInterchangeAttribute(const char* attrName) const
+{
+    std::string name = attrName ? attrName : "";
+
+    for (auto& key : knownInterchangeNames)
+    {
+        // do case-insensitive comparison.
+        if (StringUtils::Compare(key, name))
+        {
+            auto it = m_impl->m_interchangeAttribs.find(key);
+            if (it != m_impl->m_interchangeAttribs.end())
+            {
+                return it->second.c_str();
+            }
+            return "";
+        }
+    }
+
+    std::ostringstream oss;
+    oss << "Unknown attribute name '" << name << "'.";
+    throw Exception(oss.str().c_str());
+}
+
+void ViewTransform::setInterchangeAttribute(const char* attrName, const char* value)
+{
+    std::string name = attrName ? attrName : "";
+
+    for (auto& key : knownInterchangeNames)
+    {
+        // Do case-insensitive comparison.
+        if (StringUtils::Compare(key, name))
+        {
+            // use key instead of name for storing in correct capitalization.
+            if (!value || !*value)
+            {
+                m_impl->m_interchangeAttribs.erase(key);
+            } 
+            else
+            {
+                m_impl->m_interchangeAttribs[key] = value;
+            }
+            return;
+        }
+    }
+
+    std::ostringstream oss;
+    oss << "Unknown attribute name '" << name << "'.";
+    throw Exception(oss.str().c_str());
+}
+
+std::map<std::string, std::string> ViewTransform::getInterchangeAttributes() const noexcept
+{
+    return m_impl->m_interchangeAttribs;
+}
+
 
 bool ViewTransform::hasCategory(const char * category) const
 {
@@ -210,6 +274,12 @@ std::ostream & operator<< (std::ostream & os, const ViewTransform & vt)
     {
         os << ", description=" << desc;
     }
+
+    for (const auto& attr : vt.getInterchangeAttributes())
+    {
+        os << ", " << attr.first << "=" << attr.second;
+    }
+
     if (vt.getTransform(VIEWTRANSFORM_DIR_TO_REFERENCE))
     {
         os << ",\n    " << vt.getName() << " --> Reference";

--- a/src/bindings/python/PyLook.cpp
+++ b/src/bindings/python/PyLook.cpp
@@ -63,7 +63,13 @@ void bindPyLook(py::module & m)
         .def("getDescription", &Look::getDescription, 
              DOC(Look, getDescription))
         .def("setDescription", &Look::setDescription, "description"_a.none(false), 
-             DOC(Look, setDescription));
+             DOC(Look, setDescription))
+        .def("getInterchangeAttribute", &Look::getInterchangeAttribute, "attrName"_a,
+             DOC(Look, getInterchangeAttribute))
+        .def("setInterchangeAttribute", &Look::setInterchangeAttribute, "attrName"_a, "attrValue"_a,
+            DOC(Look, setInterchangeAttribute))
+        .def("getInterchangeAttributes", &Look:: getInterchangeAttributes,
+            DOC(Look, getInterchangeAttributes));
 
     defRepr(clsLook);
 }

--- a/src/bindings/python/PyViewTransform.cpp
+++ b/src/bindings/python/PyViewTransform.cpp
@@ -105,6 +105,12 @@ void bindPyViewTransform(py::module & m)
              DOC(ViewTransform, getDescription))
         .def("setDescription", &ViewTransform::setDescription, "description"_a,
              DOC(ViewTransform, setDescription))
+        .def("getInterchangeAttribute", &ViewTransform::getInterchangeAttribute, "attrName"_a,
+             DOC(ViewTransform, getInterchangeAttribute))
+        .def("setInterchangeAttribute", &ViewTransform::setInterchangeAttribute, "attrName"_a, "attrValue"_a,
+            DOC(ViewTransform, setInterchangeAttribute))
+        .def("getInterchangeAttributes", &ViewTransform:: getInterchangeAttributes,
+            DOC(ViewTransform, getInterchangeAttributes))
         .def("hasCategory", &ViewTransform::hasCategory, "category"_a,
              DOC(ViewTransform, hasCategory))
         .def("addCategory", &ViewTransform::addCategory, "category"_a,

--- a/tests/cpu/ColorSpace_tests.cpp
+++ b/tests/cpu/ColorSpace_tests.cpp
@@ -1127,57 +1127,6 @@ OCIO_ADD_TEST(ColorSpace, amf_transform_ids)
     OCIO_CHECK_EQUAL(std::string(copy->getInterchangeAttribute("amf_transform_ids")), singleID);
 }
 
-OCIO_ADD_TEST(ColorSpace, amf_transform_ids_serialization)
-{
-    // Test YAML serialization and deserialization of AmfTransformIDs.
-    auto cfg = OCIO::Config::Create();
-    auto cs = OCIO::ColorSpace::Create();
-    cs->setName("test_colorspace");
-    
-    const std::string amfIDs = 
-        "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScc_to_ACES.a1.0.3\n"
-        "urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACES_to_ACEScc.a1.0.3";
-    
-    cs->setInterchangeAttribute("amf_transform_ids", amfIDs.c_str());
-    cfg->addColorSpace(cs);
-
-    // Serialize the Config.
-    std::stringstream ss;
-    cfg->serialize(ss);
-    std::string yamlStr = ss.str();
-
-    // Verify AmfTransformIDs appears in YAML.
-    OCIO_CHECK_NE(yamlStr.find("amf_transform_ids"), std::string::npos);
-    OCIO_CHECK_NE(yamlStr.find("ACEScsc.Academy.ACEScc_to_ACES"), std::string::npos);
-
-    // Deserialize and verify.
-    std::istringstream iss(yamlStr);
-    OCIO::ConstConfigRcPtr deserializedCfg;
-    OCIO_CHECK_NO_THROW(deserializedCfg = OCIO::Config::CreateFromStream(iss));
-
-    // Verify AmfTransformIDs is preserved.
-    OCIO::ConstColorSpaceRcPtr deserializedCs = deserializedCfg->getColorSpace("test_colorspace");
-    auto deserializedIDs = deserializedCs->getInterchangeAttribute("amf_transform_ids");
-    OCIO_CHECK_EQUAL(deserializedIDs, amfIDs);
-
-    // Verify that that earlier versions reject amf_transform_ids.
-    OCIO::ConfigRcPtr cfgCopy = cfg->createEditableCopy();
-    cfgCopy->setVersion(2,4);
-    OCIO_CHECK_THROW_WHAT(cfgCopy->serialize(ss),
-        OCIO::Exception,
-        "has non-empty interchange attributes and config version is less than 2.5.");
-
-    // Test with empty AmfTransformIDs (should not appear in YAML).
-    cs->setInterchangeAttribute("amf_transform_ids", nullptr);
-    cfg->addColorSpace(cs); // Replace the existing CS.
-    ss.str("");
-    cfg->serialize(ss);
-    std::string yamlStr2 = ss.str();
-
-    // Verify empty AmfTransformIDs does not appear in YAML.
-    OCIO_CHECK_EQUAL(yamlStr2.find("amf_transform_ids"), std::string::npos);
-}
-
 OCIO_ADD_TEST(ColorSpace, icc_profile_name)
 {
     OCIO::ColorSpaceRcPtr cs = OCIO::ColorSpace::Create();

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -10200,7 +10200,7 @@ view_transforms:
         OCIO_CHECK_THROW_WHAT(
             config->validate(),
             OCIO::Exception,
-            "Config failed validation. The ViewTransform 'vt1' has non-empty "
+            "Config failed validation. The view transform 'vt1' has non-empty "
             "interchange attributes and config version is less than 2.5.");
 
         // Remove the attribute and check that the config can be downgraded to 2.4.
@@ -10248,7 +10248,7 @@ view_transforms:
         OCIO_CHECK_THROW_WHAT(
             config->validate(),
             OCIO::Exception,
-            "Config failed validation. The Look 'beauty' has non-empty "
+            "Config failed validation. The look 'beauty' has non-empty "
             "interchange attributes and config version is less than 2.5.");
 
         // Remove the attribute and check that the config can be downgraded to 2.4.

--- a/tests/cpu/Config_tests.cpp
+++ b/tests/cpu/Config_tests.cpp
@@ -10093,3 +10093,173 @@ OCIO_ADD_TEST(Config, set_config_io_proxy)
         OCIO::ClearAllCaches();
     }
 }
+
+OCIO_ADD_TEST(Config, interchange_attributes)
+{
+    std::string END = {R"(
+view_transforms:
+  - !<ViewTransform>
+    name: vt1
+    from_scene_reference: !<RangeTransform> {min_in_value: 0., min_out_value: 0.})"};
+
+    const std::string str = PROFILE_START_V<2, 5>() + END;
+
+    std::istringstream is;
+    is.str(str);
+
+    OCIO::ConfigRcPtr config;
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is)->createEditableCopy());
+    OCIO_REQUIRE_ASSERT(config);
+    OCIO_CHECK_NO_THROW(config->validate());
+
+    // Color Space
+
+    {
+        auto cs = config->getColorSpace("log")->createEditableCopy();
+        OCIO_REQUIRE_ASSERT(cs);
+
+        // Set amf_transform_ids attribute and validate.
+
+        OCIO_CHECK_NO_THROW(cs->setInterchangeAttribute("amf_transform_ids", "sample amf id"));
+        config->addColorSpace(cs);
+        OCIO_CHECK_NO_THROW(config->validate());
+
+        // Check that the attribute is in the serialized config.
+
+        std::stringstream ss;
+        config->serialize(ss);
+        auto cstrout = ss.str();
+        OCIO_CHECK_ASSERT(cstrout.find("amf_transform_ids: sample amf id") != std::string::npos);
+
+        // Check that loading the serialized config works with the attribute.
+
+        OCIO::ConstConfigRcPtr cfg2;
+        OCIO_CHECK_NO_THROW(cfg2 = OCIO::Config::CreateFromStream(ss));
+
+        OCIO::ConstColorSpaceRcPtr cs2;
+        OCIO_CHECK_NO_THROW(cs2 = config->getColorSpace("log"));
+        OCIO_CHECK_EQUAL(cs2->getInterchangeAttribute("amf_transform_ids"), std::string("sample amf id"));
+
+        // Check that the config can NOT be downgraded to 2.4 with the attribute.
+
+        config->setVersion(2, 4);
+        OCIO_CHECK_THROW_WHAT(
+            config->validate(),
+            OCIO::Exception,
+            "Config failed validation. The color space 'log' has non-empty "
+            "interchange attributes and config version is less than 2.5.");
+
+        // Remove the attribute and check that the config can be downgraded to 2.4.
+
+        OCIO_CHECK_NO_THROW(cs->setInterchangeAttribute("amf_transform_ids", ""));
+        config->addColorSpace(cs);
+        OCIO_CHECK_NO_THROW(config->validate());
+
+        // Restore version 2.5.
+
+        config->setVersion(2, 5);
+    }
+
+    // View Transform
+
+    {
+        auto vt = config->getViewTransform("vt1")->createEditableCopy();
+        OCIO_REQUIRE_ASSERT(vt);
+
+        // Set amf_transform_ids attribute and validate.
+
+        OCIO_CHECK_NO_THROW(vt->setInterchangeAttribute("amf_transform_ids", "sample amf id"));
+        config->addViewTransform(vt);
+        OCIO_CHECK_NO_THROW(config->validate());
+
+        // Setting the icc_profile_name attribute should throw.
+        OCIO_CHECK_THROW_WHAT(
+            vt->setInterchangeAttribute("icc_profile_name", "some icc profile"),
+            OCIO::Exception,
+            "Unknown attribute name 'icc_profile_name'.");
+
+        // Check that the attribute is in the serialized config.
+
+        std::stringstream ss;
+        config->serialize(ss);
+        auto cstrout = ss.str();
+        OCIO_CHECK_ASSERT(cstrout.find("amf_transform_ids: sample amf id") != std::string::npos);
+
+        // Check that loading the serialized config works with the attribute.
+
+        OCIO::ConstConfigRcPtr cfg2;
+        OCIO_CHECK_NO_THROW(cfg2 = OCIO::Config::CreateFromStream(ss));
+
+        OCIO::ConstViewTransformRcPtr vt2;
+        OCIO_CHECK_NO_THROW(vt2 = config->getViewTransform("vt1"));
+        OCIO_CHECK_EQUAL(vt2->getInterchangeAttribute("amf_transform_ids"), std::string("sample amf id"));
+
+        // Check that the config can NOT be downgraded to 2.4 with the attribute.
+
+        config->setVersion(2, 4);
+        OCIO_CHECK_THROW_WHAT(
+            config->validate(),
+            OCIO::Exception,
+            "Config failed validation. The ViewTransform 'vt1' has non-empty "
+            "interchange attributes and config version is less than 2.5.");
+
+        // Remove the attribute and check that the config can be downgraded to 2.4.
+
+        OCIO_CHECK_NO_THROW(vt->setInterchangeAttribute("amf_transform_ids", ""));
+        config->addViewTransform(vt);
+        OCIO_CHECK_NO_THROW(config->validate());
+
+        // Restore version 2.5.
+
+        config->setVersion(2, 5);
+    }
+
+    // Look
+
+    {
+        auto lk = config->getLook("beauty")->createEditableCopy();
+        OCIO_REQUIRE_ASSERT(lk);
+
+        // Set amf_transform_ids attribute and validate.
+
+        OCIO_CHECK_NO_THROW(lk->setInterchangeAttribute("amf_transform_ids", "sample amf id"));
+        config->addLook(lk);
+        OCIO_CHECK_NO_THROW(config->validate());
+
+        // Check that the attribute is in the serialized config.
+
+        std::stringstream ss;
+        config->serialize(ss);
+        auto cstrout = ss.str();
+        OCIO_CHECK_ASSERT(cstrout.find("amf_transform_ids: sample amf id") != std::string::npos);
+
+        // Check that loading the serialized config works with the attribute.
+
+        OCIO::ConstConfigRcPtr cfg2;
+        OCIO_CHECK_NO_THROW(cfg2 = OCIO::Config::CreateFromStream(ss));
+
+        OCIO::ConstLookRcPtr lk2;
+        OCIO_CHECK_NO_THROW(lk2 = config->getLook("beauty"));
+        OCIO_CHECK_EQUAL(lk2->getInterchangeAttribute("amf_transform_ids"), std::string("sample amf id"));
+
+        // Check that the config can NOT be downgraded to 2.4 with the attribute.
+
+        config->setVersion(2, 4);
+        OCIO_CHECK_THROW_WHAT(
+            config->validate(),
+            OCIO::Exception,
+            "Config failed validation. The Look 'beauty' has non-empty "
+            "interchange attributes and config version is less than 2.5.");
+
+        // Remove the attribute and check that the config can be downgraded to 2.4.
+
+        OCIO_CHECK_NO_THROW(lk->setInterchangeAttribute("amf_transform_ids", ""));
+        config->addLook(lk);
+        OCIO_CHECK_NO_THROW(config->validate());
+
+        // Restore version 2.5.
+
+        config->setVersion(2, 5);
+    }
+}
+

--- a/tests/cpu/ViewTransform_tests.cpp
+++ b/tests/cpu/ViewTransform_tests.cpp
@@ -18,6 +18,7 @@ OCIO_ADD_TEST(ViewTransform, basic)
     OCIO_CHECK_EQUAL(std::string(""), vt->getFamily());
     OCIO_CHECK_EQUAL(std::string(""), vt->getDescription());
     OCIO_CHECK_EQUAL(0, vt->getNumCategories());
+    OCIO_CHECK_EQUAL(std::string(""), vt->getInterchangeAttribute("amf_transform_ids"));
 
     vt->setName("name");
     OCIO_CHECK_EQUAL(std::string("name"), vt->getName());
@@ -25,6 +26,9 @@ OCIO_ADD_TEST(ViewTransform, basic)
     OCIO_CHECK_EQUAL(std::string("family"), vt->getFamily());
     vt->setDescription("description");
     OCIO_CHECK_EQUAL(std::string("description"), vt->getDescription());
+    vt->setInterchangeAttribute("amf_transform_ids", "amf_text");
+    OCIO_CHECK_EQUAL(std::string("amf_text"), vt->getInterchangeAttribute("amf_transform_ids"));
+    OCIO_CHECK_EQUAL(1, vt->getInterchangeAttributes().size());
 
     OCIO_CHECK_EQUAL(vt->getNumCategories(), 0);
 

--- a/tests/python/LookTest.py
+++ b/tests/python/LookTest.py
@@ -27,6 +27,7 @@ class LookTest(unittest.TestCase):
         self.look.setName('test name')
         self.look.setProcessSpace('test space')
         self.look.setDescription('test description')
+        self.look.setInterchangeAttribute('amf_transform_ids', 'test amf id')
         mat = OCIO.MatrixTransform()
         self.look.setTransform(mat)
         self.look.setInverseTransform(mat)
@@ -37,6 +38,9 @@ class LookTest(unittest.TestCase):
         self.assertEqual(other.getName(), self.look.getName())
         self.assertEqual(other.getProcessSpace(), self.look.getProcessSpace())
         self.assertEqual(other.getDescription(), self.look.getDescription())
+        self.assertEqual(
+            other.getInterchangeAttribute('amf_transform_ids'), 
+            self.look.getInterchangeAttribute('amf_transform_ids'))
         self.assertTrue(other.getTransform().equals(self.look.getTransform()))
         self.assertTrue(other.getInverseTransform().equals(self.look.getInverseTransform()))
 
@@ -90,6 +94,22 @@ class LookTest(unittest.TestCase):
         for invalid in (None, 1):
             with self.assertRaises(TypeError):
                 self.look.setDescription(invalid)
+
+    def test_interchangeAttribute(self):
+        """
+        Test the setInterchangeAttribute() and setInterchangeAttribute() methods.
+        """
+
+        # Default initialized description value is ""
+        self.assertEqual(self.look.getInterchangeAttribute('amf_transform_ids'), '')
+
+        self.look.setInterchangeAttribute('amf_transform_ids', 'sample amf')
+        self.assertEqual('sample amf', self.look.getInterchangeAttribute('amf_transform_ids'))
+        self.assertEqual(1, len(self.look.getInterchangeAttributes()))
+
+        # Wrong key tests.
+        with self.assertRaises(TypeError):
+            self.look.getInterchangeAttribute('icc_profile_ name', 'should be rejected')
 
     def test_transform(self):
         """

--- a/tests/python/ViewTransformTest.py
+++ b/tests/python/ViewTransformTest.py
@@ -70,7 +70,7 @@ class ViewTransformTest(unittest.TestCase):
         self.assertEqual(other.getDescription(), vt.getDescription())
         self.assertEqual(
             other.getInterchangeAttribute("amf_transform_ids"), 
-            other.getInterchangeAttribute("amf_transform_ids"))
+            vt.getInterchangeAttribute("amf_transform_ids"))
         self.assertTrue(other.getTransform(OCIO.VIEWTRANSFORM_DIR_TO_REFERENCE).equals(vt.getTransform(OCIO.VIEWTRANSFORM_DIR_TO_REFERENCE)))
         self.assertTrue(other.getTransform(OCIO.VIEWTRANSFORM_DIR_FROM_REFERENCE).equals(vt.getTransform(OCIO.VIEWTRANSFORM_DIR_FROM_REFERENCE)))
         self.assertEqual(list(other.getCategories()), list(vt.getCategories()))

--- a/tests/python/ViewTransformTest.py
+++ b/tests/python/ViewTransformTest.py
@@ -56,6 +56,7 @@ class ViewTransformTest(unittest.TestCase):
         vt.setName('test name')
         vt.setFamily('test family')
         vt.setDescription('test description')
+        vt.setInterchangeAttribute('amf_transform_ids', 'test amf id')
         mat = OCIO.MatrixTransform()
         vt.setTransform(mat, OCIO.VIEWTRANSFORM_DIR_TO_REFERENCE)
         vt.setTransform(direction=OCIO.VIEWTRANSFORM_DIR_FROM_REFERENCE, transform=mat)
@@ -67,6 +68,9 @@ class ViewTransformTest(unittest.TestCase):
         self.assertEqual(other.getName(), vt.getName())
         self.assertEqual(other.getFamily(), vt.getFamily())
         self.assertEqual(other.getDescription(), vt.getDescription())
+        self.assertEqual(
+            other.getInterchangeAttribute("amf_transform_ids"), 
+            other.getInterchangeAttribute("amf_transform_ids"))
         self.assertTrue(other.getTransform(OCIO.VIEWTRANSFORM_DIR_TO_REFERENCE).equals(vt.getTransform(OCIO.VIEWTRANSFORM_DIR_TO_REFERENCE)))
         self.assertTrue(other.getTransform(OCIO.VIEWTRANSFORM_DIR_FROM_REFERENCE).equals(vt.getTransform(OCIO.VIEWTRANSFORM_DIR_FROM_REFERENCE)))
         self.assertEqual(list(other.getCategories()), list(vt.getCategories()))
@@ -100,6 +104,24 @@ class ViewTransformTest(unittest.TestCase):
 
         vt.setDescription('test description')
         self.assertEqual(vt.getDescription(), 'test description')
+
+    def test_interchangeAttribute(self):
+        """
+        Test the setInterchangeAttribute() and setInterchangeAttribute() methods.
+        """
+        vt = OCIO.ViewTransform()
+
+        # Default initialized description value is ""
+        self.assertEqual(vt.getInterchangeAttribute('amf_transform_ids'), '')
+
+        vt.setInterchangeAttribute('amf_transform_ids', 'sample amf')
+        self.assertEqual('sample amf', vt.getInterchangeAttribute('amf_transform_ids'))
+        self.assertEqual(1, len(vt.getInterchangeAttributes()))
+
+        # Wrong key tests.
+        with self.assertRaises(TypeError):
+            vt.getInterchangeAttribute('icc_profile_ name', 'should be rejected')
+
 
     def test_transform(self):
         """


### PR DESCRIPTION
- Currently only the amf_transform_ids key is supported. That key is needed for ACES 2 built-in configs.