### PR TITLE
Add Supported Versions table to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,18 @@ Users should exercise caution when working with untrusted data (config files,
 LUTs, etc.). OCIO takes every precaution to read only valid data, but it 
 would be naive to say our code is immune to every exploit.
 
+## Supported Versions
+
+This gives guidance about which branches are supported with patches to 
+security vulnerabilities.
+
+| Version / branch  | Supported |
+| ----------------- | --------- |
+| main              | :white_check_mark: :construction: All fixes immediately, but this branch is under active development with a frequently changing API and ABI. |
+| 2.5.x (RB-2.5)    | :white_check_mark: All security fixes that can be backported without breaking ABI compatibility. |
+| 2.4.x (RB-2.4)    | :warning: Critical security fixes only. |
+| <= 2.3.x          | :x: No longer receiving patches. |
+
 ## Reporting Vulnerabilities
 
 Quickly resolving security related issues is a priority. The best way to report a 


### PR DESCRIPTION
This adds a Supported Versions table to SECURITY.md, describing which release branches receive security patches.

I modeled the format on the similar table in OpenImageIO's security policy, as suggested in #2032. The table covers:

- main branch (all fixes, unstable API/ABI)
- 2.5.x (all security fixes with ABI compatibility)
- 2.4.x (critical security fixes only)
- Older branches (no longer patched)

I based the support status on the recent release activity and the CVE fix history in the document. The TSC can adjust the wording if the actual policy differs from what I've documented.

Fixes #2032

Signed-off-by: Vishal Kumar Singh <vishal.kr.singh2021@gmail.com>