### PR TITLE
Prepare 2.5.2 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,13 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    # Only do security updates rather than all version updates.
+    open-pull-requests-limit: 0
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    # Only do security updates rather than all version updates.
+    open-pull-requests-limit: 0

--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -44,8 +44,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 50
-      - name:  Install sonar-scanner and build-wrapper
-        uses: sonarsource/sonarcloud-github-c-cpp@v2
+      - name:  Install build-wrapper
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
       - name: Install docs env
         run: share/ci/scripts/linux/dnf/install_docs_env.sh
       - name: Install tests env
@@ -78,6 +78,7 @@ jobs:
       - name: Generate code coverage report
         run: share/ci/scripts/linux/run_gcov.sh
       - name: Run sonar-scanner
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/wheel_workflow.yml
+++ b/.github/workflows/wheel_workflow.yml
@@ -147,6 +147,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux }}
+          CIBW_BEFORE_BUILD: "pip install sphinx-press-theme"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -209,6 +210,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
           CIBW_MANYLINUX_AARCH64_IMAGE: ${{ matrix.manylinux }}
+          CIBW_BEFORE_BUILD: "pip install sphinx-press-theme"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -268,6 +270,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BEFORE_BUILD: "pip install sphinx-press-theme"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -323,6 +326,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BEFORE_BUILD: "pip install sphinx-press-theme"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -378,6 +382,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python }}
           CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_BEFORE_BUILD: "pip install sphinx-press-theme"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,9 +396,7 @@ if(NOT DEFINED OCIO_NAMESPACE)
 elseif(OCIO_NAMESPACE STREQUAL "")
     message(FATAL_ERROR "A namespace cannot be empty.")
 else()
-    set(OCIO_NAMESPACE "OpenColorIO_${OCIO_NAMESPACE}_v${OpenColorIO_VERSION_MAJOR}_${OpenColorIO_VERSION_MINOR}${OpenColorIO_VERSION_RELEASE_TYPE}" CACHE STRING 
-        "Specify the main OCIO C++ namespace: Options include OpenColorIO OpenColorIO_<YOURFACILITY> etc.")
-    message(STATUS "Setting namespace to '${OCIO_NAMESPACE}' as none was specified.")
+    message(STATUS "Setting namespace to '${OCIO_NAMESPACE}'.")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 # Project definition.
 
 project(OpenColorIO 
-    VERSION 2.5.1
+    VERSION 2.5.2
     DESCRIPTION "OpenColorIO (OCIO) is a complete color management solution"
     HOMEPAGE_URL https://github.com/AcademySoftwareFoundation/OpenColorIO
     LANGUAGES CXX C)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,10 +23,6 @@ Include detailed steps to reproduce the issue, and any other information that
 could aid an investigation. Someone will assess the report and make every
 effort to respond within 14 days.
 
-## History of CVE Fixes
-
-None
-
 ## File Format Expectations
 
 Attempting to read an OCIO config (YAML) file will:
@@ -60,3 +56,7 @@ set of behaviors as with file loading.
 It is a bug if calling a function with well-formed arguments causes the 
 library to crash. It is a security issue if calling a function with 
 well-formed arguments causes arbitrary code execution.
+
+## History of CVE Fixes
+
+CVE-2026-42450 -- Stack buffer overflow in sscanf. (Fixed in OCIO 2.5.2)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,20 +14,16 @@ would be naive to say our code is immune to every exploit.
 
 ## Reporting Vulnerabilities
 
-Quickly resolving security related issues is a priority. If you think
-you've found a potential vulnerability in OpenColorIO, please report it by
-emailing security@opencolorio.org. Only TSC members and ASWF project
-management have access to these messages.
+Quickly resolving security related issues is a priority. The best way to report a 
+vulnerability is to file a GitHub security advisory. If that is not possible, it 
+is also fine to email your report to security@opencolorio.org. Only the project 
+administrators have access to these reports.
 
 Include detailed steps to reproduce the issue, and any other information that
 could aid an investigation. Someone will assess the report and make every
 effort to respond within 14 days.
 
-## Outstanding Security Issues
-
-None
-
-## Addressed Security Issues
+## History of CVE Fixes
 
 None
 
@@ -64,6 +60,3 @@ set of behaviors as with file loading.
 It is a bug if calling a function with well-formed arguments causes the 
 library to crash. It is a security issue if calling a function with 
 well-formed arguments causes arbitrary code execution.
-
-We do not consider this as severe as file format issues because in most 
-deployments the parameter space is not exposed to potential attackers.

--- a/docs/api/grading_transforms.rst
+++ b/docs/api/grading_transforms.rst
@@ -118,6 +118,53 @@ GradingRGBCurve
       .. doxygentypedef:: ${OCIO_NAMESPACE}::ConstGradingRGBCurveRcPtr
       .. doxygentypedef:: ${OCIO_NAMESPACE}::GradingRGBCurveRcPtr
 
+GradingHueCurveTransform
+************************
+
+.. tabs::
+
+   .. group-tab:: Python
+
+      .. autoclass:: PyOpenColorIO.GradingHueCurveTransform
+         :members:
+         :undoc-members:
+         :special-members: __init__, __str__
+         :inherited-members:
+
+   .. group-tab:: C++
+
+      .. doxygenclass:: ${OCIO_NAMESPACE}::GradingHueCurveTransform
+         :members:
+         :undoc-members:
+
+      .. doxygenfunction:: ${OCIO_NAMESPACE}::operator<<(std::ostream&, const GradingHueCurveTransform&) noexcept
+
+      .. doxygentypedef:: ${OCIO_NAMESPACE}::ConstGradingHueCurveTransformRcPtr
+      .. doxygentypedef:: ${OCIO_NAMESPACE}::GradingHueCurveTransformRcPtr
+
+GradingHueCurve
+^^^^^^^^^^^^^^^
+
+.. tabs::
+
+   .. group-tab:: Python
+
+      .. autoclass:: PyOpenColorIO.GradingHueCurve
+         :members:
+         :undoc-members:
+         :special-members: __init__, __str__
+
+   .. group-tab:: C++
+
+      .. doxygenclass:: ${OCIO_NAMESPACE}::GradingHueCurve
+         :members:
+         :undoc-members:
+
+      .. doxygenfunction:: ${OCIO_NAMESPACE}::operator<<(std::ostream&, const GradingHueCurve&)
+
+      .. doxygentypedef:: ${OCIO_NAMESPACE}::ConstGradingHueCurveRcPtr
+      .. doxygentypedef:: ${OCIO_NAMESPACE}::GradingHueCurveRcPtr
+
 GradingControlPoint
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,19 +36,52 @@ best leverage them.  We have an OCIO User Experience (UX) working group that is
 gradually working on more coverage.
 
 The documentation is a work-in-progress and we would love to have your help to 
-improve it!  An easy way to get involved is to join the #docs or #ux channel on 
+improve it!  An easy way to get involved is to join the #opencolorio channel on 
 :ref:`slack`.
+
+
+Roadmap
+=======
+
+The project attempts to maintain a roadmap to give the community insight into
+upcoming development. The items are grouped into "Now", "Next", and "Later" categories.
+"Now" indicates work that is currently in-progress. "Next" indicates work that is being
+planned for imminent development (meaning now would be a good time to provide your input).
+The roadmap is available `here. <https://roadmap.opencolorio.org>`_
 
 
 Community
 =========
+
+.. _meetings:
+
+Meetings
+********
+
+The OpenColorIO project has a Technical Steering Committee meeting on Zoom every two weeks
+at noon LA time. The Zoom link is available from the `OCIO Calendar. <https://calendar.opencolorio.org>`_
+
+There is a general working group and "office hours" meeting once a month in the same
+time slot. The Zoom link is available from the `OCIO Calendar. <https://calendar.opencolorio.org>`_
+
+These meetings are open to anyone!
+
+
+.. _slack:
+
+Slack
+*****
+
+Join us on the `ASWF Slack <https://academysoftwarefdn.slack.com/>`_ in the channels 
+`#opencolorio` and `#opencolor-configs`.
+
 
 .. _mailing_lists:
 
 Mailing Lists
 *************
 
-There are two mailing lists associated with OpenColorIO:
+Most of the conversation happens on Slack, but there are two mailing lists associated with OpenColorIO:
 
 `ocio-user <https://lists.aswf.io/g/ocio-user>`__\ ``@lists.aswf.io``
     For end users (artists, often) interested in OCIO profile design,
@@ -57,14 +90,40 @@ There are two mailing lists associated with OpenColorIO:
 `ocio-dev <https://lists.aswf.io/g/ocio-dev>`__\ ``@lists.aswf.io``
     For developers interested OCIO APIs, code integration, compilation, etc.
 
-.. _slack:
 
-Slack
-*****
+Related Projects
+================
 
-There is an OpenColorIO Slack workspace at: `<https://opencolorio.slack.com>`_.  
+.. _cif:
 
-New users may join the workspace from `here <http://slack.opencolorio.org/>`_.
+ASWF Color Interop Forum
+************************
+
+The CIF is an open, cross-project forum for discussing color interoperability across varying workflows 
+and standards. The aim isn’t necessarily to develop new standards, but rather to make recommendations 
+for how to improve color accuracy through the existing infrastructure. 
+
+Recommendations are published on the `ColorInterop GitHub. <https://github.com/AcademySoftwareFoundation/ColorInterop>`_
+
+The forum has a monthly Zoom meeting on Mondays at noon LA time, as posted on the 
+`OCIO Calendar. <https://calendar.opencolorio.org>`_
+
+Discussion happens in the `#color-interop-forum` channel on the ASWF Slack.
+
+
+.. _nano:
+
+NanoColor
+*********
+
+NanoColor is a collaboration between OpenUSD, MaterialX, and OpenColorIO to ensure that there 
+is interoperable and flexible color management among those projects and related projects in 
+the computer graphics world.
+
+The working group has a Zoom meeting every two weeks on Mondays at 1:00 pm LA time, as posted on the 
+`OCIO Calendar. <https://calendar.opencolorio.org>`_
+
+Discussion happens in the `#nanocolor` channel on the ASWF Slack.
 
 
 Search

--- a/docs/releases/ocio_2_5.rst
+++ b/docs/releases/ocio_2_5.rst
@@ -39,6 +39,15 @@ For Developers
 
 * Please see the section below about version updates to required third-party dependencies.
 
+Library Version
++++++++++++++++
+
+* The 2.5.1 release is not ABI compatible with 2.5.0 for clients that use the GPU renderer
+  API due to a change made to correct an issue with the Vulkan support introduced in 2.5.0.
+  Because the SOVERSION of both libraries remains "2.5", applications using the GPU API that
+  were compiled with the 2.5.0 release must be recompiled to use the 2.5.1 library. Any
+  further releases in the 2.5.x series will be ABI-compatible with 2.5.1.
+
 
 New Feature Guide
 =================

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,4 @@
-# Fix an issue with the OCIO's Linux container images that have OpenSSL under 1.1.1.
-# If the container images are updated with OpenSSL 1.1.1+, the restriction on
-# urllib3 version <2 can be removed.
-urllib3<2
+urllib3<3
 # The builds for documentation fails with <0.18.0
 docutils>=0.18.1
 sphinx<=7.1.2
@@ -11,4 +8,4 @@ recommonmark
 sphinx-press-theme
 sphinx-tabs
 breathe
-setuptools<68.0.0
+setuptools<83.0.0

--- a/docs/site/homepage/config.toml
+++ b/docs/site/homepage/config.toml
@@ -105,14 +105,6 @@ post_share = true
 enable = false
 preloader = "images/opencolorio-color.png"
 
-# google map
-[params.map]
-enable = false
-gmap_api = "https://maps.googleapis.com/maps/api/js?key=AIzaSyBu5nZKbeK-WHQ70oqOWo-_4VmwOwKP9YQ"
-map_latitude = "51.5223477"
-map_longitude = "-0.1622023"
-map_marker = "images/marker.png"
-
 
 ############################# ASWF LINKS ##########################
 [[params.aswf]]

--- a/ext/sampleicc/src/include/iccProfileReader.h
+++ b/ext/sampleicc/src/include/iccProfileReader.h
@@ -586,6 +586,10 @@ namespace SampleICC
             if (!Read32(istream, &sizeData, 1))
                 return false;
 
+            // ICC curve entries are indexed by 16-bit values; 65536 is the maximum.
+            if (sizeData > 65536)
+                return false;
+
             mCurve.resize(sizeData);
 
             if (sizeData)

--- a/include/OpenColorIO/OpenColorTransforms.h
+++ b/include/OpenColorIO/OpenColorTransforms.h
@@ -1367,10 +1367,10 @@ public:
     virtual HSYTransformStyle getRGBToHSY() const = 0;
     virtual void setRGBToHSY(HSYTransformStyle style) = 0;
 
-    ///**
-    // * Parameters can be made dynamic so the values can be changed through the CPU or GPU processor,
-    // * but if there are several GradingHueCurveTransform only one can have dynamic parameters.
-    // */
+    /**
+     * Parameters can be made dynamic so the values can be changed through the CPU or GPU processor,
+     * but if there are several GradingHueCurveTransform only one can have dynamic parameters.
+     */
     virtual bool isDynamic() const noexcept = 0;
     virtual void makeDynamic() noexcept = 0;
     virtual void makeNonDynamic() noexcept = 0;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=82.0.1",
     "wheel",
     "cmake>=3.14",
     "ninja; sys_platform != 'win32' and platform_machine != 'arm64'",
     # Documentation requirements (see docs/requirements.txt for details)
-    "urllib3<2",
-    "docutils>=0.18.1",
+    "urllib3<3",
+    "docutils>=0.22.4",
     "sphinx<=7.1.2",
     "six",
     "testresources",

--- a/share/cmake/modules/Findpybind11.cmake
+++ b/share/cmake/modules/Findpybind11.cmake
@@ -140,5 +140,14 @@ if(_pybind11_TARGET_CREATE)
         INTERFACE_INCLUDE_DIRECTORIES ${pybind11_INCLUDE_DIR}
     )
 
+    # /bigobj is needed for bigger binding projects due to the limit to 64k
+    # addressable sections (see pybind11Common.cmake).
+    if (MSVC)
+        set_target_properties(pybind11::module PROPERTIES
+            INTERFACE_COMPILE_OPTIONS /bigobj
+        )
+
+    endif()
+
     mark_as_advanced(pybind11_INCLUDE_DIR pybind11_VERSION)
 endif()

--- a/share/cmake/modules/install/InstallZLIB.cmake
+++ b/share/cmake/modules/install/InstallZLIB.cmake
@@ -53,8 +53,8 @@ if(NOT ZLIB_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAGE
 
     set(ZLIB_INCLUDE_DIRS "${_EXT_DIST_ROOT}/${CMAKE_INSTALL_INCLUDEDIR}")
 
-    # Windows need the "d" suffix at the end.
-    if(WIN32 AND BUILD_TYPE_DEBUG)
+    # Windows need the "d" suffix at the end (only for MSVC).
+    if(MSVC AND BUILD_TYPE_DEBUG)
         set(_ZLIB_LIB_SUFFIX "d")
     endif()
 

--- a/share/cmake/modules/install/Installexpat.cmake
+++ b/share/cmake/modules/install/Installexpat.cmake
@@ -46,9 +46,11 @@ if(NOT expat_FOUND AND OCIO_INSTALL_EXT_PACKAGES AND NOT OCIO_INSTALL_EXT_PACKAG
         if(BUILD_TYPE_DEBUG)
             set(_expat_LIB_SUFFIX "d")
         endif()
-        # Static Linking, Multi-threaded Dll naming (>=2.2.8):
-        #   https://github.com/libexpat/libexpat/blob/R_2_2_8/expat/win32/README.txt
-        set(_expat_LIB_SUFFIX "${_expat_LIB_SUFFIX}MD")
+        if (MSVC)
+            # Static Linking, Multi-threaded Dll naming (>=2.2.8):
+            #   https://github.com/libexpat/libexpat/blob/R_2_2_8/expat/win32/README.txt
+            set(_expat_LIB_SUFFIX "${_expat_LIB_SUFFIX}MD")
+        endif()
     endif()
 
     # Expat use a hardcoded lib prefix instead of CMAKE_STATIC_LIBRARY_PREFIX

--- a/src/OpenColorIO/ColorSpace.cpp
+++ b/src/OpenColorIO/ColorSpace.cpp
@@ -162,6 +162,7 @@ const char * ColorSpace::getAlias(size_t idx) const noexcept
 
 bool ColorSpace::hasAlias(const char * alias) const noexcept
 {
+    if (!alias) return false;
     for (size_t idx = 0; idx < getImpl()->m_aliases.size(); ++idx)
     {
         if (0 == Platform::Strcasecmp(getImpl()->m_aliases[idx].c_str(), alias))
@@ -430,6 +431,7 @@ int ColorSpace::getAllocationNumVars() const
 
 void ColorSpace::getAllocationVars(float * vars) const
 {
+    if(!vars) return;
     if(!getImpl()->m_allocationVars.empty())
     {
         memcpy(vars,
@@ -440,6 +442,15 @@ void ColorSpace::getAllocationVars(float * vars) const
 
 void ColorSpace::setAllocationVars(int numvars, const float * vars)
 {
+    if (numvars < 0)
+    {
+        throw Exception("setAllocationVars: numvars must not be negative.");
+    }
+    if (numvars > 0 && !vars)
+    {
+        throw Exception("setAllocationVars: vars must not be null when numvars is positive.");
+    }
+
     getImpl()->m_allocationVars.resize(numvars);
 
     if(!getImpl()->m_allocationVars.empty())

--- a/src/OpenColorIO/ColorSpaceSet.cpp
+++ b/src/OpenColorIO/ColorSpaceSet.cpp
@@ -180,6 +180,7 @@ public:
 
     void remove(const char * csName)
     {
+        if (!csName || !*csName) return;
         const std::string name = StringUtils::Lower(csName);
         if (name.empty()) return;
 

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -798,7 +798,7 @@ public:
         }
 
         const ViewVec & views = searchShared ? m_sharedViews : iter->second.m_views;
-        const auto & viewIt = FindView(views, view);
+        const auto viewIt = FindView(views, view);
 
         if (viewIt != views.end())
         {

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -4337,7 +4337,7 @@ int Config::getNumDisplaysAll() const noexcept
 
 const char * Config::getDisplayAll(int index) const noexcept
 {
-    if (index >= 0 || index < static_cast<int>(getImpl()->m_displays.size()))
+    if (index >= 0 && index < static_cast<int>(getImpl()->m_displays.size()))
     {
         return getImpl()->m_displays[index].first.c_str();
     }
@@ -4365,7 +4365,7 @@ int Config::getDisplayAllByName(const char * name) const noexcept
 
 bool Config::isDisplayTemporary(int index) const noexcept
 {
-    if (index >= 0 || index < static_cast<int>(getImpl()->m_displays.size()))
+    if (index >= 0 && index < static_cast<int>(getImpl()->m_displays.size()))
     {
         return getImpl()->m_displays[index].second.m_temporary;
     }
@@ -4375,7 +4375,7 @@ bool Config::isDisplayTemporary(int index) const noexcept
 
 void Config::setDisplayTemporary(int index, bool isTemporary) noexcept
 {
-    if (index >= 0 || index < static_cast<int>(getImpl()->m_displays.size()))
+    if (index >= 0 && index < static_cast<int>(getImpl()->m_displays.size()))
     {
         getImpl()->m_displays[index].second.m_temporary = isTemporary;
 
@@ -4410,7 +4410,7 @@ const char * Config::getView(ViewType type, const char * display, int index) con
 {
     if (!display || !*display)
     {
-        if (index >= 0 || index < static_cast<int>(getImpl()->m_sharedViews.size()))
+        if (index >= 0 && index < static_cast<int>(getImpl()->m_sharedViews.size()))
         {
             return getImpl()->m_sharedViews[index].m_name.c_str();
         }
@@ -4449,11 +4449,19 @@ const char * Config::getView(ViewType type, const char * display, int index) con
 
 void Config::getDefaultLumaCoefs(double * c3) const
 {
+    if (!c3)
+    {
+        throw Exception("getDefaultLumaCoefs: c3 must not be null.");
+    }
     memcpy(c3, &getImpl()->m_defaultLumaCoefs[0], 3*sizeof(double));
 }
 
 void Config::setDefaultLumaCoefs(const double * c3)
 {
+    if (!c3)
+    {
+        throw Exception("setDefaultLumaCoefs: c3 must not be null.");
+    }
     memcpy(&getImpl()->m_defaultLumaCoefs[0], c3, 3*sizeof(double));
 
     AutoMutex lock(getImpl()->m_cacheidMutex);

--- a/src/OpenColorIO/ContextVariableUtils.cpp
+++ b/src/OpenColorIO/ContextVariableUtils.cpp
@@ -101,10 +101,12 @@ void LoadEnvironment(EnvMap & map, bool update)
 
         const std::string env_str = (char*)*env;
 #endif
-        const int pos = static_cast<int>(env_str.find_first_of('='));
+        const auto pos = env_str.find_first_of('=');
+
+        if (pos == std::string::npos) continue;
 
         const std::string name  = env_str.substr(0, pos);
-        const std::string value = env_str.substr(pos+1, env_str.length());
+        const std::string value = env_str.substr(pos+1);
 
         if (update)
         {
@@ -122,8 +124,12 @@ void LoadEnvironment(EnvMap & map, bool update)
     }
 }
 
-std::string ResolveContextVariables(const std::string & str, const EnvMap & map, UsedEnvs & used)
+static std::string ResolveContextVariablesImpl(const std::string & str, const EnvMap & map,
+                                               UsedEnvs & used, int depth)
 {
+    // Guard against infinite recursion from cyclic variable references.
+    if (depth > 32) return str;
+
     // Early exit if no reserved tokens are found.
     if (!ContainsContextVariables(str))
     {
@@ -159,10 +165,15 @@ std::string ResolveContextVariables(const std::string & str, const EnvMap & map,
     // recursively call till string doesn't expand anymore
     if(newstr != orig)
     {
-        return ResolveContextVariables(newstr, map, used);
+        return ResolveContextVariablesImpl(newstr, map, used, depth + 1);
     }
 
     return orig;
+}
+
+std::string ResolveContextVariables(const std::string & str, const EnvMap & map, UsedEnvs & used)
+{
+    return ResolveContextVariablesImpl(str, map, used, 0);
 }
 
 bool CollectContextVariables(const Config & config, 

--- a/src/OpenColorIO/CustomKeys.h
+++ b/src/OpenColorIO/CustomKeys.h
@@ -61,14 +61,24 @@ public:
 
     bool hasKey(const char * key)
     {
-        std::string s = key;
-        return m_customKeys.count(s) > 0;
+        if (!key || !*key) return false;
+        return m_customKeys.count(key) > 0;
     }
 
     const char * getValueForKey(const char * key)
     {
-        // NB: Will throw if the map doesn't have the key.
-        return m_customKeys[key].c_str();
+        if (!key || !*key)
+        {
+            throw Exception("Key has to be a non-empty string.");
+        }
+        auto it = m_customKeys.find(key);
+        if (it == m_customKeys.end())
+        {
+            std::ostringstream oss;
+            oss << "Key '" << key << "' not found.";
+            throw Exception(oss.str().c_str());
+        }
+        return it->second.c_str();
     }
 
 private:

--- a/src/OpenColorIO/Display.cpp
+++ b/src/OpenColorIO/Display.cpp
@@ -52,7 +52,7 @@ void AddView(ViewVec & views, const char * name, const char * viewTransform,
              const char * displayColorSpace, const char * looks,
              const char * rule, const char * description)
 {
-    if (0 == Platform::Strcasecmp(displayColorSpace, OCIO_VIEW_USE_DISPLAY_NAME))
+    if (displayColorSpace && 0 == Platform::Strcasecmp(displayColorSpace, OCIO_VIEW_USE_DISPLAY_NAME))
     {
         displayColorSpace = OCIO_VIEW_USE_DISPLAY_NAME;
     }

--- a/src/OpenColorIO/Display.h
+++ b/src/OpenColorIO/Display.h
@@ -37,7 +37,7 @@ struct View
          const char * looks,
          const char * rule,
          const char * description)
-        : m_name(name)
+        : m_name(name ? name : "")
         , m_viewTransform(viewTransform ? viewTransform : "")
         , m_colorspace(colorspace ? colorspace : "")
         , m_looks(looks ? looks : "")

--- a/src/OpenColorIO/DynamicProperty.cpp
+++ b/src/OpenColorIO/DynamicProperty.cpp
@@ -280,6 +280,10 @@ void DynamicPropertyGradingRGBCurveImpl::precompute()
     {
         ConstGradingBSplineCurveRcPtr curve = m_gradingRGBCurve->getCurve(c);
         auto curveImpl = dynamic_cast<const GradingBSplineCurveImpl *>(curve.get());
+        if (!curveImpl)
+        {
+            throw Exception("DynamicPropertyGradingRGBCurveImpl: unexpected curve implementation.");
+        }
         curveImpl->computeKnotsAndCoefs(m_knotsCoefs, static_cast<int>(c), false);
     }
     if (m_knotsCoefs.m_numKnots <= 0) m_knotsCoefs.m_localBypass = true;
@@ -375,6 +379,10 @@ void DynamicPropertyGradingHueCurveImpl::precompute()
     {
         ConstGradingBSplineCurveRcPtr curve = m_gradingHueCurve->getCurve(c);
         auto curveImpl = dynamic_cast<const GradingBSplineCurveImpl *>(curve.get());
+        if (!curveImpl)
+        {
+            throw Exception("DynamicPropertyGradingHueCurveImpl: unexpected curve implementation.");
+        }
         curveImpl->computeKnotsAndCoefs(m_knotsCoefs, static_cast<int>(c),
                                         m_gradingHueCurve->getDrawCurveOnly());
     }

--- a/src/OpenColorIO/GpuShader.cpp
+++ b/src/OpenColorIO/GpuShader.cpp
@@ -11,7 +11,7 @@
 
 #include "DynamicProperty.h"
 #include "GpuShader.h"
-#include "ops/lut3d/Lut3DOpData.h"
+#include "LutLimits.h"
 #include "Platform.h"
 
 namespace OCIO_NAMESPACE
@@ -194,7 +194,7 @@ public:
 
     virtual ~PrivateImpl() {}
 
-    inline unsigned get3dLutMaxLength() const { return Lut3DOpData::maxSupportedLength; }
+    inline unsigned get3dLutMaxLength() const { return Max3DLUTLength; }
 
     inline unsigned get1dLutMaxWidth() const { return m_max1DLUTWidth; }
     inline void set1dLutMaxWidth(unsigned maxWidth) { m_max1DLUTWidth = maxWidth; }

--- a/src/OpenColorIO/GpuShaderDesc.cpp
+++ b/src/OpenColorIO/GpuShaderDesc.cpp
@@ -135,7 +135,7 @@ void GpuShaderCreator::setFunctionName(const char * name) noexcept
 {
     AutoMutex lock(getImpl()->m_cacheIDMutex);
     // Note: Remove potentially problematic double underscores from GLSL resource names.
-    getImpl()->m_functionName = StringUtils::Replace(name, "__", "_");
+    getImpl()->m_functionName = StringUtils::Replace(name ? name : "", "__", "_");
     getImpl()->m_cacheID.clear();
 }
 
@@ -148,7 +148,7 @@ void GpuShaderCreator::setResourcePrefix(const char * prefix) noexcept
 {
     AutoMutex lock(getImpl()->m_cacheIDMutex);
     // Note: Remove potentially problematic double underscores from GLSL resource names.
-    getImpl()->m_resourcePrefix = StringUtils::Replace(prefix, "__", "_");
+    getImpl()->m_resourcePrefix = StringUtils::Replace(prefix ? prefix : "", "__", "_");
     getImpl()->m_cacheID.clear();
 }
 
@@ -161,7 +161,7 @@ void GpuShaderCreator::setPixelName(const char * name) noexcept
 {
     AutoMutex lock(getImpl()->m_cacheIDMutex);
     // Note: Remove potentially problematic double underscores from GLSL resource names.
-    getImpl()->m_pixelName = StringUtils::Replace(name, "__", "_");
+    getImpl()->m_pixelName = StringUtils::Replace(name ? name : "", "__", "_");
     getImpl()->m_cacheID.clear();
 }
 

--- a/src/OpenColorIO/GpuShaderUtils.cpp
+++ b/src/OpenColorIO/GpuShaderUtils.cpp
@@ -482,7 +482,8 @@ std::string GpuShaderText::declareVarStr(const std::string & name, float v)
 std::string GpuShaderText::vectorCompareExpression(const std::string& lhs, const std::string& op, const std::string& rhs)
 {
     std::string ret = lhs + " " + op + " " + rhs;
-    if(m_lang == GPU_LANGUAGE_MSL_2_0)
+    // MSL and HLSL do not allow vector bool in if-conditions: wrap with any().
+    if(m_lang == GPU_LANGUAGE_MSL_2_0 || m_lang == GPU_LANGUAGE_HLSL_SM_5_0)
     {
         ret = "any( " + ret + " )";
     }

--- a/src/OpenColorIO/HashUtils.cpp
+++ b/src/OpenColorIO/HashUtils.cpp
@@ -21,7 +21,9 @@ std::string CacheIDHash(const char * array, std::size_t size)
     XXH128_hash_t hash = XXH3_128bits(array, size);
 
     std::stringstream oss;
-    oss << std::hex << hash.low64 << hash.high64;
+    oss << std::hex << std::setfill('0');
+    oss << std::setw(16) << hash.low64;
+    oss << std::setw(16) << hash.high64;
     return oss.str();
 }
 

--- a/src/OpenColorIO/HashUtils.cpp
+++ b/src/OpenColorIO/HashUtils.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright Contributors to the OpenColorIO Project.
 
+#include <iomanip>
 #include <sstream>
 
 #include <OpenColorIO/OpenColorIO.h>

--- a/src/OpenColorIO/ImageDesc.cpp
+++ b/src/OpenColorIO/ImageDesc.cpp
@@ -260,6 +260,7 @@ struct PackedImageDesc::Impl
         {
             // Confirm xStrideBytes is a pure packing
             // (I.e., it will divide evenly)
+            if (m_chanStrideBytes == 0) return false;
             const div_t result = div((int)m_xStrideBytes, (int)m_chanStrideBytes);
             if(result.rem != 0) return false;
 

--- a/src/OpenColorIO/Logging.cpp
+++ b/src/OpenColorIO/Logging.cpp
@@ -114,11 +114,17 @@ void SetLoggingLevel(LoggingLevel level)
 
 void SetLoggingFunction(LoggingFunction logFunction)
 {
+    if (!logFunction)
+    {
+        throw Exception("SetLoggingFunction: logFunction must not be null.");
+    }
+    AutoMutex lock(g_logmutex);
     g_loggingFunction = logFunction;
 }
 
 void ResetToDefaultLoggingFunction()
 {
+    AutoMutex lock(g_logmutex);
     g_loggingFunction = DefaultLoggingFunction;
 }
 

--- a/src/OpenColorIO/LutLimits.h
+++ b/src/OpenColorIO/LutLimits.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright Contributors to the OpenColorIO Project.
+
+#ifndef INCLUDED_OCIO_LUTLIMITS_H
+#define INCLUDED_OCIO_LUTLIMITS_H
+
+namespace OCIO_NAMESPACE
+{
+
+// Maximum number of entries supported in a 1D LUT.
+constexpr unsigned long Max1DLUTLength = 300000;
+
+// Maximum grid size supported for a 3D LUT.
+// 129 allows for a MESH dimension of 7 in the 3dl file format.
+constexpr unsigned long Max3DLUTLength = 129;
+
+} // namespace OCIO_NAMESPACE
+
+#endif // INCLUDED_OCIO_LUTLIMITS_H

--- a/src/OpenColorIO/NamedTransform.cpp
+++ b/src/OpenColorIO/NamedTransform.cpp
@@ -67,6 +67,7 @@ const char * NamedTransformImpl::getAlias(size_t idx) const noexcept
 
 bool NamedTransformImpl::hasAlias(const char * alias) const noexcept
 {
+    if (!alias || !*alias) return false;
     for (size_t idx = 0; idx < m_aliases.size(); ++idx)
     {
         if (0 == Platform::Strcasecmp(m_aliases[idx].c_str(), alias))

--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -4413,17 +4413,24 @@ inline void load(const YAML::Node& node, ConfigRcPtr & config, const char* filen
 
         results = StringUtils::Split(version, '.');
 
-        if(results.size()==1)
+        try
         {
-            profile_major_version = std::stoi(results[0].c_str());
-            profile_minor_version = 0;
+            if(results.size()==1)
+            {
+                profile_major_version = std::stoi(results[0].c_str());
+                profile_minor_version = 0;
+            }
+            else if(results.size()==2)
+            {
+                profile_major_version = std::stoi(results[0].c_str());
+                profile_minor_version = std::stoi(results[1].c_str());
+            }
+            else
+            {
+                faulty_version = true;
+            }
         }
-        else if(results.size()==2)
-        {
-            profile_major_version = std::stoi(results[0].c_str());
-            profile_minor_version = std::stoi(results[1].c_str());
-        }
-        else
+        catch (const std::exception &)
         {
             faulty_version = true;
         }

--- a/src/OpenColorIO/OCIOZArchive.cpp
+++ b/src/OpenColorIO/OCIOZArchive.cpp
@@ -387,6 +387,21 @@ void ExtractOCIOZArchive(const char * archivePath, const char * destination)
     mz_zip_reader_delete(&extracter);
 }
 
+std::vector<uint8_t> readEntryBuffer(void * reader)
+{
+    int32_t buf_size = (int32_t)mz_zip_reader_entry_save_buffer_length(reader);
+    // Reject negative values (minizip error codes) and implausibly large entries.
+    // 256 MB is well above any realistic individual OCIO config or LUT file size.
+    static constexpr size_t MAX_ENTRY_SIZE = 256 * 1024 * 1024;
+    if (buf_size <= 0 || (size_t)buf_size > MAX_ENTRY_SIZE)
+    {
+        throw Exception("OCIOZ archive entry size is invalid or exceeds maximum allowed size.");
+    }
+    std::vector<uint8_t> buffer(buf_size);
+    mz_zip_reader_entry_save_buffer(reader, &buffer[0], buf_size);
+    return buffer;
+}
+
 /**
  * \brief Callback function for getFileStringFromArchiveStream in order to get the contents of a
  *        file inside an OCIOZ archive as a buffer. 
@@ -406,11 +421,7 @@ std::vector<uint8_t> getFileBufferByPath(void * reader, mz_zip_file & info, std:
     std::vector<uint8_t> buffer;
     if (mz_path_compare_wc(filepath.c_str(), info.filename, 1) == MZ_OK)
     {
-        // Initialize the buffer for the file.
-        int32_t buf_size = (int32_t)mz_zip_reader_entry_save_buffer_length(reader);
-        buffer.resize(buf_size);
-        // Read the content of the file and return it as buffer.
-        mz_zip_reader_entry_save_buffer(reader, &buffer[0], buf_size);
+        buffer = readEntryBuffer(reader);
     }
     return buffer;
 }
@@ -434,9 +445,7 @@ std::vector<uint8_t> getFileBufferByExtension(void * reader, mz_zip_file & info,
     pystring::os::path::splitext(root, ext, info.filename);
     if (Platform::Strcasecmp(extension.c_str(), ext.c_str()) == 0)
     {
-        int32_t buf_size = (int32_t)mz_zip_reader_entry_save_buffer_length(reader);
-        buffer.resize(buf_size);
-        mz_zip_reader_entry_save_buffer(reader, &buffer[0], buf_size);
+        buffer = readEntryBuffer(reader);
     }
     return buffer;
 }

--- a/src/OpenColorIO/Platform.cpp
+++ b/src/OpenColorIO/Platform.cpp
@@ -22,7 +22,7 @@ namespace OCIO_NAMESPACE
 
 const char * GetEnvVariable(const char * name)
 {
-    static std::string value;
+    thread_local std::string value;
     Platform::Getenv(name, value);
     return value.c_str();
 }
@@ -183,12 +183,16 @@ int Strncasecmp(const char * str1, const char * str2, size_t n)
 void * AlignedMalloc(size_t size, size_t alignment)
 {
 #ifdef _WIN32
-    return _aligned_malloc(size, alignment);
+    void * memBlock = _aligned_malloc(size, alignment);
 #else
-    void* memBlock = 0x0;
-    if (!posix_memalign(&memBlock, alignment, size)) return memBlock;
-    return 0x0;
+    void* memBlock = nullptr;
+    if (posix_memalign(&memBlock, alignment, size)) memBlock = nullptr;
 #endif
+    if (!memBlock)
+    {
+        throw Exception("AlignedMalloc: memory allocation failure.");
+    }
+    return memBlock;
 }
 
 void AlignedFree(void* memBlock)

--- a/src/OpenColorIO/Processor.cpp
+++ b/src/OpenColorIO/Processor.cpp
@@ -289,6 +289,10 @@ int Processor::Impl::getNumTransforms() const
 
 const FormatMetadata & Processor::Impl::getTransformFormatMetadata(int index) const
 {
+    if (index < 0 || index >= static_cast<int>(m_ops.size()))
+    {
+        throw Exception("Processor::getTransformFormatMetadata: index out of range.");
+    }
     auto op = OCIO_DYNAMIC_POINTER_CAST<const Op>(m_ops[index]);
     return op->data()->getFormatMetadata();
 }
@@ -352,8 +356,19 @@ OptimizationFlags EnvironmentOverride(OptimizationFlags oFlags)
     const std::string envFlag = GetEnvVariable(OCIO_OPTIMIZATION_FLAGS_ENVVAR);
     if (!envFlag.empty())
     {
-        // Use 0 to allow base to be determined by the format.
-        oFlags = static_cast<OptimizationFlags>(std::stoul(envFlag, nullptr, 0));
+        try
+        {
+            // Use 0 to allow base to be determined by the format.
+            oFlags = static_cast<OptimizationFlags>(std::stoul(envFlag, nullptr, 0));
+        }
+        catch (const std::exception & e)
+        {
+            std::string msg("Illegal value for ");
+            msg += OCIO_OPTIMIZATION_FLAGS_ENVVAR;
+            msg += ": ";
+            msg += e.what();
+            throw Exception(msg.c_str());
+        }
     }
     return oFlags;
 }

--- a/src/OpenColorIO/SystemMonitor.cpp
+++ b/src/OpenColorIO/SystemMonitor.cpp
@@ -8,6 +8,7 @@
 
 #include <OpenColorIO/OpenColorIO.h>
 
+#include "Logging.h"
 #include "Mutex.h"
 #include "SystemMonitor.h"
 
@@ -62,7 +63,14 @@ ConstSystemMonitorsRcPtr SystemMonitors::Get() noexcept
     if (!monitors)
     {
         SystemMonitorsRcPtr m = std::make_shared<SystemMonitorsImpl>();
-        DynamicPtrCast<SystemMonitorsImpl>(m)->getAllMonitors();
+        try
+        {
+            DynamicPtrCast<SystemMonitorsImpl>(m)->getAllMonitors();
+        }
+        catch (const std::exception & ex)
+        {
+            LogDebug(ex.what());
+        }
         monitors = m;
     }
 

--- a/src/OpenColorIO/TokensManager.h
+++ b/src/OpenColorIO/TokensManager.h
@@ -51,6 +51,7 @@ public:
 
     void addToken(const char * token)
     {
+        if (!token || !*token) return;
         if (findToken(token) == m_tokens.end())
         {
             m_tokens.push_back(StringUtils::Trim(token));

--- a/src/OpenColorIO/Transform.cpp
+++ b/src/OpenColorIO/Transform.cpp
@@ -373,9 +373,10 @@ void CreateTransform(GroupTransformRcPtr & group, ConstOpRcPtr & op)
     }
     else
     {
+        const auto & ref = *op;
         std::ostringstream error;
         error << "CreateTransform from op. Missing implementation for: "
-                <<  typeid(op).name();
+              << typeid(ref).name();
 
         throw Exception(error.str().c_str());
     }

--- a/src/OpenColorIO/apphelpers/CategoryHelpers.cpp
+++ b/src/OpenColorIO/apphelpers/CategoryHelpers.cpp
@@ -262,6 +262,7 @@ T Intersection(const T & list0, const T & list1)
 
 StringUtils::StringVec ExtractItems(const char * strings)
 {
+    if (!strings) return {};
     StringUtils::StringVec tmp = StringUtils::Split(StringUtils::Lower(strings), ',');
     StringUtils::StringVec all;
 

--- a/src/OpenColorIO/apphelpers/DisplayViewHelpers.cpp
+++ b/src/OpenColorIO/apphelpers/DisplayViewHelpers.cpp
@@ -406,7 +406,7 @@ void AddDisplayView(ConfigRcPtr & config,
         {
             std::string errMsg;
             errMsg += "Connection color space name '";
-            errMsg += connectionColorSpaceName;
+            errMsg += connectionColorSpaceName ? connectionColorSpaceName : "(null)";
             errMsg += "' does not exist.";
 
             throw Exception(errMsg.c_str());
@@ -502,6 +502,8 @@ void AddDisplayView(ConfigRcPtr & config,
 
 void RemoveDisplayView(ConfigRcPtr & config, const char * displayName, const char * viewName)
 {
+    if (!displayName || !viewName) return;
+
     const std::string name{ config->getDisplayViewColorSpaceName(displayName, viewName) };
     const std::string csName{ name.empty() ? displayName : name };
     if (csName.empty())

--- a/src/OpenColorIO/apphelpers/MixingHelpers.cpp
+++ b/src/OpenColorIO/apphelpers/MixingHelpers.cpp
@@ -205,6 +205,11 @@ void MixingColorSpaceManagerImpl::setSelectedMixingSpaceIdx(size_t idx)
 
 void MixingColorSpaceManagerImpl::setSelectedMixingSpace(const char * mixingSpace)
 {
+    if (!mixingSpace)
+    {
+        throw Exception("Invalid null mixing space name.");
+    }
+
     for (size_t idx = 0 ; idx < m_mixingSpaces.size(); ++idx)
     {
         if (m_mixingSpaces[idx] == mixingSpace)
@@ -269,6 +274,11 @@ void MixingColorSpaceManagerImpl::setSelectedMixingEncodingIdx(size_t idx)
 
 void MixingColorSpaceManagerImpl::setSelectedMixingEncoding(const char * mixingEncoding)
 {
+    if (!mixingEncoding)
+    {
+        throw Exception("Invalid null mixing encoding name.");
+    }
+
     for (size_t idx = 0 ; idx < m_mixingEncodings.size(); ++idx)
     {
         if (m_mixingEncodings[idx] == mixingEncoding)

--- a/src/OpenColorIO/apphelpers/mergeconfigs/MergeConfigsHelpers.cpp
+++ b/src/OpenColorIO/apphelpers/mergeconfigs/MergeConfigsHelpers.cpp
@@ -477,16 +477,19 @@ ConstConfigRcPtr ConfigMerger::Impl::loadConfig(const char * value) const
         try
         {
             // Try to load the provided config using the search paths.
-            // Return as soon as they find a valid path.
-            const std::string resolvedfullpath = pystring::os::path::join(searchpaths[i], 
-                                                                          value);
+            // Return as soon as a valid path is found.
+            // Normalize the path to prevent directory traversal via '../' sequences.
+            const std::string resolvedfullpath = pystring::os::path::normpath(
+                pystring::os::path::join(searchpaths[i], value));
             return Config::CreateFromFile(resolvedfullpath.c_str());
         }
         // TODO: If the file exists but won't load, this hides the error.
         // (Tried using ExceptionMissingFile, but the implementation of that is not what I
         // expected, Config::CreateFromFile only uses that if the argument is empty, not
         // if it can't read the file.)
-        catch(...) { /* don't capture the exception */ }
+        // There is no need to log a warning here, since this is simply trying the various
+        // locations on the path that might contain the config.
+        catch(...) { }
     }
 
     // Try to load the provided base config name as a built-in config.
@@ -495,7 +498,9 @@ ConstConfigRcPtr ConfigMerger::Impl::loadConfig(const char * value) const
         // Check if the base config name is a built-in config.
         return Config::CreateFromBuiltinConfig(value);
     }
-    catch(...) { /* don't capture the exception */ }
+    // There is no need to log a warning here, since this is simply trying the various
+    // possible sources for the named config.
+    catch(...) { }
 
     // Must be a reference to a config from a previous merge.
     for (size_t i = 0; i < m_mergeParams.size(); i++)

--- a/src/OpenColorIO/apphelpers/mergeconfigs/OCIOMYaml.cpp
+++ b/src/OpenColorIO/apphelpers/mergeconfigs/OCIOMYaml.cpp
@@ -299,8 +299,7 @@ void OCIOMYaml::loadParams(const YAML::Node & node, ConfigMergingParametersRcPtr
         }                                                          
         else
         {
-            // Handle unsupported property or use default handler.
-            std::cout << "Unsupported property : " << key << std::endl;
+            LogWarning("Unsupported property in merge params: " + key);
         }
     }
 }
@@ -324,15 +323,34 @@ void OCIOMYaml::load(const YAML::Node& node, ConfigMergerRcPtr & merger, const c
             load(node["ociom_version"], version);
             results = StringUtils::Split(version, '.');
 
-            if(results.size() == 1)
+            bool faulty_version = false;
+            try
             {
-                merger->setVersion(std::stoi(results[0].c_str()), 0);
+                if(results.size() == 1)
+                {
+                    merger->setVersion(std::stoi(results[0].c_str()), 0);
+                }
+                else if(results.size() == 2)
+                {
+                    merger->setVersion(std::stoi(results[0].c_str()),
+                                       std::stoi(results[1].c_str()));
+                }
+                else
+                {
+                    faulty_version = true;
+                }
             }
-            else if(results.size() == 2)
+            catch (const std::exception &)
             {
-                merger->setVersion(std::stoi(results[0].c_str()),
-                                   std::stoi(results[1].c_str()));
+                faulty_version = true;
             }
+
+            if (faulty_version)
+            {
+                throwValueError(it->second.Tag(), it->first,
+                                "The value '" + version + "' is not a valid OCIOM version.");
+            }
+
             if (merger->getMajorVersion() > 1u || merger->getMinorVersion() > 0u)
             {
                 throwValueError(it->second.Tag(), it->first,

--- a/src/OpenColorIO/builtinconfigs/BuiltinConfigRegistry.cpp
+++ b/src/OpenColorIO/builtinconfigs/BuiltinConfigRegistry.cpp
@@ -34,6 +34,8 @@ namespace OCIO_NAMESPACE
 // Note that this function does not require initializing the built-in config registry.
 const char * ResolveConfigPath(const char * originalPath) noexcept
 {
+    if (!originalPath) return "";
+
     static const std::regex uriPattern(R"(ocio:\/\/([^\s]+))");
     std::smatch match;
     const std::string uri = originalPath;

--- a/src/OpenColorIO/fileformats/FileFormat3DL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormat3DL.cpp
@@ -314,6 +314,13 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
             // If we've found 3 ints, add it to our 3D LUT.
             else if(tmpData.size() == 3)
             {
+                if (raw3d.size() > Max3DLUTLength * Max3DLUTLength * Max3DLUTLength * 3)
+                {
+                    std::ostringstream os;
+                    os << "Error parsing .3dl file. ";
+                    os << "Too many 3D LUT entries found.";
+                    throw Exception(os.str().c_str());
+                }
                 raw3d.push_back(tmpData[0]);
                 raw3d.push_back(tmpData[1]);
                 raw3d.push_back(tmpData[2]);

--- a/src/OpenColorIO/fileformats/FileFormatCSP.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCSP.cpp
@@ -487,9 +487,16 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
     {
         // How many 1D LUT points do we have.
         nextline (istream, line);
-        int points1D = std::stoi(line.c_str());
+        int points1D = 0;
+        if (!StringToInt(&points1D, line.c_str()))
+        {
+            std::ostringstream os;
+            os << "A csp 1D LUT with invalid number of entries (";
+            os << line << ") in " << fileName << ".";
+            throw Exception(os.str().c_str());
+        }
 
-        if (points1D <= 0)
+        if (points1D <= 0 || points1D > static_cast<long>(Max1DLUTLength))
         {
             std::ostringstream os;
             os << "A csp 1D LUT with invalid number of entries (";
@@ -563,7 +570,7 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
             throw Exception(os.str().c_str());
         }
 
-        if (lutSize <= 0)
+        if (lutSize <= 0 || lutSize > static_cast<long>(Max3DLUTLength))
         {
             std::ostringstream os;
             os << "A csp 3D LUT with invalid cube size (";

--- a/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
@@ -411,9 +411,9 @@ int Lut1dUtils::IMLutGet(
     {
         char dstDepthS[16] = "";
 #ifdef _WIN32
-        const int nummatched = sscanf(InString, "%*s %d %d %s", &numtables, &length, dstDepthS, 16);
+        const int nummatched = sscanf_s(InString, "%*s %d %d %15s", &numtables, &length, dstDepthS, 16);
 #else
-        const int nummatched = sscanf(InString, "%*s %d %d %s", &numtables, &length, dstDepthS);
+        const int nummatched = sscanf(InString, "%*s %d %d %15s", &numtables, &length, dstDepthS);
 #endif
         std::string subStr(InString, 5);
         if (nummatched < 2 ||

--- a/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
@@ -275,15 +275,13 @@ bool Lut1dUtils::IMLutAlloc(IMLutStruct **plut, int num, int length)
     // targetBitDepth will be set appropriately for conversion LUTs in IMLutGet
     lut->targetBitDepth = IMLutTableSizeToBitDepth(length);
 
-    lut->tables = (unsigned short **)malloc(4 * sizeof(unsigned short *));
+    lut->tables = (unsigned short **)calloc(4, sizeof(unsigned short *));
     if (lut->tables == NULL)
     {
         delete lut;
         lut = 0;
         return false;
     }
-    for (i = 0; i < num; i++)
-        lut->tables[i] = NULL;
     for (i = 0; i < num; i++)
     {
         lut->tables[i] = (unsigned short *)malloc(length * sizeof(unsigned short));
@@ -324,7 +322,15 @@ static int tableLoad(
 
         if (isdigit(*InString))
         {
-            ptable[Count++] = (unsigned short)std::stoi(InString);
+            try
+            {
+                ptable[Count++] = (unsigned short)std::stoi(InString);
+            }
+            catch (const std::exception &)
+            {
+                errorLine = InString;
+                return Lut1dUtils::IMLUT_ERR_SYNTAX;
+            }
             if (Count >= length)
                 break;
         }
@@ -404,7 +410,18 @@ int Lut1dUtils::IMLutGet(
         }
 
         // Load first table value.
-        (lut->tables[0])[0] = (unsigned short)std::stoi(InString);
+        try
+        {
+            (lut->tables[0])[0] = (unsigned short)std::stoi(InString);
+        }
+        catch (const std::exception &)
+        {
+            errorLine = InString;
+            status = IMLUT_ERR_SYNTAX;
+            IMLutFree(&lut);
+            *plut = 0;
+            goto load_abort;
+        }
         tablestart = 1;
     }
     else
@@ -419,7 +436,8 @@ int Lut1dUtils::IMLutGet(
         if (nummatched < 2 ||
             StringUtils::Lower(subStr) != "lut: " ||
             (numtables != 1 && numtables != 3 && numtables != 4) ||
-            length <= 0)
+            length <= 0 ||
+            length > 65536)
         {
             errorLine = InString;
             status = IMLUT_ERR_SYNTAX;
@@ -435,7 +453,7 @@ int Lut1dUtils::IMLutGet(
             int dstDepth = 0;
             char floatC = ' ';
 #ifdef _WIN32
-            sscanf(dstDepthS, "%d%c", &dstDepth, &floatC, 1);
+            sscanf_s(dstDepthS, "%d%c", &dstDepth, &floatC, 1);
 #else
             sscanf(dstDepthS, "%d%c", &dstDepth, &floatC);
 #endif

--- a/src/OpenColorIO/fileformats/FileFormatHDL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatHDL.cpp
@@ -189,6 +189,13 @@ readLuts(std::istream& istream,
 
             if (result.ec == std::errc())
             {
+                // Cap per-LUT entry count: max is Max3DLUTLength^3 * 3 for a 3D LUT.
+                if (lutValues[lutname].size() > Max3DLUTLength * Max3DLUTLength * Max3DLUTLength * 3)
+                {
+                    std::ostringstream os;
+                    os << "Too many values in " << lutname << " LUT block";
+                    throw Exception(os.str().c_str());
+                }
                 lutValues[lutname].push_back(v);
             }
             else
@@ -452,6 +459,13 @@ LocalFileFormat::read(std::istream & istream,
             // Set cube size
             size_3d = lut_sizes[0];
 
+            if(size_3d < 2 || size_3d > static_cast<long>(Max3DLUTLength))
+            {
+                std::ostringstream os;
+                os << "3D LUT cube size must be between 2 and " << Max3DLUTLength << ", found: " << size_3d;
+                throw Exception(os.str().c_str());
+            }
+
             lut3d_ptr = std::make_shared<Lut3DOpData>(lut_sizes[0]);
             if (Lut3DOpData::IsValidInterpolation(interp))
             {
@@ -463,11 +477,23 @@ LocalFileFormat::read(std::istream & istream,
         if(cachedFile->hdltype == "c")
         {
             size_1d = lut_sizes[0];
+            if(size_1d < 2 || size_1d > static_cast<long>(Max1DLUTLength))
+            {
+                std::ostringstream os;
+                os << "1D LUT size must be between 2 and " << Max1DLUTLength << ", found: " << size_1d;
+                throw Exception(os.str().c_str());
+            }
         }
 
         if(cachedFile->hdltype == "3d+1d")
         {
             size_prelut = lut_sizes[1];
+            if(size_prelut < 2 || size_prelut > static_cast<long>(Max1DLUTLength))
+            {
+                std::ostringstream os;
+                os << "Prelut size must be between 2 and " << Max1DLUTLength << ", found: " << size_prelut;
+                throw Exception(os.str().c_str());
+            }
         }
     }
 

--- a/src/OpenColorIO/fileformats/FileFormatICC.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatICC.cpp
@@ -180,9 +180,14 @@ LocalCachedFileRcPtr LocalFileFormat::ReadInfo(std::istream & istream,
         ThrowErrorMessage("Error loading number of tags.", fileName);
     }
 
+    constexpr icUInt32Number MaxNumICCTags = 100;
+    if (count > MaxNumICCTags)
+    {
+        ThrowErrorMessage("Too many tags in ICC profile.", fileName);
+    }
     icc.mTags.resize(count);
 
-    // Read Tag offset table. 
+    // Read Tag offset table.
     for (i = 0; i<count; i++)
     {
         if (!SampleICC::Read32(istream, &icc.mTags[i].mTagInfo.sig, 1)

--- a/src/OpenColorIO/fileformats/FileFormatIridasCube.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasCube.cpp
@@ -205,6 +205,16 @@ LocalFileFormat::read(std::istream & istream,
                         line);
                 }
 
+                if (size1d < 2 || size1d > static_cast<long>(Max1DLUTLength))
+                {
+                    ThrowErrorMessage(
+                        ("'LUT_1D_SIZE' must be between 2 and "
+                         + std::to_string(Max1DLUTLength) + ".").c_str(),
+                        fileName,
+                        lineNumber,
+                        line);
+                }
+
                 raw.reserve(3*size1d);
                 in1d = true;
             }
@@ -226,6 +236,16 @@ LocalFileFormat::read(std::istream & istream,
                 {
                     ThrowErrorMessage(
                         "Malformed 'LUT_3D_SIZE' tag.",
+                        fileName,
+                        lineNumber,
+                        line);
+                }
+
+                if (size3d < 2 || size3d > static_cast<long>(Max3DLUTLength))
+                {
+                    ThrowErrorMessage(
+                        ("'LUT_3D_SIZE' must be between 2 and "
+                         + std::to_string(Max3DLUTLength) + ".").c_str(),
                         fileName,
                         lineNumber,
                         line);
@@ -322,9 +342,9 @@ LocalFileFormat::read(std::istream & istream,
             char valB[64] = "";
 
 #ifdef _WIN32
-            if (sscanf_s(line.c_str(), "%s %s %s %c", valR, 64, valG, 64, valB, 64, &endTok, 1) != 3)
+            if (sscanf_s(line.c_str(), "%63s %63s %63s %c", valR, 64, valG, 64, valB, 64, &endTok, 1) != 3)
 #else
-            if (sscanf(line.c_str(), "%s %s %s %c", valR, valG, valB, &endTok) != 3)
+            if (sscanf(line.c_str(), "%63s %63s %63s %c", valR, valG, valB, &endTok) != 3)
 #endif
             {
                 // It must be a float triple!

--- a/src/OpenColorIO/fileformats/FileFormatIridasCube.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasCube.cpp
@@ -241,9 +241,9 @@ LocalFileFormat::read(std::istream & istream,
                 char domainMinB[64] = "";
 
 #ifdef _WIN32
-                if (sscanf_s(line.c_str(), "domain_min %s %s %s %c", domainMinR, 64, domainMinG, 64, domainMinB, 64, &endTok, 1) != 3)
+                if (sscanf_s(line.c_str(), "domain_min %63s %63s %63s %c", domainMinR, 64, domainMinG, 64, domainMinB, 64, &endTok, 1) != 3)
 #else
-                if (sscanf(line.c_str(), "domain_min %s %s %s %c", domainMinR, domainMinG, domainMinB, &endTok) != 3)
+                if (sscanf(line.c_str(), "domain_min %63s %63s %63s %c", domainMinR, domainMinG, domainMinB, &endTok) != 3)
 #endif
                 {
                     ThrowErrorMessage(
@@ -275,9 +275,9 @@ LocalFileFormat::read(std::istream & istream,
                 char domainMaxB[64] = "";
 
 #ifdef _WIN32
-                if (sscanf_s(line.c_str(), "domain_max %s %s %s %c", domainMaxR, 64, domainMaxG, 64, domainMaxB, 64, &endTok, 1) != 3)
+                if (sscanf_s(line.c_str(), "domain_max %63s %63s %63s %c", domainMaxR, 64, domainMaxG, 64, domainMaxB, 64, &endTok, 1) != 3)
 #else
-                if (sscanf(line.c_str(), "domain_max %s %s %s %c", domainMaxR, domainMaxG, domainMaxB, &endTok) != 3)
+                if (sscanf(line.c_str(), "domain_max %63s %63s %63s %c", domainMaxR, domainMaxG, domainMaxB, &endTok) != 3)
 #endif
                 {
                     ThrowErrorMessage(

--- a/src/OpenColorIO/fileformats/FileFormatIridasItx.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasItx.cpp
@@ -165,6 +165,15 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
                         lineNumber,
                         line);
                 }
+                if (size < 2 || size > static_cast<long>(Max3DLUTLength))
+                {
+                    ThrowErrorMessage(
+                        ("LUT_3D_SIZE must be between 2 and "
+                         + std::to_string(Max3DLUTLength) + ".").c_str(),
+                        fileName,
+                        lineNumber,
+                        line);
+                }
                 size3d = size;
 
                 raw.reserve(3*size3d * size3d * size3d);
@@ -179,6 +188,15 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
                 {
                     ThrowErrorMessage(
                         "Malformed color triples specified.",
+                        fileName,
+                        lineNumber,
+                        line);
+                }
+
+                if (raw.size() > Max3DLUTLength * Max3DLUTLength * Max3DLUTLength * 3)
+                {
+                    ThrowErrorMessage(
+                        "Too many 3D LUT entries.",
                         fileName,
                         lineNumber,
                         line);

--- a/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
@@ -429,6 +429,13 @@ private:
                 os << "'. Expected quoted integer";
                 pImpl->Throw(os.str().c_str());
             }
+            if (size_3d < 2 || size_3d > static_cast<long>(Max3DLUTLength))
+            {
+                std::ostringstream os;
+                os << "Invalid LUT size value: '" << size_raw;
+                os << "'. Expected value between 2 and " << Max3DLUTLength;
+                pImpl->Throw(os.str().c_str());
+            }
             pImpl->m_lutSize = static_cast<int>(size_3d);
         }
         else if (pImpl->m_data)
@@ -441,7 +448,11 @@ private:
             StringUtils::ReplaceInPlace(what, "\"", "");
             StringUtils::ReplaceInPlace(what, "'", "");
             StringUtils::ReplaceInPlace(what, "\n", "");
-            // Append to lut string
+            // Append to lut string (cap at max possible: Max3DLUTLength^3 entries * 3 floats * 8 hex chars)
+            if (pImpl->m_lutString.size() + what.size() > Max3DLUTLength * Max3DLUTLength * Max3DLUTLength * 3 * 8)
+            {
+                pImpl->Throw("Too many characters in 'data' block");
+            }
             pImpl->m_lutString += what;
         }
     }

--- a/src/OpenColorIO/fileformats/FileFormatPandora.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatPandora.cpp
@@ -156,6 +156,16 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
                         lineNumber,
                         line);
                 }
+                if (inval < 8 || inval > static_cast<long>(Max3DLUTLength * Max3DLUTLength * Max3DLUTLength))
+                {
+                    ThrowErrorMessage(
+                        ("'in' value must be between 8 and "
+                         + std::to_string(Max3DLUTLength * Max3DLUTLength * Max3DLUTLength)
+                         + " (" + std::to_string(Max3DLUTLength) + "^3).").c_str(),
+                        fileName,
+                        lineNumber,
+                        line);
+                }
                 raw3d.reserve(inval*3);
                 lutEdgeLen = Get3DLutEdgeLenFromNumPixels(inval);
             }
@@ -208,6 +218,15 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
                 {
                     ThrowErrorMessage(
                         "Expected to find 4 integers.",
+                        fileName,
+                        lineNumber,
+                        line);
+                }
+
+                if (raw3d.size() > Max3DLUTLength * Max3DLUTLength * Max3DLUTLength * 3)
+                {
+                    ThrowErrorMessage(
+                        "Too many 3D LUT entries.",
                         fileName,
                         lineNumber,
                         line);

--- a/src/OpenColorIO/fileformats/FileFormatResolveCube.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatResolveCube.cpp
@@ -336,6 +336,15 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
                         line);
                 }
 
+                if (size1d < 2 || size1d > static_cast<long>(Max1DLUTLength))
+                {
+                    ThrowErrorMessage(
+                        ("LUT_1D_SIZE must be between 2 and "
+                         + std::to_string(Max1DLUTLength) + ".").c_str(),
+                        fileName,
+                        lineNumber,
+                        line);
+                }
                 raw1d.reserve(3*size1d);
                 has1d = true;
             }
@@ -359,6 +368,15 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
                         line);
                 }
 
+                if (size3d < 2 || size3d > static_cast<long>(Max3DLUTLength))
+                {
+                    ThrowErrorMessage(
+                        ("LUT_3D_SIZE must be between 2 and "
+                         + std::to_string(Max3DLUTLength) + ".").c_str(),
+                        fileName,
+                        lineNumber,
+                        line);
+                }
                 raw3d.reserve(3*size3d*size3d*size3d);
                 has3d = true;
             }
@@ -410,6 +428,14 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
                     }
                     else
                     {
+                        if (raw3d.size() > Max3DLUTLength * Max3DLUTLength * Max3DLUTLength * 3)
+                        {
+                            ThrowErrorMessage(
+                                "Too many 3D LUT entries.",
+                                fileName,
+                                lineNumber,
+                                line);
+                        }
                         raw3d.push_back(tmpfloats[i]);
                     }
                 }

--- a/src/OpenColorIO/fileformats/FileFormatSpi1D.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatSpi1D.cpp
@@ -135,9 +135,9 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
                 char fromMinS[64] = "";
                 char fromMaxS[64] = "";
 #ifdef _WIN32
-                if (sscanf_s(lineBuffer, "From %s %s", fromMinS, 64, fromMaxS, 64) != 2)
+                if (sscanf_s(lineBuffer, "From %63s %63s", fromMinS, 64, fromMaxS, 64) != 2)
 #else
-                if (sscanf(lineBuffer, "From %s %s", fromMinS, fromMaxS) != 2)
+                if (sscanf(lineBuffer, "From %63s %63s", fromMinS, fromMaxS) != 2)
 #endif
                 {
                     ThrowErrorMessage("Invalid 'From' Tag", currentLine, headerLine);
@@ -219,11 +219,11 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
 
                 char inputLUT[4][64] = {"", "", "", ""};
 #ifdef _WIN32
-                if (sscanf_s(lineBuffer, "%s %s %s %63s", inputLUT[0], 64,
+                if (sscanf_s(lineBuffer, "%63s %63s %63s %63s", inputLUT[0], 64,
                            inputLUT[1], 64, inputLUT[2], 64, inputLUT[3],
                            64) != components)
 #else
-                if (sscanf(lineBuffer, "%s %s %s %63s", inputLUT[0],
+                if (sscanf(lineBuffer, "%63s %63s %63s %63s", inputLUT[0],
                            inputLUT[1], inputLUT[2], inputLUT[3]) != components)
 #endif
                 {

--- a/src/OpenColorIO/fileformats/FileFormatSpi1D.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatSpi1D.cpp
@@ -179,6 +179,12 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
     {
         ThrowErrorMessage("Could not find 'Length' Tag", -1, "");
     }
+    if (lut_size < 2 || lut_size > static_cast<long>(Max1DLUTLength))
+    {
+        ThrowErrorMessage(
+            ("'Length' must be between 2 and " + std::to_string(Max1DLUTLength)).c_str(),
+            -1, "");
+    }
     if (components == -1)
     {
         ThrowErrorMessage("Could not find 'Components' Tag", -1, "");

--- a/src/OpenColorIO/fileformats/FileFormatSpi3D.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatSpi3D.cpp
@@ -153,14 +153,13 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
         char blueValueS[64] = "";
 
 #ifdef _WIN32
-        if (sscanf(lineBuffer,
-            "%d %d %d %s %s %s",
+        if (sscanf_s(lineBuffer, "%d %d %d %63s %63s %63s",
             &rIndex, &gIndex, &bIndex,
             redValueS, 64,
             greenValueS, 64,
             blueValueS, 64) == 6)
 #else
-        if (sscanf(lineBuffer, "%d %d %d %s %s %s",
+        if (sscanf(lineBuffer, "%d %d %d %63s %63s %63s",
             &rIndex, &gIndex, &bIndex,
             redValueS, greenValueS, blueValueS) == 6)
 #endif

--- a/src/OpenColorIO/fileformats/FileFormatSpi3D.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatSpi3D.cpp
@@ -128,6 +128,17 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
         throw Exception(os.str().c_str());
     }
 
+    if (rSize < 2 || rSize > static_cast<long>(Max3DLUTLength))
+    {
+        std::ostringstream os;
+        os << "Error parsing .spi3d file (";
+        os << fileName;
+        os << "). ";
+        os << "LUT size must be between 2 and " << Max3DLUTLength << ". Found: '";
+        os << lineBuffer << "'.";
+        throw Exception(os.str().c_str());
+    }
+
     Lut3DOpDataRcPtr lut3d = std::make_shared<Lut3DOpData>((unsigned long)rSize);
     if (Lut3DOpData::IsValidInterpolation(interp))
     {

--- a/src/OpenColorIO/fileformats/FileFormatSpiMtx.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatSpiMtx.cpp
@@ -68,23 +68,23 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
                                       Interpolation /*interp*/) const
 {
 
-    // Read the entire file.
-    std::ostringstream fileStream;
-
+    // Read the entire file (capped: a valid spimtx file contains exactly 12 floats).
+    constexpr size_t MAX_FILE_SIZE = 1024;
+    char fileBuf[MAX_FILE_SIZE];
+    istream.read(fileBuf, MAX_FILE_SIZE);
+    const std::streamsize bytesRead = istream.gcount();
+    if (!istream.eof())
     {
-        const int MAX_LINE_SIZE = 4096;
-        char lineBuffer[MAX_LINE_SIZE];
-
-        while (istream.good())
-        {
-            istream.getline(lineBuffer, MAX_LINE_SIZE);
-            fileStream << std::string(lineBuffer) << " ";
-        }
+        std::ostringstream os;
+        os << "Error parsing .spimtx file (";
+        os << fileName << "). ";
+        os << "File is too large to be a valid .spimtx file.";
+        throw Exception(os.str().c_str());
     }
 
     // Turn it into parts
-    const StringUtils::StringVec lineParts 
-        = StringUtils::SplitByWhiteSpaces(StringUtils::Trim(fileStream.str()));
+    const StringUtils::StringVec lineParts
+        = StringUtils::SplitByWhiteSpaces(StringUtils::Trim(std::string(fileBuf, bytesRead)));
 
     if(lineParts.size() != 12)
     {

--- a/src/OpenColorIO/fileformats/FileFormatTruelight.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatTruelight.cpp
@@ -149,6 +149,12 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
                         throw Exception(os.str().c_str());
                     }
 
+                    if (size3d[0] < 2 || size3d[0] > static_cast<long>(Max3DLUTLength))
+                    {
+                        throw Exception(("Truelight .cub LUT grid size must be between 2 and "
+                                         + std::to_string(Max3DLUTLength) + ".").c_str());
+                    }
+
                     raw3d.reserve(3*size3d[0]*size3d[1]*size3d[2]);
                 }
                 else if(parts[1] == "lutlength")
@@ -158,6 +164,12 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
                     {
                         throw Exception("Malformed lutlength tag in Truelight .cub LUT.");
                     }
+                    if (size1d < 2 || size1d > static_cast<long>(Max1DLUTLength))
+                    {
+                        throw Exception(("Truelight .cub LUT lutlength must be between 2 and "
+                                         + std::to_string(Max1DLUTLength) + ".").c_str());
+                    }
+
                     raw1d.reserve(3*size1d);
                 }
                 else if(parts[1] == "inputlut")
@@ -187,12 +199,20 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
                 {
                     if(in1d)
                     {
+                        if (raw1d.size() > Max1DLUTLength * 3)
+                        {
+                            throw Exception("Too many 1D LUT entries in Truelight .cub LUT.");
+                        }
                         raw1d.push_back(tmpfloats[0]);
                         raw1d.push_back(tmpfloats[1]);
                         raw1d.push_back(tmpfloats[2]);
                     }
                     else if(in3d)
                     {
+                        if (raw3d.size() > Max3DLUTLength * Max3DLUTLength * Max3DLUTLength * 3)
+                        {
+                            throw Exception("Too many 3D LUT entries in Truelight .cub LUT.");
+                        }
                         raw3d.push_back(tmpfloats[0]);
                         raw3d.push_back(tmpfloats[1]);
                         raw3d.push_back(tmpfloats[2]);

--- a/src/OpenColorIO/fileformats/FileFormatVF.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatVF.cpp
@@ -158,6 +158,14 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
                             fileName, lineNumber, line);
                     }
 
+                    if (size3d[0] < 2 || size3d[0] > static_cast<long>(Max3DLUTLength))
+                    {
+                        ThrowErrorMessage(
+                            ("Grid size must be between 2 and "
+                             + std::to_string(Max3DLUTLength) + ".").c_str(),
+                            fileName, lineNumber, line);
+                    }
+
                     raw3d.reserve(3*size3d[0]*size3d[1]*size3d[2]);
                 }
                 else if(parts[0] == "global_transform")
@@ -190,6 +198,12 @@ CachedFileRcPtr LocalFileFormat::read(std::istream & istream,
             {
                 if(StringVecToFloatVec(tmpfloats, parts) && (tmpfloats.size() == 3))
                 {
+                    if (raw3d.size() > Max3DLUTLength * Max3DLUTLength * Max3DLUTLength * 3)
+                    {
+                        ThrowErrorMessage(
+                            "Too many 3D LUT entries.",
+                            fileName, lineNumber, line);
+                    }
                     raw3d.push_back(tmpfloats[0]);
                     raw3d.push_back(tmpfloats[1]);
                     raw3d.push_back(tmpfloats[2]);

--- a/src/OpenColorIO/fileformats/cdl/CDLParser.cpp
+++ b/src/OpenColorIO/fileformats/cdl/CDLParser.cpp
@@ -368,7 +368,6 @@ void CDLParser::Impl::reset()
     m_elms.clear();
 
     m_lineNumber = 0;
-    m_fileName = "";
     m_isCC = false;
     m_isCCC = false;
 }
@@ -896,6 +895,11 @@ void CDLParser::Impl::CharacterDataHandler(void *userData,
     }
     // Parsing a single new line. This is valid.
     if (len == 1 && s[0] == '\n') return;
+
+    if (pImpl->m_elms.empty())
+    {
+        pImpl->throwMessage("Unexpected character data before root element");
+    }
 
     ElementRcPtr pElt = pImpl->m_elms.back();
     if (!pElt)

--- a/src/OpenColorIO/fileformats/ctf/CTFReaderHelper.cpp
+++ b/src/OpenColorIO/fileformats/ctf/CTFReaderHelper.cpp
@@ -3365,6 +3365,11 @@ ArrayBase * CTFReaderInvLut1DElt::updateDimension(const Dimensions & dims)
         return nullptr;
     }
 
+    if (dims[0] < 2 || dims[0] > Max1DLUTLength)
+    {
+        return nullptr;
+    }
+
     Array * pArray = &m_invLut->getArray();
     pArray->resize(dims[0], numColorComponents);
     return pArray;
@@ -3499,6 +3504,11 @@ ArrayBase * CTFReaderInvLut3DElt::updateDimension(const Dimensions & dims)
     const unsigned int numColorComponents = dims[max];
 
     if (dims[3] != 3 || dims[1] != dims[0] || dims[2] != dims[0])
+    {
+        return nullptr;
+    }
+
+    if (dims[0] < 2 || dims[0] > Max3DLUTLength)
     {
         return nullptr;
     }
@@ -4178,6 +4188,11 @@ ArrayBase * CTFReaderLut1DElt::updateDimension(const Dimensions & dims)
         return nullptr;
     }
 
+    if (dims[0] < 2 || dims[0] > Max1DLUTLength)
+    {
+        return nullptr;
+    }
+
     Array * pArray = &m_lut->getArray();
     pArray->resize(dims[0], numColorComponents);
     return pArray;
@@ -4239,7 +4254,7 @@ IndexMapping * CTFReaderLut1DElt::updateDimensionIM(const DimensionsIM & dims)
 
     const unsigned int numComponents = dims[0];
 
-    if (dims[0] == 0)
+    if (dims[0] < 2 || dims[0] > Max1DLUTLength)
     {
         return nullptr;
     }
@@ -4450,6 +4465,11 @@ ArrayBase * CTFReaderLut3DElt::updateDimension(const Dimensions & dims)
         return nullptr;
     }
 
+    if (dims[0] < 2 || dims[0] > Max3DLUTLength)
+    {
+        return nullptr;
+    }
+
     Array* pArray = &m_lut->getArray();
     pArray->resize(dims[0], numColorComponents);
 
@@ -4480,7 +4500,7 @@ IndexMapping * CTFReaderLut3DElt::updateDimensionIM(const DimensionsIM & dims)
 
     const unsigned numComponents = dims[0];
 
-    if (dims[0] == 0)
+    if (dims[0] < 2 || dims[0] > Max3DLUTLength)
     {
         return nullptr;
     }
@@ -4580,6 +4600,11 @@ ArrayBase * CTFReaderMatrixElt::updateDimension(const Dimensions & dims)
     const unsigned int size = dims[0];
 
     if (size != dims[1] || numColorComponents != 3)
+    {
+        return nullptr;
+    }
+
+    if (size < 3 || size > 4)
     {
         return nullptr;
     }

--- a/src/OpenColorIO/ops/exponent/ExponentOp.cpp
+++ b/src/OpenColorIO/ops/exponent/ExponentOp.cpp
@@ -41,6 +41,10 @@ ExponentOpData::ExponentOpData(const ExponentOpData & rhs)
 ExponentOpData::ExponentOpData(const double * exp4)
     :   OpData()
 {
+    if (!exp4)
+    {
+        throw Exception("ExponentOpData: exp4 must not be null.");
+    }
     memcpy(m_exp4, exp4, 4*sizeof(double));
 }
 

--- a/src/OpenColorIO/ops/fixedfunction/FixedFunctionOpGPU.cpp
+++ b/src/OpenColorIO/ops/fixedfunction/FixedFunctionOpGPU.cpp
@@ -563,18 +563,18 @@ std::string _Add_Reach_table(
     ss.indent();
 
     ss.newLine() << ss.floatDecl("i_base") << " = floor(h);";
-    ss.newLine() << ss.floatDecl("i_lo") << " = i_base + " << table.base_index << ";";
-    ss.newLine() << ss.floatDecl("i_hi") << " = i_lo + 1;";
+    ss.newLine() << ss.floatDecl("i_lo") << " = i_base + " << ss.floatKeyword() << "(" << table.base_index << ");";
+    ss.newLine() << ss.floatDecl("i_hi") << " = i_lo + 1.0;";
 
     if (dimensions == GpuShaderDesc::TEXTURE_1D)
     {
-        ss.newLine() << ss.floatDecl("lo") << " = " << ss.sampleTex1D(name, "(i_lo + 0.5) / " + std::to_string(table.total_size)) << ".r;";
-        ss.newLine() << ss.floatDecl("hi") << " = " << ss.sampleTex1D(name, "(i_hi + 0.5) / " + std::to_string(table.total_size)) << ".r;";
+        ss.newLine() << ss.floatDecl("lo") << " = " << ss.sampleTex1D(name, "(i_lo + 0.5) / " + ss.floatKeyword() + " (" + std::to_string(table.total_size) + ")") << ".r;";
+        ss.newLine() << ss.floatDecl("hi") << " = " << ss.sampleTex1D(name, "(i_hi + 0.5) / " + ss.floatKeyword() + " (" + std::to_string(table.total_size) + ")") << ".r;";
     }
     else
     {
-        ss.newLine() << ss.floatDecl("lo") << " = " << ss.sampleTex2D(name, ss.float2Const("(i_lo + 0.5) / " + std::to_string(table.total_size), "0.0")) << ".r;";
-        ss.newLine() << ss.floatDecl("hi") << " = " << ss.sampleTex2D(name, ss.float2Const("(i_hi + 0.5) / " + std::to_string(table.total_size), "0.5")) << ".r;";
+        ss.newLine() << ss.floatDecl("lo") << " = " << ss.sampleTex2D(name, ss.float2Const("(i_lo + 0.5) / " + ss.floatKeyword() + " (" + std::to_string(table.total_size) + ")", "0.0")) << ".r;";
+        ss.newLine() << ss.floatDecl("hi") << " = " << ss.sampleTex2D(name, ss.float2Const("(i_hi + 0.5) / " + ss.floatKeyword() + " (" + std::to_string(table.total_size) + ")", "0.5")) << ".r;";
     }
 
     ss.newLine() << ss.floatDecl("t") << " = h - i_base;"; // Hardcoded single degree spacing
@@ -901,13 +901,13 @@ std::string _Add_Cusp_table(
 
     if (dimensions == GpuShaderDesc::TEXTURE_1D)
     {
-        ss.newLine() << ss.float3Decl("lo") << " = " << ss.sampleTex1D(name, std::string("(i_hi - 1 + 0.5) / ") + std::to_string(g.gamut_cusp_table.total_size)) << ".rgb;";
-        ss.newLine() << ss.float3Decl("hi") << " = " << ss.sampleTex1D(name, std::string("(i_hi + 0.5) / ") + std::to_string(g.gamut_cusp_table.total_size)) << ".rgb;";
+        ss.newLine() << ss.float3Decl("lo") << " = " << ss.sampleTex1D(name, std::string("(" + ss.floatKeyword() + "(i_hi) - 1.0 + 0.5) / ") + ss.floatKeyword() + "(" + std::to_string(g.gamut_cusp_table.total_size) + ")") << ".rgb;";
+        ss.newLine() << ss.float3Decl("hi") << " = " << ss.sampleTex1D(name, std::string("(" + ss.floatKeyword() + "(i_hi) + 0.5) / ") + ss.floatKeyword() + "(" + std::to_string(g.gamut_cusp_table.total_size) + ")") << ".rgb;";
     }
     else
     {
-        ss.newLine() << ss.float3Decl("lo") << " = " << ss.sampleTex2D(name, ss.float2Const(std::string("(i_hi - 1 + 0.5) / ") + std::to_string(g.gamut_cusp_table.total_size), "0.5")) << ".rgb;";
-        ss.newLine() << ss.float3Decl("hi") << " = " << ss.sampleTex2D(name, ss.float2Const(std::string("(i_hi + 0.5) / ") + std::to_string(g.gamut_cusp_table.total_size), "0.5")) << ".rgb;";
+        ss.newLine() << ss.float3Decl("lo") << " = " << ss.sampleTex2D(name, ss.float2Const(std::string("(" + ss.floatKeyword() + "(i_hi) - 1.0 + 0.5) / ") + ss.floatKeyword() + "(" + std::to_string(g.gamut_cusp_table.total_size) + ")", "0.5")) << ".rgb;";
+        ss.newLine() << ss.float3Decl("hi") << " = " << ss.sampleTex2D(name, ss.float2Const(std::string("(" + ss.floatKeyword() + "(i_hi) + 0.5) / ") + ss.floatKeyword() + "(" + std::to_string(g.gamut_cusp_table.total_size) + ")", "0.5")) << ".rgb;";
     }
 
     ss.newLine() << ss.floatDecl("t") << " = (h - " << hues_array_name << "[i_hi - 1]) / "

--- a/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOpGPU.cpp
+++ b/src/OpenColorIO/ops/gradingprimary/GradingPrimaryOpGPU.cpp
@@ -501,9 +501,10 @@ void AddGPVideoInverseShader(GpuShaderCreatorRcPtr & shaderCreator,
 
     st.newLine() << pxl << ".rgb = ( " << pxl << ".rgb - " << props.pivotBlack << " ) * "<< props.slope
                                 <<" + " << props.pivotBlack << ";";
-    st.newLine() << pxl << ".rgb += " << props.offset << " );";
+    st.newLine() << pxl << ".rgb += " << props.offset << ";";
 }
-}
+
+} // namespace
 
 void GetGradingPrimaryGPUShaderProgram(GpuShaderCreatorRcPtr & shaderCreator,
                                        ConstGradingPrimaryOpDataRcPtr & gpData)

--- a/src/OpenColorIO/ops/gradingrgbcurve/GradingBSplineCurve.cpp
+++ b/src/OpenColorIO/ops/gradingrgbcurve/GradingBSplineCurve.cpp
@@ -1155,7 +1155,12 @@ void GradingBSplineCurveImpl::AddShaderEvalRev(GpuShaderText & st,
     st.newLine() << "float kn = " << knots << "[knotsOffs + i];";
     st.newLine() << "float C0 = C - x;";
     st.newLine() << "float discrim = sqrt(B * B - 4. * A * C0);";
-    st.newLine() << "return kn + (-2. * C0) / (discrim + B);";
+    st.newLine() << "float denom = discrim + B;";
+    st.newLine() << "if (abs(denom) < 1e-5)";
+    st.newLine() << "{";
+    st.newLine() << "  return abs(B) < 1e-5 ? kn : kn + (-C0 / B);";
+    st.newLine() << "}";
+    st.newLine() << "return kn + (-2. * C0) / denom;";
 }
 
 //------------------------------------------------------------------------------------------------
@@ -1229,7 +1234,12 @@ void GradingBSplineCurveImpl::AddShaderEvalRevHue(GpuShaderText & st,
     st.newLine() << "}";
     st.newLine() << "float C0 = C - x;";
     st.newLine() << "float discrim = sqrt(B * B - 4. * A * C0);";
-    st.newLine() << "return kn + (-2. * C0) / (discrim + B);";
+    st.newLine() << "float denom = discrim + B;";
+    st.newLine() << "if (abs(denom) < 1e-5)";
+    st.newLine() << "{";
+    st.newLine() << "  return abs(B) < 1e-5 ? kn : kn + (-C0 / B);";
+    st.newLine() << "}";
+    st.newLine() << "return kn + (-2. * C0) / denom;";
 }
 
 //------------------------------------------------------------------------------------------------
@@ -1360,7 +1370,13 @@ float GradingBSplineCurveImpl::KnotsCoefs::evalCurveRev(int c, float y) const
         const float kn = m_knotsArray[knotsOffs + i];
         const float C0 = C - y;
         const float discrim = sqrt(B * B - 4.f * A * C0);
-        return kn + (-2.f * C0) / (discrim + B);
+        const float denom = discrim + B;
+        if (std::fabs(denom) < 1e-5f)
+        {
+            // A~=0, B<0: linear segment with negative slope; use linear inverse.
+            return std::fabs(B) < 1e-5f ? kn : kn + (-C0 / B);
+        }
+        return kn + (-2.f * C0) / denom;
     }
 }
 
@@ -1432,7 +1448,13 @@ float GradingBSplineCurveImpl::KnotsCoefs::evalCurveRevHue(int c, float y) const
     }
     const float C0 = C - y;
     const float discrim = sqrt(B * B - 4.f * A * C0);
-    return kn + (-2.f * C0) / (discrim + B);
+    const float denom = discrim + B;
+    if (std::fabs(denom) < 1e-5f)
+    {
+        // A~=0, B<0: linear segment with negative slope; use linear inverse.
+        return std::fabs(B) < 1e-5f ? kn : kn + (-C0 / B);
+    }
+    return kn + (-2.f * C0) / denom;
     // Note: The caller should wrap to ensure the output is a hue on [0,1).
 }
 

--- a/src/OpenColorIO/ops/gradingtone/GradingTone.cpp
+++ b/src/OpenColorIO/ops/gradingtone/GradingTone.cpp
@@ -60,7 +60,7 @@ void GradingTone::validate() const
     static constexpr double MinSHTol  = MinSH - Error;
     static constexpr double MaxSHTol  = MaxSH + Error;
     static constexpr double MinWSCTol = MinWSC - Error;
-    static constexpr double MaxSCTol  = MaxSC - Error;
+    static constexpr double MaxSCTol  = MaxSC + Error;
 
     {
         const auto & bd = m_blacks;

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpData.cpp
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpData.cpp
@@ -58,9 +58,6 @@ Lut3DOpDataRcPtr MakeFastLut3DFromInverse(ConstLut3DOpDataRcPtr & lut)
     return result;
 }
 
-// 129 allows for a MESH dimension of 7 in the 3dl file format.
-const unsigned long Lut3DOpData::maxSupportedLength = 129;
-
 // Functional composition is a concept from mathematics where two functions
 // are combined into a single function.  This idea may be applied to ops
 // where we generate a single op that has the same (or similar) effect as
@@ -196,11 +193,11 @@ void Lut3DOpData::Lut3DArray::fill()
 
 void Lut3DOpData::Lut3DArray::resize(unsigned long length, unsigned long numColorComponents)
 {
-    if (length > maxSupportedLength)
+    if (length > Max3DLUTLength)
     {
         std::ostringstream oss;
         oss << "LUT 3D: Grid size '" << length
-            << "' must not be greater than '" << maxSupportedLength << "'.";
+            << "' must not be greater than '" << Max3DLUTLength << "'.";
         throw Exception(oss.str().c_str());
     }
     Array::resize(length, numColorComponents);
@@ -389,7 +386,7 @@ void Lut3DOpData::validate() const
         throw Exception("Lut3D has an incorrect number of color components. ");
     }
 
-    if (getArray().getLength()>maxSupportedLength)
+    if (getArray().getLength()>Max3DLUTLength)
     {
         // This should never happen. Enforced by resize.
         std::ostringstream oss;

--- a/src/OpenColorIO/ops/lut3d/Lut3DOpData.h
+++ b/src/OpenColorIO/ops/lut3d/Lut3DOpData.h
@@ -8,6 +8,7 @@
 
 #include <OpenColorIO/OpenColorIO.h>
 
+#include "LutLimits.h"
 #include "Op.h"
 #include "ops/OpArray.h"
 #include "PrivateTypes.h"
@@ -22,9 +23,6 @@ typedef OCIO_SHARED_PTR<const Lut3DOpData> ConstLut3DOpDataRcPtr;
 class Lut3DOpData : public OpData
 {
 public:
-
-    // The maximum grid size supported for a 3D LUT.
-    static const unsigned long maxSupportedLength;
 
     // Use functional composition to generate a single op that 
     // approximates the effect of the pair of ops.

--- a/src/OpenColorIO/ops/matrix/MatrixOp.cpp
+++ b/src/OpenColorIO/ops/matrix/MatrixOp.cpp
@@ -304,7 +304,12 @@ void CreateMinMaxOp(OpRcPtrVec & ops,
     bool somethingToDo = false;
     for (int i = 0; i < 3; ++i)
     {
-        scale4[i] = 1.0 / (from_max3[i] - from_min3[i]);
+        const double range = from_max3[i] - from_min3[i];
+        if (range == 0.0)
+        {
+            throw Exception("CreateMinMaxOp: from_min and from_max must not be equal.");
+        }
+        scale4[i] = 1.0 / range;
         offset4[i] = -from_min3[i] * scale4[i];
         somethingToDo |= (scale4[i] != 1.0 || offset4[i] != 0.0);
     }

--- a/src/OpenColorIO/ops/matrix/MatrixOpData.cpp
+++ b/src/OpenColorIO/ops/matrix/MatrixOpData.cpp
@@ -373,6 +373,10 @@ void MatrixOpData::MatrixArray::expandFrom3x3To4x4()
 
 void MatrixOpData::MatrixArray::setRGBA(const float * values)
 {
+    if (!values)
+    {
+        throw Exception("Matrix: setRGBA NULL pointer.");
+    }
     Values & v = getValues();
 
     v[0] = values[0];
@@ -398,6 +402,10 @@ void MatrixOpData::MatrixArray::setRGBA(const float * values)
 
 void MatrixOpData::MatrixArray::setRGBA(const double * values)
 {
+    if (!values)
+    {
+        throw Exception("Matrix: setRGBA NULL pointer.");
+    }
     Values & v = getValues();
     std::memcpy(&v[0], values, 16 * sizeof(double));
 }

--- a/src/OpenColorIO/transforms/AllocationTransform.cpp
+++ b/src/OpenColorIO/transforms/AllocationTransform.cpp
@@ -146,6 +146,10 @@ void AllocationTransform::setVars(int numvars, const float * vars)
 
     if(!getImpl()->m_vars.empty())
     {
+        if (!vars)
+        {
+            throw Exception("AllocationTransform::setVars: vars pointer must not be null.");
+        }
         memcpy(&getImpl()->m_vars[0],
             vars,
             numvars*sizeof(float));

--- a/src/OpenColorIO/transforms/FileTransform.cpp
+++ b/src/OpenColorIO/transforms/FileTransform.cpp
@@ -110,7 +110,7 @@ const char * FileTransform::getSrc() const
 
 void FileTransform::setSrc(const char * src)
 {
-    getImpl()->m_src = src;
+    getImpl()->m_src = src ? src : "";
 }
 
 const char * FileTransform::getCCCId() const
@@ -120,7 +120,7 @@ const char * FileTransform::getCCCId() const
 
 void FileTransform::setCCCId(const char * cccid)
 {
-    getImpl()->m_cccid = cccid;
+    getImpl()->m_cccid = cccid ? cccid : "";
 }
 
 CDLStyle FileTransform::getCDLStyle() const

--- a/src/OpenColorIO/transforms/FixedFunctionTransform.cpp
+++ b/src/OpenColorIO/transforms/FixedFunctionTransform.cpp
@@ -21,8 +21,15 @@ FixedFunctionTransformRcPtr FixedFunctionTransform::Create(FixedFunctionStyle st
                                                            const double * params,
                                                            size_t num)
 {
+    if (!params && num > 0)
+    {
+        throw Exception("FixedFunctionTransform::Create: params pointer must not be null.");
+    }
     FixedFunctionOpData::Params p(num);
-    std::copy(params, params + num, p.begin());
+    if (num > 0)
+    {
+        std::copy(params, params + num, p.begin());
+    }
 
     return FixedFunctionTransformRcPtr(new FixedFunctionTransformImpl(style, p),
                                        &FixedFunctionTransformImpl::deleter);
@@ -125,8 +132,15 @@ size_t FixedFunctionTransformImpl::getNumParams() const
 
 void FixedFunctionTransformImpl::setParams(const double * params, size_t num)
 {
+    if (!params && num > 0)
+    {
+        throw Exception("FixedFunctionTransform::setParams: params pointer must not be null.");
+    }
     FixedFunctionOpData::Params p(num);
-    std::copy(params, params+num, p.begin());
+    if (num > 0)
+    {
+        std::copy(params, params + num, p.begin());
+    }
     data().setParams(p);
 }
 

--- a/src/OpenColorIO/transforms/Lut3DTransform.cpp
+++ b/src/OpenColorIO/transforms/Lut3DTransform.cpp
@@ -201,9 +201,9 @@ std::ostream & operator<< (std::ostream & os, const Lut3DTransform & t)
                     rMin = std::min(rMin, rv);
                     gMin = std::min(gMin, gv);
                     bMin = std::min(bMin, bv);
-                    rMax = std::max(rMin, rv);
-                    gMax = std::max(gMin, gv);
-                    bMax = std::max(bMin, bv);
+                    rMax = std::max(rMax, rv);
+                    gMax = std::max(gMax, gv);
+                    bMax = std::max(bMax, bv);
                 }
             }
         }

--- a/src/OpenColorIO/transforms/builtins/BuiltinTransformRegistry.cpp
+++ b/src/OpenColorIO/transforms/builtins/BuiltinTransformRegistry.cpp
@@ -124,7 +124,7 @@ void BuiltinTransformRegistryImpl::registerAll() noexcept
 
 void CreateBuiltinTransformOps(OpRcPtrVec & ops, size_t nameIndex, TransformDirection direction)
 {
-    if (nameIndex > BuiltinTransformRegistry::Get()->getNumBuiltins())
+    if (nameIndex >= BuiltinTransformRegistry::Get()->getNumBuiltins())
     {
         throw Exception("Invalid built-in transform name.");
     }

--- a/src/bindings/python/PyGradingData.cpp
+++ b/src/bindings/python/PyGradingData.cpp
@@ -21,11 +21,14 @@ using GradingControlPointIterator = PyIterator<GradingBSplineCurveRcPtr, IT_CONT
 
 void CopyGradingBSpline(GradingBSplineCurveRcPtr to, const ConstGradingBSplineCurveRcPtr from)
 {
+    to->setSplineType(from->getSplineType());
+
     const size_t numPt = from->getNumControlPoints();
     to->setNumControlPoints(numPt);
     for (size_t pt = 0; pt < numPt; ++pt)
     {
         to->getControlPoint(pt) = from->getControlPoint(pt);
+        to->setSlope(pt, from->getSlope(pt));
     }
 }
 

--- a/src/utils/StringUtils.h
+++ b/src/utils/StringUtils.h
@@ -252,6 +252,8 @@ inline std::string::size_type ReverseFind(const std::string & subject, const std
 // In place replace the 'search' substring by the 'replace' string in 'str'.
 inline bool ReplaceInPlace(std::string & subject, const std::string & search, const std::string & replace)
 {
+    if (search.empty()) return false;
+
     bool changed = false;
 
     size_t pos =  0;

--- a/tests/cpu/ops/lut3d/Lut3DOpData_tests.cpp
+++ b/tests/cpu/ops/lut3d/Lut3DOpData_tests.cpp
@@ -67,8 +67,8 @@ OCIO_ADD_TEST(Lut3DOpData, clone)
 
 OCIO_ADD_TEST(Lut3DOpData, not_supported_length)
 {
-    OCIO_CHECK_NO_THROW(OCIO::Lut3DOpData{ OCIO::Lut3DOpData::maxSupportedLength });
-    OCIO_CHECK_THROW_WHAT(OCIO::Lut3DOpData{ OCIO::Lut3DOpData::maxSupportedLength + 1 },
+    OCIO_CHECK_NO_THROW(OCIO::Lut3DOpData{ OCIO::Max3DLUTLength });
+    OCIO_CHECK_THROW_WHAT(OCIO::Lut3DOpData{ OCIO::Max3DLUTLength + 1 },
                           OCIO::Exception, "must not be greater");
 }
 

--- a/tests/gpu/FixedFunctionOp_test.cpp
+++ b/tests/gpu/FixedFunctionOp_test.cpp
@@ -1107,6 +1107,74 @@ OCIO_ADD_GPU_TEST(FixedFunction, style_aces2_gamut_compress_inv)
     test.setErrorThreshold(4e-4f);
 }
 
+OCIO_ADD_GPU_TEST(FixedFunction, style_aces2_gamut_compress_no1dlut)
+{
+    // Test the 2D TEXTURE path used for Reach and Cusp table sampling
+    // OpenGL tests would otherwise not use it and prefer 1D TEXTURE
+
+    const double data[9] = {
+        // Peak luminance
+        1000.f,
+        // P3D65 gamut
+        0.680, 0.320, 0.265, 0.690, 0.150, 0.060, 0.3127, 0.3290
+    };
+    OCIO::FixedFunctionTransformRcPtr func =
+        OCIO::FixedFunctionTransform::Create(OCIO::FIXED_FUNCTION_ACES_GAMUT_COMPRESS_20, &data[0], 9);
+    func->setDirection(OCIO::TRANSFORM_DIR_INVERSE);
+
+    test.setProcessor(func);
+
+    OCIOGPUTest::CustomValues values;
+    values.m_inputValues =
+    {
+        // ACEScg primaries and secondaries scaled by 4
+        110.702453613f, 211.251770020f, 25.025110245f, 1.0f,
+        168.016815186f, 129.796249390f, 106.183448792f, 1.0f,
+        140.814849854f, 193.459213257f, 147.056488037f, 1.0f,
+        156.429519653f, 110.938514709f, 192.204727173f, 1.0f,
+        80.456542969f, 98.490524292f, 268.442108154f, 1.0f,
+        135.172195435f, 175.559280396f, 341.715240479f, 1.0f,
+        // OCIO test values
+        18.187314987f, 33.819175720f, 4.173158169f, 0.5f,
+        80.413116455f, 21.309329987f, 332.159759521f, 1.0f,
+        83.447891235f, 37.852291107f, 182.925750732f, 0.0f,
+        // ColorChecker24 (SMPTE 2065-1 2021)
+        27.411964417f, 13.382769585f, 38.146659851f, 1.0f,
+        59.987670898f, 14.391894341f, 39.841842651f, 1.0f,
+        43.298923492f, 12.199877739f, 249.107116699f, 1.0f,
+        31.489658356f, 14.075142860f, 128.878036499f, 1.0f,
+        50.749198914f, 12.731814384f, 285.658966064f, 1.0f,
+        64.728637695f, 18.593795776f, 179.324264526f, 1.0f,
+        53.399448395f, 37.394428253f, 50.924011230f, 1.0f,
+        34.719596863f, 21.616765976f, 271.008331299f, 1.0f,
+        43.910713196f, 36.788166046f, 13.975610733f, 1.0f,
+        23.196525574f, 15.118354797f, 317.544281006f, 1.0f,
+        63.348674774f, 33.283493042f, 119.145133972f, 1.0f,
+        64.908889771f, 35.371044159f, 70.842193604f, 1.0f,
+        24.876911163f, 23.143159866f, 273.228973389f, 1.0f,
+        44.203376770f, 28.918329239f, 144.154159546f, 1.0f,
+        32.824356079f, 43.447875977f, 17.892261505f, 1.0f,
+        75.830871582f, 39.872474670f, 90.752044678f, 1.0f,
+        45.823116302f, 34.652069092f, 348.832092285f, 1.0f,
+        43.597240448f, 23.079078674f, 218.454376221f, 1.0f,
+        96.212783813f, 0.322624743f, 108.271926880f, 1.0f,
+        78.222122192f, 0.094044082f, 33.296318054f, 1.0f,
+        60.364795685f, 0.031291425f, 291.004058838f, 1.0f,
+        43.659111023f, 0.038717352f, 297.386047363f, 1.0f,
+        26.623359680f, 0.269155562f, 234.276382446f, 1.0f,
+        12.961384773f, 0.366550505f, 255.025634766f, 1.0f,
+        // Spectrally non-selective 18 % reflecting diffuser
+        40.609165192f, 0.000000000f, 299.357757568f, 1.0f,
+        // Perfect reflecting diffuser
+        101.899215698f, 0.000068110f, 5.640549183f, 1.0f,
+    };
+    test.setCustomValues(values);
+
+    test.setErrorThreshold(1e-4f);
+
+    test.getShaderDesc()->setAllowTexture1D(false);
+}
+
 // The next four tests run into a problem on some graphics cards where 0.0 * Inf = 0.0,
 // rather than the correct value of NaN.  Therefore turning off TestInfinity for these tests.
 

--- a/tests/gpu/GradingPrimaryOp_test.cpp
+++ b/tests/gpu/GradingPrimaryOp_test.cpp
@@ -133,7 +133,7 @@ OCIO_ADD_GPU_TEST(GradingPrimary, style_lin_rev_dynamic)
 
 namespace GPTest3
 {
-static constexpr OCIO::GradingStyle style = OCIO::GRADING_LIN;
+static constexpr OCIO::GradingStyle style = OCIO::GRADING_VIDEO;
 static const OCIO::GradingRGBM lift{ 0.05, -0.04, 0.02, 0.05 };
 static const OCIO::GradingRGBM gamma{ 0.9,   1.4,  0.7,  0.75 };
 static const OCIO::GradingRGBM gain{ 1.2,   1.1,  1.25, 0.8 };

--- a/tests/gpu/Lut3DOp_test.cpp
+++ b/tests/gpu/Lut3DOp_test.cpp
@@ -8,6 +8,7 @@
 #include <OpenColorIO/OpenColorIO.h>
 
 #include "GPUUnitTest.h"
+#include "LutLimits.h"
 
 namespace OCIO = OCIO_NAMESPACE;
 
@@ -241,7 +242,7 @@ OCIO_ADD_GPU_TEST(Lut3DOp, 3dlut_biggest_supported)
 {
     // Linear interpolation
     OCIO::Lut3DTransformRcPtr lut = OCIO::Lut3DTransform::Create();
-    lut->setGridSize(129); // Lut3DOpData::maxSupportedLength.
+    lut->setGridSize(OCIO::Max3DLUTLength);
 
     test.setProcessor(lut);
 

--- a/tests/python/GradingDataTest.py
+++ b/tests/python/GradingDataTest.py
@@ -368,6 +368,29 @@ class GradingDataTest(unittest.TestCase):
         assertEqualBSpline(self, hcrv.lum_sat, ls)
         self.assertEqual(hcrv.lum_sat, ls)
 
+        # Check that setting the hue curve preserves the spline type.
+        hcrv.hue_sat = ls
+        ls2 = hcrv.hue_sat
+        # Spline type is now different than what hue_sat normally uses (PERIODIC_1_B_SPLINE).
+        self.assertEqual(ls2.getSplineType(), OCIO.HORIZONTAL1_B_SPLINE)
+        self.assertEqual(hcrv.hue_sat, ls)
+        self.assertEqual(ls2, ls)
+
+        # Check that setting the hue curve preserves the slopes.
+        self.assertEqual(ls.slopesAreDefault(), True)
+        slopes = ls.getSlopes()
+        slopes[1] = 0.5
+        ls.setSlopes(slopes)
+        self.assertEqual(ls.slopesAreDefault(), False)
+        hcrv.hue_sat = ls
+        ls2 = hcrv.hue_sat
+        self.assertEqual(ls2.slopesAreDefault(), False)
+        slopes2 = ls2.getSlopes()
+        self.assertEqual(slopes2[1], 0.5)
+        self.assertEqual(slopes2, slopes)
+        self.assertEqual(hcrv.hue_sat, ls)
+        self.assertEqual(ls2, ls)
+
     def test_rgbmsw(self):
         """
         Test the GradingRGBMSW struct.


### PR DESCRIPTION
This is the PR to implement the 2.5.2 release. It includes the following PRs:

PR #2252, Update 2.5 documentation regarding ABI compatability
PR #2264, Add more info to the documentation overview page
PR #2270, Fix vector comparison expression for HLSL
PR #2273, Fix linking to self-built deps on Windows + Clang
PR #2276, Adsk Contrib - Hue curve python binding was not copying all parameters
PR #2285, Adsk Contrib - Update Python documentation requirements
PR #2302, Improve CMake and Actions settings
PR #2304, Add /bigobj for pybind11 target on Windows
PR #2281, Fix OpenGL ES type issues in ACES2 FixedFunction Ops
PR #2307, Improve LUT loading checks
PR #2308, Adsk Contrib - Miscellaneous improvements suggested by Claude

In addition, it pulls in a minor bug fix from PR #2282.

Regarding the CI, the failures on Linux CY2022 are expected. Separately, the GPU Action is failing on the latest PRs, however this is due to an unrelated issue. I have run the GPU tests on this branch on Linux, Windows, and Mac and they are all passing.