### PR TITLE
Findminizip-ng.cmake now fully handles library names without trailing…

### DIFF
--- a/share/cmake/modules/Findminizip-ng.cmake
+++ b/share/cmake/modules/Findminizip-ng.cmake
@@ -150,6 +150,13 @@ if(NOT OCIO_INSTALL_EXT_PACKAGES STREQUAL ALL)
                 lib64 lib 
         )
 
+        if (minizip-ng_LIBRARY)
+            cmake_path(GET minizip-ng_LIBRARY STEM _lib_stem)
+            if (_lib_stem STREQUAL "libminizip")
+                set(minizip_LIBRARY ${minizip-ng_LIBRARY})
+            endif()
+        endif()
+
         # Get version from header or pkg-config
         if(minizip-ng_INCLUDE_DIR)
             list(GET minizip-ng_INCLUDE_DIR 0 _minizip-ng_INCLUDE_DIR)


### PR DESCRIPTION
There was what looked to be an incomplete handoff between `Findminizip-ng.cmake` and the library `CMakeLists.txt` file, where there was mechanism to handle the case where a third-party installer had installed `minizip-ng` in such a way that neither headers nor library has a `-ng` suffix (and indeed, if you pull down the base `minizip-ng` from GitHub, it installs its products without suffixes).

Anyway, there was provision in the latter file to handle this case if a certain communication variable was set, but the `Findminizip-ng.cmake` module wasn't setting that module.

I'd very much welcome criticism from those who understand both `cmake` in general and the OCIO build system in particular as to whether this is a good way to handle the situation (which ... sometimes I wonder if I'm the only MacPorts user on the planet who uses ASWF tools), or whether some other approach would be more tasteful.

