### PR TITLE
Add more info to the documentation overview page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,19 +36,52 @@ best leverage them.  We have an OCIO User Experience (UX) working group that is
 gradually working on more coverage.
 
 The documentation is a work-in-progress and we would love to have your help to 
-improve it!  An easy way to get involved is to join the #docs or #ux channel on 
+improve it!  An easy way to get involved is to join the #opencolorio channel on 
 :ref:`slack`.
+
+
+Roadmap
+=======
+
+The project attempts to maintain a roadmap to give the community insight into
+upcoming development. The items are grouped into "Now", "Next", and "Later" categories.
+"Now" indicates work that is currently in-progress. "Next" indicates work that is being
+planned for imminent development (meaning now would be a good time to provide your input).
+The roadmap is available `here. <https://roadmap.opencolorio.org>`_
 
 
 Community
 =========
+
+.. _meetings:
+
+Meetings
+********
+
+The OpenColorIO project has a Technical Steering Committee meeting on Zoom every two weeks
+at noon LA time. The Zoom link is available from the `OCIO Calendar. <https://calendar.opencolorio.org>`_
+
+There is a general working group and "office hours" meeting once a month in the same
+time slot. The Zoom link is available from the `OCIO Calendar. <https://calendar.opencolorio.org>`_
+
+These meetings are open to anyone!
+
+
+.. _slack:
+
+Slack
+*****
+
+Join us on the `ASWF Slack <https://academysoftwarefdn.slack.com/>`_ in the channels 
+`#opencolorio` and `#opencolor-configs`.
+
 
 .. _mailing_lists:
 
 Mailing Lists
 *************
 
-There are two mailing lists associated with OpenColorIO:
+Most of the conversation happens on Slack, but there are two mailing lists associated with OpenColorIO:
 
 `ocio-user <https://lists.aswf.io/g/ocio-user>`__\ ``@lists.aswf.io``
     For end users (artists, often) interested in OCIO profile design,
@@ -57,14 +90,40 @@ There are two mailing lists associated with OpenColorIO:
 `ocio-dev <https://lists.aswf.io/g/ocio-dev>`__\ ``@lists.aswf.io``
     For developers interested OCIO APIs, code integration, compilation, etc.
 
-.. _slack:
 
-Slack
-*****
+Related Projects
+================
 
-There is an OpenColorIO Slack workspace at: `<https://opencolorio.slack.com>`_.  
+.. _cif:
 
-New users may join the workspace from `here <http://slack.opencolorio.org/>`_.
+ASWF Color Interop Forum
+************************
+
+The CIF is an open, cross-project forum for discussing color interoperability across varying workflows 
+and standards. The aim isn’t necessarily to develop new standards, but rather to make recommendations 
+for how to improve color accuracy through the existing infrastructure. 
+
+Recommendations are published on the `ColorInterop GitHub. <https://github.com/AcademySoftwareFoundation/ColorInterop>`_
+
+The forum has a monthly Zoom meeting on Mondays at noon LA time, as posted on the 
+`OCIO Calendar. <https://calendar.opencolorio.org>`_
+
+Discussion happens in the `#color-interop-forum` channel on the ASWF Slack.
+
+
+.. _nano:
+
+NanoColor
+*********
+
+NanoColor is a collaboration between OpenUSD, MaterialX, and OpenColorIO to ensure that there 
+is interoperable and flexible color management among those projects and related projects in 
+the computer graphics world.
+
+The working group has a Zoom meeting every two weeks on Mondays at 1:00 pm LA time, as posted on the 
+`OCIO Calendar. <https://calendar.opencolorio.org>`_
+
+Discussion happens in the `#nanocolor` channel on the ASWF Slack.
 
 
 Search


### PR DESCRIPTION
Update the "Overview" landing page in the ReadTheDocs documentation to capture all the links we usually share in various presentations to encourage people to get involved in the project.