### PR TITLE
Fix linking to self-built deps on Windows + Clang

### DIFF
--- a/share/cmake/modules/install/InstallZLIB.cmake
+++ b/share/cmake/modules/install/InstallZLIB.cmake
@@ -53,8 +53,8 @@ if(NOT ZLIB_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAGE
 
     set(ZLIB_INCLUDE_DIRS "${_EXT_DIST_ROOT}/${CMAKE_INSTALL_INCLUDEDIR}")
 
-    # Windows need the "d" suffix at the end.
-    if(WIN32 AND BUILD_TYPE_DEBUG)
+    # Windows need the "d" suffix at the end (only for MSVC).
+    if(MSVC AND BUILD_TYPE_DEBUG)
         set(_ZLIB_LIB_SUFFIX "d")
     endif()
 

--- a/share/cmake/modules/install/Installexpat.cmake
+++ b/share/cmake/modules/install/Installexpat.cmake
@@ -46,9 +46,11 @@ if(NOT expat_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAG
         if(BUILD_TYPE_DEBUG)
             set(_expat_LIB_SUFFIX "d")
         endif()
-        # Static Linking, Multi-threaded Dll naming (>=2.2.8):
-        #   https://github.com/libexpat/libexpat/blob/R_2_2_8/expat/win32/README.txt
-        set(_expat_LIB_SUFFIX "${_expat_LIB_SUFFIX}MD")
+        if (MSVC)
+            # Static Linking, Multi-threaded Dll naming (>=2.2.8):
+            #   https://github.com/libexpat/libexpat/blob/R_2_2_8/expat/win32/README.txt
+            set(_expat_LIB_SUFFIX "${_expat_LIB_SUFFIX}MD")
+        endif()
     endif()
 
     # Expat use a hardcoded lib prefix instead of CMAKE_STATIC_LIBRARY_PREFIX


### PR DESCRIPTION
OCIO fails to build on Windows when llvm-mingw environment is used. It happens because of incorrect conditions are used to mimic the static library names. This patch makes these names generation consistent with the CMakeLists.txt files of the corresponding deps.

1) Expat: 'MD' suffix is added on MSVC only, 'd' suffix is added on WIN32, i.e. on clang as well.
2) ZLib: 'd' suffix is added only on MSVC, not on clang