### PR TITLE
Improve CMake and Actions settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "quarterly"
+    # Only do security updates rather than all version updates.
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "quarterly"
+    # Only do security updates rather than all version updates.
+    open-pull-requests-limit: 0

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,13 +8,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "quarterly"
+      interval: "monthly"
     # Only do security updates rather than all version updates.
     open-pull-requests-limit: 0
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "quarterly"
+      interval: "monthly"
     # Only do security updates rather than all version updates.
     open-pull-requests-limit: 0

--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           fetch-depth: 50
       - name:  Install build-wrapper
-        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v4
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
       - name: Install docs env
         run: share/ci/scripts/linux/dnf/install_docs_env.sh
       - name: Install tests env
@@ -78,7 +78,7 @@ jobs:
       - name: Generate code coverage report
         run: share/ci/scripts/linux/run_gcov.sh
       - name: Run sonar-scanner
-        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,9 +401,7 @@ if(NOT DEFINED OCIO_NAMESPACE)
 elseif(OCIO_NAMESPACE STREQUAL "")
     message(FATAL_ERROR "A namespace cannot be empty.")
 else()
-    set(OCIO_NAMESPACE "OpenColorIO_${OCIO_NAMESPACE}_v${OpenColorIO_VERSION_MAJOR}_${OpenColorIO_VERSION_MINOR}${OpenColorIO_VERSION_RELEASE_TYPE}" CACHE STRING 
-        "Specify the main OCIO C++ namespace: Options include OpenColorIO OpenColorIO_<YOURFACILITY> etc.")
-    message(STATUS "Setting namespace to '${OCIO_NAMESPACE}' as none was specified.")
+    message(STATUS "Setting namespace to '${OCIO_NAMESPACE}'.")
 endif()
 
 

--- a/docs/api/grading_transforms.rst
+++ b/docs/api/grading_transforms.rst
@@ -118,6 +118,53 @@ GradingRGBCurve
       .. doxygentypedef:: ${OCIO_NAMESPACE}::ConstGradingRGBCurveRcPtr
       .. doxygentypedef:: ${OCIO_NAMESPACE}::GradingRGBCurveRcPtr
 
+GradingHueCurveTransform
+************************
+
+.. tabs::
+
+   .. group-tab:: Python
+
+      .. autoclass:: PyOpenColorIO.GradingHueCurveTransform
+         :members:
+         :undoc-members:
+         :special-members: __init__, __str__
+         :inherited-members:
+
+   .. group-tab:: C++
+
+      .. doxygenclass:: ${OCIO_NAMESPACE}::GradingHueCurveTransform
+         :members:
+         :undoc-members:
+
+      .. doxygenfunction:: ${OCIO_NAMESPACE}::operator<<(std::ostream&, const GradingHueCurveTransform&) noexcept
+
+      .. doxygentypedef:: ${OCIO_NAMESPACE}::ConstGradingHueCurveTransformRcPtr
+      .. doxygentypedef:: ${OCIO_NAMESPACE}::GradingHueCurveTransformRcPtr
+
+GradingHueCurve
+^^^^^^^^^^^^^^^
+
+.. tabs::
+
+   .. group-tab:: Python
+
+      .. autoclass:: PyOpenColorIO.GradingHueCurve
+         :members:
+         :undoc-members:
+         :special-members: __init__, __str__
+
+   .. group-tab:: C++
+
+      .. doxygenclass:: ${OCIO_NAMESPACE}::GradingHueCurve
+         :members:
+         :undoc-members:
+
+      .. doxygenfunction:: ${OCIO_NAMESPACE}::operator<<(std::ostream&, const GradingHueCurve&)
+
+      .. doxygentypedef:: ${OCIO_NAMESPACE}::ConstGradingHueCurveRcPtr
+      .. doxygentypedef:: ${OCIO_NAMESPACE}::GradingHueCurveRcPtr
+
 GradingControlPoint
 ^^^^^^^^^^^^^^^^^^^
 

--- a/include/OpenColorIO/OpenColorTransforms.h
+++ b/include/OpenColorIO/OpenColorTransforms.h
@@ -1367,10 +1367,10 @@ public:
     virtual HSYTransformStyle getRGBToHSY() const = 0;
     virtual void setRGBToHSY(HSYTransformStyle style) = 0;
 
-    ///**
-    // * Parameters can be made dynamic so the values can be changed through the CPU or GPU processor,
-    // * but if there are several GradingHueCurveTransform only one can have dynamic parameters.
-    // */
+    /**
+     * Parameters can be made dynamic so the values can be changed through the CPU or GPU processor,
+     * but if there are several GradingHueCurveTransform only one can have dynamic parameters.
+     */
     virtual bool isDynamic() const noexcept = 0;
     virtual void makeDynamic() noexcept = 0;
     virtual void makeNonDynamic() noexcept = 0;


### PR DESCRIPTION
Several minor build fixes:
- Fix a CMake error in how OCIO_NAMESPACE was being used. This was discussed at the TSC meeting and the preference was for this to continue to be the full string that is used. Therefore, cleaning up some code that was incorrectly using it as part of a longer string.
- Reducing the frequency of Dependabot PRs and requesting only security fixes. Currently it seems to be proposing fixes for minor version increases that have no security aspect.
- Fix documentation comment that was causing a build failure on Windows.