### PR TITLE
Add setStringVar to Context Object Python Bindings

### DIFF
--- a/src/bindings/python/PyContext.cpp
+++ b/src/bindings/python/PyContext.cpp
@@ -168,6 +168,8 @@ void bindPyContext(py::module & m)
             { 
                 return StringVarIterator(self); 
             })
+        .def("setStringVar", &Context::setStringVar, "name"_a, "value"_a, 
+             DOC(Context, setStringVar))
         .def("clearStringVars", &Context::clearStringVars, 
              DOC(Context, clearStringVars))
         .def("getEnvironmentMode", &Context::getEnvironmentMode, 

--- a/tests/python/ContextTest.py
+++ b/tests/python/ContextTest.py
@@ -47,6 +47,8 @@ class ContextTest(unittest.TestCase):
         cont['TEST1'] = 'foobar'
         self.assertEqual(len(cont), 2)
         self.assertEqual('/foo/foobar/bar', cont.resolveStringVar('/foo/${TEST1}/bar'))
+        cont.setStringVar('foo', 'bar')
+        self.assertEqual(len(cont), 3)
         cont.clearStringVars()
         self.assertEqual(len(cont), 0)
         self.assertEqual(OCIO.ENV_ENVIRONMENT_LOAD_PREDEFINED, cont.getEnvironmentMode())


### PR DESCRIPTION
`setStringVar` is missing from the python bindings. Its present in the [Java Bindings](https://github.com/AcademySoftwareFoundation/OpenColorIO/blob/main/src/bindings/java/org/OpenColorIO/Context.java#L20)

Without this method the user is required to use dictionary-style in Python. 
`context["foo"] = ["bar"]`

I've seen this current way catch quite a few people off guard, as they are expecting a method to set arbitrary Context Variables.

With this proposed change, a user can now also do:
`context.setStringVar("foo", "bar")`


