### PR TITLE
Adsk Contrib - Fix 2023.3 Linux container break

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -57,7 +57,7 @@ jobs:
     container:
       # DockerHub: https://hub.docker.com/u/aswf
       # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
-      image: aswf/ci-ocio:${{ matrix.vfx-cy }}
+      image: aswf/ci-ocio:${{ matrix.container-tag || matrix.vfx-cy }}
     strategy:
       fail-fast: false
       matrix:
@@ -203,7 +203,8 @@ jobs:
             cxx-compiler: clang++
             cc-compiler: clang
             compiler-desc: Clang
-            vfx-cy: 2023.2
+            vfx-cy: 2023
+            container-tag: 2023.2
             install-ext-packages: MISSING
           - build: 2
             build-type: Release
@@ -216,7 +217,8 @@ jobs:
             cxx-compiler: g++
             cc-compiler: gcc
             compiler-desc: GCC
-            vfx-cy: 2023.2
+            vfx-cy: 2023
+            container-tag: 2023.2
             install-ext-packages: ALL
           - build: 1
             build-type: Release
@@ -229,7 +231,8 @@ jobs:
             cxx-compiler: g++
             cc-compiler: gcc
             compiler-desc: GCC
-            vfx-cy: 2023.2
+            vfx-cy: 2023
+            container-tag: 2023.2
             install-ext-packages: ALL
     env:
       CXX: ${{ matrix.cxx-compiler }}

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -59,7 +59,7 @@ jobs:
       # Source: https://github.com/AcademySoftwareFoundation/aswf-docker
       image: aswf/ci-ocio:${{ matrix.vfx-cy }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         build: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
         include:
@@ -203,7 +203,7 @@ jobs:
             cxx-compiler: clang++
             cc-compiler: clang
             compiler-desc: Clang
-            vfx-cy: 2023
+            vfx-cy: 2023.2
             install-ext-packages: MISSING
           - build: 2
             build-type: Release
@@ -216,7 +216,7 @@ jobs:
             cxx-compiler: g++
             cc-compiler: gcc
             compiler-desc: GCC
-            vfx-cy: 2023
+            vfx-cy: 2023.2
             install-ext-packages: ALL
           - build: 1
             build-type: Release
@@ -229,7 +229,7 @@ jobs:
             cxx-compiler: g++
             cc-compiler: gcc
             compiler-desc: GCC
-            vfx-cy: 2023
+            vfx-cy: 2023.2
             install-ext-packages: ALL
     env:
       CXX: ${{ matrix.cxx-compiler }}


### PR DESCRIPTION
Trying to get the CI working again, roll back to the previous revision of the containers.