### PR TITLE
Adsk Contrib - Update Python documentation requirements

### DIFF
--- a/.github/workflows/wheel_workflow.yml
+++ b/.github/workflows/wheel_workflow.yml
@@ -147,6 +147,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux }}
+          CIBW_BEFORE_BUILD: "pip install sphinx-press-theme"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -209,6 +210,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux }}
+          CIBW_BEFORE_BUILD: "pip install sphinx-press-theme"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -268,6 +270,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BEFORE_BUILD: "pip install sphinx-press-theme"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -323,6 +326,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BEFORE_BUILD: "pip install sphinx-press-theme"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -378,6 +382,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BEFORE_BUILD: "pip install sphinx-press-theme"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@
 urllib3<3
 # The builds for documentation fails with <0.18.0
 docutils>=0.18.1
-sphinx<=9.1.0
+sphinx<=7.1.2
 six
 testresources
 recommonmark

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,3 @@
-# Fix an issue with the OCIO's Linux container images that have OpenSSL under 1.1.1.
-# If the container images are updated with OpenSSL 1.1.1+, the restriction on
-# urllib3 version <2 can be removed.
 urllib3<3
 # The builds for documentation fails with <0.18.0
 docutils>=0.18.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,14 +1,14 @@
 # Fix an issue with the OCIO's Linux container images that have OpenSSL under 1.1.1.
 # If the container images are updated with OpenSSL 1.1.1+, the restriction on
 # urllib3 version <2 can be removed.
-urllib3<2
+urllib3<3
 # The builds for documentation fails with <0.18.0
 docutils>=0.18.1
-sphinx<=7.1.2
+sphinx<=9.1.0
 six
 testresources
 recommonmark
 sphinx-press-theme
 sphinx-tabs
 breathe
-setuptools<68.0.0
+setuptools<83.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=82.0.1",
     "wheel",
     "cmake>=3.14",
     "ninja; sys_platform != 'win32' and platform_machine != 'arm64'",
     # Documentation requirements (see docs/requirements.txt for details)
     "urllib3<3",
-    "docutils>=0.18.1",
+    "docutils>=0.22.4",
     "sphinx<=7.1.2",
     "six",
     "testresources",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ requires = [
     "cmake>=3.14",
     "ninja; sys_platform != 'win32' and platform_machine != 'arm64'",
     # Documentation requirements (see docs/requirements.txt for details)
-    "urllib3<2",
+    "urllib3<3",
     "docutils>=0.18.1",
-    "sphinx<=7.1.2",
+    "sphinx<=9.1.0",
     "six",
     "testresources",
     "recommonmark",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     # Documentation requirements (see docs/requirements.txt for details)
     "urllib3<3",
     "docutils>=0.18.1",
-    "sphinx<=9.1.0",
+    "sphinx<=7.1.2",
     "six",
     "testresources",
     "recommonmark",


### PR DESCRIPTION
Fixed the issues with the outdated installations requested by the documentation system, as mentioned by dependabot.

This fixes three "Dependabot alerts" vulnerabilities in the project's Security and Quality tab:
"setuptools vulnerable to Command Injection via package URL"
"setuptools has a path traversal vulnerability in PackageIndex.download that leads to Arbitrary File Write"
"urllib3 redirects are not disabled when retries are disabled on PoolManager instantiation"

I was unable to update Sphinx because it seems our documentation template is not compatible.

Note: It is expected that the Linux 2022 CI will fail, however, we are moving that out of the CI matrix in a separate PR.