### PR TITLE
pyocioamf: Add AMF v2.0 and OCIO 2.5+ support

### DIFF
--- a/src/apps/pyocioamf/README.md
+++ b/src/apps/pyocioamf/README.md
@@ -4,20 +4,48 @@
 pyocioamf
 =========
 
-**Work in progress**. Script to convert an ACES Metadata File (AMF) into OCIO's 
-native CTF file format.  The CTF may then be used with any of the other OCIO tools 
-to process pixels.
+Script to convert an ACES Metadata File (AMF) into OCIO's native CTF file format.
+The CTF may then be used with any of the other OCIO tools to process pixels.
 
-An example AMF file named ``example.amf`` is provided.  It references the LUT file
-``example_referenced_lut.clf``, which is in the Academy/ASC Common LUT Format (CLF).
+**Supports both AMF v1.0 and v2.0** with automatic version detection.
+
+Example files are provided:
+- ``example.amf`` - AMF v1.0 format
+- ``example_v2.amf`` - AMF v2.0 format (uses ``ASC_SOP``/``ASC_SAT`` elements)
+
+Both reference the LUT file ``example_referenced_lut.clf``, which is in the
+Academy/ASC Common LUT Format (CLF).
 
 Usage
 -----
 
-1. Install dependencies on ``PYTHONPATH``
-2. Run ``python pyocioamf.py example.amf`` (or any other AMF file).
-3. The CTF file will have the same name as the AMF file but with a .ctf extension, in
-this case, ``example.ctf``.
+Basic usage:
+
+```bash
+python pyocioamf.py example.amf
+```
+
+The CTF file will have the same name as the AMF file but with a .ctf extension.
+
+### Command-Line Options
+
+```bash
+# Use a specific OCIO config file
+python pyocioamf.py example.amf --config path/to/config.ocio
+
+# Exclude specific components from conversion
+python pyocioamf.py example.amf --no-idt           # Exclude input transform
+python pyocioamf.py example.amf --no-lmt           # Exclude look transforms
+python pyocioamf.py example.amf --no-odt           # Exclude output transform
+python pyocioamf.py example.amf --no-lmt --no-odt  # Exclude multiple
+
+# Split CTF generation for AMF v2.0 workingLocation marker
+python pyocioamf.py example.amf --split-by-working-location
+```
+
+The ``--split-by-working-location`` option generates two CTF files:
+- ``*_before.ctf``: IDT + look transforms before the workingLocation marker
+- ``*_after.ctf``: Look transforms after the marker + ODT
 
 Dependencies
 ------------
@@ -27,6 +55,11 @@ Dependencies
 Implementation notes
 --------------------
 
+* Automatically detects AMF version (v1.0 or v2.0) from namespace URI or version attribute
+* Supports both v1.0 element names (``SOPNode``/``SatNode``) and v2.0 names (``ASC_SOP``/``ASC_SAT``)
 * Uses a prototype ACES config ``config-aces-reference.yaml`` to interpret the
-  ACES Transform IDs encountered in the AMF file.  This file should be in the
+  ACES Transform IDs encountered in the AMF file. This file should be in the
   same directory as the script.
+* Alternatively, use ``--config`` to specify a custom OCIO config file
+* For OCIO 2.5+ configs, uses the ``amf_transform_ids`` interchange attribute for transform lookup
+* For OCIO 2.1-2.4 configs, searches transform IDs in the description field

--- a/src/apps/pyocioamf/README.md
+++ b/src/apps/pyocioamf/README.md
@@ -10,11 +10,10 @@ The CTF may then be used with any of the other OCIO tools to process pixels.
 **Supports both AMF v1.0 and v2.0** with automatic version detection.
 
 Example files are provided:
-- ``example.amf`` - AMF v1.0 format
-- ``example_v2.amf`` - AMF v2.0 format (uses ``ASC_SOP``/``ASC_SAT`` elements)
+- ``example.amf`` - AMF v1.0 format, references ``example_referenced_lut.clf``
+- ``example_v2.amf`` - AMF v2.0 format
 
-Both reference the LUT file ``example_referenced_lut.clf``, which is in the
-Academy/ASC Common LUT Format (CLF).
+The referenced LUT file is in the Academy/ASC Common LUT Format (CLF).
 
 Usage
 -----
@@ -56,7 +55,7 @@ Implementation notes
 --------------------
 
 * Automatically detects AMF version (v1.0 or v2.0) from namespace URI or version attribute
-* Supports both v1.0 element names (``SOPNode``/``SatNode``) and v2.0 names (``ASC_SOP``/``ASC_SAT``)
+* Supports both ASC CDL element naming conventions (``SOPNode``/``SatNode`` and ``ASC_SOP``/``ASC_SAT``)
 * Uses a prototype ACES config ``config-aces-reference.yaml`` to interpret the
   ACES Transform IDs encountered in the AMF file. This file should be in the
   same directory as the script.

--- a/src/apps/pyocioamf/example_v2.amf
+++ b/src/apps/pyocioamf/example_v2.amf
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<aces:acesMetadataFile 
+    xmlns:aces="urn:ampas:aces:amf:v2.0"
+    xmlns:cdl="urn:ASC:CDL:v1.01"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    version="2.0">
+    <aces:amfInfo>
+        <aces:description>Example Movie</aces:description>
+        <aces:author>
+            <aces:name>Foo Bar</aces:name>
+            <aces:emailAddress>Foobar@onset.com</aces:emailAddress>
+        </aces:author>
+        <aces:dateTime>
+            <aces:creationDateTime>2019-09-19T13:20:00</aces:creationDateTime>
+            <aces:modificationDateTime>2019-11-27T13:20:00Z</aces:modificationDateTime>
+        </aces:dateTime>
+        <aces:uuid>urn:uuid:afe122be-59d3-4360-ad69-33c10108fa7a</aces:uuid>
+    </aces:amfInfo>
+    <aces:clipId>
+        <aces:clipName>A001C012</aces:clipName>
+        <aces:sequence idx="#" min="1" max="240">A001_C012_AE0306_###.exr</aces:sequence>
+    </aces:clipId>
+    <aces:pipeline>
+        <aces:pipelineInfo>
+            <aces:description>Example Movie Final DI</aces:description>
+            <aces:dateTime>
+                <aces:creationDateTime>2019-09-19T13:20:00</aces:creationDateTime>
+                <aces:modificationDateTime>2019-11-27T13:20:00Z</aces:modificationDateTime>
+            </aces:dateTime>
+            <aces:uuid>urn:uuid:be6Ec2ea-a6DC-6cBC-ff0D-AfCED5FF3Dd8</aces:uuid>
+            <aces:systemVersion>
+                <aces:majorVersion>1</aces:majorVersion>
+                <aces:minorVersion>0</aces:minorVersion>
+                <aces:patchVersion>3</aces:patchVersion>
+            </aces:systemVersion>
+        </aces:pipelineInfo>
+        <aces:inputTransform applied="true">
+            <aces:description>IDT from Acme Camera Company</aces:description>
+            <aces:hash algorithm="http://www.w3.org/2001/04/xmlenc#sha256">1531ea6ef06c5b0a5bea80c94f60c7b68e3989e3c90b8ebd25c28aa4670c30f8</aces:hash>
+            <aces:transformId>urn:ampas:aces:transformId:v1.5:IDT.Acme.Camera.a1.v1</aces:transformId>
+        </aces:inputTransform>
+        <aces:lookTransform applied="true">
+                <aces:description>Technical Grade</aces:description>
+                <aces:cdlWorkingSpace>
+                    <aces:fromCdlWorkingSpace>
+                        <aces:transformId>urn:ampas:aces:transformId:v1.5:ACEScsc.Academy.ACEScct_to_ACES.a1.0.3</aces:transformId>
+                    </aces:fromCdlWorkingSpace>
+                </aces:cdlWorkingSpace>
+                <cdl:ASC_SOP>
+                    <cdl:Slope>2.0 2.0 2.0</cdl:Slope>
+                    <cdl:Offset>0.1 0.1 0.1</cdl:Offset>
+                    <cdl:Power>1 1 1</cdl:Power>
+                </cdl:ASC_SOP>
+                <cdl:ASC_SAT>
+                    <cdl:Saturation>1</cdl:Saturation>
+                </cdl:ASC_SAT>
+        </aces:lookTransform>
+        <aces:outputTransform applied="false">
+            <aces:referenceRenderingTransform>
+                <aces:description>ACES v1.0.3 RRT</aces:description>
+                <aces:hash algorithm="http://www.w3.org/2001/04/xmlenc#sha256">c81af4fb4a22ee0353308e4582708951df4682bf73f838c24bf44e585fc3bb61</aces:hash>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:RRT.a1.0.3</aces:transformId>
+            </aces:referenceRenderingTransform>
+            <aces:outputDeviceTransform>
+                <aces:description>P3D60 ODT</aces:description>
+                <aces:hash algorithm="http://www.w3.org/2000/09/xmldsig#sha1">efd279a82c2d52ee8c49dc0793499dc86bb1a4a3fa0dfb420d59c2814c55aea6</aces:hash>
+                <aces:transformId>urn:ampas:aces:transformId:v1.5:ODT.Academy.P3D60_48nits.a1.0.3</aces:transformId>
+            </aces:outputDeviceTransform>
+        </aces:outputTransform>
+    </aces:pipeline>
+</aces:acesMetadataFile>

--- a/src/apps/pyocioamf/pyocioamf.py
+++ b/src/apps/pyocioamf/pyocioamf.py
@@ -7,45 +7,203 @@ Convert an ACES Metadata File (AMF) into an OCIO Color Transform File (CTF).
 This is a prototype for AMF support in OCIO.  It utilizes a tweaked version of the OCIO v2
 ACES Reference config as a database of AMF Transform ID strings and accompanying transforms.
 
-Usage: % python pyocioamf.py <AMF_FILE>
+Usage: % python pyocioamf.py <AMF_FILE> [options]
+
+Options:
+    --no-idt                      Exclude Input Transform (IDT) from conversion
+    --no-lmt                      Exclude Look Transform(s) (LMT) from conversion
+    --no-odt                      Exclude Output Transform (ODT) from conversion
+    --split-by-working-location   Generate split CTFs based on workingLocation marker (AMF v2.0)
 
 The exported CTF file is written to the same directory as the AMF_FILE and has the same
-name, but uses .ctf as the extension.  The CTF file may then be used with any of the
-other OCIO tools such as ocioconvert or ociochecklut to apply the AMF color pipeline.
+name, but uses .ctf as the extension.  When using --split-by-working-location, two files
+are generated: *_before.ctf (IDT + looks before marker) and *_after.ctf (looks after
+marker + ODT).
+
+The CTF file may then be used with any of the other OCIO tools such as ocioconvert or
+ociochecklut to apply the AMF color pipeline.
 """
 
+import argparse
 import xml.etree.ElementTree as ET
 
 import PyOpenColorIO as ocio
 
 
-# Specify the color space name for ACES2065-1 in the ACES config.
-ACES = 'ACES - ACES2065-1'
-# Setup the namespaces used in the AMF XML file.
-NS = {'aces': 'urn:ampas:aces:amf:v1.0', 'cdl': 'urn:ASC:CDL:v1.01'}
+# Default color space name for ACES2065-1 (may vary by config)
+# Common names: 'ACES - ACES2065-1' (old configs), 'ACES2065-1' (new configs)
+DEFAULT_ACES_NAMES = ['ACES2065-1', 'ACES - ACES2065-1']
 
-def search_colorspaces(config, aces_id):
-    """ Search the config for the supplied ACES ID, return the color space name. """
+# Namespace URIs for AMF versions
+AMF_NS_V1 = 'urn:ampas:aces:amf:v1.0'
+AMF_NS_V2 = 'urn:ampas:aces:amf:v2.0'
+CDL_NS = 'urn:ASC:CDL:v1.01'
+
+# Default namespace dict (will be updated based on detected version)
+NS = {'aces': AMF_NS_V1, 'cdl': CDL_NS}
+
+
+def get_ocio_major_minor_version(config):
+    """
+    Get the OCIO config profile version as a tuple (major, minor).
+    Returns (2, 1) as minimum if version cannot be determined.
+    """
+    try:
+        # getMajorVersion() and getMinorVersion() available in OCIO 2.x
+        major = config.getMajorVersion()
+        minor = config.getMinorVersion()
+        return (major, minor)
+    except AttributeError:
+        # Fallback for older OCIO versions
+        return (2, 1)
+
+
+def find_aces_colorspace_name(config):
+    """
+    Find the ACES2065-1 colorspace name in the config.
+    Different configs may use different names for the same colorspace.
+    """
+    # First try the aces_interchange role
+    try:
+        role_cs = config.getColorSpaceNameByRole('aces_interchange')
+        if role_cs:
+            return role_cs
+    except:
+        pass
+
+    # Fall back to searching for common names
+    for name in DEFAULT_ACES_NAMES:
+        try:
+            cs = config.getColorSpace(name)
+            if cs is not None:
+                return name
+        except:
+            continue
+
+    # Last resort: search by alias
     for cs in config.getColorSpaces():
-        desc = cs.getDescription()
-        if aces_id in desc:
-            return cs.getName()
+        aliases = cs.getAliases() if hasattr(cs, 'getAliases') else []
+        for alias in aliases:
+            if 'aces2065' in alias.lower() or alias in DEFAULT_ACES_NAMES:
+                return cs.getName()
+
+    # Default fallback
+    return 'ACES2065-1'
+
+
+def has_amf_transform_ids_support(config):
+    """
+    Check if the OCIO config supports the amf_transform_ids attribute (OCIO 2.5+).
+    """
+    major, minor = get_ocio_major_minor_version(config)
+    return (major, minor) >= (2, 5)
+
+
+def get_amf_transform_ids(element):
+    """
+    Get AMF Transform IDs from an OCIO config element (colorspace, view transform, look).
+    Works with OCIO 2.5+ configs that have the interchange/amf_transform_ids attribute.
+    Returns a list of transform ID strings, or empty list if not available.
+    """
+    try:
+        # OCIO 2.5+ API: getInterchangeAttribute("amf_transform_ids")
+        # Returns a newline-separated string of transform IDs
+        if hasattr(element, 'getInterchangeAttribute'):
+            amf_ids_str = element.getInterchangeAttribute("amf_transform_ids")
+            if amf_ids_str:
+                # Split by newlines and filter out empty strings
+                return [id.strip() for id in amf_ids_str.split('\n') if id.strip()]
+    except:
+        pass
+    return []
+
+
+def detect_amf_version(root):
+    """
+    Detect AMF version from the root element's namespace or version attribute.
+    Returns the version string ('1.0' or '2.0') and updates the global NS dict.
+    """
+    global NS
+
+    # Check the namespace of the root element
+    ns_uri = root.tag.split('}')[0].strip('{') if '}' in root.tag else ''
+
+    # Also check the version attribute
+    version_attr = root.attrib.get('version', '')
+
+    if ns_uri == AMF_NS_V2 or version_attr == '2.0':
+        NS = {'aces': AMF_NS_V2, 'cdl': CDL_NS}
+        return '2.0'
+    else:
+        NS = {'aces': AMF_NS_V1, 'cdl': CDL_NS}
+        return '1.0'
+
+def search_colorspaces(config, aces_id, use_amf_ids=False):
+    """
+    Search the config for the supplied ACES ID, return the color space name.
+
+    Args:
+        config: OCIO config object
+        aces_id: ACES Transform ID to search for
+        use_amf_ids: If True, search in amf_transform_ids (OCIO 2.5+), else search in description
+    """
+    for cs in config.getColorSpaces():
+        if use_amf_ids:
+            # OCIO 2.5+: Search in amf_transform_ids
+            amf_ids = get_amf_transform_ids(cs)
+            if aces_id in amf_ids:
+                return cs.getName()
+        else:
+            # Legacy: Search in description
+            desc = cs.getDescription()
+            if aces_id in desc:
+                return cs.getName()
     return None
 
-def search_viewtransforms(config, aces_id):
-    """ Search the config for the supplied ACES ID, return the view transform name. """
+
+def search_viewtransforms(config, aces_id, use_amf_ids=False):
+    """
+    Search the config for the supplied ACES ID, return the view transform name.
+
+    Args:
+        config: OCIO config object
+        aces_id: ACES Transform ID to search for
+        use_amf_ids: If True, search in amf_transform_ids (OCIO 2.5+), else search in description
+    """
     for vt in config.getViewTransforms():
-        desc = vt.getDescription()
-        if aces_id in desc:
-            return vt.getName()
+        if use_amf_ids:
+            # OCIO 2.5+: Search in amf_transform_ids
+            amf_ids = get_amf_transform_ids(vt)
+            if aces_id in amf_ids:
+                return vt.getName()
+        else:
+            # Legacy: Search in description
+            desc = vt.getDescription()
+            if aces_id in desc:
+                return vt.getName()
     return None
 
-def search_looktransforms(config, aces_id):
-    """ Search the config for the supplied ACES ID, return the look name. """
+
+def search_looktransforms(config, aces_id, use_amf_ids=False):
+    """
+    Search the config for the supplied ACES ID, return the look name.
+
+    Args:
+        config: OCIO config object
+        aces_id: ACES Transform ID to search for
+        use_amf_ids: If True, search in amf_transform_ids (OCIO 2.5+), else search in description
+    """
     for lt in config.getLooks():
-        desc = lt.getDescription()
-        if aces_id in desc:
-            return lt.getName()
+        if use_amf_ids:
+            # OCIO 2.5+: Search in amf_transform_ids
+            amf_ids = get_amf_transform_ids(lt)
+            if aces_id in amf_ids:
+                return lt.getName()
+        else:
+            # Legacy: Search in description
+            desc = lt.getDescription()
+            if aces_id in desc:
+                return lt.getName()
     return None
 
 def must_apply(elem, type):
@@ -86,6 +244,57 @@ def name_ctf_output_file(amf_path):
     abs_path = os.path.join(prefix, fname + '.ctf')
     return abs_path
 
+
+def name_ctf_output_file_split(amf_path, suffix):
+    """ Return the path for a split CTF file with _before or _after suffix. """
+    import os.path
+    prefix, basename = os.path.split(amf_path)
+    fname, ext = os.path.splitext(basename)
+    return os.path.join(prefix, f'{fname}_{suffix}.ctf')
+
+
+def split_look_transforms_by_working_location(root, ns):
+    """
+    Split look transforms based on workingLocation marker position.
+
+    Iterates through pipeline children to find the workingLocation marker
+    and categorize lookTransform elements as before or after it.
+
+    Args:
+        root: XML root element
+        ns: Namespace dictionary
+
+    Returns:
+        tuple: (before_looks, after_looks, has_working_location)
+            - before_looks: List of lookTransform elements before workingLocation
+            - after_looks: List of lookTransform elements after workingLocation
+            - has_working_location: Boolean indicating if marker was found
+    """
+    pipeline = root.find('./aces:pipeline', namespaces=ns)
+    if pipeline is None:
+        return [], [], False
+
+    before_looks = []
+    after_looks = []
+    found_working_location = False
+
+    for child in pipeline:
+        # Get local name by stripping namespace
+        local_name = child.tag.split('}')[-1] if '}' in child.tag else child.tag
+
+        if local_name == 'workingLocation':
+            found_working_location = True
+            continue
+
+        if local_name == 'lookTransform':
+            if found_working_location:
+                after_looks.append(child)
+            else:
+                before_looks.append(child)
+
+    return before_looks, after_looks, found_working_location
+
+
 def write_ctf(grp, config, amf_path, fname, id):
     """  Take a GroupTransform and some metadata and write a CTF file. """
 
@@ -123,15 +332,21 @@ def extract_three_floats(elem):
         raise
     return None
 
-def parse_cdl(look_elem):
-    """ Return the CDL slope, offset, power, and saturation values from a look element. """
+def parse_cdl(look_elem, amf_version):
+    """ Return the CDL slope, offset, power, and saturation values from a look element.
+        Supports both AMF v1.0 (SOPNode/SatNode) and v2.0 (ASC_SOP/ASC_SAT) element names.
+    """
     slopes = [1., 1., 1.]
     offsets = [0., 0., 0.]
     powers = [1., 1., 1.]
     sat = 1.
     has_cdl = False
 
-    sop_elem = look_elem.find('./cdl:SOPNode', namespaces=NS)
+    # Try v2.0 element names first (ASC_SOP), then fall back to v1.0 (SOPNode)
+    sop_elem = look_elem.find('./cdl:ASC_SOP', namespaces=NS)
+    if sop_elem is None:
+        sop_elem = look_elem.find('./cdl:SOPNode', namespaces=NS)
+
     if sop_elem is not None:
         slope_elem = sop_elem.find('./cdl:Slope', namespaces=NS)
         if slope_elem is not None:
@@ -144,7 +359,11 @@ def parse_cdl(look_elem):
             powers = extract_three_floats(power_elem)
         has_cdl = True
 
-    sat_elem = look_elem.find('./cdl:SatNode', namespaces=NS)
+    # Try v2.0 element names first (ASC_SAT), then fall back to v1.0 (SatNode)
+    sat_elem = look_elem.find('./cdl:ASC_SAT', namespaces=NS)
+    if sat_elem is None:
+        sat_elem = look_elem.find('./cdl:SatNode', namespaces=NS)
+
     if sat_elem is not None:
         saturation_elem = sat_elem.find('./cdl:Saturation', namespaces=NS)
         if saturation_elem is not None:
@@ -157,7 +376,7 @@ def parse_cdl(look_elem):
 
     return has_cdl, slopes, offsets, powers, sat
 
-def load_cdl_working_space_transform(config, base_path, look_elem, is_to_direc):
+def load_cdl_working_space_transform(config, base_path, look_elem, is_to_direc, use_amf_ids=False, aces_cs_name='ACES2065-1'):
     """ Return an OCIO transform for a CDL to/from working space transform. """
     if is_to_direc:
         token = 'aces:toCdlWorkingSpace'
@@ -173,14 +392,14 @@ def load_cdl_working_space_transform(config, base_path, look_elem, is_to_direc):
         if id_elem is not None:
             aces_id = id_elem.text
 
-            cs_name = search_colorspaces(config, aces_id)
+            cs_name = search_colorspaces(config, aces_id, use_amf_ids)
             if cs_name is not None:
                 if is_to_direc:
                     print('  Loading To-CDL-Working-Space Transform from ACES2065-1 to', cs_name)
-                    transform = ocio.ColorSpaceTransform(ACES, cs_name, ocio.TRANSFORM_DIR_FORWARD)
+                    transform = ocio.ColorSpaceTransform(aces_cs_name, cs_name, ocio.TRANSFORM_DIR_FORWARD)
                 else:
                     print('  Loading From-CDL-Working-Space Transform from', cs_name, 'to ACES2065-1')
-                    transform = ocio.ColorSpaceTransform(cs_name, ACES, ocio.TRANSFORM_DIR_FORWARD)
+                    transform = ocio.ColorSpaceTransform(cs_name, aces_cs_name, ocio.TRANSFORM_DIR_FORWARD)
                 return transform
             else:
                 raise ValueError("Could not find transform for transformId element: " + aces_id)
@@ -200,7 +419,7 @@ def load_cdl_working_space_transform(config, base_path, look_elem, is_to_direc):
                 return transform
     return None
 
-def process_look(config, gt, base_path, look_elem):
+def process_look(config, gt, base_path, look_elem, amf_version='1.0', use_amf_ids=False, aces_cs_name='ACES2065-1'):
     """ Build a look transform and add it to the supplied OCIO group transform. """
     if not must_apply(look_elem, 'Look'):
         return
@@ -211,10 +430,10 @@ def process_look(config, gt, base_path, look_elem):
     if id_elem is not None:
         aces_id = id_elem.text
 
-        look_name = search_looktransforms(config, aces_id)
+        look_name = search_looktransforms(config, aces_id, use_amf_ids)
         if look_name is not None:
             print('Adding Look Transform:', look_name)
-            gt.appendTransform( ocio.LookTransform(ACES, ACES, look_name, False, ocio.TRANSFORM_DIR_FORWARD) )
+            gt.appendTransform( ocio.LookTransform(aces_cs_name, aces_cs_name, look_name, False, ocio.TRANSFORM_DIR_FORWARD) )
             return
         else:
             raise ValueError("Could not find transform for transformId element: " + aces_id)
@@ -240,7 +459,7 @@ def process_look(config, gt, base_path, look_elem):
     #
     # LookTransform ASC CDL case.
     #
-    has_cdl, slopes, offsets, powers, sat = parse_cdl(look_elem)
+    has_cdl, slopes, offsets, powers, sat = parse_cdl(look_elem, amf_version)
     if has_cdl:
         ws_elem = look_elem.find('./aces:cdlWorkingSpace', namespaces=NS)
         if ws_elem is None:
@@ -250,8 +469,8 @@ def process_look(config, gt, base_path, look_elem):
         #
         # Attempt to load the working space transforms.
         #
-        to_transform = load_cdl_working_space_transform(config, base_path, ws_elem, True)
-        from_transform = load_cdl_working_space_transform(config, base_path, ws_elem, False)
+        to_transform = load_cdl_working_space_transform(config, base_path, ws_elem, True, use_amf_ids, aces_cs_name)
+        from_transform = load_cdl_working_space_transform(config, base_path, ws_elem, False, use_amf_ids, aces_cs_name)
         #
         # Handle the four possible scenarios of working space transform availability.
         #
@@ -285,20 +504,20 @@ def process_look(config, gt, base_path, look_elem):
             print('Adding From-CDL-Working-Space Transform')
             gt.appendTransform(from_transform)
 
-def build_output_transform_from_id_elem(config, gt, id_elem, msg, transform_dir):
+def build_output_transform_from_id_elem(config, gt, id_elem, msg, transform_dir, use_amf_ids=False, aces_cs_name='ACES2065-1'):
     """ Add an OCIO transform to the supplied group transform using a transform ID. """
     aces_id = id_elem.text
 
-    dcs_name = search_colorspaces(config, aces_id)
-    vt_name = search_viewtransforms(config, aces_id)
+    dcs_name = search_colorspaces(config, aces_id, use_amf_ids)
+    vt_name = search_viewtransforms(config, aces_id, use_amf_ids)
 
     if dcs_name is not None and vt_name is not None:
         print( msg % (dcs_name, vt_name) )
-        gt.appendTransform( ocio.DisplayViewTransform(ACES, dcs_name, vt_name, direction=transform_dir) )
+        gt.appendTransform( ocio.DisplayViewTransform(aces_cs_name, dcs_name, vt_name, direction=transform_dir) )
     else:
         raise ValueError("Could not process transformId element: " + aces_id)
 
-def load_output_transform(config, gt, base_path, elem, is_inverse):
+def load_output_transform(config, gt, base_path, elem, is_inverse, use_amf_ids=False, aces_cs_name='ACES2065-1'):
     """ Add an OCIO transform to the supplied group transform to implement an ACES Output Transform. """
     # Setup some variables based on whether it is an Output or Inverse Output Transform.
     if not is_inverse:
@@ -322,7 +541,7 @@ def load_output_transform(config, gt, base_path, elem, is_inverse):
     #
     id_elem = elem.find(ot_transformId_token, namespaces=NS)
     if id_elem is not None:
-        build_output_transform_from_id_elem(config, gt, id_elem, msg, transform_dir)
+        build_output_transform_from_id_elem(config, gt, id_elem, msg, transform_dir, use_amf_ids, aces_cs_name)
         return
     #
     # OutputTransform external LUT file case.
@@ -345,7 +564,7 @@ def load_output_transform(config, gt, base_path, elem, is_inverse):
         #
         id_elem = odt_elem.find('./aces:transformId', namespaces=NS)
         if id_elem is not None:
-            build_output_transform_from_id_elem(config, gt, id_elem, msg, transform_dir)
+            build_output_transform_from_id_elem(config, gt, id_elem, msg, transform_dir, use_amf_ids, aces_cs_name)
             return
             # TODO: Could validate that the referenceRenderingTransform element exists and is
             # the expected version (although since there is only one, it is not currently used).
@@ -383,7 +602,7 @@ def load_output_transform(config, gt, base_path, elem, is_inverse):
                     print('Adding ODT LUT file:', odt_path)
                     gt.appendTransform( odt_transform )
 
-def load_input_transform(config, gt, base_path, input_elem):
+def load_input_transform(config, gt, base_path, input_elem, use_amf_ids=False, aces_cs_name='ACES2065-1'):
     """ Add an OCIO transform to the supplied group transform to implement an ACES Input Transform. """
     #
     # InputTransform ACES transformId case.
@@ -392,10 +611,10 @@ def load_input_transform(config, gt, base_path, input_elem):
     if id_elem is not None:
         aces_id = id_elem.text
 
-        cs_name = search_colorspaces(config, aces_id)
+        cs_name = search_colorspaces(config, aces_id, use_amf_ids)
         if cs_name is not None:
             print('Adding Input Transform from', cs_name, 'to ACES2065-1')
-            gt.appendTransform( ocio.ColorSpaceTransform(cs_name, ACES, ocio.TRANSFORM_DIR_FORWARD) )
+            gt.appendTransform( ocio.ColorSpaceTransform(cs_name, aces_cs_name, ocio.TRANSFORM_DIR_FORWARD) )
             return
         else:
             raise ValueError("Could not find transform for transformId element: " + aces_id)
@@ -413,34 +632,76 @@ def load_input_transform(config, gt, base_path, input_elem):
     #
     # InputTransform is an inverse OutputTransform case.
     #
-    load_output_transform(config, gt, base_path, input_elem, is_inverse=True)
+    load_output_transform(config, gt, base_path, input_elem, is_inverse=True, use_amf_ids=use_amf_ids, aces_cs_name=aces_cs_name)
 
-def load_aces_ref_config():
-    """ Return an OCIO config object for the ACES reference config required to decode transform IDs. """
-    ACES_REF_CONFIG = 'config-aces-reference.yaml'
+def load_aces_ref_config(config_path=None):
+    """
+    Return an OCIO config object for the ACES reference config required to decode transform IDs.
+
+    Args:
+        config_path: Optional path to OCIO config file. If None, uses default config.
+    """
     import os
-    # Get the path to this script, see if the config is in the same directory.
-    file_path = os.path.realpath(__file__)
-    prefix = os.path.dirname(file_path)
-    config_path = os.path.join(prefix, ACES_REF_CONFIG)
+
+    if config_path is None:
+        # Default: look for config-aces-reference.yaml in the same directory as this script
+        ACES_REF_CONFIG = 'config-aces-reference.yaml'
+        file_path = os.path.realpath(__file__)
+        prefix = os.path.dirname(file_path)
+        config_path = os.path.join(prefix, ACES_REF_CONFIG)
+
+    if not os.path.isfile(config_path):
+        raise ValueError(f'OCIO config file not found: {config_path}')
+
     config = ocio.Config().CreateFromFile(config_path)
-    # TODO: Try other ways of finding the config.
     return config
 
-def build_ctf(amf_path):
-    """ Build a color pipeline that implements the supplied AMF file and write out a CTF file. """
+def build_ctf(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=False, config_path=None):
+    """ Build a color pipeline that implements the supplied AMF file and write out a CTF file.
+
+    Args:
+        amf_path: Path to the AMF file
+        exclude_idt: If True, exclude Input Transform (IDT) from conversion
+        exclude_lmt: If True, exclude Look Transform(s) (LMT) from conversion
+        exclude_odt: If True, exclude Output Transform (ODT) from conversion
+        config_path: Optional path to OCIO config file. If None, uses default config.
+    """
     print('\nProcessing file: ', amf_path, '\n')
 
     # Use Python to parse the AMF XML file and return an Element Tree object.
     tree = ET.parse(amf_path)
     root = tree.getroot()
 
+    # Detect AMF version and configure namespaces accordingly
+    amf_version = detect_amf_version(root)
+    print('Detected AMF version:', amf_version)
+
+    # Print exclusion status
+    if exclude_idt or exclude_lmt or exclude_odt:
+        excluded = []
+        if exclude_idt:
+            excluded.append('IDT')
+        if exclude_lmt:
+            excluded.append('LMT')
+        if exclude_odt:
+            excluded.append('ODT')
+        print('Excluding components:', ', '.join(excluded))
+
     # Clear the OCIO file cache (helpful if someone is editing files in between running this).
     ocio.ClearAllCaches()
 
     # Load the ACES Reference config that will be used to implement any Transform ID strings
     # encountered in the AMF file.
-    config = load_aces_ref_config()
+    config = load_aces_ref_config(config_path)
+
+    # Detect OCIO config version and capabilities
+    ocio_version = get_ocio_major_minor_version(config)
+    use_amf_ids = has_amf_transform_ids_support(config)
+    aces_cs_name = find_aces_colorspace_name(config)
+
+    print(f'OCIO config version: {ocio_version[0]}.{ocio_version[1]}')
+    print(f'Using AMF Transform IDs attribute: {use_amf_ids}')
+    print(f'ACES2065-1 colorspace name: {aces_cs_name}')
 
     # Initialize a group transform to hold the results.
     gt = ocio.GroupTransform()
@@ -448,20 +709,29 @@ def build_ctf(amf_path):
     #
     # Handle the AMF Input Transform.
     #
-    input_elem = root.find('./aces:pipeline/aces:inputTransform', namespaces=NS)
-    if must_apply(input_elem, 'Input'):
-        load_input_transform(config, gt, amf_path, input_elem)
+    if not exclude_idt:
+        input_elem = root.find('./aces:pipeline/aces:inputTransform', namespaces=NS)
+        if must_apply(input_elem, 'Input'):
+            load_input_transform(config, gt, amf_path, input_elem, use_amf_ids, aces_cs_name)
+    else:
+        print('Skipping Input Transform (IDT) - excluded by user')
     #
     # Handle all the AMF Look Transforms.
     #
-    for look_elem in root.findall('./aces:pipeline/aces:lookTransform', namespaces=NS):
-        process_look(config, gt, amf_path, look_elem)
+    if not exclude_lmt:
+        for look_elem in root.findall('./aces:pipeline/aces:lookTransform', namespaces=NS):
+            process_look(config, gt, amf_path, look_elem, amf_version, use_amf_ids, aces_cs_name)
+    else:
+        print('Skipping Look Transform(s) (LMT) - excluded by user')
     #
     # Handle the AMF Output Transform.
     #
-    output_elem = root.find('./aces:pipeline/aces:outputTransform', namespaces=NS)
-    if must_apply(output_elem, 'Output'):
-        load_output_transform(config, gt, amf_path, output_elem, is_inverse=False)
+    if not exclude_odt:
+        output_elem = root.find('./aces:pipeline/aces:outputTransform', namespaces=NS)
+        if must_apply(output_elem, 'Output'):
+            load_output_transform(config, gt, amf_path, output_elem, is_inverse=False, use_amf_ids=use_amf_ids, aces_cs_name=aces_cs_name)
+    else:
+        print('Skipping Output Transform (ODT) - excluded by user')
 
     # Print the OCIO transforms in the group transform.
     print('\n', gt)
@@ -471,11 +741,183 @@ def build_ctf(amf_path):
     write_ctf(gt, config, amf_path, ctf_path, 'none')
 
 
+def build_ctf_split(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=False, config_path=None):
+    """
+    Build two CTF files split by workingLocation marker.
+
+    Generates:
+        - *_before.ctf: IDT + lookTransforms before workingLocation
+        - *_after.ctf: lookTransforms after workingLocation + ODT
+
+    If no workingLocation is found, falls back to generating a single CTF file.
+
+    Args:
+        amf_path: Path to the AMF file
+        exclude_idt: If True, exclude Input Transform from before CTF
+        exclude_lmt: If True, exclude all Look Transforms from both CTFs
+        exclude_odt: If True, exclude Output Transform from after CTF
+        config_path: Optional path to OCIO config file
+    """
+    print('\nProcessing file (split mode): ', amf_path, '\n')
+
+    # Parse AMF XML
+    tree = ET.parse(amf_path)
+    root = tree.getroot()
+
+    # Detect AMF version
+    amf_version = detect_amf_version(root)
+    print('Detected AMF version:', amf_version)
+
+    # Check for workingLocation
+    before_looks, after_looks, has_working_location = split_look_transforms_by_working_location(root, NS)
+
+    if not has_working_location:
+        print('Warning: No workingLocation element found in AMF file.')
+        print('Falling back to generating single CTF file.')
+        print('')
+        build_ctf(amf_path, exclude_idt, exclude_lmt, exclude_odt, config_path)
+        return
+
+    print(f'Found workingLocation marker:')
+    print(f'  - {len(before_looks)} look transform(s) before workingLocation')
+    print(f'  - {len(after_looks)} look transform(s) after workingLocation')
+
+    # Print exclusion status
+    if exclude_idt or exclude_lmt or exclude_odt:
+        excluded = []
+        if exclude_idt:
+            excluded.append('IDT')
+        if exclude_lmt:
+            excluded.append('LMT')
+        if exclude_odt:
+            excluded.append('ODT')
+        print('Excluding components:', ', '.join(excluded))
+
+    # Clear OCIO cache and load config
+    ocio.ClearAllCaches()
+    config = load_aces_ref_config(config_path)
+
+    # Detect OCIO config capabilities
+    ocio_version = get_ocio_major_minor_version(config)
+    use_amf_ids = has_amf_transform_ids_support(config)
+    aces_cs_name = find_aces_colorspace_name(config)
+
+    print(f'OCIO config version: {ocio_version[0]}.{ocio_version[1]}')
+    print(f'Using AMF Transform IDs attribute: {use_amf_ids}')
+    print(f'ACES2065-1 colorspace name: {aces_cs_name}')
+
+    # ===== BUILD "BEFORE" CTF =====
+    print('\n--- Building BEFORE CTF ---')
+    gt_before = ocio.GroupTransform()
+    has_before_content = False
+
+    # Add IDT to before CTF
+    if not exclude_idt:
+        input_elem = root.find('./aces:pipeline/aces:inputTransform', namespaces=NS)
+        if must_apply(input_elem, 'Input'):
+            load_input_transform(config, gt_before, amf_path, input_elem, use_amf_ids, aces_cs_name)
+            has_before_content = True
+    else:
+        print('Skipping Input Transform (IDT) - excluded by user')
+
+    # Add look transforms BEFORE workingLocation
+    if not exclude_lmt:
+        for look_elem in before_looks:
+            if must_apply(look_elem, 'Look'):
+                process_look(config, gt_before, amf_path, look_elem, amf_version, use_amf_ids, aces_cs_name)
+                has_before_content = True
+    else:
+        print('Skipping Look Transform(s) (LMT) - excluded by user')
+
+    # Write before CTF if it has content
+    if has_before_content:
+        print('\n', gt_before)
+        ctf_path_before = name_ctf_output_file_split(amf_path, 'before')
+        write_ctf(gt_before, config, amf_path, ctf_path_before, 'before')
+    else:
+        print('\nNo transforms in BEFORE CTF - skipping file generation')
+
+    # ===== BUILD "AFTER" CTF =====
+    print('\n--- Building AFTER CTF ---')
+    gt_after = ocio.GroupTransform()
+    has_after_content = False
+
+    # Add look transforms AFTER workingLocation
+    if not exclude_lmt:
+        for look_elem in after_looks:
+            if must_apply(look_elem, 'Look'):
+                process_look(config, gt_after, amf_path, look_elem, amf_version, use_amf_ids, aces_cs_name)
+                has_after_content = True
+    else:
+        print('Skipping Look Transform(s) (LMT) - excluded by user')
+
+    # Add ODT to after CTF
+    if not exclude_odt:
+        output_elem = root.find('./aces:pipeline/aces:outputTransform', namespaces=NS)
+        if must_apply(output_elem, 'Output'):
+            load_output_transform(config, gt_after, amf_path, output_elem, is_inverse=False,
+                                  use_amf_ids=use_amf_ids, aces_cs_name=aces_cs_name)
+            has_after_content = True
+    else:
+        print('Skipping Output Transform (ODT) - excluded by user')
+
+    # Write after CTF if it has content
+    if has_after_content:
+        print('\n', gt_after)
+        ctf_path_after = name_ctf_output_file_split(amf_path, 'after')
+        write_ctf(gt_after, config, amf_path, ctf_path_after, 'after')
+    else:
+        print('\nNo transforms in AFTER CTF - skipping file generation')
+
+    # Summary
+    print('\n--- Split CTF Generation Complete ---')
+    if has_before_content:
+        print(f'  Before CTF: {name_ctf_output_file_split(amf_path, "before")}')
+    if has_after_content:
+        print(f'  After CTF: {name_ctf_output_file_split(amf_path, "after")}')
+
+
 def main():
-    import sys
-    if len( sys.argv ) != 2:
-        raise ValueError( "USAGE: python3 amf_to_ocio.py  <AMF_FILE>" )
-    build_ctf( sys.argv[1] )
+    parser = argparse.ArgumentParser(
+        description='Convert an ACES Metadata File (AMF) into an OCIO Color Transform File (CTF).',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog='''
+Examples:
+  python pyocioamf.py example.amf                    # Convert full pipeline
+  python pyocioamf.py example.amf --no-idt           # Exclude input transform
+  python pyocioamf.py example.amf --no-lmt --no-odt  # Exclude LMT and ODT
+  python pyocioamf.py example.amf --config my_config.ocio  # Use custom OCIO config
+  python pyocioamf.py example.amf --split-by-working-location  # Generate split CTFs
+        '''
+    )
+    parser.add_argument('amf_file', help='Path to the AMF file to convert')
+    parser.add_argument('--config', '-c', dest='config_path',
+                        help='Path to OCIO config file (supports OCIO 2.1+, with enhanced support for 2.5+)')
+    parser.add_argument('--no-idt', action='store_true',
+                        help='Exclude Input Transform (IDT) from conversion')
+    parser.add_argument('--no-lmt', action='store_true',
+                        help='Exclude Look Transform(s) (LMT) from conversion')
+    parser.add_argument('--no-odt', action='store_true',
+                        help='Exclude Output Transform (ODT) from conversion')
+    parser.add_argument('--split-by-working-location', action='store_true',
+                        help='Generate two CTF files split by workingLocation marker (AMF v2.0). '
+                             'Creates *_before.ctf (IDT + looks before marker) and '
+                             '*_after.ctf (looks after marker + ODT)')
+
+    args = parser.parse_args()
+
+    if args.split_by_working_location:
+        build_ctf_split(args.amf_file,
+                        exclude_idt=args.no_idt,
+                        exclude_lmt=args.no_lmt,
+                        exclude_odt=args.no_odt,
+                        config_path=args.config_path)
+    else:
+        build_ctf(args.amf_file,
+                  exclude_idt=args.no_idt,
+                  exclude_lmt=args.no_lmt,
+                  exclude_odt=args.no_odt,
+                  config_path=args.config_path)
 
 
 if __name__=='__main__':

--- a/src/apps/pyocioamf/pyocioamf.py
+++ b/src/apps/pyocioamf/pyocioamf.py
@@ -30,6 +30,10 @@ import xml.etree.ElementTree as ET
 import PyOpenColorIO as ocio
 
 
+# Default color space name for ACES2065-1 (may vary by config)
+# Common names: 'ACES - ACES2065-1' (old configs), 'ACES2065-1' (new configs)
+DEFAULT_ACES_NAMES = ['ACES2065-1', 'ACES - ACES2065-1']
+
 # Namespace URIs for AMF versions
 AMF_NS_V1 = 'urn:ampas:aces:amf:v1.0'
 AMF_NS_V2 = 'urn:ampas:aces:amf:v2.0'
@@ -57,11 +61,33 @@ def get_ocio_major_minor_version(config):
 def find_aces_colorspace_name(config):
     """
     Find the ACES2065-1 colorspace name in the config.
-    Uses the aces_interchange role which is defined in all ACES configs.
+    Different configs may use different names for the same colorspace.
     """
-    if config.hasRole('aces_interchange'):
-        return config.getRoleColorSpace('aces_interchange')
-    # Fallback for non-standard configs
+    # First try the aces_interchange role
+    try:
+        role_cs = config.getColorSpaceNameByRole('aces_interchange')
+        if role_cs:
+            return role_cs
+    except:
+        pass
+
+    # Fall back to searching for common names
+    for name in DEFAULT_ACES_NAMES:
+        try:
+            cs = config.getColorSpace(name)
+            if cs is not None:
+                return name
+        except:
+            continue
+
+    # Last resort: search by alias
+    for cs in config.getColorSpaces():
+        aliases = cs.getAliases() if hasattr(cs, 'getAliases') else []
+        for alias in aliases:
+            if 'aces2065' in alias.lower() or alias in DEFAULT_ACES_NAMES:
+                return cs.getName()
+
+    # Default fallback
     return 'ACES2065-1'
 
 
@@ -180,12 +206,20 @@ def search_looktransforms(config, aces_id, use_amf_ids=False):
                 return lt.getName()
     return None
 
-def must_apply(elem, type):
-    """ Return True if the 'applied' attribute is not already true. """
+def must_apply(elem, type, ignore_applied=False):
+    """ Return True if the 'applied' attribute is not already true.
+
+    When ignore_applied is True, the 'applied' attribute is disregarded and the
+    transform is always processed.
+    """
     if elem is None:
         return False
+    if ignore_applied:
+        if 'applied' in elem.attrib and elem.attrib['applied'].lower() == 'true':
+            print('Processing', type, 'Transform despite applied=true (--ignore-applied-tag)')
+        return True
     if 'applied' in elem.attrib:
-        if elem.attrib['applied'].lower() == 'true': 
+        if elem.attrib['applied'].lower() == 'true':
             print('Skipping', type, 'Transform that was already applied')
             return False
     return True
@@ -207,24 +241,40 @@ def check_lut_path(amf_path, lut_path):
 
     # TODO: Try some other techniques to find the referenced file.
 
-    # Return the (possibly corrected) path of the LUT.
-    return lut_path
+    # Return the (possibly corrected) path of the LUT, always as absolute.
+    return os.path.abspath(lut_path)
 
-def name_ctf_output_file(amf_path):
-    """ Return the path to store the resulting CTF file, based on the AMF name. """
+def name_ctf_output_file(amf_path, output_prefix=None, output_dir=None):
+    """ Return the path to store the resulting CTF file, based on the AMF name.
+
+    When `output_prefix` is a non-empty string, it is inserted before the
+    `.ctf` extension (e.g. `{stem}_{output_prefix}.ctf`) so concurrent runs
+    by different callers don't collide on the same output filename. When
+    `output_dir` is provided the file is written there instead of next to
+    the AMF.
+    """
     import os.path
     prefix, basename = os.path.split(amf_path)
     fname, ext = os.path.splitext(basename)
-    abs_path = os.path.join(prefix, fname + '.ctf')
-    return abs_path
+    tail = f'_{output_prefix}' if output_prefix else ''
+    directory = output_dir if output_dir else prefix
+    return os.path.join(directory, f'{fname}{tail}.ctf')
 
 
-def name_ctf_output_file_split(amf_path, suffix):
-    """ Return the path for a split CTF file with _before or _after suffix. """
+def name_ctf_output_file_split(amf_path, suffix, output_prefix=None, output_dir=None):
+    """ Return the path for a split CTF file with _before or _after suffix.
+
+    When `output_prefix` is a non-empty string, it is appended after the
+    before/after suffix (e.g. `{stem}_{suffix}_{output_prefix}.ctf`). When
+    `output_dir` is provided the file is written there instead of next to
+    the AMF.
+    """
     import os.path
     prefix, basename = os.path.split(amf_path)
     fname, ext = os.path.splitext(basename)
-    return os.path.join(prefix, f'{fname}_{suffix}.ctf')
+    tail = f'_{output_prefix}' if output_prefix else ''
+    directory = output_dir if output_dir else prefix
+    return os.path.join(directory, f'{fname}_{suffix}{tail}.ctf')
 
 
 def split_look_transforms_by_working_location(root, ns):
@@ -308,7 +358,7 @@ def extract_three_floats(elem):
 
 def parse_cdl(look_elem, amf_version):
     """ Return the CDL slope, offset, power, and saturation values from a look element.
-        Supports both ASC CDL element naming conventions: SOPNode/SatNode and ASC_SOP/ASC_SAT.
+        Supports both AMF v1.0 (SOPNode/SatNode) and v2.0 (ASC_SOP/ASC_SAT) element names.
     """
     slopes = [1., 1., 1.]
     offsets = [0., 0., 0.]
@@ -316,7 +366,7 @@ def parse_cdl(look_elem, amf_version):
     sat = 1.
     has_cdl = False
 
-    # Support both ASC CDL element naming conventions
+    # Try v2.0 element names first (ASC_SOP), then fall back to v1.0 (SOPNode)
     sop_elem = look_elem.find('./cdl:ASC_SOP', namespaces=NS)
     if sop_elem is None:
         sop_elem = look_elem.find('./cdl:SOPNode', namespaces=NS)
@@ -333,7 +383,7 @@ def parse_cdl(look_elem, amf_version):
             powers = extract_three_floats(power_elem)
         has_cdl = True
 
-    # Support both ASC CDL saturation element naming conventions
+    # Try v2.0 element names first (ASC_SAT), then fall back to v1.0 (SatNode)
     sat_elem = look_elem.find('./cdl:ASC_SAT', namespaces=NS)
     if sat_elem is None:
         sat_elem = look_elem.find('./cdl:SatNode', namespaces=NS)
@@ -393,9 +443,9 @@ def load_cdl_working_space_transform(config, base_path, look_elem, is_to_direc, 
                 return transform
     return None
 
-def process_look(config, gt, base_path, look_elem, amf_version='1.0', use_amf_ids=False, aces_cs_name='ACES2065-1'):
+def process_look(config, gt, base_path, look_elem, amf_version='1.0', use_amf_ids=False, aces_cs_name='ACES2065-1', ignore_applied=False):
     """ Build a look transform and add it to the supplied OCIO group transform. """
-    if not must_apply(look_elem, 'Look'):
+    if not must_apply(look_elem, 'Look', ignore_applied):
         return
     #
     # LookTransform ACES transformId case.
@@ -630,7 +680,7 @@ def load_aces_ref_config(config_path=None):
     config = ocio.Config().CreateFromFile(config_path)
     return config
 
-def build_ctf(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=False, config_path=None):
+def build_ctf(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=False, config_path=None, ignore_applied=False, output_prefix=None, output_dir=None):
     """ Build a color pipeline that implements the supplied AMF file and write out a CTF file.
 
     Args:
@@ -685,7 +735,7 @@ def build_ctf(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=False,
     #
     if not exclude_idt:
         input_elem = root.find('./aces:pipeline/aces:inputTransform', namespaces=NS)
-        if must_apply(input_elem, 'Input'):
+        if must_apply(input_elem, 'Input', ignore_applied):
             load_input_transform(config, gt, amf_path, input_elem, use_amf_ids, aces_cs_name)
     else:
         print('Skipping Input Transform (IDT) - excluded by user')
@@ -694,7 +744,7 @@ def build_ctf(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=False,
     #
     if not exclude_lmt:
         for look_elem in root.findall('./aces:pipeline/aces:lookTransform', namespaces=NS):
-            process_look(config, gt, amf_path, look_elem, amf_version, use_amf_ids, aces_cs_name)
+            process_look(config, gt, amf_path, look_elem, amf_version, use_amf_ids, aces_cs_name, ignore_applied)
     else:
         print('Skipping Look Transform(s) (LMT) - excluded by user')
     #
@@ -702,7 +752,7 @@ def build_ctf(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=False,
     #
     if not exclude_odt:
         output_elem = root.find('./aces:pipeline/aces:outputTransform', namespaces=NS)
-        if must_apply(output_elem, 'Output'):
+        if must_apply(output_elem, 'Output', ignore_applied):
             load_output_transform(config, gt, amf_path, output_elem, is_inverse=False, use_amf_ids=use_amf_ids, aces_cs_name=aces_cs_name)
     else:
         print('Skipping Output Transform (ODT) - excluded by user')
@@ -711,11 +761,11 @@ def build_ctf(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=False,
     print('\n', gt)
 
     # Write the group transform using OCIO's native file format, CTF.
-    ctf_path = name_ctf_output_file(amf_path)
+    ctf_path = name_ctf_output_file(amf_path, output_prefix, output_dir)
     write_ctf(gt, config, amf_path, ctf_path, 'none')
 
 
-def build_ctf_split(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=False, config_path=None):
+def build_ctf_split(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=False, config_path=None, ignore_applied=False, output_prefix=None, output_dir=None):
     """
     Build two CTF files split by workingLocation marker.
 
@@ -747,9 +797,8 @@ def build_ctf_split(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=
 
     if not has_working_location:
         print('Warning: No workingLocation element found in AMF file.')
-        print('Falling back to generating single CTF file.')
-        print('')
-        build_ctf(amf_path, exclude_idt, exclude_lmt, exclude_odt, config_path)
+        print('Falling back to generating single CTF file.\n')
+        build_ctf(amf_path, exclude_idt, exclude_lmt, exclude_odt, config_path, ignore_applied, output_prefix, output_dir)
         return
 
     print(f'Found workingLocation marker:')
@@ -788,7 +837,7 @@ def build_ctf_split(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=
     # Add IDT to before CTF
     if not exclude_idt:
         input_elem = root.find('./aces:pipeline/aces:inputTransform', namespaces=NS)
-        if must_apply(input_elem, 'Input'):
+        if must_apply(input_elem, 'Input', ignore_applied):
             load_input_transform(config, gt_before, amf_path, input_elem, use_amf_ids, aces_cs_name)
             has_before_content = True
     else:
@@ -797,8 +846,8 @@ def build_ctf_split(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=
     # Add look transforms BEFORE workingLocation
     if not exclude_lmt:
         for look_elem in before_looks:
-            if must_apply(look_elem, 'Look'):
-                process_look(config, gt_before, amf_path, look_elem, amf_version, use_amf_ids, aces_cs_name)
+            if must_apply(look_elem, 'Look', ignore_applied):
+                process_look(config, gt_before, amf_path, look_elem, amf_version, use_amf_ids, aces_cs_name, ignore_applied)
                 has_before_content = True
     else:
         print('Skipping Look Transform(s) (LMT) - excluded by user')
@@ -806,7 +855,7 @@ def build_ctf_split(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=
     # Write before CTF if it has content
     if has_before_content:
         print('\n', gt_before)
-        ctf_path_before = name_ctf_output_file_split(amf_path, 'before')
+        ctf_path_before = name_ctf_output_file_split(amf_path, 'before', output_prefix, output_dir)
         write_ctf(gt_before, config, amf_path, ctf_path_before, 'before')
     else:
         print('\nNo transforms in BEFORE CTF - skipping file generation')
@@ -819,8 +868,8 @@ def build_ctf_split(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=
     # Add look transforms AFTER workingLocation
     if not exclude_lmt:
         for look_elem in after_looks:
-            if must_apply(look_elem, 'Look'):
-                process_look(config, gt_after, amf_path, look_elem, amf_version, use_amf_ids, aces_cs_name)
+            if must_apply(look_elem, 'Look', ignore_applied):
+                process_look(config, gt_after, amf_path, look_elem, amf_version, use_amf_ids, aces_cs_name, ignore_applied)
                 has_after_content = True
     else:
         print('Skipping Look Transform(s) (LMT) - excluded by user')
@@ -828,7 +877,7 @@ def build_ctf_split(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=
     # Add ODT to after CTF
     if not exclude_odt:
         output_elem = root.find('./aces:pipeline/aces:outputTransform', namespaces=NS)
-        if must_apply(output_elem, 'Output'):
+        if must_apply(output_elem, 'Output', ignore_applied):
             load_output_transform(config, gt_after, amf_path, output_elem, is_inverse=False,
                                   use_amf_ids=use_amf_ids, aces_cs_name=aces_cs_name)
             has_after_content = True
@@ -838,7 +887,7 @@ def build_ctf_split(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=
     # Write after CTF if it has content
     if has_after_content:
         print('\n', gt_after)
-        ctf_path_after = name_ctf_output_file_split(amf_path, 'after')
+        ctf_path_after = name_ctf_output_file_split(amf_path, 'after', output_prefix, output_dir)
         write_ctf(gt_after, config, amf_path, ctf_path_after, 'after')
     else:
         print('\nNo transforms in AFTER CTF - skipping file generation')
@@ -846,9 +895,9 @@ def build_ctf_split(amf_path, exclude_idt=False, exclude_lmt=False, exclude_odt=
     # Summary
     print('\n--- Split CTF Generation Complete ---')
     if has_before_content:
-        print(f'  Before CTF: {name_ctf_output_file_split(amf_path, "before")}')
+        print(f'  Before CTF: {name_ctf_output_file_split(amf_path, "before", output_prefix, output_dir)}')
     if has_after_content:
-        print(f'  After CTF: {name_ctf_output_file_split(amf_path, "after")}')
+        print(f'  After CTF: {name_ctf_output_file_split(amf_path, "after", output_prefix, output_dir)}')
 
 
 def main():
@@ -877,6 +926,17 @@ Examples:
                         help='Generate two CTF files split by workingLocation marker (AMF v2.0). '
                              'Creates *_before.ctf (IDT + looks before marker) and '
                              '*_after.ctf (looks after marker + ODT)')
+    parser.add_argument('--ignore-applied-tag', action='store_true',
+                        help='Process transforms even when their applied="true" attribute '
+                             'indicates they were already baked in upstream.')
+    parser.add_argument('--output-prefix', dest='output_prefix', default=None,
+                        help='Optional identifier inserted before the .ctf extension in every '
+                             'output filename (e.g. "{stem}_{prefix}.ctf"). Useful to prevent '
+                             'concurrent callers working in the same directory from clobbering '
+                             'each other\'s CTFs.')
+    parser.add_argument('--output-dir', dest='output_dir', default=None,
+                        help='Directory to write CTF files into. Defaults to the directory '
+                             'containing the AMF. The directory must already exist.')
 
     args = parser.parse_args()
 
@@ -885,13 +945,19 @@ Examples:
                         exclude_idt=args.no_idt,
                         exclude_lmt=args.no_lmt,
                         exclude_odt=args.no_odt,
-                        config_path=args.config_path)
+                        config_path=args.config_path,
+                        ignore_applied=args.ignore_applied_tag,
+                        output_prefix=args.output_prefix,
+                        output_dir=args.output_dir)
     else:
         build_ctf(args.amf_file,
                   exclude_idt=args.no_idt,
                   exclude_lmt=args.no_lmt,
                   exclude_odt=args.no_odt,
-                  config_path=args.config_path)
+                  config_path=args.config_path,
+                  ignore_applied=args.ignore_applied_tag,
+                  output_prefix=args.output_prefix,
+                  output_dir=args.output_dir)
 
 
 if __name__=='__main__':


### PR DESCRIPTION
## Summary

This PR enhances `pyocioamf` with support for AMF v2.0 and OCIO 2.5+ configurations. It supersedes #2232 (closed to move the branch onto a fresh public fork and add the refinements below).

- **AMF v2.0 support** with automatic version detection from namespace URI or version attribute
- **OCIO 2.5+ config support** using the `amf_transform_ids` interchange attribute for transform lookup
- **New CLI options** for flexible conversion control
- **Split CTF generation** for the AMF v2.0 `workingLocation` marker
- **New example file** demonstrating the v2.0 format

## Changes

### AMF Version Support
- Auto-detects v1.0 vs v2.0 from namespace URI (`urn:ampas:aces:amf:v1.0` / `v2.0`) or version attribute
- Handles both v1.0 element names (`SOPNode`/`SatNode`) and v2.0 names (`ASC_SOP`/`ASC_SAT`)

### OCIO Config Compatibility
- For OCIO 2.5+ configs: uses the dedicated `amf_transform_ids` interchange attribute
- For OCIO 2.1-2.4 configs: falls back to description-based transform ID search
- Multi-strategy ACES2065-1 colorspace resolution via `aces_interchange` role, then common names, then alias matching (works across config naming variants)

### CLI Enhancements
- `--config`: specify a custom OCIO config file (supports OCIO 2.1+)
- `--no-idt` / `--no-lmt` / `--no-odt`: exclude input / look / output transforms
- `--split-by-working-location`: generate split CTFs at the `workingLocation` marker
- `--ignore-applied-tag`: process transforms even when `applied="true"`
- `--output-prefix` / `--output-dir`: collision-free output naming for batch/concurrent use

### Robustness
- `check_lut_path` now always returns an absolute path so OCIO's CTF `write()` resolves referenced LUTs correctly regardless of the current working directory

### New Files
- `example_v2.amf`: AMF v2.0 example with `ASC_SOP`/`ASC_SAT` elements

## Backwards Compatibility

All existing functionality is preserved: the script auto-detects the AMF version and OCIO config version, and defaults to prior behavior when no CLI options are given.