### PR TITLE
Adsk Contrib - Update CI to VFX 2026

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -41,11 +41,11 @@ jobs:
       CC: gcc
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 50
-      - name:  Install sonar-scanner and build-wrapper
-        uses: sonarsource/sonarcloud-github-c-cpp@v2
+      - name:  Install build-wrapper
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v4
       - name: Install docs env
         run: share/ci/scripts/linux/dnf/install_docs_env.sh
       - name: Install tests env
@@ -78,7 +78,7 @@ jobs:
       - name: Generate code coverage report
         run: share/ci/scripts/linux/run_gcov.sh
       - name: Run sonar-scanner
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: sonar-scanner

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -61,12 +61,54 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        build: [7, 8, 9, 10, 11, 12, 13, 14, 15]
+        build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
         include:
+          # -------------------------------------------------------------------
+          # VFX CY2026 (Python 3.13)
+          # -------------------------------------------------------------------
+          - build: 12
+            build-type: Debug
+            build-shared: 'ON'
+            build-docs: 'OFF'
+            build-openfx: 'ON'
+            use-simd: 'ON'
+            use-oiio: 'ON'
+            cxx-standard: 20
+            cxx-compiler: clang++
+            cc-compiler: clang
+            compiler-desc: Clang
+            vfx-cy: 2026
+            install-ext-packages: MISSING
+          - build: 11
+            build-type: Release
+            build-shared: 'ON'
+            build-docs: 'ON'
+            build-openfx: 'ON'
+            use-simd: 'OFF'
+            use-oiio: 'OFF'
+            cxx-standard: 17
+            cxx-compiler: g++
+            cc-compiler: gcc
+            compiler-desc: GCC
+            vfx-cy: 2026
+            install-ext-packages: ALL
+          - build: 10
+            build-type: Release
+            build-shared: 'OFF'
+            build-docs: 'OFF'
+            build-openfx: 'OFF'
+            use-simd: 'ON'
+            use-oiio: 'OFF'
+            cxx-standard: 17
+            cxx-compiler: g++
+            cc-compiler: gcc
+            compiler-desc: GCC
+            vfx-cy: 2026
+            install-ext-packages: ALL
           # -------------------------------------------------------------------
           # VFX CY2025 (Python 3.11)
           # -------------------------------------------------------------------
-          - build: 15
+          - build: 9
             build-type: Debug
             build-shared: 'ON'
             build-docs: 'OFF'
@@ -79,7 +121,7 @@ jobs:
             compiler-desc: Clang
             vfx-cy: 2025
             install-ext-packages: MISSING
-          - build: 14
+          - build: 8
             build-type: Release
             build-shared: 'ON'
             build-docs: 'ON'
@@ -92,7 +134,7 @@ jobs:
             compiler-desc: GCC
             vfx-cy: 2025
             install-ext-packages: ALL
-          - build: 13
+          - build: 7
             build-type: Release
             build-shared: 'OFF'
             build-docs: 'OFF'
@@ -108,7 +150,7 @@ jobs:
           # -------------------------------------------------------------------
           # VFX CY2024 (Python 3.11)
           # -------------------------------------------------------------------
-          - build: 12
+          - build: 6
             build-type: Debug
             build-shared: 'ON'
             build-docs: 'OFF'
@@ -121,7 +163,7 @@ jobs:
             compiler-desc: Clang
             vfx-cy: 2024
             install-ext-packages: MISSING
-          - build: 11
+          - build: 5
             build-type: Release
             build-shared: 'ON'
             build-docs: 'ON'
@@ -134,7 +176,7 @@ jobs:
             compiler-desc: GCC
             vfx-cy: 2024
             install-ext-packages: ALL
-          - build: 10
+          - build: 4
             build-type: Release
             build-shared: 'OFF'
             build-docs: 'OFF'
@@ -150,7 +192,7 @@ jobs:
           # -------------------------------------------------------------------
           # VFX CY2023 (Python 3.10)
           # -------------------------------------------------------------------
-          - build: 9
+          - build: 3
             build-type: Debug
             build-shared: 'ON'
             build-docs: 'OFF'
@@ -163,160 +205,6 @@ jobs:
             compiler-desc: Clang
             vfx-cy: 2023
             install-ext-packages: MISSING
-          - build: 8
-            build-type: Release
-            build-shared: 'ON'
-            build-docs: 'ON'
-            build-openfx: 'ON'
-            use-simd: 'OFF'
-            use-oiio: 'OFF'
-            cxx-standard: 17
-            cxx-compiler: g++
-            cc-compiler: gcc
-            compiler-desc: GCC
-            vfx-cy: 2023
-            install-ext-packages: ALL
-          - build: 7
-            build-type: Release
-            build-shared: 'OFF'
-            build-docs: 'OFF'
-            build-openfx: 'OFF'
-            use-simd: 'ON'
-            use-oiio: 'OFF'
-            cxx-standard: 17
-            cxx-compiler: g++
-            cc-compiler: gcc
-            compiler-desc: GCC
-            vfx-cy: 2023
-            install-ext-packages: ALL
-    env:
-      CXX: ${{ matrix.cxx-compiler }}
-      CC: ${{ matrix.cc-compiler }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install docs env
-        run: share/ci/scripts/linux/dnf/install_docs_env.sh
-        if: matrix.build-docs == 'ON'
-      - name: Install tests env
-        run: share/ci/scripts/linux/dnf/install_tests_env.sh
-      - name: Create build directories
-        run: |
-          mkdir _install
-          mkdir _build
-      - name: Configure
-        run: |
-          cmake ../. \
-                -DCMAKE_INSTALL_PREFIX=../_install \
-                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
-                -DCMAKE_CXX_STANDARD=${{ matrix.cxx-standard }} \
-                -DBUILD_SHARED_LIBS=${{ matrix.build-shared }} \
-                -DOCIO_BUILD_DOCS=${{ matrix.build-docs }} \
-                -DOCIO_BUILD_OPENFX=${{ matrix.build-openfx }} \
-                -DOCIO_BUILD_GPU_TESTS=OFF \
-                -DOCIO_USE_SIMD=${{ matrix.use-simd }} \
-                -DOCIO_USE_OIIO_FOR_APPS=${{ matrix.use-oiio }} \
-                -DOCIO_INSTALL_EXT_PACKAGES=${{ matrix.install-ext-packages }} \
-                -DOCIO_WARNING_AS_ERROR=ON \
-                -DPython_EXECUTABLE=$(which python)
-        working-directory: _build
-      - name: Build
-        run: |
-          cmake --build . \
-                --target install \
-                --config ${{ matrix.build-type }} \
-                -- -j$(nproc)
-          echo "ocio_build_path=$(pwd)" >> $GITHUB_ENV
-        working-directory: _build
-      - name: Test
-        run: ctest -V -C ${{ matrix.build-type }}
-        working-directory: _build
-      - name: Test CMake Consumer with shared OCIO
-        if: matrix.build-shared == 'ON'
-        run: |
-          cmake . \
-                -DCMAKE_PREFIX_PATH=../../../_install \
-                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }}
-          cmake --build . \
-                --config ${{ matrix.build-type }}
-          ./consumer
-        working-directory: _build/tests/cmake-consumer-dist
-      - name: Test CMake Consumer with static OCIO
-        if: matrix.build-shared == 'OFF'
-        # The yaml-cpp_VERSION is set below because Findyaml-cpp.cmake needs it but is unable to 
-        # extract it from the headers, like the other modules.
-        #
-        # Prefer the static version of each dependencies by using <pkg>_STATIC_LIBRARY. 
-        # Alternatively, this can be done by setting <pkg>_LIBRARY and <pkg>_INCLUDE_DIR to 
-        # the static version of the package.
-        run: |
-          cmake . \
-                -DCMAKE_PREFIX_PATH=../../../_install \
-                -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
-                -Dexpat_ROOT=${{ env.ocio_build_path }}/ext/dist \
-                -Dexpat_STATIC_LIBRARY=ON \
-                -DImath_ROOT=${{ env.ocio_build_path }}/ext/dist \
-                -DImath_STATIC_LIBRARY=ON \
-                -Dpystring_ROOT=${{ env.ocio_build_path }}/ext/dist \
-                -Dyaml-cpp_ROOT=${{ env.ocio_build_path }}/ext/dist \
-                -Dyaml-cpp_STATIC_LIBRARY=ON \
-                -Dyaml-cpp_VERSION=0.8.0 \
-                -DZLIB_ROOT=${{ env.ocio_build_path }}/ext/dist \
-                -DZLIB_STATIC_LIBRARY=ON \
-                -Dminizip-ng_ROOT=${{ env.ocio_build_path }}/ext/dist \
-                -Dminizip-ng_STATIC_LIBRARY=ON
-          cmake --build . \
-                --config ${{ matrix.build-type }}
-          ./consumer
-        working-directory: _build/tests/cmake-consumer-dist
-
-  # ---------------------------------------------------------------------------
-  # Linux (unsupported Node.js)
-  # ---------------------------------------------------------------------------
-
-  linux-old:
-    name: 'Linux VFX CY${{ matrix.vfx-cy }} 
-      <${{ matrix.compiler-desc }} 
-       config=${{ matrix.build-type }}, 
-       shared=${{ matrix.build-shared }}, 
-       simd=${{ matrix.use-simd }}, 
-       cxx=${{ matrix.cxx-standard }}, 
-       docs=${{ matrix.build-docs }}, 
-       oiio=${{ matrix.use-oiio }}>'
-    # Avoid duplicated checks when a pull_request is opened from a local branch.
-    if: |
-      github.event_name == 'push' ||
-      github.event.pull_request.head.repo.full_name != github.repository
-    # GH-hosted VM. The build runs in ASWF 'container' defined below.
-    runs-on: ubuntu-latest
-    container:
-      # DockerHub: https://hub.docker.com/u/aswf
-      # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
-      image: aswf/ci-ocio:${{ matrix.vfx-cy }}
-      volumes:
-        - /node20217:/node20217:rw,rshared
-        - /node20217:/__e/node20:ro,rshared
-    strategy:
-      fail-fast: true
-      matrix:
-        build: [1, 2, 3]
-        include:
-          # -------------------------------------------------------------------
-          # VFX CY2022 (Python 3.9)
-          # -------------------------------------------------------------------
-          - build: 1
-            build-type: Debug
-            build-shared: 'ON'
-            build-docs: 'OFF'
-            build-openfx: 'ON'
-            use-simd: 'ON'
-            use-oiio: 'ON'
-            cxx-standard: 17
-            cxx-compiler: clang++
-            cc-compiler: clang
-            compiler-desc: Clang
-            vfx-cy: 2022
-            install-ext-packages: ALL
           - build: 2
             build-type: Release
             build-shared: 'ON'
@@ -328,9 +216,9 @@ jobs:
             cxx-compiler: g++
             cc-compiler: gcc
             compiler-desc: GCC
-            vfx-cy: 2022
-            install-ext-packages: MISSING
-          - build: 3
+            vfx-cy: 2023
+            install-ext-packages: ALL
+          - build: 1
             build-type: Release
             build-shared: 'OFF'
             build-docs: 'OFF'
@@ -341,30 +229,14 @@ jobs:
             cxx-compiler: g++
             cc-compiler: gcc
             compiler-desc: GCC
-            vfx-cy: 2022
+            vfx-cy: 2023
             install-ext-packages: ALL
     env:
       CXX: ${{ matrix.cxx-compiler }}
       CC: ${{ matrix.cc-compiler }}
     steps:
-      # Install nodejs 20 with glibc 2.17, to work around the face that the
-      # GHA runners are insisting on a node version that is too new for the
-      # glibc in the ASWF containers prior to 2023.
-      - name: Install nodejs20glibc2.17
-        run: |
-          curl --silent https://unofficial-builds.nodejs.org/download/release/v20.18.1/node-v20.18.1-linux-x64-glibc-217.tar.xz | tar -xJ --strip-components 1 -C /node20217 -f -
-      # We would like to use harden-runner, but it flags too many false
-      # positives, every time we download a dependency. We should use it only
-      # on CI runs where we are producing artifacts that users might rely on.
-      # - name: Harden Runner
-      #   uses: step-security/harden-runner@248ae51c2e8cc9622ecf50685c8bf7150c6e8813 # v1.4.3
-      #   with:
-      #     egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-        # Note: can't upgrade to actions/checkout 4.0 because it needs newer
-        # glibc than these containers have.
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install docs env
         run: share/ci/scripts/linux/dnf/install_docs_env.sh
         if: matrix.build-docs == 'ON'
@@ -517,11 +389,11 @@ jobs:
             python-version: '3.9'
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install docs env
         run: share/ci/scripts/macos/install_docs_env.sh
         if: matrix.build-docs == 'ON'
@@ -643,11 +515,11 @@ jobs:
             python-version: '3.12'
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install docs env
         run: share/ci/scripts/macos/install_docs_env.sh
         if: matrix.build-docs == 'ON'
@@ -791,11 +663,11 @@ jobs:
             python-version: '3.9'
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install docs env
         run: |
           DOXYGEN_PATH=$GITHUB_WORKSPACE/doxygen

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -317,7 +317,7 @@ jobs:
   # ---------------------------------------------------------------------------
 
   macos:
-    name: 'macOS 13
+    name: 'macOS 15 intel
       <AppleClang 
        arch=${{ matrix.arch-type }},
        config=${{ matrix.build-type }}, 
@@ -334,19 +334,8 @@ jobs:
     runs-on: macos-15-intel
     strategy:
       matrix:
-        build: [1, 2, 3, 4, 5]
+        build: [3, 4]
         include:
-          - build: 5
-            arch-type: "x86_64"
-            build-type: Release
-            build-shared: 'ON'
-            build-docs: 'OFF'
-            build-openfx: 'ON'
-            use-simd: 'ON'
-            use-oiio: 'ON'
-            cxx-standard: 20
-            python-version: '3.13'
-          # Keeping one universal build
           - build: 4
             arch-type: "x86_64;arm64"
             build-type: Release
@@ -359,34 +348,14 @@ jobs:
             python-version: '3.12'
           - build: 3
             arch-type: "x86_64"
-            build-type: Release
-            build-shared: 'ON'
-            build-docs: 'ON'
-            build-openfx: 'OFF'
-            use-simd: 'OFF'
-            use-oiio: 'OFF'
-            cxx-standard: 17
-            python-version: '3.11'
-          - build: 2
-            arch-type: "x86_64"
             build-type: Debug
-            build-shared: 'ON'
-            build-docs: 'OFF'
-            build-openfx: 'ON'
-            use-simd: 'ON'
-            use-oiio: 'OFF'
-            cxx-standard: 17
-            python-version: '3.10'
-          - build: 1
-            arch-type: "x86_64"
-            build-type: Release
             build-shared: 'OFF'
             build-docs: 'OFF'
             build-openfx: 'ON'
-            use-simd: 'ON'
+            use-simd: 'OFF'
             use-oiio: 'OFF'
             cxx-standard: 17
-            python-version: '3.9'
+            python-version: '3.10'
     steps:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -496,10 +465,10 @@ jobs:
             test-rosetta: "OFF"
             build-type: Release
             build-shared: 'ON'
-            build-docs: 'OFF'
+            build-docs: 'ON'
             build-openfx: 'OFF'
             use-simd: 'ON'
-            use-oiio: 'OFF'
+            use-oiio: 'ON'
             cxx-standard: 20
             python-version: '3.13'
           - build: 2
@@ -660,7 +629,7 @@ jobs:
             use-simd: 'ON'
             use-oiio: 'OFF'
             cxx-standard: 17
-            python-version: '3.9'
+            python-version: '3.10'
     steps:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/dependencies_latest.yml
+++ b/.github/workflows/dependencies_latest.yml
@@ -172,12 +172,12 @@ jobs:
             build-docs: 'ON'
             build-openfx: 'ON'
             cxx-standard: 20
-            python-version: '3.13'
+            python-version: '3.14'
           - build: 2
             build-docs: 'ON'
             build-openfx: 'ON'
             cxx-standard: 17
-            python-version: '3.9'
+            python-version: '3.10'
     steps:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -269,13 +269,13 @@ jobs:
             build-docs: 'ON'
             build-openfx: 'ON'
             cxx-standard: 20
-            python-version: '3.13'
+            python-version: '3.14'
             use-oiio: 'ON'
           - build: 2
             build-docs: 'ON'
             build-openfx: 'ON'
             cxx-standard: 17
-            python-version: '3.9'
+            python-version: '3.10'
             use-oiio: 'OFF'
     steps:
       - name: Setup Python

--- a/.github/workflows/dependencies_latest.yml
+++ b/.github/workflows/dependencies_latest.yml
@@ -87,7 +87,7 @@ jobs:
       CC: ${{ matrix.cc-compiler }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install docs env
         run: share/ci/scripts/linux/dnf/install_docs_env.sh
         if: matrix.build-docs == 'ON'
@@ -180,11 +180,11 @@ jobs:
             python-version: '3.9'
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install docs env
         run: share/ci/scripts/macos/install_docs_env.sh
         if: matrix.build-docs == 'ON'
@@ -279,11 +279,11 @@ jobs:
             use-oiio: 'OFF'
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install docs env
         run: |
           DOXYGEN_PATH=$GITHUB_WORKSPACE/doxygen

--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install Dart Sass
         run: sudo snap install dart-sass
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
       - name: Setup Pages

--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -54,7 +54,7 @@ jobs:
           submodules: recursive
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # 6.0.0
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo
@@ -68,7 +68,7 @@ jobs:
             --baseURL "${{ steps.pages.outputs.base_url }}/" \
             --themesDir ../..
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # 5.0.0
         with:
           path: docs/site/homepage/public
 
@@ -82,4 +82,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # 5.0.0

--- a/.github/workflows/platform_latest.yml
+++ b/.github/workflows/platform_latest.yml
@@ -86,7 +86,7 @@ jobs:
       CC: ${{ matrix.cc-compiler }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install tests env
         run: share/ci/scripts/linux/dnf/install_tests_env.sh
       - name: Create build directories
@@ -197,11 +197,11 @@ jobs:
             python-version: '3.9'
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install tests env
         run: share/ci/scripts/macos/install_tests_env.sh
       - name: Create build directories
@@ -308,11 +308,11 @@ jobs:
             python-version: '3.9'
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install tests env
         run: share/ci/scripts/windows/install_tests_env.sh
         shell: bash

--- a/.github/workflows/platform_latest.yml
+++ b/.github/workflows/platform_latest.yml
@@ -187,14 +187,14 @@ jobs:
             build-shared: ON
             cxx-standard: 23
             enable-sanitizer: OFF
-            python-version: '3.13'
+            python-version: '3.14'
           - build: 2
             build-python: OFF
             build-type: Debug
             build-shared: ON
             cxx-standard: 23
             enable-sanitizer: ON
-            python-version: '3.9'
+            python-version: '3.10'
     steps:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -299,13 +299,13 @@ jobs:
             build-type: Release
             build-shared: ON
             cxx-standard: 20
-            python-version: '3.13'
+            python-version: '3.14'
           - build: 2
             build-python: ON
             build-type: Debug
             build-shared: ON
             cxx-standard: 20
-            python-version: '3.9'
+            python-version: '3.10'
     steps:
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -55,7 +55,7 @@ jobs:
         run: git archive --format=tar.gz -o ${OCIO_TARBALL} --prefix ${OCIO_PREFIX} ${TAG}
 
       - name: Sign archive with Sigstore
-        uses: sigstore/gh-action-sigstore-python@a5caf349bc536fbef3668a10ed7f5cd309a4b53d # v3.2.0
+        uses: sigstore/gh-action-sigstore-python@04cffa1d795717b140764e8b640de88853c92acc # v3.3.0
         with:
           inputs: ${{ env.OCIO_TARBALL }}
           upload-signing-artifacts: false

--- a/.github/workflows/release-sign.yml
+++ b/.github/workflows/release-sign.yml
@@ -49,7 +49,7 @@ jobs:
         shell: bash
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Create archive
         run: git archive --format=tar.gz -o ${OCIO_TARBALL} --prefix ${OCIO_PREFIX} ${TAG}

--- a/.github/workflows/wheel_workflow.yml
+++ b/.github/workflows/wheel_workflow.yml
@@ -133,7 +133,7 @@ jobs:
           python-version: '3.11'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.0
+        uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a # v3.4.0
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -191,7 +191,7 @@ jobs:
           python-version: '3.11'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.0
+        uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a # v3.4.0
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -248,7 +248,7 @@ jobs:
           brew uninstall --ignore-dependencies openexr imath || true
             
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.0
+        uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a # v3.4.0
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -300,7 +300,7 @@ jobs:
           python-version: '3.11'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.0
+        uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a # v3.4.0
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -352,7 +352,7 @@ jobs:
           python-version: '3.11'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.0
+        uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a # v3.4.0
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
@@ -379,7 +379,7 @@ jobs:
           path: dist
           merge-multiple: true
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/wheel_workflow.yml
+++ b/.github/workflows/wheel_workflow.yml
@@ -50,19 +50,18 @@ jobs:
       github.repository == 'AcademySoftwareFoundation/OpenColorIO'
 
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - uses: actions/checkout@v4
+      - name: Build SDist
+        run: pipx run build --sdist
 
-    - name: Build SDist
-      run: pipx run build --sdist
+      - name: Check metadata
+        run: pipx run twine check dist/*
 
-    - name: Check metadata
-      run: pipx run twine check dist/*
-
-    - uses: actions/upload-artifact@v4
-      with:
-        name: cibw-sdist
-        path: dist/*.tar.gz
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
 
   # ---------------------------------------------------------------------------
   # Linux Wheels
@@ -81,10 +80,6 @@ jobs:
           # -------------------------------------------------------------------
           # CPython 64 bits manylinux_2_28
           # -------------------------------------------------------------------
-          - build: CPython 3.9 64 bits manylinux_2_28
-            manylinux: manylinux_2_28
-            python: cp39-manylinux_x86_64
-            arch: x86_64
           - build: CPython 3.10 64 bits manylinux_2_28
             manylinux: manylinux_2_28
             python: cp310-manylinux_x86_64
@@ -108,10 +103,6 @@ jobs:
           # -------------------------------------------------------------------
           # CPython 64 bits manylinux2014
           # -------------------------------------------------------------------
-          - build: CPython 3.9 64 bits manylinux2014
-            manylinux: manylinux2014
-            python: cp39-manylinux_x86_64
-            arch: x86_64
           - build: CPython 3.10 64 bits manylinux2014
             manylinux: manylinux2014
             python: cp310-manylinux_x86_64
@@ -134,9 +125,9 @@ jobs:
             arch: x86_64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         name: Install Python
         with:
           python-version: '3.11'
@@ -148,7 +139,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: cibw-wheels-${{ matrix.python }}-${{ matrix.manylinux }}
           path: ./wheelhouse/*.whl
@@ -170,10 +161,6 @@ jobs:
           # -------------------------------------------------------------------
           # CPython ARM 64 bits manylinux2014
           # -------------------------------------------------------------------
-          - build: CPython 3.9 ARM 64 bits manylinux2014
-            manylinux: manylinux2014
-            python: cp39-manylinux_aarch64
-            arch: aarch64
           - build: CPython 3.10 ARM 64 bits manylinux2014
             manylinux: manylinux2014
             python: cp310-manylinux_aarch64
@@ -196,9 +183,9 @@ jobs:
             arch: aarch64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         name: Install Python
         with:
           python-version: '3.11'
@@ -210,7 +197,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: cibw-wheels-${{ matrix.python }}-${{ matrix.manylinux }}
           path: ./wheelhouse/*.whl
@@ -232,9 +219,6 @@ jobs:
           # -------------------------------------------------------------------
           # CPython 64 bits
           # -------------------------------------------------------------------
-          - build: CPython 3.9 64 bits
-            python: cp39-macosx_x86_64
-            arch: x86_64
           - build: CPython 3.10 64 bits
             python: cp310-macosx_x86_64
             arch: x86_64
@@ -252,9 +236,9 @@ jobs:
             arch: x86_64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         name: Install Python
         with:
           python-version: '3.11'
@@ -269,7 +253,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: cibw-wheels-${{ matrix.python }}
           path: ./wheelhouse/*.whl
@@ -291,9 +275,6 @@ jobs:
           # -------------------------------------------------------------------
           # CPython ARM 64 bits
           # -------------------------------------------------------------------
-          - build: CPython 3.9 ARM 64 bits
-            python: cp39-macosx_arm64
-            arch: arm64
           - build: CPython 3.10 ARM 64 bits
             python: cp310-macosx_arm64
             arch: arm64
@@ -311,9 +292,9 @@ jobs:
             arch: arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         name: Install Python
         with:
           python-version: '3.11'
@@ -324,7 +305,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: cibw-wheels-${{ matrix.python }}
           path: ./wheelhouse/*.whl
@@ -346,9 +327,6 @@ jobs:
           # -------------------------------------------------------------------
           # CPython 64 bits
           # -------------------------------------------------------------------
-          - build: CPython 3.9 64 bits
-            python: cp39-win_amd64
-            arch: AMD64
           - build: CPython 3.10 64 bits
             python: cp310-win_amd64
             arch: AMD64
@@ -366,9 +344,9 @@ jobs:
             arch: AMD64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         name: Install Python
         with:
           python-version: '3.11'
@@ -379,20 +357,23 @@ jobs:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: cibw-wheels-${{ matrix.python }}
           path: ./wheelhouse/*.whl
 
+  # ---------------------------------------------------------------------------
+  # Upload
+  # ---------------------------------------------------------------------------
 
   upload_pypi:
     needs: [sdist, linux, linux-arm, macos, macos-arm, windows]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           pattern: cibw-*
           path: dist

--- a/docs/quick_start/installation.rst
+++ b/docs/quick_start/installation.rst
@@ -142,8 +142,8 @@ Optional OCIO functionality also depends on:
 - Doxygen (for the docs)
 - NumPy (optionally used in the Python test suite)
 - \*pybind11 >= 2.9.2 (for the Python binding)
-- Python >= 3.9 (for the Python binding only)
-- Python 3.9+ (for building the documentation)
+- Python >= 3.10 (for the Python binding only)
+- Python 3.10+ (for building the documentation)
 
 Building the documentation requires the following packages, available via PyPI:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,6 @@ classifiers =
     Topic :: Software Development :: Libraries :: Python Modules
     Programming Language :: C++
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -21,7 +20,7 @@ license_files = LICENSE
 long_description = file: README.md, LICENSE
 long_description_content_type = text/markdown
 name = opencolorio
-python_requires = '>=3.9'
+python_requires = '>=3.10'
 url = https://opencolorio.org/
 
 [options]

--- a/src/OpenColorIO/ops/gradingtone/GradingTone.cpp
+++ b/src/OpenColorIO/ops/gradingtone/GradingTone.cpp
@@ -60,7 +60,7 @@ void GradingTone::validate() const
     static constexpr double MinSHTol  = MinSH - Error;
     static constexpr double MaxSHTol  = MaxSH + Error;
     static constexpr double MinWSCTol = MinWSC - Error;
-    static constexpr double MaxSCTol  = MaxSC - Error;
+    static constexpr double MaxSCTol  = MaxSC + Error;
 
     {
         const auto & bd = m_blacks;


### PR DESCRIPTION
- Added Linux VFX CY2026
- Removed Linux VFX CY2022
- Updated actions commands, based on dependabot warnings
- Locked actions commands to fixed hashes, like OIIO
- Removed/modified the macOS runners based on TSC discussion, this reduces total runners to 20
- Removed support for Python 3.9 in both CI and Wheel generation, based on TSC discussion

- Included a very minor bug fix in GradingTone.cpp

The new build matrix may be found here (scroll to the bottom table):
https://docs.google.com/spreadsheets/d/1Iw5uRw6voB54wFpkSSOGrcAXkciZfx9nlBSVHz6N4P8/edit?usp=sharing

At the TSC we discussed what runner image to use for macOS and Windows. I left the images as they were because they are already the options that are best aligned with the VFX Platform for CY2026.