### PR TITLE
Add /bigobj for pybind11 target on Windows

### DIFF
--- a/share/cmake/modules/Findpybind11.cmake
+++ b/share/cmake/modules/Findpybind11.cmake
@@ -140,5 +140,14 @@ if(_pybind11_TARGET_CREATE)
         INTERFACE_INCLUDE_DIRECTORIES ${pybind11_INCLUDE_DIR}
     )
 
+    # /bigobj is needed for bigger binding projects due to the limit to 64k
+    # addressable sections (see pybind11Common.cmake).
+    if (MSVC)
+        set_target_properties(pybind11::module PROPERTIES
+            INTERFACE_COMPILE_OPTIONS /bigobj
+        )
+
+    endif()
+
     mark_as_advanced(pybind11_INCLUDE_DIR pybind11_VERSION)
 endif()


### PR DESCRIPTION
Address #2279, I tried to reproduce on my Windows box before fixing but unfortunately wasn't able to trigger the issue with a local install of PyBind11 3.0.3. This change simply copy the code from Installpybind11.cmake, as always these issues come from the fact we create our imported targets manually (see #1638).