### PR TITLE
Fix Windows Doxygen install script 

### DIFF
--- a/share/ci/scripts/windows/install_doxygen.sh
+++ b/share/ci/scripts/windows/install_doxygen.sh
@@ -10,7 +10,7 @@ DOXYGEN_LOCATION="$1"
 choco install jq
 
 # Get the URL of the latest zip package for Doxygen.
-url=$(curl -s 'https://api.github.com/repos/doxygen/doxygen/releases/latest' | jq -r '.assets[] | select(.name | test("doxygen-.*\.x64\.bin\.zip")) | .browser_download_url')
+url=$(curl -s 'https://api.github.com/repos/doxygen/doxygen/releases/latest' | jq -r '.assets[] | select(.name | test("doxygen-.*\\.x64\\.bin\\.zip")) | .browser_download_url')
 
 # Download the zip.
 mkdir $DOXYGEN_LOCATION


### PR DESCRIPTION
as Doxygen v1.16.0 changed the released zip name.